### PR TITLE
feat: add PdfDocument.from_bytes() to Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [Unreleased]
+
+### Features
+
+- **Python `PdfDocument.from_bytes()`** — open PDFs from in-memory bytes.
+
 ## [0.3.14] - 2026-03-03
 > Parity in API & Bug Fixing (Issue #185, #193, #202)
 

--- a/python/pdf_oxide/pdf_oxide.pyi
+++ b/python/pdf_oxide/pdf_oxide.pyi
@@ -62,6 +62,27 @@ class PdfDocument:
         """
         ...
 
+    @staticmethod
+    def from_bytes(data: bytes) -> "PdfDocument":
+        """
+        Open a PDF from bytes.
+
+        Args:
+            data: Raw PDF data
+
+        Returns:
+            PdfDocument: Opened PDF document
+
+        Raises:
+            IOError: If the data is not a valid PDF
+
+        Example:
+            >>> with open("sample.pdf", "rb") as f:
+            ...     doc = PdfDocument.from_bytes(f.read())
+            >>> print(doc.page_count())
+        """
+        ...
+
     def version(self) -> Tuple[int, int]:
         """
         Get PDF version.

--- a/src/python.rs
+++ b/src/python.rs
@@ -47,18 +47,28 @@ pub struct PyPdfDocument {
     /// Inner Rust document
     inner: RustPdfDocument,
     /// Path for DOM access (lazy initialization)
-    path: String,
+    path: Option<String>,
+    /// Raw bytes for editor initialization when opened from bytes
+    raw_bytes: Option<Vec<u8>>,
     /// Cached editor for DOM access (lazy initialization)
     editor: Option<RustDocumentEditor>,
 }
 
 impl PyPdfDocument {
-    /// Ensure the editor is initialized, creating it from the path if needed.
+    /// Ensure the editor is initialized, creating it from the path or bytes if needed.
     fn ensure_editor(&mut self) -> PyResult<()> {
         if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
+            let editor = if let Some(ref path) = self.path {
+                RustDocumentEditor::open(path)
+            } else if let Some(ref bytes) = self.raw_bytes {
+                RustDocumentEditor::open_from_bytes(bytes.clone())
+            } else {
+                return Err(PyRuntimeError::new_err("No path or bytes available for editor"));
+            };
+            self.editor =
+                Some(editor.map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to open editor: {}", e))
+                })?);
         }
         Ok(())
     }
@@ -88,7 +98,37 @@ impl PyPdfDocument {
 
         Ok(PyPdfDocument {
             inner: doc,
-            path,
+            path: Some(path),
+            raw_bytes: None,
+            editor: None,
+        })
+    }
+
+    /// Open a PDF from bytes.
+    ///
+    /// Args:
+    ///     data (bytes): Raw PDF data
+    ///
+    /// Returns:
+    ///     PdfDocument: Opened PDF document
+    ///
+    /// Raises:
+    ///     IOError: If the data is not a valid PDF
+    ///
+    /// Example:
+    ///     >>> with open("sample.pdf", "rb") as f:
+    ///     ...     doc = PdfDocument.from_bytes(f.read())
+    ///     >>> print(doc.page_count())
+    #[staticmethod]
+    fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        let bytes = data.to_vec();
+        let doc = RustPdfDocument::open_from_bytes(bytes.clone())
+            .map_err(|e| PyIOError::new_err(format!("Failed to open PDF from bytes: {}", e)))?;
+
+        Ok(PyPdfDocument {
+            inner: doc,
+            path: None,
+            raw_bytes: Some(bytes),
             editor: None,
         })
     }
@@ -679,11 +719,7 @@ impl PyPdfDocument {
     ///     ...     print(f"{text.value} at {text.bbox}")
     fn page(&mut self, index: usize) -> PyResult<PyPdfPage> {
         // Lazy-initialize editor if needed
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
 
         let editor = self.editor.as_mut().unwrap();
         let page = editor
@@ -836,11 +872,7 @@ impl PyPdfDocument {
     ///     >>> doc.set_title("My Document")
     fn set_title(&mut self, title: &str) -> PyResult<()> {
         // Lazy-initialize editor if needed
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor.set_title(title);
         }
@@ -852,11 +884,7 @@ impl PyPdfDocument {
     /// Args:
     ///     author (str): Author name
     fn set_author(&mut self, author: &str) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor.set_author(author);
         }
@@ -868,11 +896,7 @@ impl PyPdfDocument {
     /// Args:
     ///     subject (str): Document subject
     fn set_subject(&mut self, subject: &str) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor.set_subject(subject);
         }
@@ -884,11 +908,7 @@ impl PyPdfDocument {
     /// Args:
     ///     keywords (str): Comma-separated keywords
     fn set_keywords(&mut self, keywords: &str) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor.set_keywords(keywords);
         }
@@ -911,11 +931,7 @@ impl PyPdfDocument {
     ///     >>> rotation = doc.page_rotation(0)
     ///     >>> print(f"Page is rotated {rotation} degrees")
     fn page_rotation(&mut self, page: usize) -> PyResult<i32> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .get_page_rotation(page)
@@ -935,11 +951,7 @@ impl PyPdfDocument {
     ///     >>> doc.set_page_rotation(0, 90)
     ///     >>> doc.save("rotated.pdf")
     fn set_page_rotation(&mut self, page: usize, degrees: i32) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .set_page_rotation(page, degrees)
@@ -959,11 +971,7 @@ impl PyPdfDocument {
     ///     >>> doc.rotate_page(0, 90)  # Rotate 90 degrees clockwise
     ///     >>> doc.save("rotated.pdf")
     fn rotate_page(&mut self, page: usize, degrees: i32) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .rotate_page_by(page, degrees)
@@ -982,11 +990,7 @@ impl PyPdfDocument {
     ///     >>> doc.rotate_all_pages(180)  # Flip all pages upside down
     ///     >>> doc.save("rotated.pdf")
     fn rotate_all_pages(&mut self, degrees: i32) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .rotate_all_pages(degrees)
@@ -1008,11 +1012,7 @@ impl PyPdfDocument {
     ///     >>> llx, lly, urx, ury = doc.page_media_box(0)
     ///     >>> print(f"Page size: {urx - llx} x {ury - lly}")
     fn page_media_box(&mut self, page: usize) -> PyResult<(f32, f32, f32, f32)> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             let box_ = editor
                 .get_page_media_box(page)
@@ -1039,11 +1039,7 @@ impl PyPdfDocument {
         urx: f32,
         ury: f32,
     ) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .set_page_media_box(page, [llx, lly, urx, ury])
@@ -1061,11 +1057,7 @@ impl PyPdfDocument {
     /// Returns:
     ///     tuple[float, float, float, float] | None: (llx, lly, urx, ury) or None if not set
     fn page_crop_box(&mut self, page: usize) -> PyResult<Option<(f32, f32, f32, f32)>> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             let box_ = editor
                 .get_page_crop_box(page)
@@ -1099,11 +1091,7 @@ impl PyPdfDocument {
         urx: f32,
         ury: f32,
     ) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .set_page_crop_box(page, [llx, lly, urx, ury])
@@ -1130,11 +1118,7 @@ impl PyPdfDocument {
     /// >>> doc.save("cropped.pdf")
     /// ```
     fn crop_margins(&mut self, left: f32, right: f32, top: f32, bottom: f32) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .crop_margins(left, right, top, bottom)
@@ -1174,11 +1158,7 @@ impl PyPdfDocument {
         urx: f32,
         ury: f32,
     ) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .erase_region(page, [llx, lly, urx, ury])
@@ -1198,11 +1178,7 @@ impl PyPdfDocument {
     ///     >>> doc.erase_regions(0, [(72, 700, 200, 792), (300, 300, 500, 400)])
     ///     >>> doc.save("output.pdf")
     fn erase_regions(&mut self, page: usize, rects: Vec<(f32, f32, f32, f32)>) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             let rect_arrays: Vec<[f32; 4]> = rects
                 .iter()
@@ -1245,11 +1221,7 @@ impl PyPdfDocument {
     ///     >>> doc.flatten_page_annotations(0)  # Flatten page 0
     ///     >>> doc.save("flattened.pdf")
     fn flatten_page_annotations(&mut self, page: usize) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor.flatten_page_annotations(page).map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to flatten annotations: {}", e))
@@ -1271,11 +1243,7 @@ impl PyPdfDocument {
     ///     >>> doc.flatten_all_annotations()
     ///     >>> doc.save("flattened.pdf")
     fn flatten_all_annotations(&mut self) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor.flatten_all_annotations().map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to flatten annotations: {}", e))
@@ -1332,11 +1300,7 @@ impl PyPdfDocument {
     ///     >>> doc.apply_page_redactions(0)
     ///     >>> doc.save("redacted.pdf")
     fn apply_page_redactions(&mut self, page: usize) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .apply_page_redactions(page)
@@ -1358,11 +1322,7 @@ impl PyPdfDocument {
     ///     >>> doc.apply_all_redactions()
     ///     >>> doc.save("redacted.pdf")
     fn apply_all_redactions(&mut self) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .apply_all_redactions()
@@ -1416,11 +1376,7 @@ impl PyPdfDocument {
     ///         - height (float): Image height
     ///         - matrix (tuple): 6-element transformation matrix (a, b, c, d, e, f)
     fn page_images(&mut self, page: usize, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             let images = editor.get_page_images(page).map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to get page images: {}", e))
@@ -1464,11 +1420,7 @@ impl PyPdfDocument {
     /// Raises:
     ///     RuntimeError: If the image is not found or operation fails
     fn reposition_image(&mut self, page: usize, image_name: &str, x: f32, y: f32) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .reposition_image(page, image_name, x, y)
@@ -1495,11 +1447,7 @@ impl PyPdfDocument {
         width: f32,
         height: f32,
     ) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .resize_image(page, image_name, width, height)
@@ -1530,11 +1478,7 @@ impl PyPdfDocument {
         width: f32,
         height: f32,
     ) -> PyResult<()> {
-        if self.editor.is_none() {
-            let editor = RustDocumentEditor::open(&self.path)
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to open editor: {}", e)))?;
-            self.editor = Some(editor);
-        }
+        self.ensure_editor()?;
         if let Some(ref mut editor) = self.editor {
             editor
                 .set_image_bounds(page, image_name, x, y, width, height)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -203,6 +203,43 @@ def test_to_html_all_multipage():
         pytest.skip("Test fixture 'multipage.pdf' not available")
 
 
+# === From Bytes Tests ===
+
+
+def test_from_bytes_matches_file():
+    """Test that from_bytes produces the same results as opening from path."""
+    with open("tests/fixtures/simple.pdf", "rb") as f:
+        data = f.read()
+    doc_path = PdfDocument("tests/fixtures/simple.pdf")
+    doc_bytes = PdfDocument.from_bytes(data)
+
+    assert doc_path.version() == doc_bytes.version()
+    assert doc_path.page_count() == doc_bytes.page_count()
+    assert doc_path.extract_text(0) == doc_bytes.extract_text(0)
+
+
+def test_from_bytes_roundtrip():
+    """Test opening bytes from a PDF created with Pdf.from_text."""
+    from pdf_oxide import Pdf
+
+    pdf = Pdf.from_text("Hello from bytes!")
+    pdf_bytes = pdf.to_bytes()
+
+    doc = PdfDocument.from_bytes(pdf_bytes)
+    assert doc.page_count() >= 1
+    text = doc.extract_text(0)
+    assert "Hello from bytes!" in text
+
+
+def test_from_bytes_invalid():
+    """Test error handling for invalid bytes."""
+    with pytest.raises(IOError):
+        PdfDocument.from_bytes(b"not a pdf")
+
+
+# === Error Handling Tests ===
+
+
 def test_error_handling_nonexistent_file():
     """Test error handling for non-existent file."""
     with pytest.raises(IOError) as exc_info:


### PR DESCRIPTION
## Description

  Add `PdfDocument.from_bytes(data: bytes)` static method to the Python API, allowing PDFs to be opened from in-memory bytes without requiring a file path.

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Tests
  - [ ] CI/CD changes

  ## Related Issues

  ## Changes Made

  - Added `PdfDocument.from_bytes(data: bytes)` static method in `src/python.rs`

  ## Testing

  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] All new and existing tests pass locally
  - [x] I have run `cargo test --all-features`
  - [x] I have run `cargo clippy -- -D warnings`
  - [x] I have run `cargo fmt`

  ## Python Bindings (if applicable)

  - [x] Python bindings updated (if needed)
  - [x] Python tests pass
  - [ ] Python code formatted with `ruff format`
  - [ ] Python code linted with `ruff check`

  ## Documentation

  - [ ] I have updated the documentation (README, docs/, code comments)
  - [ ] I have added/updated examples (if applicable)
  - [x] I have updated CHANGELOG.md

  ## Checklist

  - [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
  - [x] I have checked my code and corrected any misspellings
  - [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes
