### PR TITLE
feat(python): expose path operations in extract_paths() dict

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -2388,6 +2388,46 @@ fn path_to_py_dict(py: Python<'_>, path: &crate::elements::PathContent) -> PyRes
         d.set_item("fill_color", py.None())?;
     }
     d.set_item("operations_count", path.operations.len())?;
+
+    // Expose path operations as list of dicts for vector extraction use cases
+    let ops_list = pyo3::types::PyList::empty(py);
+    for op in &path.operations {
+        let op_dict = pyo3::types::PyDict::new(py);
+        match op {
+            crate::elements::PathOperation::MoveTo(x, y) => {
+                op_dict.set_item("op", "move_to")?;
+                op_dict.set_item("x", *x)?;
+                op_dict.set_item("y", *y)?;
+            },
+            crate::elements::PathOperation::LineTo(x, y) => {
+                op_dict.set_item("op", "line_to")?;
+                op_dict.set_item("x", *x)?;
+                op_dict.set_item("y", *y)?;
+            },
+            crate::elements::PathOperation::CurveTo(cx1, cy1, cx2, cy2, x, y) => {
+                op_dict.set_item("op", "curve_to")?;
+                op_dict.set_item("cx1", *cx1)?;
+                op_dict.set_item("cy1", *cy1)?;
+                op_dict.set_item("cx2", *cx2)?;
+                op_dict.set_item("cy2", *cy2)?;
+                op_dict.set_item("x", *x)?;
+                op_dict.set_item("y", *y)?;
+            },
+            crate::elements::PathOperation::Rectangle(x, y, w, h) => {
+                op_dict.set_item("op", "rectangle")?;
+                op_dict.set_item("x", *x)?;
+                op_dict.set_item("y", *y)?;
+                op_dict.set_item("width", *w)?;
+                op_dict.set_item("height", *h)?;
+            },
+            crate::elements::PathOperation::ClosePath => {
+                op_dict.set_item("op", "close_path")?;
+            },
+        }
+        ops_list.append(op_dict)?;
+    }
+    d.set_item("operations", ops_list)?;
+
     Ok(d.into())
 }
 

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -784,6 +784,35 @@ def test_extract_paths():
         pytest.skip("Test fixture 'simple.pdf' not available or invalid")
 
 
+def test_extract_paths_operations():
+    """Test that extract_paths returns operations with coordinates."""
+    try:
+        doc = PdfDocument("tests/fixtures/1.pdf")
+        paths = doc.extract_paths(0)
+        assert isinstance(paths, list)
+        assert len(paths) > 0, "Expected at least one path"
+
+        for path in paths:
+            assert "operations" in path, "Path dict should contain 'operations' field"
+            assert isinstance(path["operations"], list)
+            assert len(path["operations"]) == path["operations_count"]
+
+            for op in path["operations"]:
+                assert isinstance(op, dict)
+                assert "op" in op, "Each operation should have an 'op' field"
+                op_type = op["op"]
+                assert op_type in ("move_to", "line_to", "curve_to", "rectangle", "close_path")
+
+                if op_type in ("move_to", "line_to"):
+                    assert "x" in op and "y" in op
+                elif op_type == "curve_to":
+                    assert all(k in op for k in ("cx1", "cy1", "cx2", "cy2", "x", "y"))
+                elif op_type == "rectangle":
+                    assert all(k in op for k in ("x", "y", "width", "height"))
+    except (OSError, RuntimeError):
+        pytest.skip("Test fixture '1.pdf' not available or invalid")
+
+
 def test_extract_images_invalid_page():
     """Test extract_images with invalid page index."""
     try:


### PR DESCRIPTION
## Description

Add an `operations` field to the path dict returned by `extract_paths()`, `extract_lines()`, and `extract_rects()` Python bindings.

Currently the Python API only exposes `operations_count` (the number of path operations) but not the actual operations with their coordinates. This makes it impossible to access the precise vector geometry from Python — users only get the bounding box.

Each operation is a dict with an `op` key and the relevant coordinates:
- `move_to`: `{op, x, y}`
- `line_to`: `{op, x, y}`
- `curve_to`: `{op, cx1, cy1, cx2, cy2, x, y}`
- `rectangle`: `{op, x, y, width, height}`
- `close_path`: `{op}`

**Use case:** We're building a construction document processing platform that extracts vector geometry from architectural PDFs for snap-to-geometry and CAD overlay features. pdf_oxide is the fastest library we've tested, and this change makes it fully usable for our vector extraction pipeline.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Related Issues

Relates to #147 — This PR exposes the raw path operations to Python, which is a prerequisite for the `PathContent::to_points(tolerance)` API discussed in that issue.

## Changes Made

- Modified `path_to_py_dict()` in `src/python.rs` to include an `operations` list alongside the existing `operations_count`
- Each `PathOperation` variant is converted to a Python dict with the `op` type and coordinates
- Added `test_extract_paths_operations` test in `tests/test_python.py`

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass locally (`cargo test` — 128 passed, 0 failed)
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo fmt --check` passes

## Python Bindings (if applicable)

- [x] Python bindings have been updated
- [x] Python tests pass
- [ ] `ruff format` — N/A (only added test, follows existing style)
- [ ] `ruff check` — N/A

## Documentation

- [ ] README.md or documentation site has been updated
- [ ] Code examples have been updated
- [ ] CHANGELOG.md has been updated

> Note: I didn't update CHANGELOG.md as I'm not sure which version this would target. Happy to add it if you let me know.

## Checklist

- [x] My code follows the coding guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have checked my code for spelling errors
- [x] PR title follows conventional commits format

## Additional Notes

- This is a **non-breaking, additive change** — the existing `operations_count` field is preserved, and the new `operations` field is simply added to the same dict
- The Rust `PathOperation` enum already had all the data; only the Python serialization in `path_to_py_dict()` needed updating (~40 lines)
- Coordinate values are `f32` as they come from the Rust struct, matching the existing `bbox` and `stroke_width` precision
