### PR TITLE
fix(b1): shared Form XObject per-page CTM — biggest single-fixture TF1 win (+64.7pp)

### DIFF
--- a/src/content/graphics_state.rs
+++ b/src/content/graphics_state.rs
@@ -58,6 +58,20 @@ impl Matrix {
         }
     }
 
+    /// Whether this matrix is the identity (applies no transform).
+    ///
+    /// Callers that cache CTM-transformed coordinates use this to decide
+    /// whether the cache is safe to reuse across invocations — non-identity
+    /// matrices mean coordinates differ per call.
+    pub fn is_identity(&self) -> bool {
+        self.a == 1.0
+            && self.b == 0.0
+            && self.c == 0.0
+            && self.d == 1.0
+            && self.e == 0.0
+            && self.f == 0.0
+    }
+
     /// Create a translation matrix.
     ///
     /// # Examples

--- a/src/document.rs
+++ b/src/document.rs
@@ -6206,6 +6206,30 @@ impl PdfDocument {
     pub fn extract_spans(&mut self, page_index: usize) -> Result<Vec<crate::layout::TextSpan>> {
         let mut spans = self.extract_spans_raw(page_index)?;
 
+        // Drop spans whose bbox lies entirely outside the page's MediaBox.
+        // PDFs that reuse one big Form XObject across pages (ExpertPdf and
+        // similar tools — see issue B1 / nougat_005.pdf) rely on the
+        // content stream's `W n` clip rectangle to hide the off-page
+        // portion. Our text extractor doesn't honour `W n` yet, so
+        // without this filter every page emits all 5 pages' worth of
+        // spans at distinct but out-of-bounds Y coordinates. Keep spans
+        // that even partially overlap with MediaBox so we don't drop
+        // legitimate bleed / trim-mark content.
+        if let Ok((mb_x, mb_y, mb_w, mb_h)) = self.get_page_media_box(page_index) {
+            const EDGE_TOLERANCE_PT: f32 = 2.0;
+            let left = mb_x - EDGE_TOLERANCE_PT;
+            let bottom = mb_y - EDGE_TOLERANCE_PT;
+            let right = mb_x + mb_w + EDGE_TOLERANCE_PT;
+            let top = mb_y + mb_h + EDGE_TOLERANCE_PT;
+            spans.retain(|span| {
+                let sx1 = span.bbox.x;
+                let sx2 = span.bbox.x + span.bbox.width;
+                let sy1 = span.bbox.y;
+                let sy2 = span.bbox.y + span.bbox.height;
+                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
+            });
+        }
+
         // Row-aware reading order: Y-band descending (top→bottom), X
         // ascending within a row.
         spans.sort_by(|a, b| {

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -4606,8 +4606,21 @@ impl TextExtractor {
         }
 
         // Span result cache: reuse extracted spans from self-contained Form XObjects.
-        // Only works for XObjects with own /Resources (font context is self-contained).
-        if self.extract_spans {
+        //
+        // Spans are stored in CTM-transformed page coordinates, so the cache is
+        // only correct when the caller's CTM matches the one at first extraction.
+        // Issue B1 (nougat_005.pdf): a single Form XObject carries every page's
+        // content, and each page's content stream applies a different CTM
+        // translation to position its viewport into that XObject. Reusing the
+        // cached spans returned page 0's coordinates on every page, so every
+        // page emitted identical cross-page text.
+        //
+        // Safe path: only hit the cache when the current CTM is identity. That
+        // covers the common case (reusable headers/footers stamped at the same
+        // origin) without mixing coordinate systems. For non-identity CTMs we
+        // fall through to the fresh extraction below, which applies the caller's
+        // CTM to each span.
+        if self.extract_spans && self.state_stack.current().ctm.is_identity() {
             let cached_spans = {
                 doc.xobject_spans_cache
                     .lock()
@@ -4825,9 +4838,14 @@ impl TextExtractor {
                     );
                 }
 
-                // Cache span results for self-contained Form XObjects.
-                // Only safe when XObject has own /Resources (font context is independent of page).
-                if has_own_resources && self.extract_spans {
+                // Cache span results for self-contained Form XObjects. Only
+                // safe when the XObject has its own /Resources (font context
+                // is page-independent) AND the current CTM is identity —
+                // otherwise the stored spans are in caller-specific page
+                // coordinates and would poison identity-CTM hits on other
+                // pages (see issue B1).
+                let save_identity_ctm = self.state_stack.current().ctm.is_identity();
+                if has_own_resources && self.extract_spans && save_identity_ctm {
                     let new_spans = if self.spans.len() > spans_before {
                         Some(self.spans[spans_before..].to_vec())
                     } else {

--- a/tests/test_b1_shared_form_xobject_per_page_ctm.rs
+++ b/tests/test_b1_shared_form_xobject_per_page_ctm.rs
@@ -1,0 +1,144 @@
+//! Regression test for B1: Form XObject reuse across pages with per-page CTM.
+//!
+//! Before the fix, `extract_text(n)` returned page 0's content for every
+//! `n` on PDFs where a single Form XObject carried every page's text and
+//! each page's content stream applied its own CTM translation to clip
+//! into the XObject. The bug had two causes:
+//!
+//! 1. `xobject_spans_cache` stored CTM-transformed page coordinates and
+//!    was reused across pages with different CTMs — so page N retrieved
+//!    page 0's coordinates.
+//! 2. Even with the cache disabled, spans were emitted at different Y
+//!    offsets per page (correct) but never filtered to the page's
+//!    MediaBox — so every page returned every page's text.
+//!
+//! Fix: cache only when CTM is identity, and post-filter spans by the
+//! page's MediaBox bounds.
+//!
+//! This test synthesises a two-page PDF that uses the pattern
+//! (ExpertPdf-style): one Form XObject containing text spans in two
+//! distinct Y regions, and two pages that each translate into one
+//! region via `cm`.
+
+use pdf_oxide::PdfDocument;
+
+/// Build a minimal 2-page PDF where both pages invoke the same Form
+/// XObject but with different CTM translations to render distinct text.
+///
+/// XObject coord system: `/Top Page` at Y=800, `/Bottom Page` at Y=100.
+/// Page 1 uses CTM that leaves both Y values on-page (shows both, but we
+/// only keep the one matching the MediaBox). Page 2 translates by -700
+/// so the "Bottom Page" label moves to Y=-600 (off page).
+fn minimal_shared_xobject_pdf() -> Vec<u8> {
+    // Minimal PDF is easier to build as bytes directly than via a crate.
+    // Objects (all generation 0):
+    //   1  Catalog
+    //   2  Pages (Kids = [3, 4])
+    //   3  Page 1 (MediaBox [0 0 600 900], Contents 5, Resources -> /Font F0, /XObject X0)
+    //   4  Page 2 (MediaBox [0 0 600 900], Contents 6, Resources -> F0, X0)
+    //   5  Page 1 content stream (invokes X0 at identity CTM)
+    //   6  Page 2 content stream (invokes X0 at CTM translated Y -700)
+    //   7  Font F0 (Type1 Helvetica)
+    //   8  Form XObject X0 with two TJ calls:
+    //         BT /F0 24 Tf 100 800 Td (Top Page) Tj ET
+    //         BT /F0 24 Tf 100 100 Td (Bottom Page) Tj ET
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0]; // obj 0 is reserved
+
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>");
+    let page_common = "/Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+                       /Resources << /Font << /F0 7 0 R >> /XObject << /X0 8 0 R >> >>";
+    push(&mut out, &mut offsets, &format!("<< {page_common} /Contents 5 0 R >>"));
+    push(&mut out, &mut offsets, &format!("<< {page_common} /Contents 6 0 R >>"));
+
+    // Page 1 content stream: invoke X0 at identity CTM — both labels render.
+    let page1 = "q /X0 Do Q\n";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{page1}\nendstream", page1.len() + 1),
+    );
+
+    // Page 2 content stream: translate by (0, -700) before invoking X0.
+    // `Top Page` at XObject Y=800 lands at page Y=100 (on page).
+    // `Bottom Page` at XObject Y=100 lands at page Y=-600 (off page,
+    // must be filtered).
+    let page2 = "q 1 0 0 1 0 -700 cm /X0 Do Q\n";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{page2}\nendstream", page2.len() + 1),
+    );
+
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+    // Form XObject: text operators draw two labels in distinct Y bands.
+    let xo = b"q BT /F0 24 Tf 100 800 Td (Top Page) Tj ET \
+                 BT /F0 24 Tf 100 100 Td (Bottom Page) Tj ET Q\n";
+    push(
+        &mut out,
+        &mut offsets,
+        &format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 600 900] \
+               /Resources << /Font << /F0 7 0 R >> >> /Length {} >>\nstream\n{}\nendstream",
+            xo.len(),
+            std::str::from_utf8(xo).unwrap()
+        ),
+    );
+
+    // xref table
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_offset
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn shared_xobject_with_per_page_ctm_yields_distinct_page_text() {
+    let pdf = minimal_shared_xobject_pdf();
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &pdf).unwrap();
+
+    let mut doc = PdfDocument::open(tmp.path()).expect("open");
+    assert_eq!(doc.page_count().unwrap(), 2, "fixture has 2 pages");
+
+    let p0 = doc.extract_text(0).expect("page 0");
+    let p1 = doc.extract_text(1).expect("page 1");
+
+    // Page 0 applies identity CTM — both labels are within MediaBox
+    // [0 0 600 900], so both stay.
+    assert!(p0.contains("Top Page"), "page 0 should contain 'Top Page', got {p0:?}");
+    assert!(p0.contains("Bottom Page"), "page 0 should contain 'Bottom Page', got {p0:?}");
+
+    // Page 1 translates by -700. `Top Page` at Y_obj=800 lands at page
+    // Y=100 (on page). `Bottom Page` at Y_obj=100 lands at page Y=-600
+    // (off page — must be filtered by MediaBox clip).
+    assert!(p1.contains("Top Page"), "page 1 should contain 'Top Page', got {p1:?}");
+    assert!(
+        !p1.contains("Bottom Page"),
+        "page 1 must NOT contain 'Bottom Page' (off-page, MediaBox filter should drop it); got {p1:?}"
+    );
+
+    // The two pages' text must not be identical — the whole bug report.
+    assert_ne!(p0, p1, "page 0 and page 1 must yield different text (B1 regression)");
+}

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,4 @@
+# Benchmark-harness corpus lives in .fixture-src (clone) + fixtures/ (symlinks).
+# Tracked on the feat/benchmark-harness branch only — on this branch we pull
+# it in on demand and never commit.
+benchmark-harness/


### PR DESCRIPTION
## Summary

Found via the benchmark-harness Kreuzberg sweep. `extract_text(n)` returned **page 0's content for every `n`** on PDFs where one Form XObject carries every page's text and each page's content stream applies its own CTM translation to position a viewport into it (ExpertPdf-style output — **nougat_005.pdf** scored TF1 0.254 vs pdftotext 0.924).

## Two independent bugs stacked

1. `xobject_spans_cache` in `src/document.rs` stored CTM-transformed page coordinates keyed by `ObjectRef` only. When page N invoked the same XObject with a different CTM, the cache returned page 0's coordinates wholesale. **Fix**: only hit and populate the cache when the current CTM is identity. That still covers the common case (repeated headers/footers stamped at the same origin) without mixing coordinate systems. Non-identity invocations skip the cache and re-extract, which correctly applies the caller's CTM.

2. Even with (1) fixed, every page emitted spans from the entire XObject at distinct-but-out-of-bounds Y coordinates because the text pipeline doesn't honour the content stream's `W n` clipping operator yet. **Fix**: post-filter extracted spans by the page's MediaBox (with a 2pt tolerance so bleed/trim content isn't dropped).

Added `Matrix::is_identity()` helper in `src/content/graphics_state.rs` for clean CTM-identity checks.

## Measurement — this is the headline fix of the sweep

| Fixture | Pre | Post | Δ |
|---|---:|---:|---:|
| **nougat_005** | 0.254 | 0.901 | **+64.7pp** |
| Corpus TF1 p10 | 0.776 | 0.848 | **+7.2pp** |
| Corpus TF1 mean | 0.919 | 0.925 | +0.64pp |

## Why TDD mattered here

The 170-PDF byte-diff regression sweep we'd been using couldn't catch this bug — both branches have it, so byte counts match. The harness caught it because TF1 is measured against ground truth, not against the other branch.

## Test plan

- [x] `test_b1_shared_form_xobject_per_page_ctm::shared_xobject_with_per_page_ctm_yields_distinct_page_text` — synthesises a 2-page PDF where both pages invoke the same Form XObject with different CTM translations. Page 0 sees both labels; page 1 sees only the one still inside MediaBox after −700pt translation. Fails without the fix (both pages return identical text).
- [x] `cargo test --release --lib` — 4365 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Real fixture verified: nougat_005.pdf, 5 pages, one XObject → each page now returns distinct content ("REPORTING FRAMEWORK", "COMMITMENTS Criteria 1.1", "Criteria 2.2", "Criteria 3.2 ON-SITE WASTE DIVERSION").

Part of the benchmark-harness bug-hunt sweep (B1 of B1–B9). See `fix/all-benchmark-bugfixes` for the combined release branch.