### PR TITLE
fix(ci): static link CRT for musl targets in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,7 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'aarch64-linux-gnu-gcc' || '' }}
+          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=+crt-static' || '' }}
         run: |
           cargo build --release -p pdf_oxide_cli --target ${{ matrix.target }}
           cargo build --release -p pdf_oxide_mcp --target ${{ matrix.target }}
@@ -351,6 +352,7 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'aarch64-linux-gnu-gcc' || '' }}
+          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=+crt-static' || '' }}
         run: maturin build --release --features python --target ${{ matrix.target }} --out dist
 
       - name: Build sdist


### PR DESCRIPTION
## Summary
- Adds `RUSTFLAGS: -C target-feature=+crt-static` for musl targets in the release workflow
- Fixes `aarch64-unknown-linux-musl` Python wheel build which fails because maturin can't find `libgcc_s.so.1` on the x86_64 host during wheel repair
- Static linking is the standard approach for musl and eliminates the runtime dependency entirely

## Context
The v0.3.22 release workflow failed on `Build Python wheels (aarch64-unknown-linux-musl)`. No assets were published — all downstream jobs (GitHub Release, PyPI, crates.io, npm) were skipped.

## Test plan
- [ ] Merge to main, delete `v0.3.22` tag, re-tag, and verify the release workflow passes