### PR TITLE
fix(layout): restore left-to-right order for same-line spans after row-aware sort

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -120,6 +120,16 @@ const DEFAULT_XOBJECT_CACHE_MAX_ENTRIES: usize = 1024;
 /// this pairwise heuristic.
 const FORWARD_GAP_K: f32 = 1.25;
 
+/// Fraction of the larger font size used as the Y tolerance for treating
+/// two spans as belonging to the same visual line.
+const SAME_LINE_THRESHOLD_FONT_SIZE_FACTOR: f32 = 0.5;
+
+/// Maximum allowed inter-span X gap inside a candidate same-line reorder run.
+/// If the candidate's tentative X-order contains a larger gap, the run is
+/// probably a disjoint footer/header/field layout rather than a local
+/// mixed-baseline repair.
+const SAME_LINE_REORDER_MAX_GAP_FACTOR: f32 = 3.0;
+
 // Re-export BoundedEntryCache from cache module for local use and backward compatibility
 pub(crate) use crate::cache::BoundedEntryCache;
 
@@ -4265,6 +4275,11 @@ impl PdfDocument {
                 // vertically centred across several dense-column data rows)
                 // to sort at the top of their row block.
                 Self::reorder_rowspan_labels(&mut spans);
+
+                // Restore intra-line reading order after the row-aware band sort.
+                // Off-baseline glyphs (e.g. superscripts/subscripts) can land in
+                // adjacent bands and be emitted out of X order; fix that per line.
+                Self::reorder_same_line_runs(&mut spans);
             }
 
             // OCR fallback for scanned PDFs
@@ -5268,7 +5283,7 @@ impl PdfDocument {
     /// (for example superscripts and subscripts) are not split by a fixed
     /// absolute tolerance.
     fn same_line_threshold(prev: &TextSpan, current: &TextSpan) -> f32 {
-        prev.font_size.max(current.font_size).max(1.0) * 0.5
+        prev.font_size.max(current.font_size).max(1.0) * SAME_LINE_THRESHOLD_FONT_SIZE_FACTOR
     }
 
     /// Returns `true` if `inner` is contained within `outer`,
@@ -5285,6 +5300,104 @@ impl PdfDocument {
             && inner.right() <= outer.right() + eps
             && inner.top() >= outer.top() - eps
             && inner.bottom() <= outer.bottom() + eps
+    }
+
+    /// Returns `true` if a tentative left-to-right X-ordering of `run`
+    /// contains a horizontal gap exceeding
+    /// `SAME_LINE_REORDER_MAX_GAP_FACTOR * max(font_size)` between any
+    /// two consecutive spans. Used by [`reorder_same_line_runs`] to
+    /// reject candidate runs that are vertically close but horizontally
+    /// disjoint (e.g. tightly-set footer/header rows split across the
+    /// page).
+    ///
+    /// The slice is not mutated; the X-order is computed on a local
+    /// copy of `(left_x, right_x, font_size)` triples.
+    fn run_has_large_x_gap(run: &[TextSpan]) -> bool {
+        if run.len() < 2 {
+            return false;
+        }
+
+        let mut edges: Vec<(f32, f32, f32)> = run
+            .iter()
+            .map(|s| (s.bbox.x, s.bbox.x + s.bbox.width, s.font_size))
+            .collect();
+
+        edges.sort_by(|a, b| crate::utils::safe_float_cmp(a.0, b.0));
+
+        for pair in edges.windows(2) {
+            let prev = pair[0];
+            let cur = pair[1];
+
+            let gap = cur.0 - prev.1;
+            if gap <= 0.0 {
+                continue;
+            }
+
+            let max_fs = prev.2.max(cur.2).max(1.0);
+            if gap > SAME_LINE_REORDER_MAX_GAP_FACTOR * max_fs {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Re-sort same-line spans by X after row-aware band sorting.
+    ///
+    /// Row-aware sorting can place off-baseline glyphs such as superscripts or
+    /// subscripts in adjacent Y bands before their base glyphs. This helper finds
+    /// candidate runs with the existing same-line threshold, then tentatively views
+    /// each candidate in X order. If that tentative X order contains a large gap,
+    /// the candidate is treated as disjoint footer/header/field content and is
+    /// left in the existing row-aware order.
+    ///
+    /// At the slice level no spans are merged or dropped; successful candidates are
+    /// only permuted. Downstream text assembly may then emit the reordered spans
+    /// into one visual line, which is the user-observable effect.
+    fn reorder_same_line_runs(spans: &mut [TextSpan]) {
+        let mut i = 0;
+
+        while i < spans.len() {
+            let mut j = i + 1;
+
+            while j < spans.len() {
+                let anchor = &spans[i];
+                let prev = &spans[j - 1];
+                let cur = &spans[j];
+
+                let to_prev = (cur.bbox.y - prev.bbox.y).abs();
+                let to_anchor = (cur.bbox.y - anchor.bbox.y).abs();
+
+                let tol_prev = Self::same_line_threshold(prev, cur);
+                let tol_anchor = Self::same_line_threshold(anchor, cur);
+
+                if to_prev > tol_prev || to_anchor > tol_anchor {
+                    break;
+                }
+
+                j += 1;
+            }
+
+            if j - i > 1 {
+                if Self::run_has_large_x_gap(&spans[i..j]) {
+                    // Candidate spans are vertically close, but not horizontally
+                    // contiguous. Do not X-sort them into a fake line; preserve
+                    // the row-aware order established before this helper.
+                    i = j;
+                    continue;
+                }
+
+                spans[i..j].sort_by(|a, b| {
+                    let cmp = crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x);
+                    if cmp != std::cmp::Ordering::Equal {
+                        return cmp;
+                    }
+                    a.sequence.cmp(&b.sequence)
+                });
+            }
+
+            i = j;
+        }
     }
 
     /// # Returns
@@ -15888,5 +16001,79 @@ mod tests {
         );
 
         assert!(PdfDocument::contains_rect_with_tolerance(&table, &inside, 0.1));
+    }
+
+    #[test]
+    fn reorder_same_line_runs_preserves_disjoint_x_rows() {
+        use crate::geometry::Rect;
+        use crate::layout::TextSpan;
+
+        // Two rows close enough in Y to pass the existing same_line_threshold:
+        // Δy = 4.5 and fs = 10, so threshold = 5.0.
+        // They are disjoint in X (gap of 225pt = 22.5 * fs, well over the
+        // SAME_LINE_REORDER_MAX_GAP_FACTOR = 3.0 ceiling). The helper must
+        // not X-sort them into [skersey, VerDate]; it must preserve the
+        // row-aware order.
+        let mut spans = vec![
+            TextSpan {
+                text: "VerDate".to_string(),
+                bbox: Rect::new(350.0, 200.0, 85.0, 10.0),
+                font_size: 10.0,
+                sequence: 0,
+                ..Default::default()
+            },
+            TextSpan {
+                text: "skersey".to_string(),
+                bbox: Rect::new(50.0, 195.5, 75.0, 10.0),
+                font_size: 10.0,
+                sequence: 1,
+                ..Default::default()
+            },
+        ];
+
+        PdfDocument::reorder_same_line_runs(&mut spans);
+
+        let texts: Vec<&str> = spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(texts, vec!["VerDate", "skersey"]);
+    }
+
+    #[test]
+    fn reorder_same_line_runs_orders_suffix_superscript_by_x() {
+        use crate::geometry::Rect;
+        use crate::layout::TextSpan;
+
+        // Row-aware/Y-desc order can put the superscript first because it
+        // sits higher. The tentative X-gap validation must not reject this
+        // legitimate mixed-baseline run; the X-sorted gaps are 15pt and 0pt
+        // at max_fs=14, both well under 3.0 * 14 = 42. Final order should
+        // be normal left-to-right text.
+        let mut spans = vec![
+            TextSpan {
+                text: "th".to_string(),
+                bbox: Rect::new(180.0, 205.0, 10.0, 10.0),
+                font_size: 10.0,
+                sequence: 0,
+                ..Default::default()
+            },
+            TextSpan {
+                text: "September".to_string(),
+                bbox: Rect::new(100.0, 200.0, 50.0, 14.0),
+                font_size: 14.0,
+                sequence: 1,
+                ..Default::default()
+            },
+            TextSpan {
+                text: "11".to_string(),
+                bbox: Rect::new(165.0, 200.0, 15.0, 14.0),
+                font_size: 14.0,
+                sequence: 2,
+                ..Default::default()
+            },
+        ];
+
+        PdfDocument::reorder_same_line_runs(&mut spans);
+
+        let texts: Vec<&str> = spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(texts, vec!["September", "11", "th"]);
     }
 }

--- a/tests/test_superscript_line_grouping.rs
+++ b/tests/test_superscript_line_grouping.rs
@@ -31,6 +31,43 @@ fn superscript_12pt_offset_stays_on_one_line() {
 }
 
 #[test]
+fn superscript_extracts_with_correct_glyph_order() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "8", 140.0, 180.0, "Helvetica", 28.0);
+        put(&mut page, "th", 156.0, 192.0, "Helvetica", 20.0);
+    });
+
+    assert_eq!(out.trim_end(), "8th", "got {:?}", out.trim_end());
+}
+
+#[test]
+fn subscript_between_baseline_letters_stays_in_reading_order() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "H", 100.0, 200.0, "Helvetica", 14.0);
+        put(&mut page, "2", 112.0, 197.0, "Helvetica", 9.0);
+        put(&mut page, "O", 122.0, 200.0, "Helvetica", 14.0);
+    });
+
+    let collapsed: String = out.split_whitespace().collect();
+    assert_eq!(collapsed, "H2O", "got {:?}", out.trim_end());
+}
+
+#[test]
+fn three_glyph_run_in_distinct_bands_is_x_ordered() {
+    let out = build_and_extract(|w| {
+        let mut page = w.add_letter_page();
+        put(&mut page, "a", 100.0, 200.0, "Helvetica", 14.0);
+        put(&mut page, "b", 112.0, 203.0, "Helvetica", 12.0);
+        put(&mut page, "c", 124.0, 206.0, "Helvetica", 10.0);
+    });
+
+    let collapsed: String = out.split_whitespace().collect();
+    assert_eq!(collapsed, "abc", "got {:?}", out.trim_end());
+}
+
+#[test]
 fn baseline_same_y_stays_on_one_line() {
     let out = build_and_extract(|w| {
         let mut page = w.add_letter_page();


### PR DESCRIPTION
`row_aware_span_cmp` sorts spans by quantized Y band (descending) to keep jittery rows stable. For mixed-baseline glyphs (e.g. superscripts or subscripts), this places higher-Y spans ahead of their base, producing outputs like `"th8"` instead of `"8th"`.

Add `PdfDocument::reorder_same_line_runs(&mut [TextSpan])` and invoke it after the row-aware sort + `reorder_rowspan_labels` pass. The helper finds maximal same-line runs using `same_line_threshold` and re-sorts each run by X (with `sequence` as a stable tie-break).

This preserves the existing sort semantics and only reorders spans within a visual line; no spans are merged or dropped.

Adds regression coverage for:
- superscript ordering (`"8th"`)
- subscript between baseline letters (`"H2O"` with spacing to avoid span merge)
- multi-span same-line runs across distinct Y bands (`"abc"`)

Existing same-line and multi-line behaviour unchanged.

See [superscript.pdf](https://github.com/user-attachments/files/26949823/superscript.pdf):

- Before: `th8`
- After: `8th`

This correction of intra-line ordering is the future fix noted in #394's description.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Tests
- [ ] CI/CD changes

## Related Issues

Relates to #456

## Changes Made

- Added `PdfDocument::reorder_same_line_runs`, which finds maximal same-line runs after row-aware sorting and re-sorts each run by X position, using `sequence` as a stable tie-break.
- Invoked `reorder_same_line_runs` after the existing row-aware sort and `reorder_rowspan_labels` pass, so the change is limited to intra-line ordering after the current row/rowspan ordering logic has run.
- Added regression tests covering superscript ordering (`8th`), subscript ordering (`H2O`), multi-span same-line runs across distinct Y bands (`abc`).

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I ran the targeted regression tests for this fix locally and they pass.
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

Tests run locally

- [x] `cargo test --test test_superscript_line_grouping`

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)

<img width="100" height="95" alt="image" src="https://github.com/user-attachments/assets/99582237-e731-4bf9-ab28-51acd90d0b0b" />

Before: `th8`  
After: `8th` 