### PR TITLE
fix: prescan loses outer CTM context for deeply nested text

### DIFF
--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -233,14 +233,6 @@ pub fn parse_content_stream_text_only(data: &[u8]) -> Result<Vec<Operator>> {
     Ok(operators)
 }
 
-/// SIMD-accelerated pre-scan to identify text-bearing regions in large content streams.
-///
-/// For streams > 256KB that are mostly graphics (path operators, color ops), this uses
-/// memchr to locate BT/Do operator positions in ~1ms instead of byte-by-byte scanning
-/// at ~500ms. Returns parse regions that cover BT..ET blocks and Do operators, plus
-/// preceding graphics state (q..cm) needed for correct CTM.
-///
-/// Returns `None` on ambiguous cases (fallback to full scan).
 /// Graphics state snapshot captured at a text position by [`forward_scan_ctm`].
 #[derive(Debug)]
 struct PrescanState {


### PR DESCRIPTION
## Description

The SIMD prescan optimization for large content streams (>256KB) scans backwards
up to 4KB from each BT operator to capture graphics state context. For deeply
nested text (e.g., chart axis labels inside scaled coordinate systems), the outer
scaling `cm` operators are beyond 4KB and get lost, producing extreme coordinates
(e.g., x=132,145 on a 612-wide page).

This PR adds a lightweight forward CTM scan that tracks `q`/`Q`/`cm`/`Tf` across
the full stream and records the correct graphics state at each BT/Do position.
This is much cheaper than full parsing because it only recognizes four operator types
and skips all path, color, and text operators. The prescan performance optimization
is preserved while producing correct coordinates.

When the forward scan cannot be used, the code falls back to full stream parsing
for correctness.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issue
Fixes #265

## Testing
- 10 prescan-related unit tests covering:
  - Forward CTM captures outer scaling for text in >256KB streams
  - Font state inheritance across consecutive BT blocks without Tf
  - CTM correctly restored after nested q/Q scopes
  - Multiple BT blocks at different nesting depths get correct CTMs
  - Existing prescan tests updated for new PrescanResult enum
- Verified against PDFs with chart axis labels in deeply nested coordinate systems
- All 4283 library tests pass

## Checklist
- [x] Tests pass
- [x] Code formatted
- [ ] Documentation updated (no user-facing API changes)