### PR TITLE
fix(cli): require -o for merge; route remaining default outputs beside input (#412)

### DIFF
--- a/pdf_oxide_cli/src/cli/commands/crop.rs
+++ b/pdf_oxide_cli/src/cli/commands/crop.rs
@@ -46,13 +46,9 @@ pub fn run(
         editor.set_page_crop_box(idx, crop_box)?;
     }
 
-    let out_path = output.map(|p| p.to_path_buf()).unwrap_or_else(|| {
-        let stem = file
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("output");
-        Path::new(&format!("{stem}_cropped.pdf")).to_path_buf()
-    });
+    let out_path = output
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| super::output_beside(file, "_cropped.pdf"));
 
     editor.save_with_options(
         &out_path,

--- a/pdf_oxide_cli/src/cli/commands/decrypt.rs
+++ b/pdf_oxide_cli/src/cli/commands/decrypt.rs
@@ -4,13 +4,9 @@ use std::path::Path;
 pub fn run(file: &Path, _password: &str, output: Option<&Path>) -> pdf_oxide::Result<()> {
     let mut editor = DocumentEditor::open(file)?;
 
-    let out_path = output.map(|p| p.to_path_buf()).unwrap_or_else(|| {
-        let stem = file
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("output");
-        std::path::PathBuf::from(format!("{stem}_decrypted.pdf"))
-    });
+    let out_path = output
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| super::output_beside(file, "_decrypted.pdf"));
 
     editor.save_with_options(
         &out_path,

--- a/pdf_oxide_cli/src/cli/commands/delete.rs
+++ b/pdf_oxide_cli/src/cli/commands/delete.rs
@@ -35,13 +35,9 @@ pub fn run(
         editor.remove_page(idx)?;
     }
 
-    let out_path = output.map(|p| p.to_path_buf()).unwrap_or_else(|| {
-        let stem = file
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("output");
-        Path::new(&format!("{stem}_trimmed.pdf")).to_path_buf()
-    });
+    let out_path = output
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| super::output_beside(file, "_trimmed.pdf"));
 
     editor.save_with_options(
         &out_path,

--- a/pdf_oxide_cli/src/cli/commands/merge.rs
+++ b/pdf_oxide_cli/src/cli/commands/merge.rs
@@ -8,6 +8,15 @@ pub fn run(files: &[std::path::PathBuf], output: Option<&Path>) -> pdf_oxide::Re
         ));
     }
 
+    // Validate output flag up front so we fail before opening any file.
+    let out_path = output.ok_or_else(|| {
+        pdf_oxide::Error::InvalidOperation(
+            "Merge requires -o/--output to specify the destination path \
+             (e.g. -o merged.pdf). There is no single input file to anchor a default output to."
+                .to_string(),
+        )
+    })?;
+
     let mut editor = DocumentEditor::open(&files[0])?;
 
     for source in &files[1..] {
@@ -15,16 +24,29 @@ pub fn run(files: &[std::path::PathBuf], output: Option<&Path>) -> pdf_oxide::Re
         eprintln!("Merged {} pages from {}", pages_added, source.display());
     }
 
-    let default_out;
-    let out_path = match output {
-        Some(p) => p,
-        None => {
-            default_out = super::output_dir_beside(&files[0]).join("merged.pdf");
-            &default_out
-        },
-    };
     editor.save(out_path)?;
     eprintln!("Saved to {}", out_path.display());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn run_without_output_returns_invalid_operation() {
+        let files = vec![PathBuf::from("a.pdf"), PathBuf::from("b.pdf")];
+        let err = run(&files, None).expect_err("merge with no -o should fail");
+        match err {
+            pdf_oxide::Error::InvalidOperation(msg) => {
+                assert!(
+                    msg.contains("-o") || msg.contains("--output"),
+                    "error should name the missing flag, got: {msg}"
+                );
+            },
+            other => panic!("expected InvalidOperation, got {other:?}"),
+        }
+    }
 }

--- a/pdf_oxide_cli/src/cli/commands/reorder.rs
+++ b/pdf_oxide_cli/src/cli/commands/reorder.rs
@@ -60,13 +60,9 @@ pub fn run(
         editor.remove_page(i)?;
     }
 
-    let out_path = output.map(|p| p.to_path_buf()).unwrap_or_else(|| {
-        let stem = file
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("output");
-        Path::new(&format!("{stem}_reordered.pdf")).to_path_buf()
-    });
+    let out_path = output
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| super::output_beside(file, "_reordered.pdf"));
 
     editor.save_with_options(
         &out_path,


### PR DESCRIPTION
Closes #412.

Picks up where 9dd94c0 left off. The earlier commit landed `output_beside()` / `output_dir_beside()` and converted watermark, compress, flatten, rotate, and split. The remaining four binary-output commands kept their inline `Path::new(&format!(\"{stem}_X.pdf\"))` blocks, which resolve relative to cwd, so e.g. `pdf-oxide decrypt /docs/foo.pdf` from `/tmp` still wrote `/tmp/foo_decrypted.pdf` instead of beside the input.

### Pattern-A conversions
- `decrypt.rs` → `output_beside(file, \"_decrypted.pdf\")`
- `crop.rs` → `output_beside(file, \"_cropped.pdf\")`
- `delete.rs` → `output_beside(file, \"_trimmed.pdf\")`
- `reorder.rs` → `output_beside(file, \"_reordered.pdf\")`

No behavior change vs cwd when the input is a bare filename — `output_beside` already returns `./<stem>_X.pdf` for that case (covered by `output_beside_bare_filename`).

### Merge requires `-o`
Per the issue thread, `merge` has no single input anchor — the previous default `<first-arg-dir>/merged.pdf` could silently overwrite an unrelated file in the first input's directory. New behavior: error up front with a message that names the flag.

```
$ pdf-oxide merge a.pdf b.pdf
Error: Invalid operation: Merge requires -o/--output to specify the destination path (e.g. -o merged.pdf). There is no single input file to anchor a default output to.
```

The validation runs before opening any file so the error reports without partially constructing an editor.

### Split

Already correct after 9dd94c0 (defaults to `output_dir_beside(file)`); no change needed.

### Verification

End-to-end run from `/home/phantom` against an input in `/tmp`:

```
$ pdf-oxide decrypt /tmp/in.pdf --password ''
Decrypted /tmp/in.pdf -> /tmp/in_decrypted.pdf
$ pdf-oxide crop /tmp/in.pdf --margins '10,10,10,10'
Cropped 1 page(s) ... → /tmp/in_cropped.pdf
$ pdf-oxide delete /tmp/in.pdf --pages '1'
Deleted 1 page(s) → /tmp/in_trimmed.pdf
$ pdf-oxide reorder /tmp/in.pdf --order '2,1'
Reordered 2 pages → /tmp/in_reordered.pdf
$ ls /home/phantom/in_*.pdf
ls: cannot access '/home/phantom/in_*.pdf': No such file or directory
```

Stash-bisect on the merge regression test (`run_without_output_returns_invalid_operation`):

- pre-fix code → `expected InvalidOperation, got Io(Os { code: 2, kind: NotFound })` (the test reaches the `DocumentEditor::open(&files[0])` path)
- with fix → `1 passed`

`cargo test -p pdf_oxide_cli` 12/12 pass, `cargo fmt -p pdf_oxide_cli --check` clean, `cargo clippy -p pdf_oxide_cli --all-targets -- -D warnings` clean.