### PR TITLE
Fix CTM transformation for text positions (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.2.4] - 2026-01-09
+
+### Fixed
+- CTM (Current Transformation Matrix) now correctly applied to text positions per PDF Spec ISO 32000-1:2008 Section 9.4.4 (#11)
+
+### Added
+- Structure tree: `/Alt` (alternate description) parsing for accessibility text on formulas and figures
+- Structure tree: `/Pg` (page reference) resolution - correctly maps structure elements to page numbers
+- `FormulaRenderer` module for extracting formula regions as base64 images from rendered pages
+- `ConversionOptions`: new fields `render_formulas`, `page_images`, `page_dimensions` for formula image embedding
+- Regression tests for CTM transformation
+
 ## [0.2.3] - 2026-01-07
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Yury Fedoseev <yfedoseev@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -45,6 +45,7 @@ phf = { version = "0.11", features = ["macros"] }  # Perfect hash maps for Adobe
 
 # Image processing
 image = { version = "0.24", default-features = false, features = ["png", "jpeg", "tiff"] }
+base64 = "0.22"  # For embedding images as data URIs
 tiff = "0.9"  # TIFF support including CCITT decompression
 fax = "0.2"   # CCITT Group 3/4 decompression for scanned PDFs (more lenient with malformed EOFB)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.2.3"
+version = "0.2.4"
 description = "Production-grade PDF parsing: spec-compliant text extraction, intelligent reading order, OCR support. Ultra-fast Rust performance."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/bin/export_to_html.rs
+++ b/src/bin/export_to_html.rs
@@ -124,6 +124,7 @@ fn export_pdf_to_html(
         reading_order_mode: pdf_oxide::converters::ReadingOrderMode::ColumnAware,
         bold_marker_behavior: pdf_oxide::converters::BoldMarkerBehavior::default(),
         table_detection_config: None,
+        ..Default::default()
     };
 
     // Convert to HTML

--- a/src/converters/formula_renderer.rs
+++ b/src/converters/formula_renderer.rs
@@ -1,0 +1,286 @@
+//! Formula rendering support for HTML output.
+//!
+//! This module provides functionality to extract formula regions from rendered
+//! PDF page images and embed them as base64 data URIs in HTML output.
+
+use crate::layout::TextSpan;
+use crate::structure::{StructChild, StructElem};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use image::{DynamicImage, GenericImageView, ImageFormat};
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::Path;
+
+/// Formula rendering context for a document.
+pub struct FormulaRenderer {
+    /// Pre-rendered page images
+    page_images: Vec<DynamicImage>,
+    /// Page dimensions in PDF points (width, height)
+    page_dimensions: (f32, f32),
+    /// MCID to Y coordinate mapping per page: page -> mcid -> (min_y, max_y)
+    mcid_y_maps: HashMap<u32, HashMap<u32, (f32, f32)>>,
+    /// Formula counter for logging
+    formula_count: usize,
+}
+
+/// Rendered formula with base64 data URI
+#[derive(Debug, Clone)]
+pub struct RenderedFormula {
+    /// Base64 data URI (data:image/png;base64,...)
+    pub data_uri: String,
+    /// Alt text if available
+    pub alt_text: Option<String>,
+}
+
+impl FormulaRenderer {
+    /// Create a new formula renderer with page images.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_image_paths` - Paths to pre-rendered page images (PNG format)
+    /// * `page_dimensions` - Page dimensions in PDF points (width, height)
+    ///
+    /// # Returns
+    ///
+    /// A new FormulaRenderer or an error if images cannot be loaded.
+    pub fn new<P: AsRef<Path>>(
+        page_image_paths: &[P],
+        page_dimensions: (f32, f32),
+    ) -> Result<Self, String> {
+        let mut page_images = Vec::new();
+
+        for path in page_image_paths {
+            let img = image::open(path.as_ref())
+                .map_err(|e| format!("Failed to load page image {:?}: {}", path.as_ref(), e))?;
+            page_images.push(img);
+        }
+
+        Ok(Self {
+            page_images,
+            page_dimensions,
+            mcid_y_maps: HashMap::new(),
+            formula_count: 0,
+        })
+    }
+
+    /// Build MCID to Y coordinate mappings from extracted spans.
+    ///
+    /// This must be called before rendering formulas to establish the
+    /// coordinate mapping for formula region estimation.
+    pub fn build_mcid_map(&mut self, page: u32, spans: &[TextSpan]) {
+        let mut mcid_y: HashMap<u32, (f32, f32)> = HashMap::new();
+
+        for span in spans {
+            if let Some(mcid) = span.mcid {
+                let entry = mcid_y
+                    .entry(mcid)
+                    .or_insert((span.bbox.y, span.bbox.y + span.bbox.height));
+                entry.0 = entry.0.min(span.bbox.y);
+                entry.1 = entry.1.max(span.bbox.y + span.bbox.height);
+            }
+        }
+
+        self.mcid_y_maps.insert(page, mcid_y);
+    }
+
+    /// Render a formula element as a base64 image.
+    ///
+    /// Returns None if the formula cannot be rendered (e.g., no valid bounds).
+    pub fn render_formula(&mut self, elem: &StructElem, page: u32) -> Option<RenderedFormula> {
+        let bounds = self.estimate_formula_bounds(elem, page)?;
+        let (top_y, bot_y) = bounds;
+
+        let page_image = self.page_images.get(page as usize)?;
+        let data_uri = self.crop_formula_region(page_image, top_y, bot_y)?;
+
+        self.formula_count += 1;
+
+        Some(RenderedFormula {
+            data_uri,
+            alt_text: elem.alt_text.clone(),
+        })
+    }
+
+    /// Estimate formula bounds from neighboring text MCIDs.
+    fn estimate_formula_bounds(&self, elem: &StructElem, page: u32) -> Option<(f32, f32)> {
+        let mcid_y_map = self.mcid_y_maps.get(&page)?;
+
+        let mut mcids = Vec::new();
+        collect_mcids_recursive(elem, &mut mcids);
+
+        if mcids.is_empty() {
+            return None;
+        }
+
+        let min_mcid = *mcids.iter().min().unwrap();
+        let max_mcid = *mcids.iter().max().unwrap();
+
+        // Find text above (highest MCID < min_mcid)
+        let text_above_y = mcid_y_map
+            .iter()
+            .filter(|(&m, _)| m < min_mcid)
+            .max_by_key(|(&m, _)| m)
+            .map(|(_, (min_y, _))| *min_y);
+
+        // Find text below (lowest MCID > max_mcid)
+        let text_below_y = mcid_y_map
+            .iter()
+            .filter(|(&m, _)| m > max_mcid)
+            .min_by_key(|(&m, _)| m)
+            .map(|(_, (_, max_y))| *max_y);
+
+        if let (Some(above_y), Some(below_y)) = (text_above_y, text_below_y) {
+            let gap_height = above_y - below_y;
+            if gap_height > 30.0 {
+                // Take middle 40% of gap (30% margin on each side)
+                let margin = gap_height * 0.30;
+                let top_y = above_y - margin;
+                let bot_y = below_y + margin;
+                if top_y > bot_y {
+                    return Some((top_y, bot_y));
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Crop a formula region from a page image and return as base64 data URI.
+    fn crop_formula_region(
+        &self,
+        page_image: &DynamicImage,
+        top_y: f32,
+        bot_y: f32,
+    ) -> Option<String> {
+        let (img_width, img_height) = page_image.dimensions();
+        let pdf_height = self.page_dimensions.1;
+        let scale = img_height as f32 / pdf_height;
+
+        // Convert PDF coords to image coords (Y inverted)
+        let img_top = ((pdf_height - top_y) * scale) as u32;
+        let img_bot = ((pdf_height - bot_y) * scale) as u32;
+
+        if img_bot <= img_top || img_bot > img_height {
+            return None;
+        }
+
+        let height = img_bot - img_top;
+
+        // Crop the region
+        let cropped = page_image.crop_imm(0, img_top, img_width, height);
+
+        // Trim whitespace (find bounding box of non-white pixels)
+        let trimmed = trim_whitespace(&cropped);
+
+        // Add small border
+        let bordered = add_border(&trimmed, 10, 5);
+
+        // Encode as PNG and convert to base64
+        let mut buffer = Cursor::new(Vec::new());
+        bordered.write_to(&mut buffer, ImageFormat::Png).ok()?;
+
+        let base64_data = BASE64.encode(buffer.into_inner());
+        Some(format!("data:image/png;base64,{}", base64_data))
+    }
+
+    /// Get the number of formulas rendered so far.
+    pub fn formula_count(&self) -> usize {
+        self.formula_count
+    }
+}
+
+/// Collect MCIDs from a structure element recursively.
+fn collect_mcids_recursive(elem: &StructElem, mcids: &mut Vec<u32>) {
+    for child in &elem.children {
+        match child {
+            StructChild::MarkedContentRef { mcid, .. } => {
+                mcids.push(*mcid);
+            },
+            StructChild::StructElem(child_elem) => {
+                collect_mcids_recursive(child_elem, mcids);
+            },
+            _ => {},
+        }
+    }
+}
+
+/// Trim whitespace from an image by finding the bounding box of non-white pixels.
+fn trim_whitespace(img: &DynamicImage) -> DynamicImage {
+    let (width, height) = img.dimensions();
+    let rgba = img.to_rgba8();
+
+    // Find bounds of non-white content
+    let mut min_x = width;
+    let mut max_x = 0u32;
+    let mut min_y = height;
+    let mut max_y = 0u32;
+
+    for y in 0..height {
+        for x in 0..width {
+            let pixel = rgba.get_pixel(x, y);
+            // Check if pixel is not white (threshold)
+            if pixel[0] < 250 || pixel[1] < 250 || pixel[2] < 250 {
+                min_x = min_x.min(x);
+                max_x = max_x.max(x);
+                min_y = min_y.min(y);
+                max_y = max_y.max(y);
+            }
+        }
+    }
+
+    // If no content found, return original
+    if min_x >= max_x || min_y >= max_y {
+        return img.clone();
+    }
+
+    // Crop to content bounds
+    img.crop_imm(min_x, min_y, max_x - min_x + 1, max_y - min_y + 1)
+}
+
+/// Add a white border around an image.
+fn add_border(img: &DynamicImage, horizontal: u32, vertical: u32) -> DynamicImage {
+    let (width, height) = img.dimensions();
+    let new_width = width + 2 * horizontal;
+    let new_height = height + 2 * vertical;
+
+    let mut bordered =
+        image::RgbaImage::from_pixel(new_width, new_height, image::Rgba([255, 255, 255, 255]));
+
+    // Convert to rgba8 once to avoid repeated conversions
+    let rgba = img.to_rgba8();
+
+    // Copy original image into center
+    for y in 0..height {
+        for x in 0..width {
+            let pixel = rgba.get_pixel(x, y);
+            bordered.put_pixel(x + horizontal, y + vertical, *pixel);
+        }
+    }
+
+    DynamicImage::ImageRgba8(bordered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::structure::StructType;
+
+    #[test]
+    fn test_collect_mcids_recursive() {
+        // Basic test for MCID collection
+        let elem = StructElem {
+            struct_type: StructType::Formula,
+            children: vec![
+                StructChild::MarkedContentRef { mcid: 10, page: 0 },
+                StructChild::MarkedContentRef { mcid: 11, page: 0 },
+            ],
+            page: Some(0),
+            attributes: HashMap::new(),
+            alt_text: None,
+        };
+
+        let mut mcids = Vec::new();
+        collect_mcids_recursive(&elem, &mut mcids);
+        assert_eq!(mcids, vec![10, 11]);
+    }
+}

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -18,6 +18,19 @@ fn resolve_object(document: &mut PdfDocument, obj: &Object) -> Result<Object, Er
     }
 }
 
+/// Build a mapping from page object IDs to page indices.
+/// This allows resolving /Pg references in marked content references.
+fn build_page_map(document: &mut PdfDocument) -> HashMap<u32, u32> {
+    let mut page_map = HashMap::new();
+    let page_count = document.page_count().unwrap_or(0);
+    for i in 0..page_count {
+        if let Ok(page_ref) = document.get_page_ref(i) {
+            page_map.insert(page_ref.id, i as u32);
+        }
+    }
+    page_map
+}
+
 /// Parse the structure tree from a PDF document.
 ///
 /// Reads the StructTreeRoot from the document catalog and recursively parses
@@ -43,6 +56,9 @@ pub fn parse_structure_tree(document: &mut PdfDocument) -> Result<Option<StructT
         Some(obj) => obj,
         None => return Ok(None), // Not a tagged PDF
     };
+
+    // Build page map for resolving /Pg references
+    let page_map = build_page_map(document);
 
     // Resolve the StructTreeRoot object
     let struct_tree_root_obj = resolve_object(document, struct_tree_root_ref)?;
@@ -81,7 +97,7 @@ pub fn parse_structure_tree(document: &mut PdfDocument) -> Result<Option<StructT
                 // Multiple root elements
                 for elem_obj in arr {
                     if let Some(elem) =
-                        parse_struct_elem(document, &elem_obj, &struct_tree.role_map)?
+                        parse_struct_elem(document, &elem_obj, &struct_tree.role_map, &page_map)?
                     {
                         struct_tree.add_root_element(elem);
                     }
@@ -89,7 +105,9 @@ pub fn parse_structure_tree(document: &mut PdfDocument) -> Result<Option<StructT
             },
             _ => {
                 // Single root element
-                if let Some(elem) = parse_struct_elem(document, &k_obj, &struct_tree.role_map)? {
+                if let Some(elem) =
+                    parse_struct_elem(document, &k_obj, &struct_tree.role_map, &page_map)?
+                {
                     struct_tree.add_root_element(elem);
                 }
             },
@@ -105,6 +123,7 @@ pub fn parse_structure_tree(document: &mut PdfDocument) -> Result<Option<StructT
 /// * `document` - The PDF document
 /// * `obj` - The object to parse (should be a dictionary)
 /// * `role_map` - RoleMap for custom structure types
+/// * `page_map` - Mapping from page object IDs to page indices
 ///
 /// # Returns
 /// * `Ok(Some(StructElem))` - Successfully parsed structure element
@@ -114,6 +133,7 @@ fn parse_struct_elem(
     document: &mut PdfDocument,
     obj: &Object,
     role_map: &HashMap<String, String>,
+    page_map: &HashMap<u32, u32>,
 ) -> Result<Option<StructElem>, Error> {
     let obj = resolve_object(document, obj)?;
 
@@ -145,10 +165,11 @@ fn parse_struct_elem(
 
     let mut struct_elem = StructElem::new(struct_type);
 
-    // Get /Pg (page) - optional
-    if let Some(_pg_obj) = dict.get("Pg") {
-        // Page reference - we'd need to resolve this to a page number
-        // For now, skip (requires page tree traversal)
+    // Get /Pg (page) - optional, resolve to page number
+    if let Some(Object::Reference(pg_ref)) = dict.get("Pg") {
+        if let Some(&page_num) = page_map.get(&pg_ref.id) {
+            struct_elem.page = Some(page_num);
+        }
     }
 
     // Get /A (attributes) - optional
@@ -161,6 +182,16 @@ fn parse_struct_elem(
         }
     }
 
+    // Get /Alt (alternate description) - optional, per PDF spec Section 14.9.3
+    // This provides a human-readable description of the element's content
+    // (e.g., for formulas: "E equals m c squared")
+    if let Some(alt_obj) = dict.get("Alt") {
+        let alt_obj = resolve_object(document, alt_obj)?;
+        if let Some(alt_bytes) = alt_obj.as_string() {
+            struct_elem.alt_text = Some(String::from_utf8_lossy(alt_bytes).to_string());
+        }
+    }
+
     // Parse /K (children) - can be:
     // 1. A single integer (MCID)
     // 2. A dictionary (marked content reference with MCID and Pg)
@@ -168,7 +199,7 @@ fn parse_struct_elem(
     // 4. Another StructElem (dictionary with /Type /StructElem)
     if let Some(k_obj) = dict.get("K") {
         let k_obj = resolve_object(document, k_obj)?;
-        parse_k_children(document, &k_obj, &mut struct_elem, role_map)?;
+        parse_k_children(document, &k_obj, &mut struct_elem, role_map, page_map)?;
     }
 
     Ok(Some(struct_elem))
@@ -180,6 +211,7 @@ fn parse_k_children(
     k_obj: &Object,
     parent: &mut StructElem,
     role_map: &HashMap<String, String>,
+    page_map: &HashMap<u32, u32>,
 ) -> Result<(), Error> {
     match k_obj {
         Object::Integer(mcid) => {
@@ -206,12 +238,13 @@ fn parse_k_children(
 
                     Object::Dictionary(_) => {
                         // Could be a StructElem or marked content reference
-                        if let Some(child_elem) = parse_struct_elem(document, &child_obj, role_map)?
+                        if let Some(child_elem) =
+                            parse_struct_elem(document, &child_obj, role_map, page_map)?
                         {
                             parent.add_child(StructChild::StructElem(Box::new(child_elem)));
                         } else {
                             // Try parsing as marked content reference
-                            if let Some(mcr) = parse_marked_content_ref(&child_obj)? {
+                            if let Some(mcr) = parse_marked_content_ref(&child_obj, page_map)? {
                                 parent.add_child(mcr);
                             }
                         }
@@ -231,11 +264,11 @@ fn parse_k_children(
 
         Object::Dictionary(_) => {
             // Single dictionary child
-            if let Some(child_elem) = parse_struct_elem(document, k_obj, role_map)? {
+            if let Some(child_elem) = parse_struct_elem(document, k_obj, role_map, page_map)? {
                 parent.add_child(StructChild::StructElem(Box::new(child_elem)));
             } else {
                 // Try parsing as marked content reference
-                if let Some(mcr) = parse_marked_content_ref(k_obj)? {
+                if let Some(mcr) = parse_marked_content_ref(k_obj, page_map)? {
                     parent.add_child(mcr);
                 }
             }
@@ -260,7 +293,10 @@ fn parse_k_children(
 /// - /Type /MCR
 /// - /Pg - Page containing the marked content
 /// - /MCID - Marked content ID
-fn parse_marked_content_ref(obj: &Object) -> Result<Option<StructChild>, Error> {
+fn parse_marked_content_ref(
+    obj: &Object,
+    page_map: &HashMap<u32, u32>,
+) -> Result<Option<StructChild>, Error> {
     let dict = match obj.as_dict() {
         Some(d) => d,
         None => return Ok(None),
@@ -281,9 +317,17 @@ fn parse_marked_content_ref(obj: &Object) -> Result<Option<StructChild>, Error> 
         .and_then(|obj| obj.as_integer())
         .ok_or_else(|| Error::InvalidPdf("MCR missing /MCID".into()))?;
 
-    // Get /Pg (page reference)
-    // For now, we'll use 0 as placeholder - proper implementation would resolve page reference
-    let page = 0; // TODO: Resolve page reference
+    // Get /Pg (page reference) and resolve to page number
+    let page = dict
+        .get("Pg")
+        .and_then(|pg_obj| {
+            if let Object::Reference(pg_ref) = pg_obj {
+                page_map.get(&pg_ref.id).copied()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0); // Default to page 0 if no /Pg
 
     Ok(Some(StructChild::MarkedContentRef {
         mcid: mcid as u32,
@@ -357,10 +401,16 @@ fn parse_parent_tree_entry(
 ) -> Result<ParentTreeEntry, Error> {
     let obj = resolve_object(document, obj)?;
 
+    // Note: Parent tree entries don't need page resolution since they're
+    // used for reverse lookups, not for primary structure traversal
+    let empty_page_map = HashMap::new();
+
     match obj {
         Object::Dictionary(_) => {
             // Could be a StructElem dictionary or ObjectRef
-            if let Some(struct_elem) = parse_struct_elem(document, &obj, &HashMap::new())? {
+            if let Some(struct_elem) =
+                parse_struct_elem(document, &obj, &HashMap::new(), &empty_page_map)?
+            {
                 Ok(ParentTreeEntry::StructElem(Box::new(struct_elem)))
             } else {
                 // Fallback: treat as empty StructElem

--- a/src/structure/types.rs
+++ b/src/structure/types.rs
@@ -55,6 +55,7 @@ impl Default for StructTreeRoot {
 /// - `/P` - Parent structure element
 /// - `/Pg` - Page containing this element (optional)
 /// - `/A` - Attributes (optional)
+/// - `/Alt` - Alternate description (optional, per Section 14.9.3)
 #[derive(Debug, Clone)]
 pub struct StructElem {
     /// Structure type (e.g., "Document", "P", "H1", "Sect")
@@ -68,6 +69,11 @@ pub struct StructElem {
 
     /// Attributes (optional)
     pub attributes: HashMap<String, Object>,
+
+    /// Alternate description for accessibility (optional)
+    /// Per PDF spec Section 14.9.3, this provides a human-readable
+    /// description of the element's content (e.g., formula LaTeX or description)
+    pub alt_text: Option<String>,
 }
 
 impl StructElem {
@@ -78,6 +84,7 @@ impl StructElem {
             children: Vec::new(),
             page: None,
             attributes: HashMap::new(),
+            alt_text: None,
         }
     }
 

--- a/tests/test_config_adapter.rs
+++ b/tests/test_config_adapter.rs
@@ -183,6 +183,7 @@ fn test_config_adapter_all_options_combined() {
         extract_tables: true,
         image_output_dir: Some("/output/images".to_string()),
         table_detection_config: None,
+        ..Default::default()
     };
 
     let config = TextPipelineConfig::from_conversion_options(&options);

--- a/tests/test_converters.rs
+++ b/tests/test_converters.rs
@@ -385,6 +385,7 @@ fn test_comprehensive_document_conversion() {
         reading_order_mode: ReadingOrderMode::TopToBottomLeftToRight,
         bold_marker_behavior: BoldMarkerBehavior::Conservative,
         table_detection_config: None,
+        ..Default::default()
     };
 
     let mut chars = Vec::new();


### PR DESCRIPTION
## Summary
- Fix CTM (Current Transformation Matrix) application to text positions per PDF Spec ISO 32000-1:2008 Section 9.4.4
- Add regression tests for CTM translation, scaling, and combined transforms
- Parse `/Alt` (alternate description) for accessibility text on formulas/figures
- Resolve `/Pg` (page reference) to map structure elements to page numbers
- New `FormulaRenderer` module for extracting formula regions as base64 data URIs
- Add `ConversionOptions`: `render_formulas`, `page_images`, `page_dimensions`
- Bump version to 0.2.4 (Rust + Python)

## Test plan
- [x] All existing tests pass
- [x] New CTM regression tests added
- [x] Verified fix on sample.pdf from Issue #11

Fixes #11