### PR TITLE
fix(deps): bump imageproc 0.26.1 → 0.26.2 (RUSTSEC-2026-0115/0116/0117)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "imageproc"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8046da590889acc65f5880004580ebb269bbef84d6c0f5c543ec2dece46638"
+checksum = "645329c490783f3ea465d2b6c7c08286fece97f15e714fd533b6c70a3ead2252"
 dependencies = [
  "ab_glyph",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ ort = { version = "=2.0.0-rc.11", optional = true, default-features = false, fea
     "ndarray",
     "load-dynamic",
 ] }
-imageproc = { version = "0.26", optional = true }
+imageproc = { version = "0.26.2", optional = true }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bumps `imageproc` from `0.26.1` → `0.26.2` to patch three unsound security advisories
- Fixes the `Dependency Check (cargo-deny)` CI failure blocking the v0.3.41 release

## Advisories fixed

| ID | Description |
|---|---|
| [RUSTSEC-2026-0115](https://rustsec.org/advisories/RUSTSEC-2026-0115) | Fragile bounds check when sampling from image |
| [RUSTSEC-2026-0116](https://rustsec.org/advisories/RUSTSEC-2026-0116) | Improper check of an invariant resulting in incorrect bounds checks |
| [RUSTSEC-2026-0117](https://rustsec.org/advisories/RUSTSEC-2026-0117) | Fragile bounds check when sampling from image |

## Test plan

- [ ] CI `Dependency Check (cargo-deny)` passes
- [ ] All existing tests pass (imageproc is optional, only used in `ocr` feature)