### PR TITLE
fix: encrypted stream decoding p. 2

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2033,8 +2033,8 @@ impl TextExtractor {
                 // Form XObject - extract text from it
                 log::debug!("Processing Form XObject: {}", name);
 
-                // Decode the stream data with error recovery
-                let stream_data = match xobject.decode_stream_data() {
+                // Decode the stream data with error recovery, respecting encryption
+                let stream_data = match doc.decode_stream_with_encryption(&xobject, xobject_ref) {
                     Ok(data) => data,
                     Err(e) => {
                         log::warn!(


### PR DESCRIPTION
## Description

fix: eagerly initialize encryption handler and apply it to Form XObject stream decoding

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Related Issues

Relates to #2 

Fixes #

## Changes Made

- Encryption initialization timing: Changed encryption handler initialization from lazy to eager during document construction so the handler is available when decode_stream_with_encryption is called.

- Form XObject encryption support: Updated text extraction for Form XObjects to use the document's decode_stream_with_encryption method instead of the basic decode_stream_data so we can deal with encrypted form content.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass locally
- [ ] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)


## Additional Notes


