### PR TITLE
docs: fix "Quick Start - Rust" section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@
 //! ```ignore
 //! use pdf_oxide::PdfDocument;
 //! use pdf_oxide::pipeline::{TextPipeline, TextPipelineConfig};
+//! use pdf_oxide::pipeline::converters::OutputConverter;
 //! use pdf_oxide::pipeline::converters::MarkdownOutputConverter;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Description
Added an additional `use` statement to the quickstart example for rust.
The old example did not compile, as the `OutputConverter` trait was out of scope.
The now altered example does compile and produces the desired results.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Related Issue
No related issue, since the change is trivial I did not bother opening an issue beforehand. 

## Testing
Tried compiling the example before the change -> Does not compile.
Compiled and ran the example after the change -> Does compile and produces the desired output.

## Checklist
- [x] Tests pass
- [x] Code formatted
- [x] Documentation updated