### PR TITLE
release(v0.3.35): preserve narrow-glyph doublets in text extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.35] - 2026-04-19
+> Narrow-glyph doublet preservation in text extraction
+
+### Text extraction correctness
+
+- **Adjacent narrow-glyph doublets no longer collapsed at small font sizes (#378, PR #379).**
+  `TextExtractor::deduplicate_overlapping_chars` and
+  `deduplicate_overlapping_spans` used a hardcoded 2 pt absolute threshold to
+  detect duplicate glyphs from stroke+fill render passes. For narrow glyphs
+  (`l`, `r`, `I`, `i`) in compact fonts at small sizes the per-glyph advance
+  width drops to ≤ 2 pt (Helvetica `l` ≈ 2.5 pt at 9 pt), so legitimate
+  adjacent doublets one full advance apart fell inside the dedup window and
+  one of the two glyphs was silently dropped. Visible corruption included
+  `controller → controler`, `billed → biled`, `warranty → warrnty`,
+  `following → folowing`, and `VIII → VII`. Builds on prior #102 / #253,
+  which added same-text and same-character identity guards but kept the 2 pt
+  threshold — this fix addresses the residual case where both glyphs are
+  identical (passing the identity check) yet still legitimate neighbours.
+  Threshold now scales with each glyph's own `advance_width` (fallback
+  `bbox.width`) as `min(advance_width * 0.30, 2.0)`. Real render-pass
+  duplicates sit well under 5 % of one advance apart and continue to
+  collapse; heaviest kerning observed in the wild is ≤ 20 % of advance, so
+  legitimate kerned neighbours are preserved. Tunables hoisted to
+  `TextExtractor::DEDUP_OVERLAP_RATIO` / `DEDUP_OVERLAP_CAP_PT` associated
+  constants so both dedup paths share one source of truth. Regression
+  coverage spans the matrix of four narrow glyphs × three small body-text
+  sizes (7 / 9 / 11 pt) on both the per-char and per-span paths, plus
+  positive cases proving stroke+fill duplicates at ~0 pt offset still
+  collapse.
+
+### Community Contributors
+
+- **[@Hugues-DTANKOUO](https://github.com/Hugues-DTANKOUO)** — Reported #378
+  with a precise root-cause analysis (the 2 pt absolute threshold falling
+  below one advance width for narrow glyphs in compact fonts at small sizes)
+  and authored PR #379 with the advance-scaled threshold and a
+  parametrised regression matrix covering the four narrow glyphs across
+  three body-text sizes.
+
 ## [0.3.34] - 2026-04-18
 > Idiomatic page API, structured tables, column-order, image, and ICC colour fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,7 +2588,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.34"
+version = "0.3.35"
 dependencies = [
  "aes",
  "barcoders",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.34"
+version = "0.3.35"
 dependencies = [
  "clap",
  "is-terminal",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.34"
+version = "0.3.35"
 dependencies = [
  "pdf_oxide",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.34"
+version = "0.3.35"
 # Anchor patterns with a leading slash — Cargo uses gitignore-style globs, so
 # a bare "README.md" matches every README.md recursively (was pulling in 20+
 # subdir READMEs plus js/node_modules/*/README.md into the sdist). Leading /

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.34</Version>
+    <Version>0.3.35</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/go/README.md
+++ b/go/README.md
@@ -16,11 +16,11 @@ go get github.com/yfedoseev/pdf_oxide/go
 # Use @latest to always get the newest release:
 go run github.com/yfedoseev/pdf_oxide/go/cmd/install@latest
 # Or pin to a specific version:
-go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.34
+go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.35
 
 # Installer prints the CGO_* env vars to export — e.g.:
-export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.34/include"
-export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.34/lib/linux_amd64/libpdf_oxide.a \
+export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.35/include"
+export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.35/lib/linux_amd64/libpdf_oxide.a \
   -lm -lpthread -ldl -lrt -lgcc_s -lutil -lc"
 ```
 

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -50,7 +50,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion   = "0.3.34"
+	fallbackVersion   = "0.3.35"
 	BaseURL           = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	DefaultInstallDir = ".pdf_oxide"
 	dirPerm           = 0o750

--- a/go/lib/README.md
+++ b/go/lib/README.md
@@ -8,18 +8,21 @@ repository bloat (Rust staticlibs for 6 platforms).
 ## Install (one-time per machine)
 
 ```bash
-go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.34
+# Always resolves to the matching FFI assets for the installer's own version.
+go run github.com/yfedoseev/pdf_oxide/go/cmd/install@latest
+# Or pin to a specific version:
+go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.35
 ```
 
 The installer detects `GOOS`/`GOARCH`, downloads the matching asset from
-`https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.34/…`, and
-extracts `libpdf_oxide.a` + `pdf_oxide.h` into `~/.pdf_oxide/v0.3.34/`.
+`https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.35/…`, and
+extracts `libpdf_oxide.a` + `pdf_oxide.h` into `~/.pdf_oxide/v0.3.35/`.
 
 It then prints the `CGO_CFLAGS` / `CGO_LDFLAGS` you need to export:
 
 ```
-export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.34/include"
-export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.34/lib/linux_amd64/libpdf_oxide.a -lm -lpthread -ldl -lrt -lgcc_s -lutil -lc"
+export CGO_CFLAGS="-I$HOME/.pdf_oxide/v0.3.35/include"
+export CGO_LDFLAGS="$HOME/.pdf_oxide/v0.3.35/lib/linux_amd64/libpdf_oxide.a -lm -lpthread -ldl -lrt -lgcc_s -lutil -lc"
 ```
 
 After that, `go build` / `go test` work normally.
@@ -30,7 +33,7 @@ If you prefer to wire installation into your own project's build, add this
 to any `.go` file in your project:
 
 ```go
-//go:generate go run github.com/yfedoseev/pdf_oxide/go/cmd/install@v0.3.34 --write-flags=.
+//go:generate go run github.com/yfedoseev/pdf_oxide/go/cmd/install@latest --write-flags=.
 ```
 
 Running `go generate ./...` then drops a `cgo_flags.go` next to your

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.34"
+version = "0.3.35"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.34"
+version = "0.3.35"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.34"
+version = "0.3.35"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2016,6 +2016,24 @@ pub struct TextExtractor {
 }
 
 impl TextExtractor {
+    /// Fraction of a glyph's advance width considered "overlap" for
+    /// duplicate detection. Used by both `deduplicate_overlapping_chars`
+    /// and `deduplicate_overlapping_spans`.
+    ///
+    /// 0.30 comfortably catches real render-pass duplicates
+    /// (stroke+fill, bold shadow, outline+fill) which sit well under
+    /// 5 % of one advance apart, while staying below typical heaviest
+    /// kerning (≤ 20 % of advance) so legitimate narrow-glyph
+    /// neighbours (`ll`, `rr`, `II`, `ii`) are preserved.
+    const DEDUP_OVERLAP_RATIO: f32 = 0.30;
+
+    /// Absolute cap on the overlap window (in PDF points).
+    ///
+    /// Preserves pre-ratio v0.3.x behaviour for pathologically
+    /// oversized advance values (drop-caps, large display text) where
+    /// 30 % of the advance would swallow legitimate neighbours.
+    const DEDUP_OVERLAP_CAP_PT: f32 = 2.0;
+
     /// Create a new text extractor with default configuration.
     ///
     /// # Examples
@@ -2743,30 +2761,23 @@ impl TextExtractor {
     /// first one.
     ///
     /// The threshold is expressed as a fraction of the glyph's `advance_width`
-    /// rather than an absolute point value. Real rendering duplicates
-    /// (stroke+fill, bold shadow, outline+fill) sit at nearly identical
-    /// positions — well under 30 % of one advance apart. Legitimate adjacent
-    /// doublets of narrow glyphs (`ll`, `rr`, `II`, `ii` at small font sizes)
-    /// are separated by one full advance; an absolute threshold of e.g. 2 pt
-    /// would wrongly collapse them on fonts where a narrow glyph's advance
-    /// drops below ~2 pt (e.g. Helvetica at ≤ 9 pt).
+    /// (see [`Self::DEDUP_OVERLAP_RATIO`]) rather than an absolute point
+    /// value. Real rendering duplicates (stroke+fill, bold shadow,
+    /// outline+fill) sit at nearly identical positions — well under 30 % of
+    /// one advance apart. Legitimate adjacent doublets of narrow glyphs
+    /// (`ll`, `rr`, `II`, `ii` at small font sizes) are separated by one
+    /// full advance; an absolute threshold of e.g. 2 pt would wrongly
+    /// collapse them on fonts where a narrow glyph's advance drops below
+    /// ~2 pt (e.g. Helvetica at ≤ 9 pt).
     ///
-    /// Capped at 2 pt to preserve the existing behaviour for pathologically
-    /// oversized advance values, and falls back to `bbox.width` when
-    /// `advance_width` is missing from the font dictionary.
+    /// Capped at [`Self::DEDUP_OVERLAP_CAP_PT`] to preserve the existing
+    /// behaviour for pathologically oversized advance values, and falls
+    /// back to `bbox.width` when `advance_width` is missing from the font
+    /// dictionary.
     fn deduplicate_overlapping_chars(&mut self) {
         if self.chars.is_empty() {
             return;
         }
-
-        /// Fraction of a glyph's advance considered "overlap". 0.30 catches
-        /// the tightest stroke+fill duplicates (~5 % advance apart in the
-        /// wild) without swallowing legitimate narrow-doublet spacing
-        /// (heaviest kerning observed is ≤ 20 % of advance).
-        const OVERLAP_RATIO: f32 = 0.30;
-        /// Absolute cap on the overlap window. Preserves v0.3.x behaviour
-        /// on oversized advance values (drop-caps, large display text).
-        const OVERLAP_CAP_PT: f32 = 2.0;
 
         let mut deduplicated = Vec::with_capacity(self.chars.len());
         let mut prev_y_rounded: Option<i32> = None;
@@ -2782,16 +2793,17 @@ impl TextExtractor {
                 (prev_y_rounded, prev_x, prev_char)
             {
                 // Reference width: advance_width if known, else bbox.width,
-                // else the legacy 2 pt cap (keeps behaviour for pathological
+                // else the legacy cap (keeps behaviour for pathological
                 // inputs without advance metrics).
                 let ref_width = if ch.advance_width > 0.0 {
                     ch.advance_width
                 } else if ch.bbox.width > 0.0 {
                     ch.bbox.width
                 } else {
-                    OVERLAP_CAP_PT
+                    Self::DEDUP_OVERLAP_CAP_PT
                 };
-                let threshold = (ref_width * OVERLAP_RATIO).min(OVERLAP_CAP_PT);
+                let threshold =
+                    (ref_width * Self::DEDUP_OVERLAP_RATIO).min(Self::DEDUP_OVERLAP_CAP_PT);
                 // Same character, same line, and within `threshold` horizontally
                 ch.char == prev_ch && y_rounded == prev_y && (x - prev_x_val).abs() < threshold
             } else {
@@ -3004,20 +3016,16 @@ impl TextExtractor {
     ///   duplicates across columns
     ///
     /// The geometric threshold is expressed as a fraction of the span's
-    /// per-glyph width (bbox.width / char_count), capped at 2 pt. An absolute
-    /// threshold would wrongly collapse legitimate single-glyph spans of
-    /// adjacent narrow glyphs (`ll`, `rr`, `II`, `ii` at small font sizes) in
-    /// PDFs that emit text glyph-by-glyph with kerning.
+    /// per-glyph width (bbox.width / char_count), capped by
+    /// [`Self::DEDUP_OVERLAP_CAP_PT`] and scaled by
+    /// [`Self::DEDUP_OVERLAP_RATIO`]. An absolute threshold would wrongly
+    /// collapse legitimate single-glyph spans of adjacent narrow glyphs
+    /// (`ll`, `rr`, `II`, `ii` at small font sizes) in PDFs that emit text
+    /// glyph-by-glyph with kerning.
     fn deduplicate_overlapping_spans(&mut self) {
         if self.spans.is_empty() {
             return;
         }
-
-        /// Fraction of a span's per-glyph width considered "overlap".
-        /// Mirror of the `deduplicate_overlapping_chars` heuristic.
-        const OVERLAP_RATIO: f32 = 0.30;
-        /// Absolute cap preserving legacy behaviour for oversized spans.
-        const OVERLAP_CAP_PT: f32 = 2.0;
 
         // Phase 0 (B7): same-text overlapping spans from stroke+fill render
         // passes. Maps (newspaper / poster) frequently draw every label
@@ -3055,7 +3063,8 @@ impl TextExtractor {
                 // treated as overlapping with their legitimate neighbour.
                 let char_count = span.text.chars().count().max(1) as f32;
                 let per_glyph_width = (span.bbox.width / char_count).max(0.1);
-                let threshold = (per_glyph_width * OVERLAP_RATIO).min(OVERLAP_CAP_PT);
+                let threshold =
+                    (per_glyph_width * Self::DEDUP_OVERLAP_RATIO).min(Self::DEDUP_OVERLAP_CAP_PT);
                 y_rounded == prev_y && (x - prev_x_val).abs() < threshold && span.text == *prev_txt
             } else {
                 false
@@ -8573,17 +8582,69 @@ mod tests {
 
     #[test]
     fn test_deduplicate_keeps_narrow_glyph_doublets() {
-        // Regression: `ll`, `rr`, `II` in small-font body text were wrongly
-        // collapsed to a single glyph because the dedup threshold was a
-        // hardcoded 2 pt — larger than the advance width of narrow glyphs at
-        // ≤ 9 pt in most fonts (Helvetica `l` ≈ 2.5 pt at 9 pt, smaller
-        // below). This caused visible corruption like `controller → controler`
-        // and `billed → biled`.
+        // Regression: `ll`, `rr`, `II`, `ii` in small-font body text were
+        // wrongly collapsed to a single glyph because the dedup threshold
+        // was a hardcoded 2 pt — larger than the advance width of narrow
+        // glyphs at ≤ 9 pt in most fonts (Helvetica `l` ≈ 2.5 pt at 9 pt,
+        // smaller below). This caused visible corruption like
+        // `controller → controler` and `billed → biled`.
+        //
+        // Exercises the matrix of four narrow glyphs across three small
+        // body-text sizes. Advance widths are the real Helvetica per-em
+        // values (0.278 em for `l`/`i`, 0.333 em for `r`, 0.278 em for `I`).
+        let narrow_char = |c: char, x: f32, font_size: f32, advance_em: f32| TextChar {
+            char: c,
+            bbox: Rect::new(x, 700.0, advance_em * font_size * 0.6, font_size),
+            font_name: "Helvetica".to_string(),
+            font_size,
+            font_weight: FontWeight::Normal,
+            color: Color::black(),
+            mcid: None,
+            is_italic: false,
+            is_monospace: false,
+            origin_x: x,
+            origin_y: 700.0,
+            rotation_degrees: 0.0,
+            advance_width: advance_em * font_size,
+            matrix: None,
+        };
+
+        // (glyph, Helvetica per-em advance width)
+        let cases: &[(char, f32)] = &[('l', 0.278), ('r', 0.333), ('I', 0.278), ('i', 0.278)];
+        // Body-text sizes where narrow-glyph advance falls at or below 2 pt.
+        let sizes: &[f32] = &[7.0, 9.0, 11.0];
+
+        for &(glyph, advance_em) in cases {
+            for &font_size in sizes {
+                let advance = advance_em * font_size;
+                let mut extractor = TextExtractor::new();
+                extractor.chars = vec![
+                    narrow_char(glyph, 100.0, font_size, advance_em),
+                    narrow_char(glyph, 100.0 + advance, font_size, advance_em),
+                ];
+
+                extractor.deduplicate_overlapping_chars();
+                assert_eq!(
+                    extractor.chars.len(),
+                    2,
+                    "Adjacent narrow-glyph doublet ('{glyph}{glyph}') at {font_size} pt \
+                     (advance = {advance:.2} pt) must not be collapsed",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_deduplicate_still_collapses_narrow_glyph_stroke_fill_duplicates() {
+        // Positive regression: even with the advance-scaled threshold,
+        // stroke+fill render passes on narrow glyphs (two `l`s at ~0 pt
+        // offset) must still be collapsed. The ratio (0.30) comfortably
+        // catches real duplicates (< 5 % of one advance apart) while
+        // staying below typical heaviest kerning (~20 %).
         let mut extractor = TextExtractor::new();
 
-        let narrow = |c: char, x: f32| TextChar {
-            char: c,
-            // bbox.width reflects the visible ink (narrower than advance).
+        let narrow_at = |x: f32| TextChar {
+            char: 'l',
             bbox: Rect::new(x, 700.0, 1.5, 9.0),
             font_name: "Helvetica".to_string(),
             font_size: 9.0,
@@ -8595,19 +8656,20 @@ mod tests {
             origin_x: x,
             origin_y: 700.0,
             rotation_degrees: 0.0,
-            // Helvetica `l` advance = 0.278 em → 2.5 pt at 9 pt.
-            advance_width: 2.5,
+            advance_width: 2.5, // 0.278 em × 9 pt
             matrix: None,
         };
 
-        // "ll" in a 9 pt body line: consecutive narrow glyphs one advance apart.
-        extractor.chars = vec![narrow('l', 100.0), narrow('l', 102.5)];
+        // Stroke pass and fill pass typically land within 0.05 pt of each
+        // other (2 % of advance at 9 pt Helvetica `l`).
+        extractor.chars = vec![narrow_at(100.0), narrow_at(100.05)];
 
         extractor.deduplicate_overlapping_chars();
         assert_eq!(
             extractor.chars.len(),
-            2,
-            "Adjacent narrow-glyph doublets (ll, rr, II) must not be collapsed"
+            1,
+            "Stroke+fill narrow-glyph duplicates (same char at ~0 pt offset) \
+             must still be collapsed"
         );
     }
 
@@ -8676,16 +8738,70 @@ mod tests {
     fn test_deduplicate_spans_keeps_narrow_glyph_doublets() {
         // Regression: PDFs that emit kerned text glyph-by-glyph produce
         // consecutive single-character spans. Two adjacent narrow-glyph
-        // spans (`l`, `r`, `I` at ≤ 9 pt) sit roughly one advance-width
+        // spans (`l`, `r`, `I`, `i` at ≤ 9 pt) sit roughly one advance-width
         // apart, which used to fall under the hardcoded 2 pt geometric
         // threshold and get collapsed. The threshold now scales with each
         // span's per-glyph width so legitimate doublets survive.
+        //
+        // Exercises the matrix of four narrow glyphs across three small
+        // body-text sizes.
+        let narrow_span =
+            |glyph: char, x: f32, font_size: f32, advance: f32, seq: usize| TextSpan {
+                artifact_type: None,
+                text: glyph.to_string(),
+                bbox: Rect::new(x, 700.0, advance, font_size),
+                font_name: "Helvetica".to_string(),
+                font_size,
+                font_weight: FontWeight::Normal,
+                color: Color::black(),
+                mcid: None,
+                sequence: seq,
+                split_boundary_before: false,
+                offset_semantic: false,
+                is_italic: false,
+                is_monospace: false,
+                char_spacing: 0.0,
+                word_spacing: 0.0,
+                horizontal_scaling: 100.0,
+                primary_detected: false,
+                char_widths: vec![],
+            };
+
+        // (glyph, Helvetica per-em advance width)
+        let cases: &[(char, f32)] = &[('l', 0.278), ('r', 0.333), ('I', 0.278), ('i', 0.278)];
+        let sizes: &[f32] = &[7.0, 9.0, 11.0];
+
+        for &(glyph, advance_em) in cases {
+            for &font_size in sizes {
+                let advance = advance_em * font_size;
+                let mut extractor = TextExtractor::new();
+                extractor.spans = vec![
+                    narrow_span(glyph, 100.0, font_size, advance, 0),
+                    narrow_span(glyph, 100.0 + advance, font_size, advance, 1),
+                ];
+
+                extractor.deduplicate_overlapping_spans();
+                assert_eq!(
+                    extractor.spans.len(),
+                    2,
+                    "Adjacent single-glyph narrow-doublet spans ('{glyph}{glyph}') \
+                     at {font_size} pt (advance = {advance:.2} pt) must not be collapsed",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_deduplicate_spans_still_collapses_stroke_fill_narrow_glyphs() {
+        // Positive regression: stroke+fill single-glyph narrow spans at
+        // ~0 pt offset must still be collapsed by the geometric dedup
+        // phase. The ratio (0.30) comfortably catches real duplicates
+        // while preserving legitimate doublets.
         let mut extractor = TextExtractor::new();
 
-        let narrow = |x: f32, seq: usize| TextSpan {
+        let narrow_at = |x: f32, seq: usize| TextSpan {
             artifact_type: None,
             text: "l".to_string(),
-            // Per-glyph width (Helvetica `l` ≈ 2.5 pt at 9 pt).
             bbox: Rect::new(x, 700.0, 2.5, 9.0),
             font_name: "Helvetica".to_string(),
             font_size: 9.0,
@@ -8704,14 +8820,15 @@ mod tests {
             char_widths: vec![],
         };
 
-        // "ll" emitted as two single-glyph spans one advance apart.
-        extractor.spans = vec![narrow(100.0, 0), narrow(102.5, 1)];
+        // Stroke pass + fill pass at ~2 % of advance apart.
+        extractor.spans = vec![narrow_at(100.0, 0), narrow_at(100.05, 1)];
 
         extractor.deduplicate_overlapping_spans();
         assert_eq!(
             extractor.spans.len(),
-            2,
-            "Adjacent single-glyph narrow-doublet spans must not be collapsed"
+            1,
+            "Stroke+fill narrow-glyph duplicate spans (same text at ~0 pt offset) \
+             must still be collapsed"
         );
     }
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2738,12 +2738,35 @@ impl TextExtractor {
     /// all renders are extracted. We keep only one character when multiple chars
     /// at nearly the same position exist.
     ///
-    /// Heuristic: If two consecutive characters on the same line (Y rounded to integer)
-    /// are within 2pt horizontally, keep only the first one.
+    /// Heuristic: If two consecutive characters on the same line (Y rounded to
+    /// integer) overlap by a fraction of their own advance width, keep only the
+    /// first one.
+    ///
+    /// The threshold is expressed as a fraction of the glyph's `advance_width`
+    /// rather than an absolute point value. Real rendering duplicates
+    /// (stroke+fill, bold shadow, outline+fill) sit at nearly identical
+    /// positions — well under 30 % of one advance apart. Legitimate adjacent
+    /// doublets of narrow glyphs (`ll`, `rr`, `II`, `ii` at small font sizes)
+    /// are separated by one full advance; an absolute threshold of e.g. 2 pt
+    /// would wrongly collapse them on fonts where a narrow glyph's advance
+    /// drops below ~2 pt (e.g. Helvetica at ≤ 9 pt).
+    ///
+    /// Capped at 2 pt to preserve the existing behaviour for pathologically
+    /// oversized advance values, and falls back to `bbox.width` when
+    /// `advance_width` is missing from the font dictionary.
     fn deduplicate_overlapping_chars(&mut self) {
         if self.chars.is_empty() {
             return;
         }
+
+        /// Fraction of a glyph's advance considered "overlap". 0.30 catches
+        /// the tightest stroke+fill duplicates (~5 % advance apart in the
+        /// wild) without swallowing legitimate narrow-doublet spacing
+        /// (heaviest kerning observed is ≤ 20 % of advance).
+        const OVERLAP_RATIO: f32 = 0.30;
+        /// Absolute cap on the overlap window. Preserves v0.3.x behaviour
+        /// on oversized advance values (drop-caps, large display text).
+        const OVERLAP_CAP_PT: f32 = 2.0;
 
         let mut deduplicated = Vec::with_capacity(self.chars.len());
         let mut prev_y_rounded: Option<i32> = None;
@@ -2758,8 +2781,19 @@ impl TextExtractor {
             let should_skip = if let (Some(prev_y), Some(prev_x_val), Some(prev_ch)) =
                 (prev_y_rounded, prev_x, prev_char)
             {
-                // Same character, same line, and within 2pt horizontally
-                ch.char == prev_ch && y_rounded == prev_y && (x - prev_x_val).abs() < 2.0
+                // Reference width: advance_width if known, else bbox.width,
+                // else the legacy 2 pt cap (keeps behaviour for pathological
+                // inputs without advance metrics).
+                let ref_width = if ch.advance_width > 0.0 {
+                    ch.advance_width
+                } else if ch.bbox.width > 0.0 {
+                    ch.bbox.width
+                } else {
+                    OVERLAP_CAP_PT
+                };
+                let threshold = (ref_width * OVERLAP_RATIO).min(OVERLAP_CAP_PT);
+                // Same character, same line, and within `threshold` horizontally
+                ch.char == prev_ch && y_rounded == prev_y && (x - prev_x_val).abs() < threshold
             } else {
                 false
             };
@@ -2964,12 +2998,26 @@ impl TextExtractor {
     /// Deduplicate overlapping text spans on the same line.
     ///
     /// Uses hybrid geometric + content-based deduplication:
-    /// - Geometric check (same Y, X within 2pt) - catches identical positions
-    /// - Content check (same text, same line Y, different X) - catches duplicates across columns
+    /// - Geometric check (same Y, X within a fraction of the span's per-glyph
+    ///   advance) — catches identical positions
+    /// - Content check (same text, same line Y, different X) — catches
+    ///   duplicates across columns
+    ///
+    /// The geometric threshold is expressed as a fraction of the span's
+    /// per-glyph width (bbox.width / char_count), capped at 2 pt. An absolute
+    /// threshold would wrongly collapse legitimate single-glyph spans of
+    /// adjacent narrow glyphs (`ll`, `rr`, `II`, `ii` at small font sizes) in
+    /// PDFs that emit text glyph-by-glyph with kerning.
     fn deduplicate_overlapping_spans(&mut self) {
         if self.spans.is_empty() {
             return;
         }
+
+        /// Fraction of a span's per-glyph width considered "overlap".
+        /// Mirror of the `deduplicate_overlapping_chars` heuristic.
+        const OVERLAP_RATIO: f32 = 0.30;
+        /// Absolute cap preserving legacy behaviour for oversized spans.
+        const OVERLAP_CAP_PT: f32 = 2.0;
 
         // Phase 0 (B7): same-text overlapping spans from stroke+fill render
         // passes. Maps (newspaper / poster) frequently draw every label
@@ -3002,7 +3050,13 @@ impl TextExtractor {
             let geometric_duplicate = if let (Some(prev_y), Some(prev_x_val), Some(ref prev_txt)) =
                 (prev_y_rounded, prev_x, &prev_text)
             {
-                y_rounded == prev_y && (x - prev_x_val).abs() < 2.0 && span.text == *prev_txt
+                // Threshold scales with the span's per-glyph advance so that
+                // single-glyph narrow spans (`l`, `r`, `I`) are never wrongly
+                // treated as overlapping with their legitimate neighbour.
+                let char_count = span.text.chars().count().max(1) as f32;
+                let per_glyph_width = (span.bbox.width / char_count).max(0.1);
+                let threshold = (per_glyph_width * OVERLAP_RATIO).min(OVERLAP_CAP_PT);
+                y_rounded == prev_y && (x - prev_x_val).abs() < threshold && span.text == *prev_txt
             } else {
                 false
             };
@@ -8517,6 +8571,46 @@ mod tests {
         assert_eq!(extractor.chars[0].char, 'A');
     }
 
+    #[test]
+    fn test_deduplicate_keeps_narrow_glyph_doublets() {
+        // Regression: `ll`, `rr`, `II` in small-font body text were wrongly
+        // collapsed to a single glyph because the dedup threshold was a
+        // hardcoded 2 pt — larger than the advance width of narrow glyphs at
+        // ≤ 9 pt in most fonts (Helvetica `l` ≈ 2.5 pt at 9 pt, smaller
+        // below). This caused visible corruption like `controller → controler`
+        // and `billed → biled`.
+        let mut extractor = TextExtractor::new();
+
+        let narrow = |c: char, x: f32| TextChar {
+            char: c,
+            // bbox.width reflects the visible ink (narrower than advance).
+            bbox: Rect::new(x, 700.0, 1.5, 9.0),
+            font_name: "Helvetica".to_string(),
+            font_size: 9.0,
+            font_weight: FontWeight::Normal,
+            color: Color::black(),
+            mcid: None,
+            is_italic: false,
+            is_monospace: false,
+            origin_x: x,
+            origin_y: 700.0,
+            rotation_degrees: 0.0,
+            // Helvetica `l` advance = 0.278 em → 2.5 pt at 9 pt.
+            advance_width: 2.5,
+            matrix: None,
+        };
+
+        // "ll" in a 9 pt body line: consecutive narrow glyphs one advance apart.
+        extractor.chars = vec![narrow('l', 100.0), narrow('l', 102.5)];
+
+        extractor.deduplicate_overlapping_chars();
+        assert_eq!(
+            extractor.chars.len(),
+            2,
+            "Adjacent narrow-glyph doublets (ll, rr, II) must not be collapsed"
+        );
+    }
+
     // ========================================================================
     // NEW COMPREHENSIVE TESTS: Span deduplication
     // ========================================================================
@@ -8576,6 +8670,49 @@ mod tests {
         let mut extractor = TextExtractor::new();
         extractor.deduplicate_overlapping_spans();
         assert!(extractor.spans.is_empty());
+    }
+
+    #[test]
+    fn test_deduplicate_spans_keeps_narrow_glyph_doublets() {
+        // Regression: PDFs that emit kerned text glyph-by-glyph produce
+        // consecutive single-character spans. Two adjacent narrow-glyph
+        // spans (`l`, `r`, `I` at ≤ 9 pt) sit roughly one advance-width
+        // apart, which used to fall under the hardcoded 2 pt geometric
+        // threshold and get collapsed. The threshold now scales with each
+        // span's per-glyph width so legitimate doublets survive.
+        let mut extractor = TextExtractor::new();
+
+        let narrow = |x: f32, seq: usize| TextSpan {
+            artifact_type: None,
+            text: "l".to_string(),
+            // Per-glyph width (Helvetica `l` ≈ 2.5 pt at 9 pt).
+            bbox: Rect::new(x, 700.0, 2.5, 9.0),
+            font_name: "Helvetica".to_string(),
+            font_size: 9.0,
+            font_weight: FontWeight::Normal,
+            color: Color::black(),
+            mcid: None,
+            sequence: seq,
+            split_boundary_before: false,
+            offset_semantic: false,
+            is_italic: false,
+            is_monospace: false,
+            char_spacing: 0.0,
+            word_spacing: 0.0,
+            horizontal_scaling: 100.0,
+            primary_detected: false,
+            char_widths: vec![],
+        };
+
+        // "ll" emitted as two single-glyph spans one advance apart.
+        extractor.spans = vec![narrow(100.0, 0), narrow(102.5, 1)];
+
+        extractor.deduplicate_overlapping_spans();
+        assert_eq!(
+            extractor.spans.len(),
+            2,
+            "Adjacent single-glyph narrow-doublet spans must not be collapsed"
+        );
     }
 
     // ========================================================================

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- Cherry-picks PR #379 (by @Hugues-DTANKOUO) which fixes #378: narrow-glyph doublets (`ll`, `rr`, `tt`, `ff`, `II`, `ii`) collapsing in `extract_chars`/`extract_spans` because the dedup window used a hardcoded 2 pt threshold larger than one advance width for narrow glyphs in compact fonts at small sizes. Threshold now scales as `min(advance_width * 0.30, 2.0)`. Tunables hoisted to `TextExtractor::DEDUP_OVERLAP_RATIO` / `DEDUP_OVERLAP_CAP_PT`.
- Bumps version 0.3.34 → 0.3.35 across all packages: `Cargo.toml`, `pdf_oxide_cli`, `pdf_oxide_mcp`, `Cargo.lock`, `pyproject.toml`, `js/package.json`, `wasm-pkg/package.json`, `csharp/PdfOxide.csproj`, `go/cmd/install/main.go` (`fallbackVersion`), and the two Go READMEs.
- `go/lib/README.md` now documents `@latest` as the recommended Go install command (matching `go/README.md`).
- CHANGELOG.md entry under `[0.3.35] - 2026-04-19` with `Text extraction correctness` and `Community Contributors` sections crediting [@Hugues-DTANKOUO](https://github.com/Hugues-DTANKOUO) for both the report and the PR.

## Regression validation

Ran `extract_text_simple` on 318 PDFs (academic, government, forms, newspapers, IRS, issue-regression, pdfium corpora) comparing v0.3.34 baseline vs this branch:

| Status | Count |
|---|---:|
| UNCHANGED | 244 |
| DIFFERS_BYTE (sub-1%) | 71 |
| SIMILAR (1-5%) | 1 |
| BOTH_FAIL (pre-existing parser errors, identical on both versions) | 2 |
| BASE_FAIL / HEAD_FAIL / SHRUNK / EXPANDED | 0 |

**Bug fix confirmed in real corpus.** Direct evidence in `pdfs/academic/arxiv_2510.25332v1.pdf`:
- BASE `Data Col ection` → HEAD `Data Collection`
- BASE `striped backstil` → HEAD `striped backstill`
- BASE `. .` → HEAD `...`

Across the full sample, **9 narrow-doublet words newly appear** on HEAD that were missing on BASE (`backstill`, `bottom`, `followed`, `fully`, `pulling`, `putting`, `sitting`, `swatter`, `umbrella`, plus `allg`, `tti`, `https` in three other PDFs). **Zero doublet words are lost** on HEAD — no inverse regression.

## Test plan

- [x] `cargo build --release --example extract_text_simple` (both branch and v0.3.34 baseline)
- [x] 318-PDF text-extraction regression vs v0.3.34 (no regressions, fix confirmed)
- [x] PR #379 author ran `cargo test --lib` (4409 passed) + clippy + fmt
- [ ] Full release-pipeline CI (Python wheels, Node prebuilds, WASM, C# NativeAOT, Go installer)

Closes #378.