### PR TITLE
fix(layout): font-size-relative same-line tolerance in text assembly

### DIFF
--- a/src/bin/debug_extraction.rs
+++ b/src/bin/debug_extraction.rs
@@ -67,13 +67,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("=== SPACING ANALYSIS ===\n");
             println!("Analyzing gaps between consecutive spans on same line:\n");
 
-            let line_tolerance = 2.0;
             let mut prev_idx: Option<usize> = None;
 
             for (i, span) in spans.iter().enumerate() {
                 if let Some(prev_i) = prev_idx {
                     let prev = &spans[prev_i];
                     let y_diff = (prev.bbox.y - span.bbox.y).abs();
+
+                    // Same-line tolerance scales with the larger of the two
+                    // font sizes so superscripts and subscripts stay on the
+                    // line they belong to (matches PdfDocument::same_line_threshold).
+                    let line_tolerance = prev.font_size.max(span.font_size).max(1.0) * 0.5;
 
                     // Same line check
                     if y_diff < line_tolerance {

--- a/src/bin/debug_extraction.rs
+++ b/src/bin/debug_extraction.rs
@@ -79,8 +79,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // line they belong to (matches PdfDocument::same_line_threshold).
                     let line_tolerance = prev.font_size.max(span.font_size).max(1.0) * 0.5;
 
-                    // Same line check
-                    if y_diff < line_tolerance {
+                    // Same-line check. Uses `<=` so the boundary case
+                    // (y_diff exactly equal to the tolerance) is
+                    // classified as same-line. Production treats a span
+                    // as a new line only when `y_diff > threshold`, so
+                    // the equality case belongs on the same-line side;
+                    // this debug tool should report boundary deltas the
+                    // same way.
+                    if y_diff <= line_tolerance {
                         let gap = span.bbox.x - (prev.bbox.x + prev.bbox.width);
                         let space_threshold = prev.font_size * 0.25;
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -4290,7 +4290,7 @@ impl PdfDocument {
                     let gap = span.bbox.x - prev_end_x;
                     let delta_x = span.bbox.x - prev.bbox.x;
 
-                    if y_diff > 2.0 {
+                    if y_diff > Self::same_line_threshold(prev, span) {
                         let font_size = span.font_size.max(10.0);
                         let line_height = font_size * 1.2;
                         let num_breaks = (y_diff / line_height).round() as usize;
@@ -4304,21 +4304,15 @@ impl PdfDocument {
                                 text.push('\n');
                             }
                         } else if delta_x < -fs * 3.0 {
-                            // Same baseline (y_diff <= 2.0) but the
-                            // current span starts well to the LEFT of
-                            // the previous span's start — i.e., the
-                            // upstream sort handed us spans in
-                            // non-monotonic X order. Common cause: a
-                            // multi-column page whose XY-cut routing
-                            // groups column-side spans across rows so
-                            // adjacent iteration items belong to
-                            // different visual rows that happen to
-                            // share a Y band. Without a separator the
-                            // texts glue together (e.g.
-                            // `instancesinstancesinstances` from three
-                            // table-header cells in a stats grid).
-                            // Treat the backwards jump as a logical
-                            // break and emit a newline.
+                            // Same visual line, but the current span starts well to the LEFT of the
+                            // previous span's start — i.e., the upstream ordering is non-monotonic in X.
+                            // This commonly occurs with multi-column layouts or XY-cut artifacts where
+                            // spans from different visual rows fall within the same Y tolerance band
+                            // (see `same_line_threshold`).
+                            //
+                            // Without inserting a separator, these spans would be concatenated
+                            // (e.g. `instancesinstancesinstances` from adjacent table headers).
+                            // Treat this backward X jump as a logical break and emit a newline.
                             if !text.ends_with('\n') {
                                 text.push('\n');
                             }
@@ -5157,6 +5151,16 @@ impl PdfDocument {
                 char::from_u32(base).unwrap_or(c)
             })
             .collect()
+    }
+
+    /// Returns the Y tolerance (in points) for treating two spans as
+    /// belonging to the same visual line during text assembly.
+    ///
+    /// The threshold scales with the larger font size so mixed-size runs
+    /// (for example superscripts and subscripts) are not split by a fixed
+    /// absolute tolerance.
+    fn same_line_threshold(prev: &TextSpan, current: &TextSpan) -> f32 {
+        prev.font_size.max(current.font_size).max(1.0) * 0.5
     }
 
     /// # Returns
@@ -6221,7 +6225,7 @@ impl PdfDocument {
                     if let Some(prev) = prev_span {
                         let y_diff = (prev.bbox.y - span.bbox.y).abs();
 
-                        if y_diff > 2.0 {
+                        if y_diff > Self::same_line_threshold(prev, span) {
                             let font_size = span.font_size.max(10.0);
                             let line_height = font_size * 1.2;
                             let num_breaks = (y_diff / line_height).round() as usize;
@@ -6270,7 +6274,7 @@ impl PdfDocument {
                 for span in *spans {
                     if let Some(prev) = prev_span {
                         let y_diff = (prev.bbox.y - span.bbox.y).abs();
-                        if y_diff > 2.0 {
+                        if y_diff > Self::same_line_threshold(prev, span) {
                             text.push('\n');
                         } else if Self::should_insert_space(prev, span) {
                             text.push(' ');
@@ -6299,7 +6303,7 @@ impl PdfDocument {
             for span in &spans_without_mcid {
                 if let Some(prev) = prev_span {
                     let y_diff = (prev.bbox.y - span.bbox.y).abs();
-                    if y_diff > 2.0 {
+                    if y_diff > Self::same_line_threshold(prev, span) {
                         text.push('\n');
                     } else if Self::should_insert_space(prev, span) {
                         text.push(' ');
@@ -6402,7 +6406,7 @@ impl PdfDocument {
                 for span in spans {
                     if let Some(prev) = prev_span {
                         let y_diff = (prev.bbox.y - span.bbox.y).abs();
-                        if y_diff > 2.0 {
+                        if y_diff > Self::same_line_threshold(prev, span) {
                             let font_size = span.font_size.max(10.0);
                             let line_height = font_size * 1.2;
                             let num_breaks = (y_diff / line_height).round() as usize;
@@ -6443,7 +6447,7 @@ impl PdfDocument {
                 for span in *spans {
                     if let Some(prev) = prev_span {
                         let y_diff = (prev.bbox.y - span.bbox.y).abs();
-                        if y_diff > 2.0 {
+                        if y_diff > Self::same_line_threshold(prev, span) {
                             text.push('\n');
                         } else if Self::should_insert_space(prev, span) {
                             text.push(' ');
@@ -6477,7 +6481,7 @@ impl PdfDocument {
             for span in &spans_without_mcid {
                 if let Some(prev) = prev_span {
                     let y_diff = (prev.bbox.y - span.bbox.y).abs();
-                    if y_diff > 2.0 {
+                    if y_diff > Self::same_line_threshold(prev, span) {
                         text.push('\n');
                     } else if Self::should_insert_space(prev, span) {
                         text.push(' ');

--- a/src/document.rs
+++ b/src/document.rs
@@ -124,6 +124,16 @@ const DEFAULT_OBJECT_CACHE_MAX_BYTES: usize = 64 * 1024 * 1024;
 /// Default maximum number of entries for the XObject span/image caches.
 const DEFAULT_XOBJECT_CACHE_MAX_ENTRIES: usize = 1024;
 
+/// Heuristic multiplier for the forward-gap guard in the main
+/// assembly loop's compound newline predicate
+/// (`y_diff > 2.0 && gap > K * max(fs)`). Visual gap-sweep over
+/// synthetic two-column examples at fs=10 and fs=14 placed the
+/// plausible operating band at roughly 0.7-1.5; 1.25 is a
+/// conservative interim pick. Not corpus-calibrated; a page-level
+/// layout signal would be a stronger long-term replacement for
+/// this pairwise heuristic.
+const FORWARD_GAP_K: f32 = 1.25;
+
 // Re-export BoundedEntryCache from cache module for local use and backward compatibility
 pub(crate) use crate::cache::BoundedEntryCache;
 
@@ -4291,7 +4301,7 @@ impl PdfDocument {
                     let delta_x = span.bbox.x - prev.bbox.x;
 
                     if y_diff > Self::same_line_threshold(prev, span) {
-                        let font_size = span.font_size.max(10.0);
+                        let font_size = prev.font_size.max(span.font_size).max(10.0);
                         let line_height = font_size * 1.2;
                         let num_breaks = (y_diff / line_height).round() as usize;
                         for _ in 0..num_breaks.clamp(1, 3) {
@@ -4344,6 +4354,16 @@ impl PdfDocument {
                             // -1.75 pt and -12.75 pt sit alongside
                             // delta_x values of 56 pt and 78 pt.
                             text.push(' ');
+                        }
+                    } else if y_diff > 2.0
+                        && gap > FORWARD_GAP_K * prev.font_size.max(span.font_size).max(1.0)
+                    {
+                        // Forward-gap guard: pairs newly admitted to same-line
+                        // handling by the widened threshold get a column/field-
+                        // boundary check against FORWARD_GAP_K * max(fs). See
+                        // the constant's doc comment for calibration notes.
+                        if !text.ends_with('\n') {
+                            text.push('\n');
                         }
                     } else if Self::should_insert_space(prev, span) {
                         text.push(' ');
@@ -5169,10 +5189,11 @@ impl PdfDocument {
         // Get font size (use the larger of the two)
         let font_size = prev.font_size.max(current.font_size).max(1.0);
 
-        // Check if spans are on the same line
-        // Y difference should be small (< 30% of font size)
+        // Same-line gate. Uses the shared threshold so the assembly
+        // loop's same-line decision and the space-insertion decision
+        // cannot disagree about where a line ends.
         let y_diff = (prev.bbox.y - current.bbox.y).abs();
-        if y_diff > font_size * 0.3 {
+        if y_diff > Self::same_line_threshold(prev, current) {
             return false; // Different lines - no space needed
         }
 
@@ -6226,7 +6247,7 @@ impl PdfDocument {
                         let y_diff = (prev.bbox.y - span.bbox.y).abs();
 
                         if y_diff > Self::same_line_threshold(prev, span) {
-                            let font_size = span.font_size.max(10.0);
+                            let font_size = prev.font_size.max(span.font_size).max(10.0);
                             let line_height = font_size * 1.2;
                             let num_breaks = (y_diff / line_height).round() as usize;
                             for _ in 0..num_breaks.clamp(1, 3) {
@@ -6407,7 +6428,7 @@ impl PdfDocument {
                     if let Some(prev) = prev_span {
                         let y_diff = (prev.bbox.y - span.bbox.y).abs();
                         if y_diff > Self::same_line_threshold(prev, span) {
-                            let font_size = span.font_size.max(10.0);
+                            let font_size = prev.font_size.max(span.font_size).max(10.0);
                             let line_height = font_size * 1.2;
                             let num_breaks = (y_diff / line_height).round() as usize;
                             for _ in 0..num_breaks.clamp(1, 3) {

--- a/tests/test_line_grouping_dead_band.rs
+++ b/tests/test_line_grouping_dead_band.rs
@@ -1,0 +1,190 @@
+//! Regression tests for the widened same-line threshold fix:
+//! forward-gap guard, `should_insert_space` harmonization, and
+//! threshold-boundary behavior.
+
+use pdf_oxide::document::PdfDocument;
+use pdf_oxide::writer::{PageBuilder, PdfWriter};
+
+fn put(page: &mut PageBuilder<'_>, text: &str, x: f32, y: f32, font: &str, size: f32) {
+    page.add_text(text, x, y, font, size);
+    // Force a BT/ET boundary so adjacent add_text calls are emitted as
+    // separate text objects. Without this, the extractor may merge them
+    // into a single span, making these regression assertions ineffective.
+    page.draw_rect(0.0, 0.0, 0.0, 0.0);
+}
+
+fn build_and_extract(build_fn: impl FnOnce(&mut PdfWriter)) -> String {
+    let mut writer = PdfWriter::new();
+    build_fn(&mut writer);
+    let bytes = writer.finish().expect("build PDF");
+    let mut doc = PdfDocument::from_bytes(bytes).expect("open PDF");
+    doc.extract_text(0).expect("extract page 0")
+}
+
+fn newline_between(out: &str, before: &str, after: &str) -> bool {
+    let a = out
+        .find(before)
+        .unwrap_or_else(|| panic!("missing {:?}: {:?}", before, out));
+    let b = out
+        .find(after)
+        .unwrap_or_else(|| panic!("missing {:?}: {:?}", after, out));
+    out[a + before.len()..b].contains('\n')
+}
+
+// A. Title (20pt) + small right-aligned marker (10pt), y_diff=4.5pt.
+#[test]
+fn title_plus_right_aligned_marker_splits() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "Form 1040", 72.0, 700.0, "Helvetica", 20.0);
+        put(&mut page, "(Rev. Jan 2024)", 260.0, 695.5, "Helvetica", 10.0);
+    });
+
+    assert!(newline_between(&out, "Form 1040", "(Rev. Jan 2024)"), "got {:?}", out);
+}
+
+// B. Header (16pt) + small instruction (9pt), y_diff=3.5pt.
+#[test]
+fn header_plus_small_instruction_splits() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "Section 3", 72.0, 700.0, "Helvetica", 16.0);
+        put(&mut page, "(see instructions)", 240.0, 696.5, "Helvetica", 9.0);
+    });
+
+    assert!(newline_between(&out, "Section 3", "(see instructions)"), "got {:?}", out);
+}
+
+// C. Body (11pt) + small annotation (8pt) in dead-band, y_diff=3.5pt.
+#[test]
+fn body_plus_small_annotation_splits() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "See reference 12", 72.0, 700.0, "Helvetica", 11.0);
+        put(&mut page, "[updated 2024]", 220.0, 696.5, "Helvetica", 8.0);
+    });
+
+    assert!(newline_between(&out, "See reference 12", "[updated 2024]"), "got {:?}", out);
+}
+
+// D. Two-row small-gutter dead-band layout. K=1.5 accepts narrow intra-row
+// gaps as residual — pin row-boundary integrity only.
+#[test]
+fn small_gutter_dead_band_rows_preserved() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "AA1", 72.0, 700.0, "Helvetica", 10.0);
+        put(&mut page, "BB1", 92.0, 700.0, "Helvetica", 10.0);
+        put(&mut page, "AA2", 72.0, 685.6, "Helvetica", 10.0);
+        put(&mut page, "BB2", 92.0, 682.1, "Helvetica", 10.0);
+    });
+
+    assert!(newline_between(&out, "BB1", "AA2"), "got {:?}", out);
+}
+
+// E1. 12pt pair at y_diff=5.99 < 6.0 = 0.5*max(fs): stays same-line.
+#[test]
+fn threshold_boundary_inside_stays_same_line() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "LLL", 72.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "RRR", 95.0, 694.01, "Helvetica", 12.0);
+    });
+
+    let out = out.trim_end();
+    assert!(!newline_between(out, "LLL", "RRR"), "got {:?}", out);
+}
+
+// E2. 12pt pair at y_diff=6.01 > 6.0: splits into two lines.
+#[test]
+fn threshold_boundary_outside_splits() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "LLL", 72.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "RRR", 95.0, 693.99, "Helvetica", 12.0);
+    });
+
+    assert!(newline_between(&out, "LLL", "RRR"), "got {:?}", out);
+}
+
+// 12pt pair at y_diff=1.5 (below old 2.0 threshold): the forward-gap
+// guard's y_diff gate must not fire even with a wide word-spacing gap.
+#[test]
+fn pair_below_old_threshold_space_merges() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "Alpha", 100.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "Beta", 180.0, 698.5, "Helvetica", 12.0);
+    });
+
+    let out = out.trim_end();
+    assert!(out.contains("Alpha Beta"), "got {:?}", out);
+}
+
+// 12pt pair in dead-band (y_diff=4.0) with a narrow gap ~5pt
+// (gap/fs ≈ 0.4): documented residual — space-merges rather than splits.
+#[test]
+fn pair_dead_band_narrow_gap_space_merges() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "First", 100.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "Second", 128.0, 696.0, "Helvetica", 12.0);
+    });
+
+    let out = out.trim_end();
+    assert!(out.contains("First Second"), "got {:?}", out);
+    assert!(!newline_between(out, "First", "Second"), "got {:?}", out);
+}
+
+// 12pt pair at y_diff=7.0 (above the 6.0 same-line threshold): splits.
+#[test]
+fn pair_above_new_threshold_splits() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "High", 100.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "Low", 100.0, 693.0, "Helvetica", 12.0);
+    });
+
+    assert!(newline_between(&out, "High", "Low"), "got {:?}", out);
+}
+
+// Wide-gutter two-column, fs=10, intra-row y_diff=4.0 and gap >> 1.5*fs.
+// Forward-gap guard fires regardless of the dead-band Y-jitter.
+#[test]
+fn wide_gutter_dead_band_column_splits() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "Left", 80.0, 700.0, "Helvetica", 10.0);
+        put(&mut page, "Right", 400.0, 696.0, "Helvetica", 10.0);
+    });
+
+    assert!(newline_between(&out, "Left", "Right"), "got {:?}", out);
+}
+
+// F. Aligned two-column negative control — fix must not change extraction
+// when every row has identical baselines.
+#[test]
+fn aligned_two_column_extracts_unchanged() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "HdrLeft", 72.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "HdrRight", 300.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "BodyLeft", 72.0, 685.6, "Helvetica", 12.0);
+        put(&mut page, "BodyRight", 300.0, 685.6, "Helvetica", 12.0);
+        put(&mut page, "FootLeft", 72.0, 671.2, "Helvetica", 12.0);
+        put(&mut page, "FootRight", 300.0, 671.2, "Helvetica", 12.0);
+    });
+
+    for cell in [
+        "HdrLeft",
+        "HdrRight",
+        "BodyLeft",
+        "BodyRight",
+        "FootLeft",
+        "FootRight",
+    ] {
+        assert!(out.contains(cell), "missing {:?}: {:?}", cell, out);
+    }
+    assert!(newline_between(&out, "HdrRight", "BodyLeft"), "got {:?}", out);
+    assert!(newline_between(&out, "BodyRight", "FootLeft"), "got {:?}", out);
+}

--- a/tests/test_superscript_line_grouping.rs
+++ b/tests/test_superscript_line_grouping.rs
@@ -1,0 +1,109 @@
+use pdf_oxide::document::PdfDocument;
+use pdf_oxide::writer::{PageBuilder, PdfWriter};
+
+fn put(page: &mut PageBuilder<'_>, text: &str, x: f32, y: f32, font: &str, size: f32) {
+    page.add_text(text, x, y, font, size);
+    // Force a BT/ET boundary so adjacent add_text calls are emitted as
+    // separate text objects. Without this, the extractor may merge them
+    // into a single span, making these regression assertions ineffective.
+    page.draw_rect(0.0, 0.0, 0.0, 0.0);
+}
+
+fn build_and_extract(build_fn: impl FnOnce(&mut PdfWriter)) -> String {
+    let mut writer = PdfWriter::new();
+    build_fn(&mut writer);
+    let bytes = writer.finish().expect("build PDF");
+    let mut doc = PdfDocument::from_bytes(bytes).expect("open PDF");
+    doc.extract_text(0).expect("extract page 0")
+}
+
+#[test]
+fn superscript_12pt_offset_stays_on_one_line() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "8", 140.0, 180.0, "Helvetica", 28.0);
+        put(&mut page, "th", 156.0, 192.0, "Helvetica", 20.0);
+    });
+
+    let out = out.trim_end();
+    assert!(!out.contains('\n'), "got {:?}", out);
+    assert!(out.contains('8') && out.contains("th"), "got {:?}", out);
+}
+
+#[test]
+fn baseline_same_y_stays_on_one_line() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "8", 140.0, 180.0, "Helvetica", 28.0);
+        put(&mut page, "th", 156.0, 180.0, "Helvetica", 20.0);
+    });
+
+    assert_eq!(out.trim_end(), "8th", "got {:?}", out.trim_end());
+}
+
+#[test]
+fn two_lines_normal_leading_still_split() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "First line of body text.", 72.0, 700.0, "Helvetica", 12.0);
+        put(&mut page, "Second line of body text.", 72.0, 685.6, "Helvetica", 12.0);
+    });
+
+    let first = out.find("First line").expect("first line present");
+    let second = out.find("Second line").expect("second line present");
+    let between = &out[first + "First line".len()..second];
+    assert!(between.contains('\n'), "got {:?}", out);
+}
+
+#[test]
+fn multi_line_body_text_preserves_breaks() {
+    let lines = [
+        "LineAAA", "LineBBB", "LineCCC", "LineDDD", "LineEEE", "LineFFF",
+    ];
+
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        let mut y = 700.0;
+        for line in &lines {
+            put(&mut page, line, 72.0, y, "Helvetica", 12.0);
+            y -= 14.4;
+        }
+    });
+
+    for pair in lines.windows(2) {
+        let a = out
+            .find(pair[0])
+            .unwrap_or_else(|| panic!("missing {:?}: {:?}", pair[0], out));
+        let b = out
+            .find(pair[1])
+            .unwrap_or_else(|| panic!("missing {:?}: {:?}", pair[1], out));
+        let between = &out[a + pair[0].len()..b];
+        assert!(
+            between.contains('\n'),
+            "missing newline between {:?} and {:?}: {:?}",
+            pair[0],
+            pair[1],
+            out
+        );
+    }
+}
+
+#[test]
+fn superscript_then_next_line_still_breaks() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "8", 140.0, 700.0, "Helvetica", 28.0);
+        put(&mut page, "th", 156.0, 712.0, "Helvetica", 20.0);
+        put(&mut page, "Next paragraph line.", 72.0, 672.0, "Helvetica", 12.0);
+    });
+
+    assert!(out.contains('8') && out.contains("th"), "got {:?}", out);
+
+    let super_end = out
+        .find("th")
+        .or_else(|| out.find('8'))
+        .expect("superscript present");
+    let body_start = out.find("Next paragraph line").expect("body line present");
+    let between = &out[super_end..body_start];
+    assert!(between.contains('\n'), "got {:?}", out);
+}


### PR DESCRIPTION
`extract_text_with_options` and six sibling Tagged-PDF assembly paths used a hard-coded `y_diff > 2.0` newline gate. That splits realistic mixed-size inline runs onto separate lines: a 12 pt superscript offset on a 28 pt base (`8` + raised `th`) emits `th\n8` instead of staying on one line.

The fix is to factor the decision into `PdfDocument::same_line_threshold(prev, cur)` and use a font-size-relative threshold:

    max(prev.font_size, cur.font_size).max(1.0) * 0.5

This removes the hard-coded constant and makes the decision scale with the text being compared. Using `max(a, b)` keeps it order-independent and consistent with other font-relative heuristics already in the codebase.

In addition, this revision aligns the surrounding logic so that widening the same-line threshold does not introduce inconsistencies elsewhere:
- the spacing gate (`should_insert_space`) now uses the same threshold
- a forward-gap guard is applied to prevent cross-column merges in reading order
- line-height / `num_breaks` calculations use the same font-size basis

This PR fixes line grouping only. Mixed-size spans now remain on the same output line, but intra-line ordering is unchanged (`th8` vs `8th`). Ordering is addressed in a follow-up PR.

Regression coverage is synthetic (`PdfWriter`-built, no external PDF fixtures): superscript stays on one line, baseline same-Y case remains `8th`, normal 14.4 pt body leading still splits, multi-line body text preserves breaks, and a superscript followed by a true next line still emits a newline.

## Description

Fix same-line detection for mixed-size inline spans in text assembly by replacing the hard-coded 2 pt newline threshold with a font-size-relative helper shared across the untagged and Tagged-PDF assembly paths, and by aligning newline and spacing decisions to avoid inconsistent behaviour.

See [superscript.pdf](https://github.com/user-attachments/files/26949823/superscript.pdf):

- Before: `th\n8`
- After: `th8`

This is still not the correct final output (`8th`), but it fixes the line-grouping error. Correct intra-line ordering is handled separately.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Tests
- [ ] CI/CD changes

## Related Issues

Relates to #456

## Changes Made

<!-- List the main changes made in this PR -->

- Replaced the hard-coded `2.0` same-line/newline threshold in `extract_text_with_options` and six sibling Tagged-PDF assembly paths with `PdfDocument::same_line_threshold(prev, cur)`
- Added a shared font-size-relative helper using `max(prev.font_size, cur.font_size).max(1.0) * 0.5`
- Updated `should_insert_space` to use the same threshold, removing inconsistent newline/spacing behaviour
- Added a forward-gap guard (`gap > K * max(fs)`) to prevent cross-column merges in reading order
- Aligned font-size usage in line-height / `num_breaks` calculations
- Updated `debug_extraction` to use the same tolerance
- Added synthetic regression tests built with PdfWriter so the reproducer does not depend on external PDF fixtures

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I ran the targeted regression tests for this fix locally and they pass.  
  `cargo test --all-features -- --skip wasm::` currently fails on an unrelated  
  pre-existing serialization test (`document::tests::test_page_text_serializable`)  
  both before and after my change.
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

Tests run locally

- [x] `cargo test --test test_superscript_line_grouping`

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)

<img width="100" height="95" alt="image" src="https://github.com/user-attachments/assets/99582237-e731-4bf9-ab28-51acd90d0b0b" />

Before: `th\n8`  
After: `th8`  

This is still not the correct final ordering (`8th`), but it resolves the incorrect line break.

## Additional Notes

This PR fixes a line-grouping issue. It intentionally leaves intra-line ordering as a separate concern for a follow-up change.