### PR TITLE
release/v0.3.29: fix npm gypfile auto-inject

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["js"]
 
 [package]
 name = "pdf_oxide"
-version = "0.3.28"
+version = "0.3.29"
 include = [
     "src/**/*",
     "benches/**/*",

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.28</Version>
+    <Version>0.3.29</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>
@@ -32,12 +32,12 @@
 
     <!-- Release Notes -->
     <PackageReleaseNotes>
-v0.3.28 — NativeAOT + LibraryImport migration (#333) + v0.3.28 shipping fixes
-- v0.3.28 was canceled mid-release after the release pipeline surfaced
+v0.3.29 — NativeAOT + LibraryImport migration (#333) + v0.3.29 shipping fixes
+- v0.3.29 was canceled mid-release after the release pipeline surfaced
   binding.gyp framework wiring, binding.cc C++20 syntax, and a
   go/.gitignore negation that silently blocked the Go staticlib commits.
-  v0.3.28 rolls the same feature set (#311-#335) forward with those three
-  bugs fixed; no v0.3.28 artifact was ever published to NuGet.
+  v0.3.29 rolls the same feature set (#311-#335) forward with those three
+  bugs fixed; no v0.3.29 artifact was ever published to NuGet.
 - Migrated all 881 native declarations from DllImport to LibraryImport
   so the binding is NativeAOT-publish-ready and trim-safe.
 - Target frameworks trimmed to net8.0 + net10.0 (both current LTS).

--- a/go/lib/README.md
+++ b/go/lib/README.md
@@ -6,7 +6,7 @@ populated by the release CI pipeline and committed to the Go module so that
 `go get github.com/yfedoseev/pdf_oxide/go` works without requiring users to
 build Rust themselves.
 
-Starting with **v0.3.28**, each platform ships a static archive
+Starting with **v0.3.29**, each platform ships a static archive
 (`libpdf_oxide.a`) rather than a shared object. CGo links the archive
 directly via `#cgo ... LDFLAGS` (see `go/pdf_oxide.go`), so the resulting Go
 binary is self-contained — no `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` / `PATH`
@@ -26,7 +26,7 @@ lib/
 
 ### Windows ARM64 caveat
 
-Windows ARM64 temporarily remains on dynamic linking in v0.3.28 because
+Windows ARM64 temporarily remains on dynamic linking in v0.3.29 because
 Rust's `aarch64-pc-windows-gnullvm` target is Tier 3 and not yet production-
 ready for our CI. Go binaries built for Windows ARM64 must still ship
 `pdf_oxide.dll` alongside the executable. Tracked as a follow-up; Linux,

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",
@@ -61,8 +61,8 @@
   "devDependencies": {
     "@types/node": "^18.0.0",
     "node-addon-api": "^8.7.0",
-    "node-gyp": "^10.2.0",
     "rimraf": "^5.0.0",
     "typescript": "^5.3.0"
-  }
+  },
+  "gypfile": false
 }

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.28"
+version = "0.3.29"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ name = "pdf-oxide"
 path = "src/main.rs"
 
 [dependencies]
-pdf_oxide = { version = "0.3.28", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.29", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.28"
+version = "0.3.29"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ name = "pdf-oxide-mcp"
 path = "src/main.rs"
 
 [dependencies]
-pdf_oxide = { version = "0.3.28", path = ".." }
+pdf_oxide = { version = "0.3.29", path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.28"
+version = "0.3.29"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
npm auto-injects gypfile:true + install:'node-gyp rebuild' when node-gyp is in devDependencies. Removed node-gyp from devDeps (CI uses npx), added explicit gypfile:false. Version bump to 0.3.29.