### PR TITLE
Add image embedding support for HTML and Markdown output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.2.5] - 2026-01-09
+
+### Added
+- **Image embedding**: Both HTML and Markdown now support embedded base64 images when `embed_images=true` (default)
+  - HTML: `<img src="data:image/png;base64,...">`
+  - Markdown: `![alt](data:image/png;base64,...)` (works in Obsidian, Typora, VS Code, Jupyter)
+- **Image file export**: Set `embed_images=false` + `image_output_dir` to save images as files with relative path references
+- New `embed_images` option in `ConversionOptions` to control embedding behavior
+- `PdfImage::to_base64_data_uri()` method for converting images to data URIs
+- `PdfImage::to_png_bytes()` method for in-memory PNG encoding
+- Python bindings: new `embed_images` parameter for `to_html`, `to_markdown`, and `*_all` methods
+
 ## [0.2.4] - 2026-01-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["Yury Fedoseev <yfedoseev@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.2.4"
+version = "0.2.5"
 description = "Production-grade PDF parsing: spec-compliant text extraction, intelligent reading order, OCR support. Ultra-fast Rust performance."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -197,6 +197,16 @@ pub struct ConversionOptions {
     /// If Some(path), images are saved to the specified directory.
     pub image_output_dir: Option<String>,
 
+    /// Embed images as base64 data URIs in output.
+    ///
+    /// When true (default), images are embedded directly as base64 data URIs.
+    /// This creates self-contained files that don't require external image files.
+    /// Works in HTML and Markdown (Obsidian, Typora, VS Code, Jupyter support base64).
+    ///
+    /// When false, images are saved to `image_output_dir` and referenced by path.
+    /// Note: GitHub/GitLab Markdown renderers block base64 images for security.
+    pub embed_images: bool,
+
     /// Reading order determination mode.
     ///
     /// Controls how text blocks are ordered in the output.
@@ -245,6 +255,7 @@ impl Default for ConversionOptions {
     /// - extract_tables: false
     /// - include_images: true
     /// - image_output_dir: None
+    /// - embed_images: true (base64 for HTML)
     /// - reading_order_mode: StructureTreeFirst (PDF-spec-compliant for Tagged PDFs, falls back to XY-Cut for untagged)
     /// - bold_marker_behavior: Conservative (no bold markers for whitespace-only content)
     /// - table_detection_config: None (uses defaults when table detection is enabled)
@@ -258,6 +269,7 @@ impl Default for ConversionOptions {
             extract_tables: false,
             include_images: true,
             image_output_dir: None,
+            embed_images: true,
             reading_order_mode: ReadingOrderMode::StructureTreeFirst { mcid_order: vec![] },
             bold_marker_behavior: BoldMarkerBehavior::Conservative,
             table_detection_config: None,
@@ -358,10 +370,27 @@ mod tests {
         assert!(!opts.extract_tables);
         assert!(opts.include_images);
         assert_eq!(opts.image_output_dir, None);
+        assert!(opts.embed_images);
         assert_eq!(
             opts.reading_order_mode,
             ReadingOrderMode::StructureTreeFirst { mcid_order: vec![] }
         );
+    }
+
+    #[test]
+    fn test_conversion_options_embed_images() {
+        // Default: embed_images = true
+        let opts = ConversionOptions::default();
+        assert!(opts.embed_images);
+
+        // Custom: embed_images = false
+        let opts = ConversionOptions {
+            embed_images: false,
+            image_output_dir: Some("images/".to_string()),
+            ..Default::default()
+        };
+        assert!(!opts.embed_images);
+        assert_eq!(opts.image_output_dir, Some("images/".to_string()));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,10 @@ pub enum Error {
     #[error("Stream decoding error: {0}")]
     Decode(String),
 
+    /// Encoding error (e.g., image encoding)
+    #[error("Encoding error: {0}")]
+    Encode(String),
+
     /// Unsupported stream filter
     #[error("Unsupported filter: {0}")]
     UnsupportedFilter(String),

--- a/src/pipeline/config.rs
+++ b/src/pipeline/config.rs
@@ -95,6 +95,7 @@ impl DocumentType {
                 preserve_layout: true, // Preserve formatting
                 extract_tables: true,  // Detect tables
                 image_output_dir: None,
+                embed_images: true,
             },
             word_boundary_mode: WordBoundaryMode::Primary,
             enable_hyphenation_reconstruction: true, // Aggressive hyphenation
@@ -120,6 +121,7 @@ impl DocumentType {
                 preserve_layout: true, // Headers/footers matter
                 extract_tables: true,  // Essential for reports
                 image_output_dir: None,
+                embed_images: true,
             },
             word_boundary_mode: WordBoundaryMode::Primary,
             enable_hyphenation_reconstruction: true,
@@ -145,6 +147,7 @@ impl DocumentType {
                 preserve_layout: false, // Minimal formatting
                 extract_tables: false,
                 image_output_dir: None,
+                embed_images: true,
             },
             word_boundary_mode: WordBoundaryMode::Tiebreaker,
             enable_hyphenation_reconstruction: true, // Essential for novels
@@ -170,6 +173,7 @@ impl DocumentType {
                 preserve_layout: true,
                 extract_tables: true,
                 image_output_dir: None,
+                embed_images: true,
             },
             word_boundary_mode: WordBoundaryMode::Primary,
             enable_hyphenation_reconstruction: false, // Not applicable to CJK
@@ -195,6 +199,7 @@ impl DocumentType {
                 preserve_layout: true,
                 extract_tables: true,
                 image_output_dir: None,
+                embed_images: true,
             },
             word_boundary_mode: WordBoundaryMode::Tiebreaker,
             enable_hyphenation_reconstruction: false, // Different rules
@@ -516,6 +521,7 @@ impl TextPipelineConfig {
                 preserve_layout: opts.preserve_layout,
                 extract_tables: opts.extract_tables,
                 image_output_dir: opts.image_output_dir.clone(),
+                embed_images: opts.embed_images,
             },
             word_boundary_mode: WordBoundaryMode::Tiebreaker, // Keep old behavior compatible
             enable_hyphenation_reconstruction: true,
@@ -1060,6 +1066,19 @@ pub struct OutputConfig {
     ///
     /// Default: None
     pub image_output_dir: Option<String>,
+
+    /// Embed images as base64 data URIs.
+    ///
+    /// When true (default):
+    /// - HTML output embeds images as base64 data URIs
+    /// - Creates self-contained HTML files
+    ///
+    /// When false:
+    /// - Images are saved to `image_output_dir` and referenced by path
+    /// - Markdown always uses file references (base64 not well supported)
+    ///
+    /// Default: true
+    pub embed_images: bool,
 }
 
 impl Default for OutputConfig {
@@ -1071,6 +1090,7 @@ impl Default for OutputConfig {
             preserve_layout: false,
             extract_tables: false,
             image_output_dir: None,
+            embed_images: true,
         }
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -254,7 +254,7 @@ impl PyPdfDocument {
     ///     >>> markdown = doc.to_markdown(0, detect_headings=True)
     ///     >>> with open("output.md", "w") as f:
     ///     ...     f.write(markdown)
-    #[pyo3(signature = (page, preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None))]
+    #[pyo3(signature = (page, preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None, embed_images=true))]
     fn to_markdown(
         &mut self,
         page: usize,
@@ -262,6 +262,7 @@ impl PyPdfDocument {
         detect_headings: bool,
         include_images: bool,
         image_output_dir: Option<String>,
+        embed_images: bool,
     ) -> PyResult<String> {
         let options = RustConversionOptions {
             preserve_layout,
@@ -269,6 +270,7 @@ impl PyPdfDocument {
             extract_tables: false,
             include_images,
             image_output_dir,
+            embed_images,
             ..Default::default()
         };
 
@@ -297,7 +299,7 @@ impl PyPdfDocument {
     ///     >>> html = doc.to_html(0, preserve_layout=False)
     ///     >>> with open("output.html", "w") as f:
     ///     ...     f.write(html)
-    #[pyo3(signature = (page, preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None))]
+    #[pyo3(signature = (page, preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None, embed_images=true))]
     fn to_html(
         &mut self,
         page: usize,
@@ -305,6 +307,7 @@ impl PyPdfDocument {
         detect_headings: bool,
         include_images: bool,
         image_output_dir: Option<String>,
+        embed_images: bool,
     ) -> PyResult<String> {
         let options = RustConversionOptions {
             preserve_layout,
@@ -312,6 +315,7 @@ impl PyPdfDocument {
             extract_tables: false,
             include_images,
             image_output_dir,
+            embed_images,
             ..Default::default()
         };
 
@@ -339,13 +343,14 @@ impl PyPdfDocument {
     ///     >>> markdown = doc.to_markdown_all(detect_headings=True)
     ///     >>> with open("book.md", "w") as f:
     ///     ...     f.write(markdown)
-    #[pyo3(signature = (preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None))]
+    #[pyo3(signature = (preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None, embed_images=true))]
     fn to_markdown_all(
         &mut self,
         preserve_layout: bool,
         detect_headings: bool,
         include_images: bool,
         image_output_dir: Option<String>,
+        embed_images: bool,
     ) -> PyResult<String> {
         let options = RustConversionOptions {
             preserve_layout,
@@ -353,6 +358,7 @@ impl PyPdfDocument {
             extract_tables: false,
             include_images,
             image_output_dir,
+            embed_images,
             ..Default::default()
         };
 
@@ -380,13 +386,14 @@ impl PyPdfDocument {
     ///     >>> html = doc.to_html_all(preserve_layout=True)
     ///     >>> with open("book.html", "w") as f:
     ///     ...     f.write(html)
-    #[pyo3(signature = (preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None))]
+    #[pyo3(signature = (preserve_layout=false, detect_headings=true, include_images=true, image_output_dir=None, embed_images=true))]
     fn to_html_all(
         &mut self,
         preserve_layout: bool,
         detect_headings: bool,
         include_images: bool,
         image_output_dir: Option<String>,
+        embed_images: bool,
     ) -> PyResult<String> {
         let options = RustConversionOptions {
             preserve_layout,
@@ -394,6 +401,7 @@ impl PyPdfDocument {
             extract_tables: false,
             include_images,
             image_output_dir,
+            embed_images,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Summary
- New `embed_images` option in `ConversionOptions` (default: `true`)
- **HTML**: Images embedded as base64 data URIs (`<img src="data:image/png;base64,...">`)
- **Markdown**: Images embedded as base64 (`![alt](data:image/png;base64,...)`)
  - Works in Obsidian, Typora, VS Code, Jupyter
- Set `embed_images=false` + `image_output_dir` to save images as files with relative paths
- New `PdfImage` methods: `to_base64_data_uri()`, `to_png_bytes()`
- Python bindings: new `embed_images` parameter for `to_html`, `to_markdown`, and `*_all` methods

## Test plan
- [x] All existing tests pass (914 tests)
- [x] New tests for base64 encoding added
- [x] New tests for embed_images option added