### PR TITLE
Release v0.3.13: Fix multi-byte character extraction (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.13] - 2026-03-02
+> Character Extraction Quality, Multi-byte Encoding (Issue #186)
+
+### Bug Fixes — Character Extraction (#186)
+
+Reported by **@cole-dda** — garbled output when using `extract_chars()` on PDFs with multi-byte encodings (CJK text, Type0 fonts).
+
+- **Multi-byte decoding in show_text** — fixed `extract_chars()` to correctly handle 2-byte and variable-width encodings (Identity-H/V, Shift-JIS, etc.). Previously, characters were processed byte-by-byte, causing multi-byte characters to be split and garbled. Now uses the same robust decoding logic as `extract_spans()`.
+- **Improved character positioning accuracy** — replaced the 0.5em fixed-width estimate in `show_text` with actual glyph widths from the font dictionary. This ensures that character bounding boxes (`bbox`) and origins are precisely positioned, matching the actual PDF rendering.
+- **Accurate character advancement** — character spacing (`Tc`) and word spacing (`Tw`) are now correctly scaled by horizontal scaling (`Th`) during character-level extraction, ensuring correct text matrix updates.
+
+### Community Contributors
+
+Thank you to **@cole-dda** for identifying and reporting the character extraction quality issue with an excellent reproduction case (#186). Your report directly led to identifying the divergence between our high-level and low-level extraction paths, making `extract_chars()` significantly more robust for CJK and other multi-byte documents. We really appreciate your contribution to making PDF Oxide better!
+
 ## [0.3.12] - 2026-03-01
 > Text Extraction Quality, Determinism, Performance, Markdown Conversion
 
@@ -9,7 +24,8 @@ All notable changes to PDFOxide are documented here.
 
 Reported by **@Goldziher** — systematic evaluation across 10 PDFs covering word merging, encoding failures, and RTL text.
 
-- **CID font width calculation** — fixed text-to-user space conversion for CID fonts. Glyph widths were not correctly scaled, causing word boundary detection to merge adjacent words (`destinationmachine` → `destination machine`, `helporganizeas` → `help organize as`).
+- **CID font width calculation** — fixed text-to-user space conversion for CID fonts.
+ Glyph widths were not correctly scaled, causing word boundary detection to merge adjacent words (`destinationmachine` → `destination machine`, `helporganizeas` → `help organize as`).
 
 - **Font-change word boundary detection** — when PDF font changes mid-line (e.g., regular→italic for product names in LaTeX), we now detect this as a word boundary even without explicit spacing. Fixes `introducesDocling` → `introduces Docling`, `PyTorch[2]` → `PyTorch [2]`.
 
@@ -40,7 +56,8 @@ Reported by **@Goldziher** — systematic evaluation across 10 PDFs covering wor
 
 Reported by **@yunho-c** — broken markdown output on the Analog Devices AD5940/AD5941 datasheet (two-column layout with bullet lists).
 
-- **Bullet character detection and list formatting** — PDF bullet characters (`►`, `•`, `▪`, `▸`, `‣`, `◦`, `●`, `■`, `◆`, `○`, `□`) were rendered as inline text with no line breaks. Now detected and converted to markdown `- ` list items with proper line separation. Page 0 of ad5940-5941.pdf: 0 → 57 properly formatted list items.
+- **Bullet character detection and list formatting** — PDF bullet characters (`►`, `•`, `▪`, `▸`, `‣`, `◦`, `●`, `■`, `◆`, `○`, `□`) were rendered as inline text with no line breaks.
+ Now detected and converted to markdown `- ` list items with proper line separation. Page 0 of ad5940-5941.pdf: 0 → 57 properly formatted list items.
 
 - **Heading over-detection** — base font size calculation included small bullet/subscript spans (8.8pt `►` characters), pulling the median down to ~8.8pt. This caused 11pt body text to exceed the 1.15× heading ratio threshold and get promoted to `### H3`. Fixed by excluding spans < 9pt from the median calculation. Page 0: 35 → 0 spurious headings.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "pdf_oxide_mcp", "pdf_oxide_cli"]
 
 [package]
 name = "pdf_oxide"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 authors = ["Yury Fedoseev <yfedoseev@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -339,4 +339,4 @@ cargo build && cargo test && cargo fmt && cargo clippy -- -D warnings
 
 ---
 
-**Rust** + **Python** + **WASM** + **CLI** + **MCP** | MIT/Apache-2.0 | 100% pass rate on 3,830 PDFs | 0.8ms mean | 5× faster than PyMuPDF | v0.3.12
+**Rust** + **Python** + **WASM** + **CLI** + **MCP** | MIT/Apache-2.0 | 100% pass rate on 3,830 PDFs | 0.8ms mean | 5× faster than PyMuPDF | v0.3.13

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ name = "pdf-oxide"
 path = "src/main.rs"
 
 [dependencies]
-pdf_oxide = { version = "0.3.12", path = ".." }
+pdf_oxide = { version = "0.3.13", path = ".." }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ name = "pdf-oxide-mcp"
 path = "src/main.rs"
 
 [dependencies]
-pdf_oxide = { version = "0.3.12", path = ".." }
+pdf_oxide = { version = "0.3.13", path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.12"
+version = "0.3.13"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/scripts/bench_compare_versions.sh
+++ b/scripts/bench_compare_versions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Benchmark comparison across v0.3.10, v0.3.11, v0.3.12
+# Benchmark comparison across v0.3.11, v0.3.12, v0.3.13
 # Usage: bench_compare_versions.sh <version_label> <binary_path> <output_csv>
 # Runs a single version on all 6 datasets, outputs CSV with per-PDF timing
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -5689,8 +5689,6 @@ impl TextExtractor {
 
     fn show_text(&mut self, text: &[u8]) -> Result<()> {
         // PDF spec Section 7.3.4.2: implementation limit of 32,767 bytes per string.
-        // Malformed PDFs may exceed this (e.g., veraPDF 6-1-12-t03-fail-c.pdf with 65K chars).
-        // Cap to spec limit to prevent text blowup.
         let text = if text.len() > 32_767 {
             log::warn!(
                 "String exceeds PDF spec limit: {} bytes (max 32,767), truncating",
@@ -5700,75 +5698,115 @@ impl TextExtractor {
         } else {
             text
         };
-        for &byte in text {
-            let char_code = byte as u16;
 
-            // Get current state values (no borrow after this)
+        // Get current state values (used for all characters in this string)
+        let state = self.state_stack.current();
+        let font_name = state.font_name.clone();
+        let font_size = state.font_size;
+        let horizontal_scaling = state.horizontal_scaling;
+        let char_space = state.char_space;
+        let word_space = state.word_space;
+        let fill_color_rgb = state.fill_color_rgb;
+        let ctm = state.ctm;
+
+        // Get current font
+        let font = font_name.as_ref().and_then(|name| self.fonts.get(name));
+
+        // Determine byte grouping for Type0 CID fonts based on encoding.
+        let byte_mode = if let Some(font) = font {
+            if font.subtype == "Type0" {
+                match &font.encoding {
+                    crate::fonts::Encoding::Identity => ByteMode::TwoByte,
+                    crate::fonts::Encoding::Standard(name) => {
+                        if (name.contains("Identity") && !name.contains("OneByteIdentity"))
+                            || name.contains("UCS2")
+                            || name.contains("UTF16")
+                        {
+                            ByteMode::TwoByte
+                        } else if name.contains("RKSJ") {
+                            ByteMode::ShiftJIS
+                        } else if name.contains("EUC")
+                            || name.contains("GBK")
+                            || name.contains("GBpc")
+                            || name.contains("GB-")
+                            || name.contains("CNS")
+                            || name.contains("B5")
+                            || name.contains("KSC")
+                            || name.contains("KSCms")
+                        {
+                            ByteMode::TwoByte
+                        } else {
+                            ByteMode::OneByte
+                        }
+                    },
+                    _ => ByteMode::OneByte,
+                }
+            } else {
+                ByteMode::OneByte
+            }
+        } else {
+            ByteMode::OneByte
+        };
+
+        let mut i = 0;
+        while i < text.len() {
+            // Decode char_code based on byte_mode
+            let (char_code, bytes_consumed) = match byte_mode {
+                ByteMode::TwoByte if i + 1 < text.len() => {
+                    (((text[i] as u16) << 8) | (text[i + 1] as u16), 2)
+                },
+                ByteMode::ShiftJIS => {
+                    let b = text[i];
+                    let is_lead = (0x81..=0x9F).contains(&b) || (0xE0..=0xFC).contains(&b);
+                    if is_lead && i + 1 < text.len() {
+                        (((b as u16) << 8) | (text[i + 1] as u16), 2)
+                    } else {
+                        (b as u16, 1)
+                    }
+                },
+                _ => (text[i] as u16, 1),
+            };
+            i += bytes_consumed;
+
+            // Get current text matrix (may be updated by previous characters)
             let state = self.state_stack.current();
-            let font_name = state.font_name.clone();
             let text_matrix = state.text_matrix;
-            let ctm = state.ctm;
-            let font_size = state.font_size;
-            let horizontal_scaling = state.horizontal_scaling;
-            let char_space = state.char_space;
-            let word_space = state.word_space;
-            let fill_color_rgb = state.fill_color_rgb;
-
-            // Get current font
-            let font = font_name.as_ref().and_then(|name| self.fonts.get(name));
 
             // Get Unicode string using font mapping
-            // BUG FIX #2: Handle multi-character ligature expansion (e.g., "fi", "fl", "ff")
-            // char_to_unicode() returns a String which may contain multiple characters when
-            // a ligature glyph is expanded to its constituent ASCII characters.
             let unicode_string = if let Some(font) = font {
-                let result = font
-                    .char_to_unicode(char_code as u32)
-                    .unwrap_or_else(|| "?".to_string());
-
-                // DEBUG: Log when we get 'd' or ρ to trace the issue
-                if result == "d"
-                    || result.contains('ρ')
-                    || result.contains('r') && char_code == 0x72
-                {
-                    log::trace!(
-                        "Text extraction: font '{}', code 0x{:02X} → '{}' (bytes: {:?})",
-                        font_name.as_ref().unwrap_or(&String::from("?")),
-                        char_code,
-                        result,
-                        result.as_bytes()
-                    );
-                }
-
-                result
+                font.char_to_unicode(char_code as u32)
+                    .unwrap_or_else(|| fallback_char_to_unicode(char_code as u32))
+            } else if char_code < 256 && (char_code as u8).is_ascii() {
+                (char_code as u8 as char).to_string()
             } else {
-                // No font loaded, use identity mapping
-                if byte.is_ascii() {
-                    (byte as char).to_string()
-                } else {
-                    "?".to_string()
-                }
+                "?".to_string()
             };
 
             // Calculate character position in user space
-            // Per PDF Spec ISO 32000-1:2008 Section 9.4.4, the rendering matrix is:
-            // Trm = [fontSize 0 0 fontSize 0 rise] × Th × Tm × CTM
-            // To get position in user space, we apply: text_matrix × CTM
             let text_pos = text_matrix.transform_point(0.0, 0.0);
             let pos = ctm.transform_point(text_pos.x, text_pos.y);
 
-            // Calculate effective font size (accounting for CTM and text matrix scaling)
+            // Calculate effective font size
             let combined_char = ctm.multiply(&text_matrix);
             let effective_font_size = font_size
                 * (combined_char.d * combined_char.d + combined_char.b * combined_char.b).sqrt();
 
-            // Calculate character dimensions
-            // Use effective font size and better width estimate based on horizontal scaling
-            let char_width_ratio = 0.5; // Average character width-to-height ratio
-            let glyph_width = effective_font_size * horizontal_scaling / 100.0 * char_width_ratio;
-            let height = effective_font_size;
+            // Calculate character dimensions using accurate glyph width
+            let glyph_width_font_units = if let Some(font) = font {
+                font.get_glyph_width(char_code)
+            } else {
+                500.0 // Default 0.5em
+            };
 
-            // Determine font weight
+            let fs_factor = font_size / 1000.0;
+            let hs_factor = horizontal_scaling / 100.0;
+            let glyph_width_user_space = glyph_width_font_units * fs_factor * hs_factor;
+
+            // For TextChar, we use the device-space width
+            let glyph_width_device_space = glyph_width_user_space * combined_char.a.abs();
+            let height_device_space = effective_font_size;
+
+            // Determine font weight and style
             let font_weight = if let Some(font) = font {
                 if font.is_bold() {
                     FontWeight::Bold
@@ -5778,20 +5816,21 @@ impl TextExtractor {
             } else {
                 FontWeight::Normal
             };
+            let is_italic_char = if let Some(font) = font {
+                font.is_italic()
+            } else {
+                false
+            };
 
             // Get color
             let (r, g, b) = fill_color_rgb;
             let color = Color::new(r, g, b);
 
-            // Compose CTM and text_matrix for full transformation (v0.3.1)
-            // This gives us the complete transformation from text space to device space
+            // Compose CTM and text_matrix for full transformation
             let final_matrix = ctm.multiply(&text_matrix);
-            // Calculate rotation from matrix: atan2(b, a)
             let rotation_degrees = final_matrix.b.atan2(final_matrix.a).to_degrees();
 
-            // Guard against malformed fonts that map a single byte to an unreasonably
-            // long Unicode string (e.g., 1024 repeated chars from corrupted CMap/encoding).
-            // Normal mappings produce 1-4 chars (single char, ligature, or combining sequence).
+            // Guard against malformed fonts
             let unicode_string = if unicode_string.chars().count() > 8 {
                 log::warn!(
                     "Malformed character mapping: code 0x{:04X} maps to {} chars, truncating",
@@ -5803,19 +5842,20 @@ impl TextExtractor {
                 unicode_string
             };
 
-            // Process each character in the expanded string
-            // For ligatures (e.g., "fi" from ﬁ), we create multiple TextChar objects
-            // and distribute them horizontally across the glyph width
+            // Process each character in the expanded string (ligatures)
             let char_count = unicode_string.chars().count();
-            let char_width = if char_count > 0 {
-                glyph_width / char_count as f32
+            let char_width_device = if char_count > 0 {
+                glyph_width_device_space / char_count as f32
             } else {
-                glyph_width
+                glyph_width_device_space
+            };
+            let char_width_user = if char_count > 0 {
+                glyph_width_user_space / char_count as f32
+            } else {
+                glyph_width_user_space
             };
 
             for (char_index, unicode_char) in unicode_string.chars().enumerate() {
-                // Skip NULL characters (U+0000) and other control characters
-                // These are often artifacts from PDF encoding and should not be extracted
                 let should_skip = unicode_char == '\0'
                     || (unicode_char.is_control()
                         && unicode_char != '\t'
@@ -5823,42 +5863,36 @@ impl TextExtractor {
                         && unicode_char != '\r');
 
                 if !should_skip {
-                    // Calculate position for this character within the ligature
-                    // Distribute characters horizontally across the glyph width
-                    let x_offset = char_index as f32 * char_width;
+                    let x_offset_device = char_index as f32 * char_width_device;
+                    let x_offset_user = char_index as f32 * char_width_user;
 
-                    // Create TextChar with effective font size
-                    let font_name_str = font_name.clone().unwrap_or_default();
-                    let is_italic_char = font_name
-                        .as_ref()
-                        .and_then(|name| self.fonts.get(name))
-                        .map(|font| font.is_italic())
-                        .unwrap_or(false);
-
-                    // Calculate origin position for this character
-                    let char_origin_x = pos.x + x_offset;
+                    let char_origin_x = pos.x + x_offset_device;
                     let char_origin_y = pos.y;
 
                     let text_char = TextChar {
                         char: unicode_char,
-                        bbox: Rect::new(char_origin_x, char_origin_y, char_width, height),
-                        font_name: font_name_str,
+                        bbox: Rect::new(
+                            char_origin_x,
+                            char_origin_y,
+                            char_width_device,
+                            height_device_space,
+                        ),
+                        font_name: font_name.clone().unwrap_or_default(),
                         font_size: effective_font_size,
                         font_weight,
                         color,
                         mcid: self.current_mcid,
                         is_italic: is_italic_char,
-                        // Transformation properties (v0.3.1, Issue #27)
                         origin_x: char_origin_x,
                         origin_y: char_origin_y,
                         rotation_degrees,
-                        advance_width: char_width,
+                        advance_width: char_width_device,
                         matrix: Some([
                             final_matrix.a,
                             final_matrix.b,
                             final_matrix.c,
                             final_matrix.d,
-                            final_matrix.e + x_offset, // Adjust translation for char position
+                            final_matrix.e + x_offset_user,
                             final_matrix.f,
                         ]),
                     };
@@ -5867,20 +5901,14 @@ impl TextExtractor {
                 }
             }
 
-            // Advance text position (always do this once per PDF byte, not per expanded character)
-            // Tx = (w0 * Tfs + Tc + Tw) * Th / 100
-            // where w0 is glyph width (we estimate using char_width_ratio)
-            // Note: Use the nominal font_size here, not effective_font_size,
-            // because text matrix scaling is already applied to the text position
-            let mut tx = char_width_ratio * font_size;
-            tx += char_space;
-            // Check if ANY character in the expanded string is a space
-            if unicode_string.chars().any(|c| c == ' ') {
-                tx += word_space;
+            // Advance text position: Tx = (w0 * Tfs + Tc + Tw) * Th
+            let mut tx = glyph_width_user_space;
+            tx += char_space * hs_factor;
+            if char_code == 32 {
+                tx += word_space * hs_factor;
             }
-            tx *= horizontal_scaling / 100.0;
 
-            // Update text matrix
+            // Update text matrix in current state
             let state_mut = self.state_stack.current_mut();
             state_mut.text_matrix.e += tx;
         }
@@ -5954,7 +5982,8 @@ impl Default for TextExtractor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fonts::Encoding;
+    use crate::fonts::{Encoding, LazyCMap};
+    use std::sync::Arc;
 
     fn create_test_font() -> FontInfo {
         FontInfo {
@@ -6133,6 +6162,51 @@ mod tests {
         assert_eq!(chars.len(), 2);
         assert_eq!(chars[0].char, 'H');
         assert_eq!(chars[1].char, 'i');
+    }
+
+    /// Test extraction of multi-byte characters from Type0 fonts (Identity-H)
+    /// This verifies the fix for Issue #186 where extract_chars() was garbling CJK text.
+    #[test]
+    fn test_extract_type0_multibyte_character_extraction() {
+        let mut extractor = TextExtractor::new();
+
+        // Create a mock Type0 font with Identity-H encoding
+        let mut font = create_test_font();
+        font.subtype = "Type0".to_string();
+        font.encoding = Encoding::Standard("Identity-H".to_string());
+
+        // Create a valid ToUnicode CMap stream that maps CID 0x4E2D to '中' and 0x6587 to '文'
+        let cmap_data = b"
+            /CIDInit /ProcSet findresource begin
+            12 dict begin
+            begincmap
+            /CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+            /CMapName /Adobe-Identity-UCS def
+            /CMapType 2 def
+            1 begincodespacerange <0000> <FFFF> endcodespacerange
+            2 beginbfchar
+            <4E2D> <4E2D>
+            <6587> <6587>
+            endbfchar
+            endcmap
+            CMapName currentdict /CMap defineresource pop
+            end
+            end
+        ";
+
+        // Use public parse_tounicode_cmap to create CMap, then wrap in LazyCMap
+        let lazy_cmap = LazyCMap::new(cmap_data.to_vec());
+        font.to_unicode = Some(lazy_cmap);
+
+        extractor.add_font("F1".to_string(), font);
+
+        // Content stream with 2-byte CIDs for "中文" (0x4E2D 0x6587)
+        let stream = b"BT /F1 12 Tf 0 0 Td <4E2D6587> Tj ET";
+        let chars = extractor.extract(stream).unwrap();
+
+        assert_eq!(chars.len(), 2);
+        assert_eq!(chars[0].char, '中');
+        assert_eq!(chars[1].char, '文');
     }
 
     #[test]

--- a/src/ocr/mod.rs
+++ b/src/ocr/mod.rs
@@ -154,14 +154,9 @@ pub fn detect_page_type(doc: &mut PdfDocument, page: usize) -> Result<PageType> 
     let high_coverage = largest_image_area > page_area * 4.0; // ~72 DPI equivalent
 
     if text_len <= 50 || text_is_garbled {
-        // No substantial (or garbled) text — classify based on images
-        if high_coverage {
-            Ok(PageType::ScannedPage)
-        } else if !images.is_empty() {
-            Ok(PageType::ScannedPage) // Small images but no text still needs OCR
-        } else {
-            Ok(PageType::NativeText)
-        }
+        // No substantial (or garbled) text, and we know images exist (early return above).
+        // Treat as scanned page.
+        Ok(PageType::ScannedPage)
     } else if high_coverage && text_len < 500 {
         // Some text but a large image covers the page — hybrid
         Ok(PageType::HybridPage)

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -81,7 +81,7 @@ impl ParallelExtractor {
         // Each batch is processed by a single PdfDocument instance, amortizing
         // the cost of document open, xref parse, page tree walk, and font loading.
         let num_threads = rayon::current_num_threads().max(1);
-        let batch_size = (page_count + num_threads - 1) / num_threads;
+        let batch_size = page_count.div_ceil(num_threads);
         let batches: Vec<(usize, usize)> = (0..page_count)
             .step_by(batch_size)
             .map(|start| (start, (start + batch_size).min(page_count)))
@@ -139,7 +139,7 @@ impl ParallelExtractor {
         let options = options.clone();
 
         let num_threads = rayon::current_num_threads().max(1);
-        let batch_size = (page_count + num_threads - 1) / num_threads;
+        let batch_size = page_count.div_ceil(num_threads);
         let batches: Vec<(usize, usize)> = (0..page_count)
             .step_by(batch_size)
             .map(|start| (start, (start + batch_size).min(page_count)))

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -864,7 +864,7 @@ fn cmyk_to_rgb(c: f32, m: f32, y: f32, k: f32) -> (f32, f32, f32) {
 /// intersected with the current clip region.
 fn apply_pending_clip(
     pending_clip: &mut Option<(tiny_skia::Path, FillRule)>,
-    clip_stack: &mut Vec<Option<tiny_skia::Mask>>,
+    clip_stack: &mut [Option<tiny_skia::Mask>],
     pixmap: &Pixmap,
     base_transform: Transform,
     gs_stack: &GraphicsStateStack,

--- a/src/rendering/path_rasterizer.rs
+++ b/src/rendering/path_rasterizer.rs
@@ -16,6 +16,7 @@ impl PathRasterizer {
     }
 
     /// Fill a path with the current fill color.
+    #[allow(dead_code)]
     pub fn fill_path(
         &self,
         pixmap: &mut Pixmap,
@@ -29,6 +30,7 @@ impl PathRasterizer {
     }
 
     /// Stroke a path with the current stroke color and line style.
+    #[allow(dead_code)]
     pub fn stroke_path(
         &self,
         pixmap: &mut Pixmap,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -499,10 +499,8 @@ impl WasmPdfDocument {
                 if let Some(ref val) = ann.field_value {
                     obj.insert("field_value".into(), serde_json::Value::from(val.as_str()));
                 }
-                if let Some(ref action) = ann.action {
-                    if let crate::annotations::LinkAction::Uri(ref uri) = action {
-                        obj.insert("action_uri".into(), serde_json::Value::from(uri.as_str()));
-                    }
+                if let Some(crate::annotations::LinkAction::Uri(ref uri)) = ann.action {
+                    obj.insert("action_uri".into(), serde_json::Value::from(uri.as_str()));
                 }
 
                 serde_json::Value::Object(obj)
@@ -775,16 +773,8 @@ impl WasmPdfDocument {
             })?;
 
             let obj = js_sys::Object::new();
-            js_sys::Reflect::set(
-                &obj,
-                &JsValue::from_str("width"),
-                &JsValue::from(img.width() as u32),
-            )?;
-            js_sys::Reflect::set(
-                &obj,
-                &JsValue::from_str("height"),
-                &JsValue::from(img.height() as u32),
-            )?;
+            js_sys::Reflect::set(&obj, &JsValue::from_str("width"), &JsValue::from(img.width()))?;
+            js_sys::Reflect::set(&obj, &JsValue::from_str("height"), &JsValue::from(img.height()))?;
             js_sys::Reflect::set(&obj, &JsValue::from_str("format"), &JsValue::from_str("png"))?;
             let uint8_array = js_sys::Uint8Array::from(png_data.as_slice());
             js_sys::Reflect::set(&obj, &JsValue::from_str("data"), &uint8_array)?;

--- a/tests/test_ocr.rs
+++ b/tests/test_ocr.rs
@@ -11,8 +11,8 @@
 
 use image::{DynamicImage, GenericImageView, RgbImage};
 use pdf_oxide::ocr::{
-    crop_text_region, preprocess_for_detection, preprocess_for_recognition, OcrConfig,
-    OcrConfigBuilder, OcrExtractOptions, OcrOutput, OcrSpan,
+    crop_text_region, preprocess_for_detection, preprocess_for_recognition, DetResizeStrategy,
+    OcrConfig, OcrConfigBuilder, OcrExtractOptions, OcrOutput, OcrSpan,
 };
 
 /// Create a simple test image with solid color.
@@ -30,7 +30,8 @@ fn create_test_image(width: u32, height: u32) -> DynamicImage {
 #[test]
 fn test_preprocess_for_detection_basic() {
     let img = create_test_image(640, 480);
-    let (tensor, scale) = preprocess_for_detection(&img, 960).unwrap();
+    let strategy = DetResizeStrategy::MaxSide { max_side: 960 };
+    let (tensor, scale) = preprocess_for_detection(&img, &strategy).unwrap();
 
     // Check tensor shape [1, 3, H, W]
     assert_eq!(tensor.shape()[0], 1); // Batch size
@@ -47,7 +48,8 @@ fn test_preprocess_for_detection_basic() {
 #[test]
 fn test_preprocess_for_detection_large_image() {
     let img = create_test_image(2000, 1500);
-    let (tensor, scale) = preprocess_for_detection(&img, 960).unwrap();
+    let strategy = DetResizeStrategy::MaxSide { max_side: 960 };
+    let (tensor, scale) = preprocess_for_detection(&img, &strategy).unwrap();
 
     // Scale should be < 1.0 since image is larger than max_side
     assert!(scale < 1.0);

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
This release fixes issue #186 where `extract_chars()` was producing garbled output for multi-byte/Type0 fonts (CJK text).

**Changes:**
- **Robust Multi-byte Decoding:** Synchronized `show_text` logic with the high-level extraction path to correctly handle Identity-H/V, Shift-JIS, and other multi-byte encodings.
- **Accurate Positioning:** Replaced fixed-width estimates with actual glyph widths from the font dictionary for precise character bounding boxes.
- **Improved Advancement:** Correctly scales character and word spacing by horizontal scaling factors.
- **Code Quality:** Resolved numerous pre-existing Clippy and formatting issues across the codebase.

Closes #186. Refactoring task for logic consolidation created as #187.