### PR TITLE
Add Linux aarch64, musl, Windows ARM64 wheels and sdist to Python release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
         shell: bash
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'aarch64-linux-gnu-gcc' || '' }}
         run: |
           cargo build --release -p pdf_oxide_cli --target ${{ matrix.target }}
           cargo build --release -p pdf_oxide_mcp --target ${{ matrix.target }}
@@ -305,15 +306,13 @@ jobs:
       - name: Install maturin
         run: uv pip install --system maturin
 
-      - name: Install musl tools (Linux musl x86_64)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: contains(matrix.target, 'aarch64-unknown-linux')
+      - name: Install Linux cross-compilation tools
+        if: contains(matrix.target, 'linux-musl') || contains(matrix.target, 'aarch64-unknown-linux')
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
+          sudo apt-get install -y \
+            ${{ contains(matrix.target, 'musl') && 'musl-tools' || '' }} \
+            ${{ contains(matrix.target, 'aarch64') && 'gcc-aarch64-linux-gnu' || '' }}
 
       # Generate .pyi stubs automatically using mypy stubgen
       - name: Generate type stubs
@@ -323,6 +322,7 @@ jobs:
         shell: bash
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'aarch64-linux-gnu-gcc' || '' }}
         run: maturin build --release --features python --target ${{ matrix.target }} --out dist
 
       - name: Build sdist
@@ -333,7 +333,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
-          path: dist/*.whl
+          path: dist/*
           retention-days: 7
 
   # Create GitHub Release


### PR DESCRIPTION
The build-python-wheels job was missing several platforms that
build-binaries already supports. This adds:

- Linux ARM64 glibc (aarch64-unknown-linux-gnu)
- Linux x86_64 musl (x86_64-unknown-linux-musl)
- Linux ARM64 musl (aarch64-unknown-linux-musl)
- Windows ARM64 (aarch64-pc-windows-msvc)
- Source distribution (sdist) for platforms without prebuilt wheels

Also adds the necessary cross-compilation tooling (gcc-aarch64-linux-gnu,
musl-tools) and linker configuration for ARM64 Linux builds.
