### PR TITLE
fix(ci): use maturin-action for musllinux wheels in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,6 @@ jobs:
         shell: bash
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'aarch64-linux-gnu-gcc' || '' }}
-          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=+crt-static' || '' }}
         run: |
           cargo build --release -p pdf_oxide_cli --target ${{ matrix.target }}
           cargo build --release -p pdf_oxide_mcp --target ${{ matrix.target }}
@@ -284,16 +282,6 @@ jobs:
             target: aarch64-unknown-linux-gnu
             artifact_name: wheels-linux-aarch64
 
-          # Linux x86_64 (musl)
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            artifact_name: wheels-linux-x86_64-musl
-
-          # Linux ARM64 (musl)
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            artifact_name: wheels-linux-aarch64-musl
-
           # macOS x86_64 (Intel)
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -334,12 +322,10 @@ jobs:
         run: uv pip install --system maturin
 
       - name: Install Linux cross-compilation tools
-        if: contains(matrix.target, 'linux-musl') || contains(matrix.target, 'aarch64-unknown-linux')
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            ${{ contains(matrix.target, 'musl') && 'musl-tools' || '' }} \
-            ${{ contains(matrix.target, 'aarch64') && 'gcc-aarch64-linux-gnu' || '' }}
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Download type stubs
         uses: actions/download-artifact@v8
@@ -351,8 +337,6 @@ jobs:
         shell: bash
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-musl' && 'aarch64-linux-gnu-gcc' || '' }}
-          RUSTFLAGS: ${{ contains(matrix.target, 'musl') && '-C target-feature=+crt-static' || '' }}
         run: maturin build --release --features python --target ${{ matrix.target }} --out dist
 
       - name: Build sdist
@@ -366,10 +350,42 @@ jobs:
           path: dist/*
           retention-days: 7
 
+  # Build Python wheels for musl targets (Docker-based via maturin-action)
+  build-python-wheels-musl:
+    name: Build Python wheels (linux ${{ matrix.target }} musllinux)
+    needs: [validate, generate-python-stubs]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download type stubs
+        uses: actions/download-artifact@v8
+        with:
+          name: python-type-stubs
+          path: python/pdf_oxide/
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: musllinux_1_2
+          args: --release --features python --out dist
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-linux-${{ matrix.target }}-musl
+          path: dist/*
+          retention-days: 7
+
   # Create GitHub Release
   create-release:
     name: Create GitHub Release
-    needs: [validate, build-binaries, build-python-wheels, build-wasm]
+    needs: [validate, build-binaries, build-python-wheels, build-python-wheels-musl, build-wasm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Moves musl wheel builds (x86_64 + aarch64) to a new `build-python-wheels-musl` job using `PyO3/maturin-action@v1`
- Removes broken manual musl cross-compilation from `build-python-wheels`
- Cleans up dead RUSTFLAGS/linker env vars from the previous fix attempt

## Why
Manual `maturin build --target aarch64-unknown-linux-musl` on x86_64 hosts **cannot work** for Python wheels:
1. auditwheel repair fails — `libgcc_s.so.1` not found on host
2. `+crt-static` workaround fails — musl can't produce cdylib (shared libs)

`maturin-action` handles this via Docker containers with the correct musl toolchain + zig linker. This is the standard approach used by pydantic-core, polars, tokenizers, watchfiles, and matches our own `python.yml`.

## Context
The `aarch64-unknown-linux-musl` target was added for v0.3.22 but has **never successfully built**. v0.3.21 released without it.

## Test plan
- [ ] Merge, delete v0.3.22 tag, re-tag, verify release workflow passes all targets