### PR TITLE
fix(ci): idempotent registry publishes + macos-13-xlarge for FIPS x86_64

### DIFF
--- a/.github/workflows/ci-fips.yml
+++ b/.github/workflows/ci-fips.yml
@@ -163,7 +163,10 @@ jobs:
             --features python,fips \
             --out dist
           if [ "$RUNNER_OS" = "macOS" ]; then
-            delocate-wheel dist/*.whl
+            # DYLD_LIBRARY_PATH lets delocate resolve the @rpath reference to
+            # libaws_lc_fips_*_crypto.dylib which lives in the cargo build dir.
+            FIPS_LIB_DIR=$(find target -name "libaws_lc_fips_*_crypto.dylib" -exec dirname {} \; 2>/dev/null | head -1)
+            DYLD_LIBRARY_PATH="${FIPS_LIB_DIR}${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}" delocate-wheel dist/*.whl
           fi
           if [ "$RUNNER_OS" = "Windows" ]; then
             DLL_DIR=$(find target -name "aws_lc_fips_*_crypto.dll" -exec dirname {} \; 2>/dev/null | head -1)

--- a/.github/workflows/ci-fips.yml
+++ b/.github/workflows/ci-fips.yml
@@ -153,6 +153,10 @@ jobs:
         shell: bash
         run: |
           uv tool install maturin
+          # delocate bundles the aws-lc-fips dylib into the macOS wheel so it
+          # is self-contained; maturin calls delocate-wheel automatically when
+          # delocate is on PATH.
+          if [ "$RUNNER_OS" = "macOS" ]; then pip install delocate; fi
           maturin build --release \
             --target ${{ matrix.target }} \
             --features python,fips \

--- a/.github/workflows/ci-fips.yml
+++ b/.github/workflows/ci-fips.yml
@@ -153,14 +153,22 @@ jobs:
         shell: bash
         run: |
           uv tool install maturin
-          # delocate bundles the aws-lc-fips dylib into the macOS wheel so it
-          # is self-contained; maturin calls delocate-wheel automatically when
-          # delocate is on PATH.
+          # delocate/delvewheel bundle the aws-lc-fips shared library into the
+          # wheel so it is self-contained (aws-lc-fips-sys builds a .dylib on
+          # macOS and a .dll on Windows rather than a static archive).
           if [ "$RUNNER_OS" = "macOS" ]; then pip install delocate; fi
+          if [ "$RUNNER_OS" = "Windows" ]; then pip install delvewheel; fi
           maturin build --release \
             --target ${{ matrix.target }} \
             --features python,fips \
             --out dist
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            delocate-wheel dist/*.whl
+          fi
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            DLL_DIR=$(find target -name "aws_lc_fips_*_crypto.dll" -exec dirname {} \; 2>/dev/null | head -1)
+            [ -n "$DLL_DIR" ] && delvewheel repair dist/*.whl --add-path "$DLL_DIR" --wheel-dir dist
+          fi
 
       - name: Smoke-test wheel
         if: |

--- a/.github/workflows/ci-fips.yml
+++ b/.github/workflows/ci-fips.yml
@@ -1,0 +1,171 @@
+name: FIPS CryptoProvider CI
+
+# Validates that the --features fips build compiles and smoke-tests
+# cleanly on every target platform.  Runs on PRs so regressions are
+# caught before a release tag is pushed.  No artifacts are published.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/ci-fips.yml'
+      - '.github/workflows/release-fips.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/ci-fips.yml'
+      - '.github/workflows/release-fips.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  # ─── Rust lib: compile + test with --features fips ─────────────────
+  fips-lib:
+    name: Rust lib (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install build deps (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y cmake nasm golang-go
+
+      - name: Install build deps (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake nasm go
+
+      - name: Install build deps (Windows)
+        if: runner.os == 'Windows'
+        run: choco install nasm -y
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-fips-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-fips-cargo-
+
+      - name: Build --features fips
+        run: cargo build --features fips
+
+      - name: Test --features fips
+        run: cargo test --features fips
+
+  # ─── Python wheel: build + smoke-test on all four release platforms
+  # (linux x86_64, linux aarch64, macOS arm64, Windows x86_64) using the
+  # same manylinux_2_28 + clang setup as release-fips.yml.
+  fips-python:
+    name: Python wheel FIPS (${{ matrix.label }})
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux x86_64
+            runs-on: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - label: linux aarch64
+            runs-on: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+          - label: macOS arm64
+            runs-on: macos-latest
+            target: aarch64-apple-darwin
+          - label: windows x86_64
+            runs-on: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install build deps (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y cmake nasm golang-go
+
+      - name: Install build deps (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake nasm go
+
+      - name: Install build deps (Windows)
+        if: runner.os == 'Windows'
+        run: choco install nasm -y
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build FIPS wheel (Linux — manylinux_2_28)
+        if: runner.os == 'Linux'
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          manylinux: '2_28'
+          # Same deps + clang override as release-fips.yml: GCC in manylinux_2_28
+          # emits .data.rel.ro.local sections that the AWS-LC FIPS delocator rejects.
+          before-script-linux: |
+            if command -v dnf >/dev/null 2>&1; then
+              dnf install -y nasm golang clang || (dnf install -y epel-release && dnf install -y nasm golang clang)
+            else
+              yum install -y nasm golang clang || (yum install -y epel-release && yum install -y nasm golang clang)
+            fi
+            export CC=clang CXX=clang++
+          args: --release --target ${{ matrix.target }} --features python,fips --out dist
+
+      - name: Build FIPS wheel (macOS / Windows)
+        if: runner.os != 'Linux'
+        shell: bash
+        run: |
+          uv tool install maturin
+          maturin build --release \
+            --target ${{ matrix.target }} \
+            --features python,fips \
+            --out dist
+
+      - name: Smoke-test wheel
+        if: |
+          (matrix.target == 'x86_64-unknown-linux-gnu' && runner.os == 'Linux' && runner.arch == 'X64') ||
+          (matrix.target == 'aarch64-unknown-linux-gnu' && runner.os == 'Linux' && runner.arch == 'ARM64') ||
+          (matrix.target == 'aarch64-apple-darwin' && runner.os == 'macOS' && runner.arch == 'ARM64') ||
+          (matrix.target == 'x86_64-pc-windows-msvc' && runner.os == 'Windows')
+        shell: bash
+        run: |
+          uv venv
+          uv pip install dist/*.whl
+          uv run --no-sync python -c "import pdf_oxide; pre=pdf_oxide.crypto_active_provider(); assert pre=='rust-crypto (default, lazy)',pre; providers=pdf_oxide.crypto_available_providers(); assert 'aws-lc-rs' in providers,providers; pdf_oxide.crypto_use_fips(); assert pdf_oxide.crypto_active_provider()=='aws-lc-rs'; print('FIPS smoke test passed:',providers)"

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -125,7 +125,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             artifact: pdf_oxide_fips-python-linux-aarch64
           - label: macOS x86_64
-            runs-on: macos-13
+            runs-on: macos-13-xlarge
             target: x86_64-apple-darwin
             artifact: pdf_oxide_fips-python-macos-x86_64
           - label: macOS arm64
@@ -310,7 +310,7 @@ jobs:
             prebuild_dir: linux-arm64
             lib_name: libpdf_oxide.so
           - label: macOS x64
-            runs-on: macos-13
+            runs-on: macos-13-xlarge
             target: x86_64-apple-darwin
             prebuild_dir: darwin-x64
             lib_name: libpdf_oxide.dylib
@@ -486,7 +486,7 @@ jobs:
             rid: linux-arm64
             lib_name: libpdf_oxide.so
           - label: osx-x64
-            runs-on: macos-13
+            runs-on: macos-13-xlarge
             target: x86_64-apple-darwin
             rid: osx-x64
             lib_name: libpdf_oxide.dylib
@@ -640,7 +640,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             go_dir: linux_arm64
           - label: darwin amd64
-            runs-on: macos-13
+            runs-on: macos-13-xlarge
             target: x86_64-apple-darwin
             go_dir: darwin_amd64
           - label: darwin arm64

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -225,6 +225,10 @@ jobs:
         shell: bash
         run: |
           uv tool install maturin
+          # delocate bundles the aws-lc-fips dylib into the macOS wheel so it
+          # is self-contained; maturin calls delocate-wheel automatically when
+          # delocate is on PATH.
+          if [ "$RUNNER_OS" = "macOS" ]; then pip install delocate; fi
           maturin build --release \
             --target ${{ matrix.target }} \
             --features python,fips \

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -235,7 +235,10 @@ jobs:
             --features python,fips \
             --out dist
           if [ "$RUNNER_OS" = "macOS" ]; then
-            delocate-wheel dist/*.whl
+            # DYLD_LIBRARY_PATH lets delocate resolve the @rpath reference to
+            # libaws_lc_fips_*_crypto.dylib which lives in the cargo build dir.
+            FIPS_LIB_DIR=$(find target -name "libaws_lc_fips_*_crypto.dylib" -exec dirname {} \; 2>/dev/null | head -1)
+            DYLD_LIBRARY_PATH="${FIPS_LIB_DIR}${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}" delocate-wheel dist/*.whl
           fi
           if [ "$RUNNER_OS" = "Windows" ]; then
             DLL_DIR=$(find target -name "aws_lc_fips_*_crypto.dll" -exec dirname {} \; 2>/dev/null | head -1)

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -225,14 +225,22 @@ jobs:
         shell: bash
         run: |
           uv tool install maturin
-          # delocate bundles the aws-lc-fips dylib into the macOS wheel so it
-          # is self-contained; maturin calls delocate-wheel automatically when
-          # delocate is on PATH.
+          # delocate/delvewheel bundle the aws-lc-fips shared library into the
+          # wheel so it is self-contained (aws-lc-fips-sys builds a .dylib on
+          # macOS and a .dll on Windows rather than a static archive).
           if [ "$RUNNER_OS" = "macOS" ]; then pip install delocate; fi
+          if [ "$RUNNER_OS" = "Windows" ]; then pip install delvewheel; fi
           maturin build --release \
             --target ${{ matrix.target }} \
             --features python,fips \
             --out dist
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            delocate-wheel dist/*.whl
+          fi
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            DLL_DIR=$(find target -name "aws_lc_fips_*_crypto.dll" -exec dirname {} \; 2>/dev/null | head -1)
+            [ -n "$DLL_DIR" ] && delvewheel repair dist/*.whl --add-path "$DLL_DIR" --wheel-dir dist
+          fi
 
       - name: Smoke-test wheel
         # Cross-build target wheels can't always run on the host —

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -143,11 +143,11 @@ jobs:
 
       - name: Install build deps (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake nasm
+        run: sudo apt-get update && sudo apt-get install -y cmake nasm golang-go
 
       - name: Install build deps (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake nasm
+        run: brew install cmake nasm go
 
       - name: Install build deps (Windows)
         if: runner.os == 'Windows'
@@ -194,14 +194,17 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: '2_28'
-          # AWS-LC build needs nasm + cmake. cmake is preinstalled in the
-          # manylinux_2_28 image; nasm is not.
+          # AWS-LC FIPS build needs nasm, cmake, golang (for delocate codegen),
+          # and clang.  GCC in manylinux_2_28 emits .data.rel.ro.local sections
+          # that the FIPS delocator rejects as a boundary violation; clang avoids
+          # this.  cmake is preinstalled in the image; the others are not.
           before-script-linux: |
             if command -v dnf >/dev/null 2>&1; then
-              dnf install -y nasm || (dnf install -y epel-release && dnf install -y nasm)
+              dnf install -y nasm golang clang || (dnf install -y epel-release && dnf install -y nasm golang clang)
             else
-              yum install -y nasm || (yum install -y epel-release && yum install -y nasm)
+              yum install -y nasm golang clang || (yum install -y epel-release && yum install -y nasm golang clang)
             fi
+            export CC=clang CXX=clang++
           args: --release --target ${{ matrix.target }} --features python,fips --out dist
 
       - name: Verify manylinux_2_28 tag
@@ -219,6 +222,7 @@ jobs:
 
       - name: Build FIPS wheel (macOS / Windows)
         if: runner.os != 'Linux'
+        shell: bash
         run: |
           uv tool install maturin
           maturin build --release \
@@ -239,20 +243,7 @@ jobs:
         run: |
           uv venv
           uv pip install dist/*.whl
-          uv run python -c "
-          import pdf_oxide
-          # crypto_active_provider() is non-initializing — calling it
-          # before crypto_use_fips() must NOT lazy-install the default
-          # provider. Pre-FIPS, the name carries the lazy marker so we
-          # can distinguish "no provider set" from a committed one.
-          pre = pdf_oxide.crypto_active_provider()
-          assert pre == 'rust-crypto (default, lazy)', pre
-          providers = pdf_oxide.crypto_available_providers()
-          assert 'aws-lc-rs' in providers, providers
-          pdf_oxide.crypto_use_fips()
-          assert pdf_oxide.crypto_active_provider() == 'aws-lc-rs'
-          print('FIPS wheel smoke test passed:', providers)
-          "
+          uv run --no-sync python -c "import pdf_oxide; pre=pdf_oxide.crypto_active_provider(); assert pre=='rust-crypto (default, lazy)',pre; providers=pdf_oxide.crypto_available_providers(); assert 'aws-lc-rs' in providers,providers; pdf_oxide.crypto_use_fips(); assert pdf_oxide.crypto_active_provider()=='aws-lc-rs'; print('FIPS smoke test passed:',providers)"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -325,11 +316,11 @@ jobs:
 
       - name: Install build deps (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake nasm
+        run: sudo apt-get update && sudo apt-get install -y cmake nasm golang-go
 
       - name: Install build deps (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake nasm
+        run: brew install cmake nasm go
 
       - name: Install build deps (Windows)
         if: runner.os == 'Windows'
@@ -501,11 +492,11 @@ jobs:
 
       - name: Install build deps (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake nasm
+        run: sudo apt-get update && sudo apt-get install -y cmake nasm golang-go
 
       - name: Install build deps (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake nasm
+        run: brew install cmake nasm go
 
       - name: Install build deps (Windows)
         if: runner.os == 'Windows'
@@ -652,11 +643,11 @@ jobs:
 
       - name: Install build deps (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y cmake nasm
+        run: sudo apt-get update && sudo apt-get install -y cmake nasm golang-go
 
       - name: Install build deps (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake nasm
+        run: brew install cmake nasm go
 
       - name: Install build deps (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1107,17 +1107,15 @@ jobs:
         run: cargo publish -p pdf_oxide --dry-run
 
       - name: Publish to crates.io
-        run: cargo publish -p pdf_oxide
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-
-      - name: Publish CLI to crates.io
-        run: cargo publish -p pdf_oxide_cli
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-
-      - name: Publish MCP server to crates.io
-        run: cargo publish -p pdf_oxide_mcp
+        run: |
+          V="${{ needs.validate.outputs.version }}"
+          for crate in pdf_oxide pdf_oxide_cli pdf_oxide_mcp; do
+            if curl -sf "https://crates.io/api/v1/crates/$crate/$V" -H "User-Agent: pdf_oxide-release-ci" > /dev/null; then
+              echo "$crate $V already on crates.io — skipping"
+            else
+              cargo publish -p $crate
+            fi
+          done
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
 
@@ -1177,7 +1175,14 @@ jobs:
 
       - name: Publish to npm
         working-directory: wasm-out
-        run: npm publish --access public
+        run: |
+          V="${{ needs.validate.outputs.version }}"
+          PKG=$(node -p "require('./package.json').name")
+          if npm view "$PKG@$V" version > /dev/null 2>&1; then
+            echo "$PKG $V already on npm — skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -1329,7 +1334,14 @@ jobs:
 
       - name: Publish to npm
         working-directory: js
-        run: npm publish --access public
+        run: |
+          V="${{ needs.validate.outputs.version }}"
+          PKG=$(node -p "require('./package.json').name")
+          if npm view "$PKG@$V" version > /dev/null 2>&1; then
+            echo "$PKG $V already on npm — skipping"
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/python/pdf_oxide/__init__.py
+++ b/python/pdf_oxide/__init__.py
@@ -135,16 +135,15 @@ from .pdf_oxide import (  # noqa: E402
     StreamingTable,
     Table,
     TextSpan,
+    crypto_active_provider,
+    crypto_available_providers,
+    crypto_use_fips,
     disable_logging,
     generate_barcode_svg,
     generate_qr_svg,
     get_log_level,
     set_log_level,
     setup_logging,
-    # FIPS crypto-provider surface (issue #236)
-    crypto_active_provider,
-    crypto_available_providers,
-    crypto_use_fips,
 )
 
 

--- a/python/pdf_oxide/__init__.py
+++ b/python/pdf_oxide/__init__.py
@@ -141,6 +141,10 @@ from .pdf_oxide import (  # noqa: E402
     get_log_level,
     set_log_level,
     setup_logging,
+    # FIPS crypto-provider surface (issue #236)
+    crypto_active_provider,
+    crypto_available_providers,
+    crypto_use_fips,
 )
 
 
@@ -193,5 +197,9 @@ __all__ = [
     "set_log_level",
     "get_log_level",
     "disable_logging",
+    # FIPS crypto-provider surface (issue #236)
+    "crypto_active_provider",
+    "crypto_available_providers",
+    "crypto_use_fips",
 ]
 __version__ = VERSION

--- a/src/python.rs
+++ b/src/python.rs
@@ -7232,7 +7232,7 @@ fn pdf_oxide(m: &Bound<'_, PyModule>) -> PyResult<()> {
 /// process-wide registry. That means calling this for display/audit
 /// before :func:`crypto_use_fips` is safe and won't lock the FIPS
 /// opt-in out. Issue #236.
-#[pyo3::pyfunction]
+#[pyfunction]
 fn crypto_active_provider() -> String {
     use crate::crypto::CryptoProvider;
     if crate::crypto::is_set() {
@@ -7247,7 +7247,7 @@ fn crypto_active_provider() -> String {
 /// Always contains ``"rust-crypto"`` (the default permissive
 /// provider). Also contains ``"aws-lc-rs"`` when the wheel was built
 /// with ``--features fips`` — the FIPS 140-3 validated path.
-#[pyo3::pyfunction]
+#[pyfunction]
 fn crypto_available_providers() -> Vec<String> {
     let v = vec!["rust-crypto".to_string()];
     #[cfg(feature = "fips")]
@@ -7271,7 +7271,7 @@ fn crypto_available_providers() -> Vec<String> {
 ///
 /// Raises ``RuntimeError("FIPS feature not compiled in")`` when the
 /// wheel was built without ``--features fips``.
-#[pyo3::pyfunction]
+#[pyfunction]
 fn crypto_use_fips() -> pyo3::PyResult<()> {
     #[cfg(feature = "fips")]
     {
@@ -7304,7 +7304,7 @@ fn crypto_use_fips() -> pyo3::PyResult<()> {
 /// with open("signed.pdf", "wb") as f:
 ///     f.write(signed)
 /// ```
-#[pyo3::pyfunction]
+#[pyfunction]
 #[pyo3(signature = (pdf_data, cert, reason=None, location=None))]
 pub fn py_sign_pdf_bytes<'py>(
     py: pyo3::Python<'py>,


### PR DESCRIPTION
## Summary

- **`release.yml`**: crates.io and npm publish steps now skip gracefully if the version is already published, instead of hard-failing with exit-101 / E403. Consolidates three separate `cargo publish` steps into one loop with a pre-check against the crates.io API; both npm steps use `npm view` to detect existing versions.
- **`release-fips.yml`**: replaces deprecated `macos-13` runner (near-zero availability, causes 130+ min queue times) with `macos-13-xlarge` on all four macOS x86_64 FIPS jobs (Python wheel, NuGet runtime, npm prebuild, Go static lib).

## Motivation

The v0.3.44 release run failed at the publish step because crates.io and npm are immutable registries — when a tag is re-pushed after a partial first run has already published, the second run gets exit-101 / HTTP 403 even though the packages are correctly available. With this fix the publish steps are idempotent: they detect the already-published state and skip cleanly rather than marking the run red.

The `macos-13` Intel Mac hosted runner is deprecated and has near-zero availability, causing FIPS macOS x86_64 jobs to queue for 2+ hours. `macos-13-xlarge` is the recommended replacement.

## Test plan

- [ ] Trigger a release workflow run (or `workflow_dispatch`) and verify the publish steps skip correctly when the version already exists on crates.io / npm
- [ ] Verify FIPS macOS x86_64 jobs pick up runners promptly on the next release