### PR TITLE
fix(tables): tolerate sub-pixel drift in table-retain containment

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -4080,6 +4080,19 @@ impl PdfDocument {
             // the span list so `reorder_rowspan_labels` below can
             // promote them to the top of their row block.
             if !tables.is_empty() {
+                // Absorb floating-point accumulation error in the
+                // difference between a span's directly-computed
+                // bbox.right (origin + width, small accumulation)
+                // and a table bbox.right (min/max reduction across
+                // many cell edges, larger accumulation). Without
+                // this slack, a span whose real geometry is inside
+                // the table by construction but whose f32 right-edge
+                // exceeds the table's f32 right-edge by ~0.01–0.05pt
+                // gets wrongly kept in the flow stream, producing
+                // duplicated output. 0.1pt is well below any
+                // visually meaningful PDF layout distance.
+                const RETAIN_TOLERANCE: f32 = 0.1;
+
                 // Build the set of cell text strings that every detected
                 // table will render via `table.render_text()`. Labels
                 // whose exact text already appears as a cell in some
@@ -4124,18 +4137,26 @@ impl PdfDocument {
 
                 if preserved_label_indices.is_empty() {
                     spans.retain(|s| {
-                        !tables
-                            .iter()
-                            .any(|t| t.bbox.is_some_and(|b| b.contains_rect(&s.bbox)))
+                        !tables.iter().any(|t| {
+                            t.bbox.is_some_and(|b| {
+                                Self::contains_rect_with_tolerance(&b, &s.bbox, RETAIN_TOLERANCE)
+                            })
+                        })
                     });
                 } else {
                     let kept: Vec<crate::layout::TextSpan> = spans
                         .drain(..)
                         .enumerate()
                         .filter_map(|(i, s)| {
-                            let in_table = tables
-                                .iter()
-                                .any(|t| t.bbox.is_some_and(|b| b.contains_rect(&s.bbox)));
+                            let in_table = tables.iter().any(|t| {
+                                t.bbox.is_some_and(|b| {
+                                    Self::contains_rect_with_tolerance(
+                                        &b,
+                                        &s.bbox,
+                                        RETAIN_TOLERANCE,
+                                    )
+                                })
+                            });
                             if !in_table || preserved_label_indices.contains(&i) {
                                 Some(s)
                             } else {
@@ -5157,6 +5178,22 @@ impl PdfDocument {
                 char::from_u32(base).unwrap_or(c)
             })
             .collect()
+    }
+
+    /// Returns `true` if `inner` is contained within `outer`,
+    /// allowing `eps` points of floating-point slack on all four
+    /// edges. Used at the table-retain sites to absorb ~0.02pt drift
+    /// in span right-edges relative to table bboxes computed from
+    /// min/max reductions over many cell edges.
+    fn contains_rect_with_tolerance(
+        outer: &crate::geometry::Rect,
+        inner: &crate::geometry::Rect,
+        eps: f32,
+    ) -> bool {
+        inner.left() >= outer.left() - eps
+            && inner.right() <= outer.right() + eps
+            && inner.top() >= outer.top() - eps
+            && inner.bottom() <= outer.bottom() + eps
     }
 
     /// # Returns
@@ -15452,5 +15489,78 @@ mod tests {
         // Should return a finite value without panicking
         let size = BoundedObjectCache::estimate_size(&obj);
         assert!(size > 0);
+    }
+
+    // -----------------------------------------------------------------
+    // PdfDocument::contains_rect_with_tolerance
+    //
+    // Pins the table-retain tolerance behaviour: spans whose f32
+    // right-edge drifts a fraction of a point past the table bbox
+    // (due to accumulated width-sum error) must still count as
+    // contained, but spans that actually extend beyond the table
+    // must not. Each test's first block is a geometry sanity check
+    // so a Rect::new construction mistake fails loudly rather than
+    // silently exercising the wrong geometry.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn contains_rect_with_tolerance_absorbs_subpixel_drift() {
+        use crate::geometry::Rect;
+        let table = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let drifted = Rect::new(10.0, 10.0, 90.02, 80.0);
+
+        // Geometry sanity: drifted span right-edge should sit ~0.02pt
+        // past table right-edge. If this fails, the test construction
+        // is wrong, not the tolerance logic. Tolerance is 1e-4pt
+        // because `0.02f32` is not representable exactly — the
+        // observed drift lands within ~4e-6 of 0.02.
+        assert!(
+            (drifted.right() - table.right() - 0.02).abs() < 1e-4,
+            "drifted span right-edge should be 0.02pt past table right-edge; got drift = {}",
+            drifted.right() - table.right()
+        );
+        assert_eq!(drifted.left(), 10.0, "span should start at x=10");
+        assert_eq!(drifted.top(), 10.0, "span should start at y=10");
+        assert_eq!(drifted.bottom(), 90.0, "span should end at y=90");
+
+        // Behavior: 0.02pt drift is absorbed by 0.1pt tolerance.
+        assert!(PdfDocument::contains_rect_with_tolerance(&table, &drifted, 0.1));
+    }
+
+    #[test]
+    fn contains_rect_with_tolerance_rejects_genuinely_outside() {
+        use crate::geometry::Rect;
+        let table = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let outside = Rect::new(10.0, 10.0, 91.0, 80.0);
+
+        // Geometry sanity: outside span right-edge should sit 1.0pt
+        // past table right-edge.
+        assert!(
+            (outside.right() - table.right() - 1.0).abs() < 1e-6,
+            "outside span right-edge should be 1.0pt past table right-edge; got drift = {}",
+            outside.right() - table.right()
+        );
+
+        // Behavior: 1.0pt beyond is outside 0.1pt tolerance.
+        assert!(!PdfDocument::contains_rect_with_tolerance(&table, &outside, 0.1));
+    }
+
+    #[test]
+    fn contains_rect_with_tolerance_accepts_fully_inside() {
+        use crate::geometry::Rect;
+        let table = Rect::new(0.0, 0.0, 100.0, 100.0);
+        let inside = Rect::new(10.0, 10.0, 80.0, 80.0);
+
+        // Geometry sanity: control span should be strictly inside the
+        // table on every edge.
+        assert!(
+            inside.left() > table.left()
+                && inside.right() < table.right()
+                && inside.top() > table.top()
+                && inside.bottom() < table.bottom(),
+            "control span should be strictly inside the table"
+        );
+
+        assert!(PdfDocument::contains_rect_with_tolerance(&table, &inside, 0.1));
     }
 }


### PR DESCRIPTION
After detecting a table, the retain logic drops spans contained in the table bbox using `Rect::contains_rect`, which uses strict `>=` / `<=` on all four sides. But in practice, this can cause an issue when span right-edges can drift ~0.02pt outside the table bbox right edge due to an accumulation of float errors during the upstream width computation. When that happens, the strict containment check rejects the span, so it falls through to the flow path while also being rendered via the table path, and one ends up with duplicated output.

Fix: at the retain call sites in `document.rs`, use a 0.1pt tolerance on all four edges. `Rect::contains_rect` itself remains strict; tolerance is strictly a rendering-pipeline concern.

I picked 0.1pt because the drift I’ve seen is ~0.02pt, so this gives a bit of headroom without being anywhere near large enough to admit spans that are genuinely outside the table. It’s not corpus-calibrated, but it should be safely below anything that matters at page scale.

## Description

Fix duplicate rendering of spans caused by sub-pixel float drift at the table-retain boundary. Introduces a tolerance-based containment check at the two retain call sites while keeping the underlying geometry primitive strict.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

## Changes Made

- Introduced `RETAIN_TOLERANCE` (0.1pt) at the table-retain boundary in `document.rs`
- Replaced strict `Rect::contains_rect` checks at the two retain sites with a tolerance-aware predicate
- Extracted `PdfDocument::contains_rect_with_tolerance` helper to avoid duplicating the logic
- Added targeted unit tests covering drift, outside, and control cases

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [ ] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

I ran the targeted regression tests for this fix locally and they pass.  
`cargo test --all-features -- --skip wasm::` currently fails on an unrelated pre-existing serialization test (`document::tests::test_page_text_serializable`).

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)

## Additional Notes

One thing worth calling out: this is logically independent of #394, but it may matter when validating it on a broader corpus. If a page both triggers table detection and has spans drifting just outside the table boundary, you get duplicated output that shows up as noise in line-grouping comparisons. I haven’t hit that combination on the local inputs I was using for #394, but it seems plausible that some slice of a larger regression set would. If so, this removes that source of noise.