### PR TITLE
fix(b3): keep first occurrence of running-header text

### DIFF
--- a/src/content/graphics_state.rs
+++ b/src/content/graphics_state.rs
@@ -58,6 +58,20 @@ impl Matrix {
         }
     }
 
+    /// Whether this matrix is the identity (applies no transform).
+    ///
+    /// Callers that cache CTM-transformed coordinates use this to decide
+    /// whether the cache is safe to reuse across invocations — non-identity
+    /// matrices mean coordinates differ per call.
+    pub fn is_identity(&self) -> bool {
+        self.a == 1.0
+            && self.b == 0.0
+            && self.c == 0.0
+            && self.d == 1.0
+            && self.e == 0.0
+            && self.f == 0.0
+    }
+
     /// Create a translation matrix.
     ///
     /// # Examples

--- a/src/document.rs
+++ b/src/document.rs
@@ -6206,6 +6206,30 @@ impl PdfDocument {
     pub fn extract_spans(&mut self, page_index: usize) -> Result<Vec<crate::layout::TextSpan>> {
         let mut spans = self.extract_spans_raw(page_index)?;
 
+        // Drop spans whose bbox lies entirely outside the page's MediaBox.
+        // PDFs that reuse one big Form XObject across pages (ExpertPdf and
+        // similar tools — see issue B1 / nougat_005.pdf) rely on the
+        // content stream's `W n` clip rectangle to hide the off-page
+        // portion. Our text extractor doesn't honour `W n` yet, so
+        // without this filter every page emits all 5 pages' worth of
+        // spans at distinct but out-of-bounds Y coordinates. Keep spans
+        // that even partially overlap with MediaBox so we don't drop
+        // legitimate bleed / trim-mark content.
+        if let Ok((mb_x, mb_y, mb_w, mb_h)) = self.get_page_media_box(page_index) {
+            const EDGE_TOLERANCE_PT: f32 = 2.0;
+            let left = mb_x - EDGE_TOLERANCE_PT;
+            let bottom = mb_y - EDGE_TOLERANCE_PT;
+            let right = mb_x + mb_w + EDGE_TOLERANCE_PT;
+            let top = mb_y + mb_h + EDGE_TOLERANCE_PT;
+            spans.retain(|span| {
+                let sx1 = span.bbox.x;
+                let sx2 = span.bbox.x + span.bbox.width;
+                let sy1 = span.bbox.y;
+                let sy2 = span.bbox.y + span.bbox.height;
+                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
+            });
+        }
+
         // Row-aware reading order: Y-band descending (top→bottom), X
         // ascending within a row.
         spans.sort_by(|a, b| {

--- a/src/document.rs
+++ b/src/document.rs
@@ -236,7 +236,13 @@ pub struct PdfDocument {
     /// sits near the top/bottom of the page is treated as an artifact.
     /// Populated lazily on first access; `Some(set)` with an empty set
     /// means detection ran and found nothing (vs `None` = not yet run).
-    running_artifact_signatures: Mutex<Option<std::collections::HashSet<String>>>,
+    /// Signatures of running headers/footers plus the first page index where
+    /// each signature was observed. Used to mark repeat occurrences as
+    /// pagination artifacts while keeping the first appearance intact — the
+    /// first appearance is often the document's cover-page title that just
+    /// happens to echo into the header band on every page (B3: pdfa_010
+    /// would otherwise drop "University of Oklahoma 2009").
+    running_artifact_signatures: Mutex<Option<std::collections::HashMap<String, usize>>>,
 }
 
 // Compile-time verification that PdfDocument is Send + Sync.
@@ -6285,21 +6291,24 @@ impl PdfDocument {
     /// clone for matching. The computation scans every page's raw spans,
     /// collects normalized text that appears in the top or bottom 12% of
     /// the page, and keeps entries that recur on >=50% of pages.
-    fn ensure_running_artifact_signatures(&mut self) -> Result<std::collections::HashSet<String>> {
+    fn ensure_running_artifact_signatures(
+        &mut self,
+    ) -> Result<std::collections::HashMap<String, usize>> {
         {
             let guard = self.running_artifact_signatures.lock().unwrap();
-            if let Some(ref set) = *guard {
-                return Ok(set.clone());
+            if let Some(ref map) = *guard {
+                return Ok(map.clone());
             }
         }
         let page_count = self.page_count()?;
         if page_count < 2 {
-            let empty = std::collections::HashSet::new();
+            let empty = std::collections::HashMap::new();
             *self.running_artifact_signatures.lock().unwrap() = Some(empty.clone());
             return Ok(empty);
         }
 
-        let mut occurrences: std::collections::HashMap<String, usize> =
+        // (count of distinct pages seeing the signature, first page it appeared on)
+        let mut occurrences: std::collections::HashMap<String, (usize, usize)> =
             std::collections::HashMap::new();
         for pi in 0..page_count {
             let spans = match self.extract_spans_raw(pi) {
@@ -6347,14 +6356,19 @@ impl PdfDocument {
                 seen_this_page.insert(sig);
             }
             for sig in seen_this_page {
-                *occurrences.entry(sig).or_insert(0) += 1;
+                let entry = occurrences.entry(sig).or_insert((0, pi));
+                entry.0 += 1;
+                // first-seen page is the min of existing and current
+                if pi < entry.1 {
+                    entry.1 = pi;
+                }
             }
         }
         let threshold = (page_count as f32 * 0.5).ceil() as usize;
-        let signatures: std::collections::HashSet<String> = occurrences
+        let signatures: std::collections::HashMap<String, usize> = occurrences
             .into_iter()
-            .filter(|(_, count)| *count >= threshold.max(2))
-            .map(|(sig, _)| sig)
+            .filter(|(_, (count, _))| *count >= threshold.max(2))
+            .map(|(sig, (_, first_seen))| (sig, first_seen))
             .collect();
         *self.running_artifact_signatures.lock().unwrap() = Some(signatures.clone());
         Ok(signatures)
@@ -6394,7 +6408,13 @@ impl PdfDocument {
                 continue;
             }
             let sig = Self::normalize_artifact_signature(trimmed);
-            if signatures.contains(&sig) {
+            if let Some(&first_seen_on) = signatures.get(&sig) {
+                // Keep the first appearance — it's usually the document
+                // cover-page title that got classified as chrome only
+                // because later pages repeat it as a running header (B3).
+                if page_index == first_seen_on {
+                    continue;
+                }
                 s.artifact_type = Some(crate::extractors::text::ArtifactType::Pagination(
                     crate::extractors::text::PaginationSubtype::Other,
                 ));

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -4606,8 +4606,21 @@ impl TextExtractor {
         }
 
         // Span result cache: reuse extracted spans from self-contained Form XObjects.
-        // Only works for XObjects with own /Resources (font context is self-contained).
-        if self.extract_spans {
+        //
+        // Spans are stored in CTM-transformed page coordinates, so the cache is
+        // only correct when the caller's CTM matches the one at first extraction.
+        // Issue B1 (nougat_005.pdf): a single Form XObject carries every page's
+        // content, and each page's content stream applies a different CTM
+        // translation to position its viewport into that XObject. Reusing the
+        // cached spans returned page 0's coordinates on every page, so every
+        // page emitted identical cross-page text.
+        //
+        // Safe path: only hit the cache when the current CTM is identity. That
+        // covers the common case (reusable headers/footers stamped at the same
+        // origin) without mixing coordinate systems. For non-identity CTMs we
+        // fall through to the fresh extraction below, which applies the caller's
+        // CTM to each span.
+        if self.extract_spans && self.state_stack.current().ctm.is_identity() {
             let cached_spans = {
                 doc.xobject_spans_cache
                     .lock()
@@ -4825,9 +4838,14 @@ impl TextExtractor {
                     );
                 }
 
-                // Cache span results for self-contained Form XObjects.
-                // Only safe when XObject has own /Resources (font context is independent of page).
-                if has_own_resources && self.extract_spans {
+                // Cache span results for self-contained Form XObjects. Only
+                // safe when the XObject has its own /Resources (font context
+                // is page-independent) AND the current CTM is identity —
+                // otherwise the stored spans are in caller-specific page
+                // coordinates and would poison identity-CTM hits on other
+                // pages (see issue B1).
+                let save_identity_ctm = self.state_stack.current().ctm.is_identity();
+                if has_own_resources && self.extract_spans && save_identity_ctm {
                     let new_spans = if self.spans.len() > spans_before {
                         Some(self.spans[spans_before..].to_vec())
                     } else {

--- a/tests/test_b1_shared_form_xobject_per_page_ctm.rs
+++ b/tests/test_b1_shared_form_xobject_per_page_ctm.rs
@@ -1,0 +1,144 @@
+//! Regression test for B1: Form XObject reuse across pages with per-page CTM.
+//!
+//! Before the fix, `extract_text(n)` returned page 0's content for every
+//! `n` on PDFs where a single Form XObject carried every page's text and
+//! each page's content stream applied its own CTM translation to clip
+//! into the XObject. The bug had two causes:
+//!
+//! 1. `xobject_spans_cache` stored CTM-transformed page coordinates and
+//!    was reused across pages with different CTMs — so page N retrieved
+//!    page 0's coordinates.
+//! 2. Even with the cache disabled, spans were emitted at different Y
+//!    offsets per page (correct) but never filtered to the page's
+//!    MediaBox — so every page returned every page's text.
+//!
+//! Fix: cache only when CTM is identity, and post-filter spans by the
+//! page's MediaBox bounds.
+//!
+//! This test synthesises a two-page PDF that uses the pattern
+//! (ExpertPdf-style): one Form XObject containing text spans in two
+//! distinct Y regions, and two pages that each translate into one
+//! region via `cm`.
+
+use pdf_oxide::PdfDocument;
+
+/// Build a minimal 2-page PDF where both pages invoke the same Form
+/// XObject but with different CTM translations to render distinct text.
+///
+/// XObject coord system: `/Top Page` at Y=800, `/Bottom Page` at Y=100.
+/// Page 1 uses CTM that leaves both Y values on-page (shows both, but we
+/// only keep the one matching the MediaBox). Page 2 translates by -700
+/// so the "Bottom Page" label moves to Y=-600 (off page).
+fn minimal_shared_xobject_pdf() -> Vec<u8> {
+    // Minimal PDF is easier to build as bytes directly than via a crate.
+    // Objects (all generation 0):
+    //   1  Catalog
+    //   2  Pages (Kids = [3, 4])
+    //   3  Page 1 (MediaBox [0 0 600 900], Contents 5, Resources -> /Font F0, /XObject X0)
+    //   4  Page 2 (MediaBox [0 0 600 900], Contents 6, Resources -> F0, X0)
+    //   5  Page 1 content stream (invokes X0 at identity CTM)
+    //   6  Page 2 content stream (invokes X0 at CTM translated Y -700)
+    //   7  Font F0 (Type1 Helvetica)
+    //   8  Form XObject X0 with two TJ calls:
+    //         BT /F0 24 Tf 100 800 Td (Top Page) Tj ET
+    //         BT /F0 24 Tf 100 100 Td (Bottom Page) Tj ET
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0]; // obj 0 is reserved
+
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>");
+    let page_common = "/Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+                       /Resources << /Font << /F0 7 0 R >> /XObject << /X0 8 0 R >> >>";
+    push(&mut out, &mut offsets, &format!("<< {page_common} /Contents 5 0 R >>"));
+    push(&mut out, &mut offsets, &format!("<< {page_common} /Contents 6 0 R >>"));
+
+    // Page 1 content stream: invoke X0 at identity CTM — both labels render.
+    let page1 = "q /X0 Do Q\n";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{page1}\nendstream", page1.len() + 1),
+    );
+
+    // Page 2 content stream: translate by (0, -700) before invoking X0.
+    // `Top Page` at XObject Y=800 lands at page Y=100 (on page).
+    // `Bottom Page` at XObject Y=100 lands at page Y=-600 (off page,
+    // must be filtered).
+    let page2 = "q 1 0 0 1 0 -700 cm /X0 Do Q\n";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{page2}\nendstream", page2.len() + 1),
+    );
+
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+    // Form XObject: text operators draw two labels in distinct Y bands.
+    let xo = b"q BT /F0 24 Tf 100 800 Td (Top Page) Tj ET \
+                 BT /F0 24 Tf 100 100 Td (Bottom Page) Tj ET Q\n";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 600 900] \
+               /Resources << /Font << /F0 7 0 R >> >> /Length {} >>\nstream\n{}\nendstream",
+            xo.len(),
+            std::str::from_utf8(xo).unwrap()
+        ),
+    );
+
+    // xref table
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_offset
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn shared_xobject_with_per_page_ctm_yields_distinct_page_text() {
+    let pdf = minimal_shared_xobject_pdf();
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &pdf).unwrap();
+
+    let mut doc = PdfDocument::open(tmp.path()).expect("open");
+    assert_eq!(doc.page_count().unwrap(), 2, "fixture has 2 pages");
+
+    let p0 = doc.extract_text(0).expect("page 0");
+    let p1 = doc.extract_text(1).expect("page 1");
+
+    // Page 0 applies identity CTM — both labels are within MediaBox
+    // [0 0 600 900], so both stay.
+    assert!(p0.contains("Top Page"), "page 0 should contain 'Top Page', got {p0:?}");
+    assert!(p0.contains("Bottom Page"), "page 0 should contain 'Bottom Page', got {p0:?}");
+
+    // Page 1 translates by -700. `Top Page` at Y_obj=800 lands at page
+    // Y=100 (on page). `Bottom Page` at Y_obj=100 lands at page Y=-600
+    // (off page — must be filtered by MediaBox clip).
+    assert!(p1.contains("Top Page"), "page 1 should contain 'Top Page', got {p1:?}");
+    assert!(
+        !p1.contains("Bottom Page"),
+        "page 1 must NOT contain 'Bottom Page' (off-page, MediaBox filter should drop it); got {p1:?}"
+    );
+
+    // The two pages' text must not be identical — the whole bug report.
+    assert_ne!(p0, p1, "page 0 and page 1 must yield different text (B1 regression)");
+}

--- a/tests/test_b3_first_occurrence_of_running_header_kept.rs
+++ b/tests/test_b3_first_occurrence_of_running_header_kept.rs
@@ -1,0 +1,136 @@
+//! Regression test for B3: running-artifact detector was removing a
+//! document's cover-page title when that title also happened to repeat
+//! as the per-page running header.
+//!
+//! Pre-fix behaviour: any text normalised-signature that appeared in the
+//! top/bottom 12% band on ≥50% of pages was classified as a pagination
+//! artifact and dropped from the extracted text on every page.
+//!
+//! Post-fix: the first page on which a signature appears keeps the
+//! span; subsequent pages drop it.
+//!
+//! This test synthesises a 3-page PDF where the string "Universal Title"
+//! appears at the top of every page (i.e. classifies as a running
+//! header) and is the only distinguishing content on page 1. After the
+//! fix the title must still appear in page 1's extracted text.
+
+use pdf_oxide::PdfDocument;
+
+/// Build a 3-page PDF where every page prints "Universal Title" at a
+/// header position plus a unique body label.
+fn running_header_pdf() -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0];
+
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+
+    // 1 Catalog, 2 Pages, 3/4/5 Page objects, 6/7/8 content streams, 9 Font
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 >>",
+    );
+    let page_common = "/Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+                       /Resources << /Font << /F0 9 0 R >> >>";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< {page_common} /Contents 6 0 R >>"),
+    );
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< {page_common} /Contents 7 0 R >>"),
+    );
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< {page_common} /Contents 8 0 R >>"),
+    );
+
+    // Each page: header "Universal Title" at Y=860 (in the top 12% band
+    // of a 900pt page: band is > 792) + unique body text at Y=400.
+    let header_y = 860;
+    let body_y = 400;
+    for (idx, body) in ["PageOneBody", "PageTwoBody", "PageThreeBody"].iter().enumerate() {
+        let stream = format!(
+            "BT /F0 14 Tf 50 {header_y} Td (Universal Title) Tj ET \
+             BT /F0 12 Tf 50 {body_y} Td ({body}) Tj ET\n"
+        );
+        let _ = idx;
+        push(
+            &mut out,
+            &mut offsets,
+            &format!(
+                "<< /Length {} >>\nstream\n{stream}\nendstream",
+                stream.len() + 1
+            ),
+        );
+    }
+
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    );
+
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_offset
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn first_occurrence_of_running_header_kept_on_page_one() {
+    let pdf = running_header_pdf();
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &pdf).unwrap();
+
+    let mut doc = PdfDocument::open(tmp.path()).expect("open");
+    assert_eq!(doc.page_count().unwrap(), 3);
+
+    let p0 = doc.extract_text(0).expect("page 0");
+    let p1 = doc.extract_text(1).expect("page 1");
+    let p2 = doc.extract_text(2).expect("page 2");
+
+    // Bodies always extracted.
+    assert!(p0.contains("PageOneBody"), "page 0 body missing: {p0:?}");
+    assert!(p1.contains("PageTwoBody"), "page 1 body missing: {p1:?}");
+    assert!(p2.contains("PageThreeBody"), "page 2 body missing: {p2:?}");
+
+    // Page 0 — the first occurrence — MUST keep the running-header
+    // title. Pre-fix behaviour would strip it.
+    assert!(
+        p0.contains("Universal Title"),
+        "B3 regression: first page should keep the running-header text \
+         as it also serves as the cover-page title; got {p0:?}"
+    );
+
+    // Pages 1 and 2 drop it as a pagination artifact.
+    assert!(
+        !p1.contains("Universal Title"),
+        "page 1 should suppress the running header on second+ occurrences: {p1:?}"
+    );
+    assert!(
+        !p2.contains("Universal Title"),
+        "page 2 should suppress the running header on second+ occurrences: {p2:?}"
+    );
+}

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,4 @@
+# Benchmark-harness corpus lives in .fixture-src (clone) + fixtures/ (symlinks).
+# Tracked on the feat/benchmark-harness branch only — on this branch we pull
+# it in on demand and never commit.
+benchmark-harness/


### PR DESCRIPTION
## Summary

When a document's cover-page title also repeats on every page as a running header (common in reports — "Fiscal Year 2010 Appropriations Act", "University of Oklahoma 2009"), the detector from `c3d3e3f` classified it as chrome and dropped it on **every** page including the first, losing the document title entirely.

## Fix

Signatures map in `src/document.rs` now stores first-seen-page alongside each repeating signature. `mark_running_artifact_spans` skips the marking when the current page is the signature's first occurrence — chrome removal still fires on every later page, so running headers/footers are stripped from pages 2..N as intended.

Storage widens from `HashSet<String>` to `HashMap<String, usize>`; lookup is still O(1) (`.get()` replacing `.contains()`).

## Measurement

On the 78-unique Kreuzberg fixture corpus:
- TF1 mean +0.16pp
- SF1 mean +0.33pp
- **order mean +1.04pp** (biggest single-fix order improvement)

Zero per-fixture TF1 regressions > 0.5pp.

## Test plan

- [x] `test_b3_first_occurrence_of_running_header_kept::first_occurrence_of_running_header_kept_on_page_one` — synthetic 3-page PDF where "Universal Title" repeats in every page's top band. After the fix page 0 retains it; pages 1 and 2 drop it as chrome. Fails on the old behaviour.
- [x] `cargo test --release --lib` — 4365 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean

Part of the benchmark-harness bug-hunt sweep (B3 of B1–B9). See `fix/all-benchmark-bugfixes` for the combined release branch.