### PR TITLE
release(v0.3.32): fix windows-gnu staticlib shrink hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.32] - 2026-04-15
+
+### Release pipeline
+
+- **Fix `x86_64-pc-windows-gnu` native-lib build failing the v0.3.31 release.** The new `scripts/shrink-staticlib.sh` introduced in v0.3.31 ran `objcopy --strip-debug` on every archive member. The MinGW cross-compile toolchain emits split-debug `.dwo` members that contain *only* DWARF sections; after stripping those sections the member has no sections left and objcopy aborted the whole archive with `'...rcgu.dwo' has no sections`, failing the job that produces the Go Windows-x64 FFI tarball. Fix: drop `.dwo` archive members via `ar d` before invoking `objcopy`. No functional change to Rust, Python, Node, WASM, or C# artifacts — those built and uploaded successfully in v0.3.31; this release exists solely to unblock the Windows-x64 Go install path.
+
 ## [0.3.31] - 2026-04-15
 
 ### Text extraction correctness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "aes",
  "barcoders",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "clap",
  "is-terminal",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "pdf_oxide",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["js"]
 
 [package]
 name = "pdf_oxide"
-version = "0.3.31"
+version = "0.3.32"
 # Anchor patterns with a leading slash — Cargo uses gitignore-style globs, so
 # a bare "README.md" matches every README.md recursively (was pulling in 20+
 # subdir READMEs plus js/node_modules/*/README.md into the sdist). Leading /

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.31</Version>
+    <Version>0.3.32</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/go/README.md
+++ b/go/README.md
@@ -13,11 +13,11 @@ The fastest Go PDF library for text extraction, image extraction, and markdown c
 go get github.com/yfedoseev/pdf_oxide/go
 
 # One-time per machine: download the native FFI library
-go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.31
+go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.32
 
 # Installer prints the CGO_* env vars to export — e.g.:
-export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.31/include"
-export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.31/lib/linux_amd64/libpdf_oxide.a \
+export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.32/include"
+export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.32/lib/linux_amd64/libpdf_oxide.a \
   -lm -lpthread -ldl -lrt -lgcc_s -lutil -lc"
 ```
 

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -4,7 +4,7 @@
 //
 // Usage:
 //
-//	go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.31
+//	go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.32
 //
 // Flags:
 //
@@ -50,7 +50,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion   = "0.3.31"
+	fallbackVersion   = "0.3.32"
 	BaseURL           = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	DefaultInstallDir = ".pdf_oxide"
 	dirPerm           = 0o750
@@ -61,7 +61,7 @@ const (
 )
 
 // resolveVersion returns the module version baked in by `go run ...@<tag>`.
-// `debug.ReadBuildInfo()` reports Main.Version as "v0.3.31" for that path,
+// `debug.ReadBuildInfo()` reports Main.Version as "v0.3.32" for that path,
 // "(devel)" for local builds inside the checkout, or "" when build info is
 // missing entirely. We strip the leading "v" so the rest of the code can
 // treat version as a plain semver string.
@@ -132,7 +132,7 @@ func main() {
 }
 
 func run() error {
-	version := flag.String("version", resolveVersion(), "Version to download (semver, e.g. 0.3.31). Defaults to the installer's own module version — so `go run ...@latest` and `go run ...@v0.3.31` both just work.")
+	version := flag.String("version", resolveVersion(), "Version to download (semver, e.g. 0.3.32). Defaults to the installer's own module version — so `go run ...@latest` and `go run ...@v0.3.32` both just work.")
 	installDir := flag.String("dir", "", "Install directory (default: $HOME/.pdf_oxide)")
 	writeFlagsDir := flag.String("write-flags", "", "Directory in which to write cgo_flags.go (default: empty — just print env vars)")
 	envOnly := flag.Bool("env-only", false, "Skip download; print env vars for an existing install")
@@ -202,7 +202,7 @@ func staticlibName(platform string) string {
 
 func downloadAndExtract(version, assetSuffix, targetDir string, verifyChecksum bool) error {
 	if !versionRegex.MatchString(version) {
-		return fmt.Errorf("invalid version %q (expected semver like 0.3.31)", version)
+		return fmt.Errorf("invalid version %q (expected semver like 0.3.32)", version)
 	}
 	assetName := "pdf_oxide-go-ffi-" + assetSuffix + ".tar.gz"
 	baseURL := BaseURL + "/v" + version + "/"

--- a/go/lib/README.md
+++ b/go/lib/README.md
@@ -8,18 +8,18 @@ repository bloat (Rust staticlibs for 6 platforms).
 ## Install (one-time per machine)
 
 ```bash
-go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.31
+go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.32
 ```
 
 The installer detects `GOOS`/`GOARCH`, downloads the matching asset from
-`https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.31/…`, and
-extracts `libpdf_oxide.a` + `pdf_oxide.h` into `~/.pdf_oxide/v0.3.31/`.
+`https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.32/…`, and
+extracts `libpdf_oxide.a` + `pdf_oxide.h` into `~/.pdf_oxide/v0.3.32/`.
 
 It then prints the `CGO_CFLAGS` / `CGO_LDFLAGS` you need to export:
 
 ```
-export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.31/include"
-export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.31/lib/linux_amd64/libpdf_oxide.a -lm -lpthread -ldl -lrt -lgcc_s -lutil -lc"
+export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.32/include"
+export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.32/lib/linux_amd64/libpdf_oxide.a -lm -lpthread -ldl -lrt -lgcc_s -lutil -lc"
 ```
 
 After that, `go build` / `go test` work normally.
@@ -30,7 +30,7 @@ If you prefer to wire installation into your own project's build, add this
 to any `.go` file in your project:
 
 ```go
-//go:generate go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.31 --write-flags=.
+//go:generate go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.32 --write-flags=.
 ```
 
 Running `go generate ./...` then drops a `cgo_flags.go` next to your

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.31"
+version = "0.3.32"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ name = "pdf-oxide"
 path = "src/main.rs"
 
 [dependencies]
-pdf_oxide = { version = "0.3.31", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.32", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.31"
+version = "0.3.32"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ name = "pdf-oxide-mcp"
 path = "src/main.rs"
 
 [dependencies]
-pdf_oxide = { version = "0.3.31", path = ".." }
+pdf_oxide = { version = "0.3.32", path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.31"
+version = "0.3.32"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/scripts/shrink-staticlib.sh
+++ b/scripts/shrink-staticlib.sh
@@ -31,6 +31,19 @@ case "$(uname -s)" in
     # GNU binutils path. objcopy handles archives: it iterates members and
     # applies the operation to each, then rewrites the archive in place.
     if command -v objcopy >/dev/null 2>&1; then
+      # Split-debug `.dwo` archive members (emitted by the mingw cross-compile
+      # toolchain on x86_64-pc-windows-gnu) contain *only* DWARF sections.
+      # `objcopy --strip-debug` removes their only sections and then aborts
+      # the whole archive with "has no sections". Drop these members first so
+      # objcopy has nothing debug-only left to process.
+      if command -v ar >/dev/null 2>&1; then
+        mapfile -t dwo_members < <(ar t "$LIB" 2>/dev/null | grep -E '\.dwo$' || true)
+        if [[ ${#dwo_members[@]} -gt 0 ]]; then
+          for m in "${dwo_members[@]}"; do
+            ar d "$LIB" "$m" || true
+          done
+        fi
+      fi
       # llvm-objcopy rejects "same input and output" on some distros; write to
       # a sibling tmp file and move it into place atomically.
       tmp="${LIB}.shrink.tmp"

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- Fix `scripts/shrink-staticlib.sh` choking on MinGW split-debug `.dwo` archive members (`objcopy: '...rcgu.dwo' has no sections`) — drop those members with `ar d` before running objcopy.
- Bump version **0.3.31 → 0.3.32** across every binding: Rust (workspace + `pdf_oxide_cli` + `pdf_oxide_mcp`), Python (`pyproject.toml`), Node (`js/package.json`), WASM (`wasm-pkg/package.json`), C# (`PdfOxide.csproj`), Go installer (`fallbackVersion` + examples), and `Cargo.lock`.

## Why

The v0.3.31 Release pipeline failed on `Build native lib (x86_64-pc-windows-gnu)` — the only failing job out of the whole matrix. The MinGW cross-compile emits `.dwo` (split-debug) members inside `libpdf_oxide.a` that contain *only* DWARF sections; `objcopy --strip-debug` removed their only sections and then bailed on the archive. That broke the Go Windows-x64 FFI tarball upload.

All other v0.3.31 artifacts (Rust crate, Python wheels, Node addon, WASM, C# NuGet, Go FFI for Linux/macOS) built and uploaded successfully. This release exists solely to unblock the Windows-x64 Go install path.

## Test plan

- [ ] Release workflow for `v0.3.32` tag completes green on all native-lib targets, including `x86_64-pc-windows-gnu`.
- [ ] `pdf_oxide-go-ffi-windows-x86_64.tar.gz` is present among the `v0.3.32` release assets.
- [ ] `go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.32` on Windows x64 downloads and extracts the asset, then prints CGO env vars pointing at `~/.pdf_oxide/v0.3.32/`.
- [ ] `cargo check --workspace` clean (verified locally).
- [ ] Shrink script still trims Linux/macOS `.a` files as before (unchanged path for those targets).