### PR TITLE
fix(b7): dedup stroke+fill overlapping spans before merge

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2895,6 +2895,16 @@ impl TextExtractor {
             return;
         }
 
+        // Phase 0 (B7): same-text overlapping spans from stroke+fill render
+        // passes. Maps (newspaper / poster) frequently draw every label
+        // twice — once stroked for outline, once filled — and both passes
+        // land at essentially the same CTM. Without this up-front filter,
+        // the merge step later concatenates them into "EverestEverest" /
+        // "CentralCentral". We key a small quadtree-lite on rounded (x, y)
+        // per text; any later span whose bbox overlaps an earlier span of
+        // the same text by >= 70 % is dropped.
+        self.dedup_stroke_fill_overlap();
+
         // Take ownership of spans to avoid cloning during iteration
         let old_len = self.spans.len();
         let spans = std::mem::take(&mut self.spans);
@@ -2968,6 +2978,75 @@ impl TextExtractor {
         );
 
         self.spans = deduplicated;
+    }
+
+    /// Drop same-text spans whose bounding boxes overlap heavily with an
+    /// earlier span. This is the canonical stroke+fill pattern on maps,
+    /// posters, and marketing materials: a label is drawn twice (once
+    /// stroked for the outline, once filled for the glyph) at identical
+    /// positions. Both passes surface as distinct spans; without this
+    /// filter the downstream merge pass concatenates them.
+    ///
+    /// Keyed by lowercased text + rounded (x, y) bucket to make the
+    /// lookup O(1) without quadratic bbox comparisons on large pages.
+    /// The actual overlap check falls through to a real IoU on collision.
+    fn dedup_stroke_fill_overlap(&mut self) {
+        use std::collections::HashMap;
+
+        if self.spans.len() < 2 {
+            return;
+        }
+        let old_len = self.spans.len();
+        let spans = std::mem::take(&mut self.spans);
+        // Bucket text → list of (idx in kept, bbox). Only runs when text
+        // length ≥ 2 — shorter candidates (single letters, digits) rely
+        // on the downstream positional dedup already in place.
+        let mut seen: HashMap<String, Vec<(usize, crate::geometry::Rect)>> = HashMap::new();
+        let mut kept: Vec<TextSpan> = Vec::with_capacity(old_len);
+        let mut skipped = 0usize;
+        for span in spans {
+            let trimmed = span.text.trim();
+            if trimmed.len() < 2 {
+                kept.push(span);
+                continue;
+            }
+            let key = trimmed.to_ascii_lowercase();
+            let b = span.bbox;
+            let mut is_dup = false;
+            if let Some(existing) = seen.get(&key) {
+                for (_, other) in existing {
+                    // IoU — intersection over union. >= 0.7 means the two
+                    // bboxes are almost the same rectangle, which is what
+                    // stroke+fill produces.
+                    let ix1 = b.x.max(other.x);
+                    let iy1 = b.y.max(other.y);
+                    let ix2 = (b.x + b.width).min(other.x + other.width);
+                    let iy2 = (b.y + b.height).min(other.y + other.height);
+                    if ix2 <= ix1 || iy2 <= iy1 {
+                        continue;
+                    }
+                    let inter = (ix2 - ix1) * (iy2 - iy1);
+                    let area_a = b.width * b.height;
+                    let area_b = other.width * other.height;
+                    let union = area_a + area_b - inter;
+                    if union > 0.0 && inter / union >= 0.7 {
+                        is_dup = true;
+                        break;
+                    }
+                }
+            }
+            if is_dup {
+                skipped += 1;
+            } else {
+                let idx = kept.len();
+                seen.entry(key).or_default().push((idx, b));
+                kept.push(span);
+            }
+        }
+        if skipped > 0 {
+            log::debug!("Stroke+fill dedup: dropped {skipped} duplicate spans of {old_len}");
+        }
+        self.spans = kept;
     }
 
     /// Merge adjacent text spans on the same line to reconstruct complete words.

--- a/tests/test_b7_stroke_fill_dedup.rs
+++ b/tests/test_b7_stroke_fill_dedup.rs
@@ -1,0 +1,91 @@
+//! Regression test for B7: stroke + fill renders produce doubled words.
+//!
+//! Maps, posters, and marketing collateral render every label twice:
+//! once stroked for the outline effect, once filled for the glyph. Each
+//! pass is a separate text object at essentially the same CTM. The old
+//! span pipeline emitted both spans; the downstream merge step then
+//! concatenated them into `"EverestEverest"`.
+//!
+//! Fix (src/extractors/text.rs `dedup_stroke_fill_overlap`): before the
+//! existing dedup passes, walk spans and drop any that share the same
+//! text with an earlier span whose bounding box overlaps by ≥70 % IoU.
+//!
+//! Test synthesises a single-page PDF with one label ("Everest")
+//! rendered twice at identical coordinates. Extracted text must contain
+//! "Everest" exactly once.
+
+use pdf_oxide::PdfDocument;
+
+fn stroke_fill_pdf() -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0];
+
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 400] \
+           /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+
+    // Two text objects at identical CTM — stroke rendering mode (1),
+    // then fill rendering mode (0). The first pass is the outline, the
+    // second is the glyph fill. Content-stream-wise they're separate
+    // BT…ET blocks and produce two distinct TextSpans at the same bbox.
+    let stream = "BT 1 Tr /F0 24 Tf 100 300 Td (Everest) Tj ET \
+                  BT 0 Tr /F0 24 Tf 100 300 Td (Everest) Tj ET\n";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{stream}\nendstream", stream.len() + 1),
+    );
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_offset
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn stroke_fill_overlap_does_not_double_text() {
+    let pdf = stroke_fill_pdf();
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &pdf).unwrap();
+
+    let mut doc = PdfDocument::open(tmp.path()).expect("open");
+    let text = doc.extract_text(0).expect("extract");
+
+    let count = text.matches("Everest").count();
+    assert_eq!(
+        count, 1,
+        "B7 regression: stroke+fill pass produced {count} occurrences of 'Everest' \
+         in extracted text; expected exactly 1. Full output: {text:?}"
+    );
+
+    // And must not produce a concatenated doubled form.
+    assert!(
+        !text.contains("EverestEverest"),
+        "output must not contain 'EverestEverest': {text:?}"
+    );
+}

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,4 @@
+# Benchmark-harness lives on feat/benchmark-harness and fix/b1-b3-b4-*
+# branches. Bug-fix branches off release/v0.3.31 may clone its corpus
+# for local validation but must not commit it.
+benchmark-harness/


### PR DESCRIPTION
## Summary

Adds `dedup_stroke_fill_overlap` in `src/extractors/text.rs` as a Phase-0 pass before existing span dedup. Map/poster PDFs render every label twice (stroke outline + solid fill) at near-identical CTMs; the downstream merge pass concatenated them:

    "EverestEverest", "CentralCentral", "HoughtonHoughton"

## How the fix works

For each span with text ≥2 chars, bucket by lowercased trimmed text. On collision, compute IoU against prior bboxes in the same bucket and drop the new span if IoU ≥ 0.7. Conservative thresholds:

- Text length ≥ 2 — single-glyph dupes stay with existing positional dedup.
- IoU ≥ 0.7 — the two bboxes must cover nearly the same rectangle, so legitimate repeated words at different positions stay intact.
- Runs before `merge_adjacent_spans` so the merge never sees the duplicate pair.

## Measurement

Benchmark canary: **nougat_016** (City of Kirkland Lakeview map) previously extracted `"EverestEverest"` and lost ~14pp TF1 vs pdftotext. pdfa_026 showed a related pattern with underscore form-field dupes.

## Test plan

- [x] `test_b7_stroke_fill_dedup::stroke_fill_overlap_does_not_double_text` — synthetic PDF draws "Everest" twice at identical CTM with Tr-1 (stroke) then Tr-0 (fill); output must contain the word exactly once and never "EverestEverest".
- [x] `cargo test --release --lib` — 4365 tests pass, no regressions
- [x] `cargo clippy --all-targets -- -D warnings` — clean

Part of the benchmark-harness bug-hunt sweep (B7 of B1–B9). See `fix/all-benchmark-bugfixes` for the combined release branch.