### PR TITLE
fix: encrypted stream decoding

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -308,7 +308,7 @@ impl PdfDocument {
     /// # PDF Spec Reference
     ///
     /// ISO 32000-1:2008, Section 7.6.2 - Streams must be decrypted BEFORE applying filters.
-    fn decode_stream_with_encryption(
+    pub(crate) fn decode_stream_with_encryption(
         &self,
         stream_obj: &Object,
         obj_ref: ObjectRef,
@@ -2625,7 +2625,8 @@ impl PdfDocument {
                 if let Some(subtype) = dict.get("Subtype").and_then(|s| s.as_name()) {
                     if subtype == "Image" {
                         // Extract the image
-                        match extract_image_from_xobject(&xobj_loaded) {
+                        let obj_ref = xobj.as_reference();
+                        match extract_image_from_xobject(Some(self), &xobj_loaded, obj_ref) {
                             Ok(image) => images.push(image),
                             Err(_) => {
                                 // Skip images that fail to extract


### PR DESCRIPTION
## Description

You might not want this since you have to do it globally, and might have a better way of doing it -- just for your information! 

Performs default decryption before decompression for encrypted PDFs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Related Issues

## Changes Made

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass locally
- [ ] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Additional Notes

To generate a corrupt.pdf from test.pdf: 

`qpdf --allow-weak-crypto --encrypt "" "" 128 -- test.pdf corrupt.pdf`
