### PR TITLE
release: v0.3.47 — text-extraction quality, CJK + RTL fixes, table-detection hardening, WASM file ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
           after_kb=$(( $(stat -c%s "$out") / 1024 ))
           echo "Before wasm-opt: ${before_kb} KB"
           echo "After  wasm-opt: ${after_kb} KB"
-          # Size regression gate: v0.3.46 baseline after -Oz is ~11.25 MB
+          # Size regression gate: v0.3.47 baseline after -Oz is ~11.25 MB
           # (grew from 10.4 MB with fast_image_resize SIMD downscaling and
           # hayro-jbig2 JBIG2 decoder added to the rendering feature).
           # Ceiling leaves ~6% headroom above the 11520 KB measured baseline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
 
       # Validate the produced module using wasm-tools.
       - name: Install wasm-tools
-        uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: wasm-tools
 
@@ -1072,7 +1072,7 @@ jobs:
         with:
           key: taplo
       - name: Install taplo
-        uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: taplo-cli
       - name: Check TOML formatting
@@ -1089,7 +1089,7 @@ jobs:
         with:
           key: shear
       - name: Install cargo-shear
-        uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: cargo-shear
       - name: Check for unused dependencies
@@ -1113,7 +1113,7 @@ jobs:
         with:
           key: hack
       - name: Install cargo-hack
-        uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: cargo-hack
       - name: Build each feature (singletons + default + all-features)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1039,7 +1039,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Check dependencies
-        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
+        uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
         with:
           command: check
           arguments: --all-features

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
@@ -44,6 +44,6 @@ jobs:
         run: cargo build --lib
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1077,7 +1077,7 @@ jobs:
           fail_on_unmatched_files: false
 
       - name: Install cargo-cyclonedx
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2
         with:
           tool: cargo-cyclonedx
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -41,6 +41,6 @@ jobs:
           retention-days: 5
 
       - name: Upload Scorecard results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,181 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.47] - 2026-05-11
+
+This release closes the remaining bugs surfaced by the kreuzberg
+integration (issue [#484](https://github.com/yfedoseev/pdf_oxide/issues/484))
+and ships the related text-extraction quality fixes.  Word-F1 against the
+pdftotext-derived ground truth corpus now meets the kreuzberg quality
+floor for every PDF in the issue 484 set.
+
+### Fixed
+
+- **kreuzberg regression suite — all 24 PDFs now meet the F1 floor
+  ([#484](https://github.com/yfedoseev/pdf_oxide/issues/484))** —
+  `extract_text` previously failed three documents reported by
+  @Goldziher on the kreuzberg corpus: `pdfa_039.pdf` (swimming-results
+  table) returned F1 0.810, `pr-136-example.pdf` (CJK financial document)
+  returned F1 0.709, and `annotations.pdf` returned F1 0.545.  Three
+  separate root-cause fixes restore them to F1 ≥ 0.85:
+  - `eliminate duplicate emission of multi-row table labels` — the
+    text-only spatial fallback in `detect_tables_with_lines` now
+    requires `config.text_fallback=true` (which `extract_text` does
+    not pass) so report-style PDFs with decorative ruling lines no
+    longer get their cell content emitted twice; `span_in_table` adds
+    a text-match fallback to catch label spans whose font ascent
+    extends slightly above the cell's ink box (issue-53-example.pdf
+    F1 0.867 → 0.992).
+  - `tighten cross-font glue and decimal merge for CJK + Latin
+    layouts` — `cross_font_word_glue` no longer fires on a CJK ↔
+    non-CJK boundary (CJK ideographs satisfy `is_alphabetic()` per
+    Unicode and were being concatenated with adjacent Latin); the
+    `decimal_merge` heuristic requires a column-boundary-sized gap
+    (gap > 0.4 em) so per-glyph Tj operators in CJK documents stop
+    mangling "2013" into "201.3" (pr-136 F1 0.709 → 0.884).
+  - `narrow CJK boundary forced-space to script glyphs only` —
+    `should_insert_space` now actively inserts a space at the
+    CJK ↔ non-CJK boundary to match pdftotext tokenisation, but
+    restricted to actual script glyphs (ideographs, kana, hangul);
+    fullwidth ASCII operators like ＜ ＞ ＝ μ stay inline with
+    adjacent digits/Latin so compound tokens like "60000≤Q＜80000"
+    are preserved (issue-336 text quality gate stays at PASS).
+  Reported by @Goldziher.
+
+- **`extract_spans` now exposes a `merge_tm_tj_runs` opt-out
+  ([#488](https://github.com/yfedoseev/pdf_oxide/issues/488))** —
+  Same-line Tm+Tj runs were unconditionally batched into a single
+  `TextSpan`, throwing away the per-Tm positioning that downstream
+  layout-analysis code (e.g. column-aware table detection) needs.
+  `SpanMergingConfig::merge_tm_tj_runs` (default `true` for backward
+  compatibility) now flushes the span buffer at every Tm operator so
+  callers can opt in to one span per Tm+Tj group, matching the
+  granularity of `pdftotext -bbox-layout`.  Reported by @haberman.
+
+- **`saveEncryptedToBytes` no longer panics in browser WASM
+  ([#492](https://github.com/yfedoseev/pdf_oxide/issues/492))** —
+  `generate_file_id` (per ISO 32000-1 §14.4) called
+  `std::time::SystemTime::now()`, which is unimplemented on
+  `wasm32-unknown-unknown`.  Cfg-gated so the WASM build derives the
+  file identifier from `uuid::Uuid::new_v4()` only — still a unique
+  opaque 16-byte ID per the spec.  Reported by @eersis-byte.
+
+- **CJK fullwidth operator spacing in `to_markdown` / `to_html`
+  ([#485](https://github.com/yfedoseev/pdf_oxide/issues/485)) —
+  partial fix.** Two layers:
+  - `pipeline/converters/has_horizontal_gap` suppresses space
+    insertion when one side is CJK and the other is CJK or a
+    fullwidth/math operator (≤, ＜, ＞, ＝, μ, etc.), mirroring the
+    text-extraction CJK-pair suppression.
+  - `extract_cell_text` no longer inserts an unconditional space
+    between adjacent spans on the same row of a table cell — uses
+    the same gap-aware separator rules as the inline-flow path so
+    multi-span cells like `60000≤Q＜80000` (rendered as 5 separate
+    Tj operators) keep their compound tokens intact.
+  The fix lifts `extract_text` from F1 0.612 to 0.820 on
+  `issue-336-example.pdf`.  `to_markdown` / `to_html` still score
+  below threshold (0.577 / 0.632 vs 0.69 / 0.65) because the
+  underlying tables get fragmented into single-row tables that the
+  is_real_grid filter rejects, after which the column-based reading
+  order splits each row across multiple `<p>` paragraphs — that
+  reading-order layer is tracked separately for a follow-up.
+
+- **Text-only spatial table fallback for line-less tables in
+  `to_markdown`
+  ([#486](https://github.com/yfedoseev/pdf_oxide/issues/486)) —
+  partial fix.** `extract_page_tables` now opts in to a relaxed
+  text-only detection when the caller is a converter (text_fallback=
+  true), with the column ceiling raised from 15 to 25 so that
+  sailing-score grids with 16-18 score columns are no longer
+  rejected outright.  Markdown still drops the score data on the
+  larger nougat_018 table because the fragmentation produces
+  single-row sub-tables that fail `is_real_grid` — converging the
+  fragmented sub-tables into one logical table is the remaining
+  work.
+
+- **HTML table cell rendering aligned with markdown
+  ([#487](https://github.com/yfedoseev/pdf_oxide/issues/487)) —
+  partial fix.** `to_html` now uses the same span-walking and
+  bold/italic preservation as `to_markdown`'s
+  `render_table_markdown`.  Three of four affected docs improved
+  by 1-4 % Jaccard but two (nougat_018, nougat_026) still trail the
+  threshold pending the table-fragmentation work above.
+
+- **RTL inline emphasis stripping in markdown extraction
+  ([#459](https://github.com/yfedoseev/pdf_oxide/issues/459))** —
+  RTL detection now strips `<strong>` / `<em>` markers from
+  visually-reversed runs in `to_markdown` consistently with the
+  plain-text path; spec basis ISO 32000-1 §14.8.2.3.3 (Reverse-
+  Order Show Strings).  46 unit tests in
+  `tests/test_rtl_script_support.rs` cover the detector, BiDi
+  algorithm, and inline-flow integration.
+
+- **Multi-byte CMap parsing and array-form `beginbfrange`
+  (§9.7.5)** — `beginbfrange ... endbfrange` array notation
+  `<src> <src> [<dst1> <dst2> ...]` was not fully covered; the
+  CMap parser now matches the spec's allowed grammar so multi-byte
+  CIDs map correctly through ToUnicode CMaps.
+
+- **`/StructTreeRoot`-only tagged PDFs (§14.7.4)** — Documents
+  that declare `/StructTreeRoot` in the catalog without a
+  `/MarkInfo` dictionary (PDF 1.4 documents, valid per the spec)
+  now correctly use the structure tree for table-cell content
+  extraction.  Resolves `/OBJR` content-item references during
+  tree traversal so OBJR-referenced annotations and XObjects are
+  no longer lost.
+
+- **Indirect references in MediaBox/CropBox accessors (§7.7.3.4)**
+  — Page attribute accessors now resolve `/MediaBox` and `/CropBox`
+  through indirect references and the `/Pages` inheritance chain.
+  This is what made the Bucket A errors in the issue 484 retest
+  comment (`annotations*.pdf`, `pdfa_039.pdf`) parse successfully.
+
+- **CTM-aware cache key for Form XObject span extraction** — Form
+  XObject spans were cached by XObject reference alone, returning
+  stale coordinates for the same XObject reused on multiple pages
+  with different CTM transforms.  Cache key now includes the CTM
+  so repeated XObjects produce correctly-positioned spans on each
+  invocation.
+
+- **`notdefrange` U+FFFD no longer blocks the CID-as-Unicode
+  fallback (§9.10.2)** — Per the spec, U+FFFD (REPLACEMENT
+  CHARACTER) signals "no proper Unicode mapping", so a notdefrange
+  hit must not stop the priority list.  The Identity CID-as-Unicode
+  fallback (Priority 3) now fires correctly for composite fonts
+  whose ToUnicode CMap returns U+FFFD.
+
+- **ToUnicode Priority-3 fallback guarded for composite fonts
+  (§9.10.2)** — The CID-as-Unicode fallback is now only applied
+  to fonts whose CMap is one of the predefined composite-font
+  CMaps or whose CIDFont uses one of the Adobe character
+  collections, matching the spec's enumeration; misapplication on
+  other fonts could produce mojibake on previously-working files.
+
+### Notes
+
+- All 4 987 unit tests pass; one quality-gate test
+  (`test_text_fallback_detects_lineless_grid` in
+  `src/structure/spatial_table_detector.rs`) was updated to set
+  `text_fallback: true` explicitly since the default no longer
+  enables it.
+- Six quality-gate Jaccard tests in
+  `tests/test_corpus_extraction_quality.rs` remain failing
+  against their target thresholds (issue-336 md/html, nougat_018
+  md/html, nougat_026 html, pdfa_036 html); those are tracked
+  under #485, #486, #487 as the partial-fix work continues.
+
+### Thanks
+
+This release was driven entirely by community bug reports and the
+kreuzberg integration test feedback loop:
+
+- @Goldziher (kreuzberg-dev) — opened #484 with a calibrated 166-PDF
+  regression suite and follow-up retest comments that turned every
+  remaining gap into a focused root-cause fix
+- @haberman — opened #488 with a minimal Rust reproducer for the
+  Tm+Tj merging issue
+- @eersis-byte — opened #492 with the WASM `SystemTime` panic backtrace
+
 ## [0.3.46] - 2026-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,25 +164,54 @@ floor for every PDF in the issue 484 set.
   collections, matching the spec's enumeration; misapplication on
   other fonts could produce mojibake on previously-working files.
 
+- **Reject prose / TOC / underline-annotation false-positive
+  tables in `to_html` and `to_markdown`** — Wide pages of
+  ordinary paragraph text were sometimes detected as multi-column
+  tables: word x-positions cluster into "columns" by accident, and
+  decorative horizontal rules (newsletter mastheads, annotation
+  underlines, page borders) tricked the line-based detector into
+  treating two adjacent lines as a header + data row.  The
+  detection pipeline now applies several post-`is_real_grid`
+  guards that look at the *shape* of the candidate's cell
+  content rather than just its grid geometry:
+  - `looks_like_prose_table` rejects a candidate when more than
+    12 % of cells end with a mid-sentence `,` or `;`, more than
+    25 % of cells start with a lowercase ASCII letter
+    (continuation fragments like "and", "the", "to"), or more
+    than 10 % of cells are pure leader dots (the `. . . . . .`
+    runs in tables of contents).
+  - The text-only spatial fallback and the horizontal-rule-
+    bounded path both now require ≥ 3 rows of evidence.  A
+    title plus a wrapped body line is the signature of prose,
+    not a table; only the line-based intersection / cluster
+    paths (which have authoritative visual evidence) still
+    accept 2-row tables.
+  - `should_insert_space` no longer forces a space at the
+    CJK ↔ ASCII-punctuation boundary.  The boundary forced-
+    space added in v0.3.47 was correctly inserting a space at
+    "神鹰集团" + "2015" but was wrongly producing "する ."
+    instead of "する." in Japanese technical text; ASCII
+    clause punctuation hugs the preceding token in every
+    script, so the rule is now suppressed when the
+    transitioning glyph IS the punctuation.
+  - `text_fallback` defaults back to `true` on
+    `TableDetectionConfig`.  The new prose-shape filter
+    replaces the gate-based protection added earlier in the
+    cycle, so the public `extract_tables` API again detects
+    line-less data tables out of the box.
+
 ### Notes
 
-- All 4 987 unit tests pass; one quality-gate test
-  (`test_text_fallback_detects_lineless_grid` in
-  `src/structure/spatial_table_detector.rs`) was updated to set
-  `text_fallback: true` explicitly since the default no longer
-  enables it.
 - `tests/test_corpus_extraction_quality.rs` now strips markdown
   formatting markers (`**bold**`, `*italic*`, `|` separators,
   `---|---|---` rule, `# heading`, ```` ``` ```` fences) before
   computing Jaccard against the plain-text GT — mirrors the HTML
   test's existing `strip_html` step so the score reflects text
   content rather than formatting markup.
-- Four quality-gate Jaccard tests in
-  `tests/test_corpus_extraction_quality.rs` remain failing
-  against their target thresholds (nougat_018 md/html,
-  nougat_026 html, pdfa_036 html); those are tracked
-  under #486, #487 as the remaining partial-fix work.  15 of 19
-  quality gates now pass (up from 13 at the start of this branch).
+- All 19 quality-gate Jaccard tests in
+  `tests/test_corpus_extraction_quality.rs` now pass (up from
+  13 at the start of this branch).  The kreuzberg issue 484
+  corpus passes its F1 floor on every PDF.
 
 ### Thanks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,9 @@ floor for every PDF in the issue 484 set.
   opaque 16-byte ID per the spec.  Reported by @eersis-byte.
 
 - **CJK fullwidth operator spacing in `to_markdown` / `to_html`
-  ([#485](https://github.com/yfedoseev/pdf_oxide/issues/485)) —
-  partial fix.** Two layers:
+  ([#485](https://github.com/yfedoseev/pdf_oxide/issues/485))** —
+  Four coordinated changes restore `issue-336-example.pdf` to PASS
+  on all three quality gates (text, markdown, html):
   - `pipeline/converters/has_horizontal_gap` suppresses space
     insertion when one side is CJK and the other is CJK or a
     fullwidth/math operator (≤, ＜, ＞, ＝, μ, etc.), mirroring the
@@ -73,13 +74,22 @@ floor for every PDF in the issue 484 set.
     the same gap-aware separator rules as the inline-flow path so
     multi-span cells like `60000≤Q＜80000` (rendered as 5 separate
     Tj operators) keep their compound tokens intact.
-  The fix lifts `extract_text` from F1 0.612 to 0.820 on
-  `issue-336-example.pdf`.  `to_markdown` / `to_html` still score
-  below threshold (0.577 / 0.632 vs 0.69 / 0.65) because the
-  underlying tables get fragmented into single-row tables that the
-  is_real_grid filter rejects, after which the column-based reading
-  order splits each row across multiple `<p>` paragraphs — that
-  reading-order layer is tracked separately for a follow-up.
+  - `consolidate_adjacent_table_fragments` (new helper in
+    `spatial_table_detector`) merges vertically-adjacent tables that
+    share an identical column structure.  The line-based detector
+    emits one fragment per ruling-rule strip on PDFs that draw a
+    horizontal rule between every pair of rows; each fragment was
+    failing `is_real_grid` and falling through to paragraph flow
+    with column-based reading order, producing orphan
+    `<p>40000≤Q</p>` / `<p>＜55000</p>` pairs.  Consolidating before
+    the filter lets the merged multi-row table survive.
+  - `is_real_grid` accepts wide consolidated tables that have
+    dense data rows alongside sparse header / multi-row-label rows
+    — the strict 70 % dense-ratio gate was rejecting real tables
+    whose column headers split across multiple visual rows.
+  Score improvements on `issue-336-example.pdf`:
+  text 0.612 → 0.820, markdown 0.577 → 0.863, html 0.632 → 0.646
+  (all PASS their thresholds).
 
 - **Text-only spatial table fallback for line-less tables in
   `to_markdown`
@@ -88,11 +98,13 @@ floor for every PDF in the issue 484 set.
   text-only detection when the caller is a converter (text_fallback=
   true), with the column ceiling raised from 15 to 25 so that
   sailing-score grids with 16-18 score columns are no longer
-  rejected outright.  Markdown still drops the score data on the
-  larger nougat_018 table because the fragmentation produces
-  single-row sub-tables that fail `is_real_grid` — converging the
-  fragmented sub-tables into one logical table is the remaining
-  work.
+  rejected outright.  The fragmented-table consolidation from #485
+  also kicks in here, recovering most of the row labels and
+  identifier columns.  `nougat_018.pdf` markdown still trails its
+  threshold (0.656 vs 0.90) because the score columns themselves —
+  variable-width sparse cells with parenthesised drop-scores —
+  evade column detection; that is the remaining piece tracked
+  separately.
 
 - **HTML table cell rendering aligned with markdown
   ([#487](https://github.com/yfedoseev/pdf_oxide/issues/487)) —
@@ -159,11 +171,18 @@ floor for every PDF in the issue 484 set.
   `src/structure/spatial_table_detector.rs`) was updated to set
   `text_fallback: true` explicitly since the default no longer
   enables it.
-- Six quality-gate Jaccard tests in
+- `tests/test_corpus_extraction_quality.rs` now strips markdown
+  formatting markers (`**bold**`, `*italic*`, `|` separators,
+  `---|---|---` rule, `# heading`, ```` ``` ```` fences) before
+  computing Jaccard against the plain-text GT — mirrors the HTML
+  test's existing `strip_html` step so the score reflects text
+  content rather than formatting markup.
+- Four quality-gate Jaccard tests in
   `tests/test_corpus_extraction_quality.rs` remain failing
-  against their target thresholds (issue-336 md/html, nougat_018
-  md/html, nougat_026 html, pdfa_036 html); those are tracked
-  under #485, #486, #487 as the partial-fix work continues.
+  against their target thresholds (nougat_018 md/html,
+  nougat_026 html, pdfa_036 html); those are tracked
+  under #486, #487 as the remaining partial-fix work.  15 of 19
+  quality gates now pass (up from 13 at the start of this branch).
 
 ### Thanks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.46"
+version = "0.3.47"
 dependencies = [
  "aes 0.9.0",
  "aws-lc-rs",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.46"
+version = "0.3.47"
 dependencies = [
  "clap",
  "is-terminal",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.46"
+version = "0.3.47"
 dependencies = [
  "pdf_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.46"
+version = "0.3.47"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.46</Version>
+    <Version>0.3.47</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -52,7 +52,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion = "0.3.46"
+	fallbackVersion = "0.3.47"
 	BaseURL         = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	// cacheSubdir lives under os.UserCacheDir() — XDG_CACHE_HOME on Linux,
 	// ~/Library/Caches on macOS (Time-Machine-excluded), %LocalAppData% on

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.46"
+version = "0.3.47"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ doctest = false
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.46", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.47", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.46"
+version = "0.3.47"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.46", path = ".." }
+pdf_oxide = { version = "0.3.47", path = ".." }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.46"
+version = "0.3.47"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/document.rs
+++ b/src/document.rs
@@ -4231,14 +4231,26 @@ impl PdfDocument {
             base_spans = base_spans.filter_by_rect(region, mode);
         }
 
-        // Structure tree: check MarkInfo first (cheap) to skip non-tagged PDFs.
+        // Structure tree: try to load when MarkInfo says "marked" OR when the
+        // catalog directly references a StructTreeRoot (PDF 1.4 documents such
+        // as hello_structure.pdf predate the MarkInfo dictionary but are still
+        // valid tagged PDFs per §14.7.1).  Checking the catalog for
+        // /StructTreeRoot is cheap — it's a single dictionary key lookup.
         let cached_tree = {
             let cached = self.structure_tree_cache.lock_or_recover().clone();
             match cached {
                 Some(tree) => tree,
                 None => {
                     let is_marked = self.mark_info().map(|m| m.marked).unwrap_or(false);
-                    let tree = if is_marked {
+                    // Fall back to checking the catalog directly when MarkInfo is
+                    // absent or /Marked is false — presence of /StructTreeRoot is
+                    // authoritative for "is this a tagged PDF" per the spec.
+                    let has_struct_tree_root = !is_marked && self
+                        .catalog()
+                        .ok()
+                        .and_then(|cat| cat.as_dict().map(|d| d.contains_key("StructTreeRoot")))
+                        .unwrap_or(false);
+                    let tree = if is_marked || has_struct_tree_root {
                         self.structure_tree().ok().flatten().map(Arc::new)
                     } else {
                         None
@@ -10438,7 +10450,12 @@ impl PdfDocument {
                 Some(tree) => tree,
                 None => {
                     let is_marked = self.mark_info().map(|m| m.marked).unwrap_or(false);
-                    let tree = if is_marked {
+                    let has_struct_tree_root = !is_marked && self
+                        .catalog()
+                        .ok()
+                        .and_then(|cat| cat.as_dict().map(|d| d.contains_key("StructTreeRoot")))
+                        .unwrap_or(false);
+                    let tree = if is_marked || has_struct_tree_root {
                         self.structure_tree().ok().flatten().map(Arc::new)
                     } else {
                         None

--- a/src/document.rs
+++ b/src/document.rs
@@ -5735,7 +5735,7 @@ impl PdfDocument {
     /// sailing-score / competition-table PDFs where two adjacent columns (e.g. Q8=1,
     /// F9=10) are stored as a single Tj text run "1.10" spanning both column cells.
     /// kreuzberg's GT tokenises them as separate words; we must split at the dot.
-    fn is_column_spanning_decimal(span: &TextSpan) -> bool {
+    pub(crate) fn is_column_spanning_decimal(span: &TextSpan) -> bool {
         let text = &span.text;
         let dot_pos = match text.find('.') {
             Some(p) if p > 0 && p < text.len() - 1 => p,
@@ -5751,6 +5751,21 @@ impl PdfDocument {
             return false;
         }
         let char_count = text.chars().count();
+        // Signal 1: sparse char_widths array.  When the font's glyph
+        // iteration produces fewer advance-width entries than there are
+        // characters in the decoded string, the span was assembled from two
+        // (or more) concatenated Tj runs whose widths come from different
+        // points in the glyph table.  This is the exact pattern issue 487
+        // nougat_018 sailing-score grids hit: each score cell is emitted as
+        // a single Tj like `1.10` with `char_widths=[w]` while the PDF
+        // semantically means "1" followed by "10" in adjacent score
+        // columns.  bbox.width can still be tight here (the producer set
+        // it to cover just the rendered glyph run), so the existing
+        // bbox-inflation check below misses these.  Catch them via the
+        // sparse-cw signal directly.
+        if !span.char_widths.is_empty() && span.char_widths.len() < char_count {
+            return true;
+        }
         let expected_width = if !span.char_widths.is_empty() {
             let cw_sum: f32 = span.char_widths.iter().sum();
             cw_sum * (char_count as f32 / span.char_widths.len() as f32)
@@ -5777,7 +5792,7 @@ impl PdfDocument {
     /// where "Theorem" widths come from the font's glyph table and "1.7" doesn't have
     /// matching glyph entries).  Return the byte offset at which to insert a space,
     /// or None if no split is appropriate.
-    fn char_widths_boundary_split(span: &TextSpan) -> Option<usize> {
+    pub(crate) fn char_widths_boundary_split(span: &TextSpan) -> Option<usize> {
         let cw_len = span.char_widths.len();
         if cw_len == 0 {
             return None;
@@ -5987,7 +6002,7 @@ impl PdfDocument {
     /// Priority 1: column-spanning decimal (nougat_018 sailing tables).
     /// Priority 2: char_widths boundary split (pdfa_004 CID-font merge artifacts).
     #[inline]
-    fn push_span_text(out: &mut String, span: &TextSpan) {
+    pub(crate) fn push_span_text(out: &mut String, span: &TextSpan) {
         // A span whose entire text is one or more newline/CR characters is a
         // ToUnicode line-break signal.  Treat it as a logical newline separator rather
         // than emitting the raw control characters verbatim as visible content.

--- a/src/document.rs
+++ b/src/document.rs
@@ -4388,7 +4388,7 @@ impl PdfDocument {
                     // Using per-cell bboxes (rather than the coarser table bbox) prevents
                     // dropping paragraph spans that lie inside the table's outer bounding
                     // box but were not captured as table cells by the spatial detector.
-                    tables.iter().any(|t| {
+                    if tables.iter().any(|t| {
                         t.rows.iter().any(|r| {
                             r.cells.iter().any(|c| {
                                 c.bbox.is_some_and(|b| {
@@ -4399,6 +4399,37 @@ impl PdfDocument {
                                     )
                                 })
                             })
+                        })
+                    }) {
+                        return true;
+                    }
+                    // Fallback: text-based match. The bbox check above uses
+                    // a tight 0.1pt tolerance and rejects spans whose font
+                    // ascent extends slightly above the cell's ink box (issue
+                    // 484: "FY 15 1st Q TTL" labels in JAL traffic table —
+                    // span height = font_size = 10.7pt, but cell bbox height
+                    // = 15.96pt covers two ink rows so the label glyphs reach
+                    // ~0.4pt above the cell's top edge). When a span's
+                    // trimmed text exactly matches some cell's text, the cell
+                    // already owns it — keeping it in flow would duplicate.
+                    let trimmed = s.text.trim();
+                    if trimmed.is_empty() {
+                        return false;
+                    }
+                    if !table_cell_texts.contains(trimmed) {
+                        return false;
+                    }
+                    // Require spatial proximity: the span must lie inside
+                    // some table's outer bbox so we don't drop body text that
+                    // coincidentally matches a cell's text elsewhere on the page.
+                    tables.iter().any(|t| {
+                        t.bbox.is_some_and(|tb| {
+                            let cx = s.bbox.x + s.bbox.width / 2.0;
+                            let cy = s.bbox.y + s.bbox.height / 2.0;
+                            cx >= tb.x - RETAIN_TOLERANCE
+                                && cx <= tb.x + tb.width + RETAIN_TOLERANCE
+                                && cy >= tb.y - RETAIN_TOLERANCE
+                                && cy <= tb.y + tb.height + RETAIN_TOLERANCE
                         })
                     })
                 };
@@ -5636,6 +5667,8 @@ impl PdfDocument {
                 | 0x4E00..=0x9FFF // CJK Unified Ideographs
                 | 0xAC00..=0xD7AF // Hangul Syllables
                 | 0x20000..=0x2A6DF // CJK Unified Ideographs Extension B
+                | 0xFF00..=0xFFEF // Halfwidth and Fullwidth Forms
+                | 0x3000..=0x303F // CJK Symbols and Punctuation
             )
         };
         if prev_tail.is_some_and(is_cjk) && curr_head.is_some_and(is_cjk) {
@@ -5645,6 +5678,26 @@ impl PdfDocument {
         // Calculate horizontal gap
         let prev_end_x = prev.bbox.x + prev.bbox.width;
         let gap = current.bbox.x - prev_end_x;
+
+        // CJK ↔ non-CJK boundary: pdftotext (and the GT it produces) inserts
+        // a space wherever a CJK ideograph meets a Latin/digit character on
+        // the same line, regardless of how tightly the two glyphs were
+        // typeset.  Without this, mixed-script content like "神鹰集团" + "2015"
+        // collapses into one word-F1 token "神鹰集团2015", which never matches
+        // GT's separate "神鹰集团" and "2015" tokens (issue 484, pr-136).
+        // Force a space at the script boundary as long as the two glyphs are
+        // not horizontally overlapping (genuine kerning) and the gap is
+        // within the same-line column.
+        let crosses_cjk_boundary = match (prev_tail, curr_head) {
+            (Some(p), Some(c)) => is_cjk(p) != is_cjk(c),
+            _ => false,
+        };
+        if crosses_cjk_boundary
+            && gap > -0.5
+            && gap < font_size * 5.0
+        {
+            return true;
+        }
 
         // Space threshold: 0.15 × font size
         // Typical space width is ~0.25em, so 0.15em catches gaps > 60% of a space.
@@ -6321,29 +6374,32 @@ impl PdfDocument {
                 }
             }
 
-            // Only subtypes whose /Contents is rendered as visible page content.
-            // Per ISO 32000-1 §12.5.6.2 (Table 166), the /Contents key in ALL markup
-            // Per ISO 32000-1 §12.5.6.2 (Table 166), the /Contents of markup
-            // annotations — including Highlight, Underline, StrikeOut, Squiggly,
-            // Ink, Caret, FileAttachment, Redact, and geometric shapes (Line,
-            // Circle, Square, Polygon, PolyLine) — is popup/comment text written
-            // by a reviewer, NOT text displayed on the page. Only FreeText, Text
-            // (note icon), and Stamp annotations have /Contents that represents the
-            // annotation's visible label or overlay.
-            let has_contents = matches!(subtype_lc.as_str(), "text" | "freetext" | "stamp");
-            if !has_contents {
+            // Only FreeText and Stamp have /Contents representing visible page text.
+            // Text (sticky-note) /Contents is reviewer comment text shown in a pop-up
+            // window, not rendered on the page — exclude it to avoid injecting popup
+            // notes into the body text stream.
+            // For FreeText/Stamp: try /Contents first; fall back to AP stream so that
+            // Stamp annotations with empty /Contents but a rendered AP stream are included.
+            let is_visible = matches!(subtype_lc.as_str(), "freetext" | "stamp");
+            if !is_visible {
                 continue;
             }
 
-            let text = match dict.get("Contents") {
-                Some(Object::String(s)) => {
+            let text = {
+                let from_contents = if let Some(Object::String(s)) = dict.get("Contents") {
                     let decoded = Self::decode_pdf_text_string(s).trim().to_string();
-                    if decoded.is_empty() {
-                        continue;
+                    if decoded.is_empty() { None } else { Some(decoded) }
+                } else {
+                    None
+                };
+                if let Some(t) = from_contents {
+                    t
+                } else {
+                    match self.extract_text_from_ap_stream(&dict) {
+                        Some(ap_text) if !ap_text.trim().is_empty() => ap_text.trim().to_string(),
+                        _ => continue,
                     }
-                    decoded
-                },
-                _ => continue,
+                }
             };
 
             // Use /Rect as the annotation's bounding box.
@@ -6573,7 +6629,7 @@ impl PdfDocument {
                     // Skip them here to avoid duplicate text at the end of output.
                     continue;
                 },
-                "freetext" | "stamp" | "text" => {
+                "freetext" | "stamp" => {
                     if let Some(Object::String(s)) = dict.get("Contents") {
                         let decoded = Self::decode_pdf_text_string(s);
                         let trimmed = decoded.trim().to_string();
@@ -6582,6 +6638,9 @@ impl PdfDocument {
                         }
                     }
                 },
+                // Text (sticky-note) /Contents is reviewer popup comment text, not
+                // visible page content — skip to avoid injecting popup notes.
+                "text" => {},
                 // Geometric shape annotations — per §12.5.6.2, their /Contents is
                 // also popup/comment text, same as the markup group below.
                 "line" | "circle" | "square" | "polygon" | "polyline" => {
@@ -15878,11 +15937,13 @@ mod tests {
 
     #[test]
     fn test_annotation_text_type() {
+        // Text (sticky-note) /Contents is reviewer popup comment text, not visible page
+        // content — it must NOT appear in extract_text output (ISO 32000-1 §12.5.6.2).
         let annot = b"4 0 obj\n<< /Type /Annot /Subtype /Text /Contents (Sticky note) >>\nendobj\n"
             .to_vec();
         let pdf = build_pdf_with_annotations(vec![(4, annot)]);
         let doc = PdfDocument::from_bytes(pdf).unwrap();
-        assert!(doc.extract_text(0).unwrap().contains("Sticky note"));
+        assert!(!doc.extract_text(0).unwrap().contains("Sticky note"));
     }
 
     #[test]
@@ -15957,6 +16018,8 @@ mod tests {
 
     #[test]
     fn test_annotation_multiple() {
+        // FreeText /Contents is visible page text; Text (sticky-note) /Contents is popup
+        // comment — only FreeText should appear in extract_text output.
         let a1 =
             b"4 0 obj\n<< /Type /Annot /Subtype /FreeText /Contents (First) >>\nendobj\n".to_vec();
         let a2 =
@@ -15965,7 +16028,7 @@ mod tests {
         let doc = PdfDocument::from_bytes(pdf).unwrap();
         let text = doc.extract_text(0).unwrap();
         assert!(text.contains("First"));
-        assert!(text.contains("Second"));
+        assert!(!text.contains("Second"));
     }
 
     #[test]

--- a/src/document.rs
+++ b/src/document.rs
@@ -10713,6 +10713,17 @@ impl PdfDocument {
             &config,
         );
 
+        // Issue 484/486/487: when a logical multi-row table is drawn with a
+        // horizontal ruling line between every pair of rows, the line-based
+        // detector emits one Table per row strip. Each fragment is a 1- or
+        // 2-row table that fails is_real_grid below and gets dropped, after
+        // which the cells fall through to paragraph flow with column-based
+        // reading order — producing orphan `<p>40000≤Q</p>` /
+        // `<p>＜55000</p>` pairs.  Consolidate vertically-adjacent fragments
+        // that share an identical column structure BEFORE applying
+        // is_real_grid so the merged multi-row table survives the filter.
+        let raw_tables = crate::structure::spatial_table_detector::consolidate_adjacent_table_fragments(raw_tables);
+
         // Per #457 Step 4: spatial detection without struct-tree backing
         // is prone to false positives on form-style layouts (label-colon-
         // value pairs that align horizontally, form fillable boxes drawn

--- a/src/document.rs
+++ b/src/document.rs
@@ -4224,7 +4224,10 @@ impl PdfDocument {
 
         // Table detection uses base spans only (no widget spans).
         let tables = if options.extract_tables {
-            self.extract_page_tables(page_index, &base_spans, options)
+            // text_fallback=false: extract_text preserves the pre-v0.3.47 behaviour
+            // where line-less pages return no tables.  Only the structured-output
+            // converters (to_markdown, to_html) opt in to text-only spatial fallback.
+            self.extract_page_tables(page_index, &base_spans, options, false)
         } else {
             Vec::new()
         };
@@ -10389,6 +10392,7 @@ impl PdfDocument {
         page_index: usize,
         spans: &[TextSpan],
         options: &crate::converters::ConversionOptions,
+        text_fallback: bool,
     ) -> Vec<crate::structure::Table> {
         // Strategy 1: Structure tree (tagged PDFs)
         let struct_tree_opt = {
@@ -10465,7 +10469,14 @@ impl PdfDocument {
         }
 
         // Strategy 2: Hybrid spatial detection (v0.3.14)
-        let config = options.table_detection_config.clone().unwrap_or_default();
+        let mut config = options.table_detection_config.clone().unwrap_or_default();
+        // Converter callers (to_markdown, to_html) opt in to text-only spatial
+        // fallback so that line-less tables (e.g. sailing-score grids) are still
+        // detected when no ruling lines are present.  The public extract_tables()
+        // API keeps text_fallback = false for backward compatibility.
+        if text_fallback {
+            config.text_fallback = true;
+        }
 
         // Extract vector paths (lines/rects) for visual detection
         let paths = self.extract_paths(page_index).unwrap_or_default();
@@ -10488,8 +10499,14 @@ impl PdfDocument {
                 (config.horizontal_strategy, config.vertical_strategy),
                 (TableStrategy::Text, TableStrategy::Text)
             );
-            if !is_text_only {
+            if !is_text_only && !config.text_fallback {
                 return Vec::new();
+            }
+            if !is_text_only && config.text_fallback {
+                log::debug!(
+                    "No ruling lines on page {} — using text-only spatial fallback (issue #486)",
+                    page_index
+                );
             }
         }
         let paths = table_paths;
@@ -10541,7 +10558,7 @@ impl PdfDocument {
         // value pairs that align horizontally, form fillable boxes drawn
         // with thin lines). Drop tables that don't look like real grids.
         let raw_count = raw_tables.len();
-        let tables: Vec<crate::structure::Table> = raw_tables
+        let mut tables: Vec<crate::structure::Table> = raw_tables
             .into_iter()
             .filter(|t| t.is_real_grid())
             .collect();
@@ -10560,6 +10577,105 @@ impl PdfDocument {
                 page_index
             );
         }
+
+        // Text-only spatial fallback for converter paths (to_markdown / to_html — issue #486).
+        //
+        // Wide data tables (e.g. sailing-score grids with 16-18 columns) exceed the default
+        // `max_table_columns: 15` limit and are rejected by the main pipeline.  When the
+        // caller explicitly opted in to text-only detection (text_fallback=true), retry with
+        // a relaxed config that raises the column ceiling and adjusts tolerances so that
+        // genuinely wide data tables are captured.
+        //
+        // Safety guards:
+        // - Only fires when the main pipeline returned no tables (avoids double-counting).
+        // - Only fires when the caller is a converter (text_fallback=true).
+        // - When ruling lines exist, spans are filtered to the line-bounded region to
+        //   prevent page headers/footers from being erroneously included in the table.
+        // - Results must pass is_real_grid() just like main-pipeline tables.
+        if config.text_fallback && tables.is_empty() {
+            use crate::structure::spatial_table_detector::detect_tables_from_spans_column_aware;
+            // Build a relaxed config derived from the caller's config.
+            // We only raise the limits known to block wide data tables (e.g. sailing
+            // score grids with 16-18 columns that exceed the default max_table_columns=15).
+            let relaxed_config = crate::structure::spatial_table_detector::TableDetectionConfig {
+                // Allow up to 25 columns — covers 17-column sailing score tables.
+                max_table_columns: config.max_table_columns.max(25),
+                // Tighter column grouping than the default 15 pt so that nearby
+                // score columns are not merged into each other.
+                column_tolerance: config.column_tolerance.min(10.0),
+                // Looser merge threshold so that columns with slight X scatter
+                // (e.g. centred numeric cells) are aggregated correctly.
+                column_merge_threshold: config.column_merge_threshold.max(30.0),
+                // Inherit all other settings from caller's config.
+                ..config.clone()
+            };
+
+            // When ruling lines are present on the page, restrict text detection to
+            // spans that fall within the VERTICAL-LINE Y bounds.  Vertical lines
+            // define the table's column structure and their Y extent precisely
+            // delineates the table rows, excluding page headers and footers which
+            // sit above/below the table frame.
+            //
+            // Note: we use V-line Y bounds specifically (not total path bbox) because
+            // H-lines in these PDFs often span the full page height (outer frame),
+            // while V-lines are confined to the interior table region.
+            let candidate_spans: Vec<crate::layout::TextSpan>;
+            let fallback_spans: &[crate::layout::TextSpan] = {
+                let v_lines: Vec<_> = paths
+                    .iter()
+                    .filter(|p| {
+                        p.is_vertical_line(2.0)
+                    })
+                    .collect();
+                if !v_lines.is_empty() {
+                    let vline_y_min =
+                        v_lines.iter().map(|p| p.bbox.y).fold(f32::INFINITY, f32::min);
+                    let vline_y_max = v_lines
+                        .iter()
+                        .map(|p| p.bbox.y + p.bbox.height)
+                        .fold(f32::NEG_INFINITY, f32::max);
+                    // Small margin to include spans whose centres just touch the frame.
+                    const V_MARGIN: f32 = 5.0;
+                    candidate_spans = input_spans
+                        .iter()
+                        .filter(|s| {
+                            let cy = s.bbox.y + s.bbox.height * 0.5;
+                            cy >= vline_y_min - V_MARGIN && cy <= vline_y_max + V_MARGIN
+                        })
+                        .cloned()
+                        .collect();
+                    log::debug!(
+                        "Text fallback (page {}): V-lines Y=[{:.1},{:.1}] — filtered {} spans to {}",
+                        page_index,
+                        vline_y_min,
+                        vline_y_max,
+                        input_spans.len(),
+                        candidate_spans.len()
+                    );
+                    &candidate_spans
+                } else {
+                    input_spans
+                }
+            };
+
+            let text_candidates =
+                detect_tables_from_spans_column_aware(fallback_spans, &relaxed_config);
+            let pre_filter = text_candidates.len();
+            let text_tables: Vec<_> = text_candidates
+                .into_iter()
+                .filter(|t| t.is_real_grid())
+                .collect();
+            if !text_tables.is_empty() {
+                log::debug!(
+                    "Text-only relaxed fallback found {} table(s) on page {} ({} filtered by is_real_grid) — issue #486",
+                    text_tables.len(),
+                    page_index,
+                    pre_filter - text_tables.len(),
+                );
+                tables = text_tables;
+            }
+        }
+
         tables
     }
 
@@ -10609,7 +10725,10 @@ impl PdfDocument {
         let base_spans = self.extract_spans(page_index)?;
 
         let tables = if options.extract_tables {
-            self.extract_page_tables(page_index, &base_spans, options)
+            // text_fallback=true: to_markdown explicitly targets structured output,
+            // so we enable the text-only spatial fallback for line-less tables
+            // (e.g. sailing-score grids with no ruling lines — issue #486).
+            self.extract_page_tables(page_index, &base_spans, options, true)
         } else {
             Vec::new()
         };
@@ -11043,7 +11162,10 @@ impl PdfDocument {
         let base_spans = self.extract_spans(page_index)?;
 
         let tables = if options.extract_tables {
-            self.extract_page_tables(page_index, &base_spans, options)
+            // text_fallback=true: to_html explicitly targets structured output,
+            // so we enable the text-only spatial fallback for line-less tables
+            // (e.g. sailing-score grids with no ruling lines — issue #486).
+            self.extract_page_tables(page_index, &base_spans, options, true)
         } else {
             Vec::new()
         };
@@ -11197,7 +11319,9 @@ impl PdfDocument {
 
         // Step 2: Extract tables if enabled
         let tables = if options.extract_tables {
-            self.extract_page_tables(page_index, &spans, options)
+            // text_fallback=false: to_plain_text uses the conservative pre-v0.3.47
+            // behaviour to avoid false-positive table detection in key-value layouts.
+            self.extract_page_tables(page_index, &spans, options, false)
         } else {
             Vec::new()
         };

--- a/src/document.rs
+++ b/src/document.rs
@@ -1781,6 +1781,26 @@ impl PdfDocument {
         }
     }
 
+    /// Resolve a single-level indirect reference (PDF spec §7.3.10).
+    ///
+    /// If `obj` is `Object::Reference(...)`, loads and returns the target object.
+    /// For any other object type, returns a clone unchanged.  This is the
+    /// canonical way to handle "any value may be a direct or indirect reference"
+    /// throughout the parser.
+    fn resolve_obj_ref(&self, obj: &Object) -> Object {
+        if let Some(obj_ref) = obj.as_reference() {
+            match self.load_object(obj_ref) {
+                Ok(resolved) => resolved,
+                Err(e) => {
+                    log::warn!("Failed to resolve indirect reference {:?}: {}", obj_ref, e);
+                    obj.clone()
+                },
+            }
+        } else {
+            obj.clone()
+        }
+    }
+
     /// Peek at an XObject's /Subtype without loading the full object.
     /// Returns true if the XObject is a Form XObject, false if Image or unknown.
     /// For compressed objects or on any error, returns true (conservative — will load fully).
@@ -3106,9 +3126,14 @@ impl PdfDocument {
             .as_dict()
             .ok_or_else(|| Error::InvalidPdf("Page is not a dictionary".to_string()))?;
 
-        let media_box = page_dict
+        // Resolve indirect reference if present — PDF spec §7.3.10 permits any value
+        // to be an indirect reference, e.g. `/MediaBox 174 0 R` where 174 0 R is `[0 0 612 792]`.
+        let media_box_obj_raw = page_dict
             .get("MediaBox")
-            .and_then(|o| o.as_array())
+            .ok_or_else(|| Error::InvalidPdf("MediaBox not found or not an array".to_string()))?;
+        let media_box_obj = self.resolve_obj_ref(media_box_obj_raw);
+        let media_box = media_box_obj
+            .as_array()
             .ok_or_else(|| Error::InvalidPdf("MediaBox not found or not an array".to_string()))?;
 
         if media_box.len() < 4 {
@@ -9905,10 +9930,13 @@ impl PdfDocument {
             }
         }
 
-        // Get MediaBox (required, may be inherited)
+        // Get MediaBox (required, may be inherited).
+        // PDF spec §7.3.10: any value may be a direct or indirect reference.
         let media_box = page_dict
             .get("MediaBox")
-            .and_then(|o| o.as_array())
+            .map(|o| self.resolve_obj_ref(o))
+            .as_ref()
+            .and_then(|o| o.as_array().map(|a| a.to_owned()))
             .map(|arr| {
                 let x0 = arr.first().and_then(obj_to_f32).unwrap_or(0.0);
                 let y0 = arr.get(1).and_then(obj_to_f32).unwrap_or(0.0);
@@ -9920,10 +9948,13 @@ impl PdfDocument {
                 0.0, 0.0, 612.0, 792.0, // Letter size default
             ));
 
-        // Get CropBox (optional, falls back to MediaBox)
+        // Get CropBox (optional, falls back to MediaBox).
+        // PDF spec §7.3.10: any value may be a direct or indirect reference.
         let crop_box = page_dict
             .get("CropBox")
-            .and_then(|o| o.as_array())
+            .map(|o| self.resolve_obj_ref(o))
+            .as_ref()
+            .and_then(|o| o.as_array().map(|a| a.to_owned()))
             .map(|arr| {
                 let x0 = arr.first().and_then(obj_to_f32).unwrap_or(0.0);
                 let y0 = arr.get(1).and_then(obj_to_f32).unwrap_or(0.0);
@@ -9932,9 +9963,12 @@ impl PdfDocument {
                 crate::geometry::Rect::from_points(x0, y0, x1, y1)
             });
 
-        // Get rotation (optional, default 0)
+        // Get rotation (optional, default 0).
+        // PDF spec §7.3.10: Rotate may also be an indirect reference.
         let rotation = page_dict
             .get("Rotate")
+            .map(|o| self.resolve_obj_ref(o))
+            .as_ref()
             .and_then(|o| match o {
                 Object::Integer(i) => Some(*i as i32),
                 _ => None,

--- a/src/document.rs
+++ b/src/document.rs
@@ -10659,13 +10659,11 @@ impl PdfDocument {
 
         // Strategy 2: Hybrid spatial detection (v0.3.14)
         let mut config = options.table_detection_config.clone().unwrap_or_default();
-        // Converter callers (to_markdown, to_html) opt in to text-only spatial
-        // fallback so that line-less tables (e.g. sailing-score grids) are still
-        // detected when no ruling lines are present.  The public extract_tables()
-        // API keeps text_fallback = false for backward compatibility.
-        if text_fallback {
-            config.text_fallback = true;
-        }
+        // Honour the caller's text_fallback choice regardless of the default
+        // on `TableDetectionConfig` — `extract_text` / `to_plain_text` pass
+        // `text_fallback=false` to opt out of text-only spatial fallback even
+        // though the type-level default is `true`.
+        config.text_fallback = text_fallback;
 
         // Extract vector paths (lines/rects) for visual detection
         let paths = self.extract_paths(page_index).unwrap_or_default();
@@ -10751,7 +10749,10 @@ impl PdfDocument {
         // `<p>＜55000</p>` pairs.  Consolidate vertically-adjacent fragments
         // that share an identical column structure BEFORE applying
         // is_real_grid so the merged multi-row table survives the filter.
-        let raw_tables = crate::structure::spatial_table_detector::consolidate_adjacent_table_fragments(raw_tables);
+        let raw_tables =
+            crate::structure::spatial_table_detector::consolidate_adjacent_table_fragments(
+                raw_tables,
+            );
 
         // Per #457 Step 4: spatial detection without struct-tree backing
         // is prone to false positives on form-style layouts (label-colon-

--- a/src/document.rs
+++ b/src/document.rs
@@ -5711,7 +5711,16 @@ impl PdfDocument {
             (Some(p), Some(c)) => is_cjk_script(p) != is_cjk_script(c),
             _ => false,
         };
-        if crosses_cjk_boundary && gap > -0.5 && gap < font_size * 5.0 {
+        // ASCII punctuation hugs the preceding token in every script —
+        // pdftotext's GT renders "する." with no space and "神鹰，2015"
+        // with no space before the comma either.  Suppress the boundary
+        // forced-space when the transitioning glyph IS the punctuation;
+        // the space-threshold path below still handles real gaps.
+        let is_clause_punct =
+            |c: char| matches!(c, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}');
+        let punct_at_boundary = curr_head.is_some_and(is_clause_punct)
+            || prev_tail.is_some_and(|c| matches!(c, '(' | '[' | '{'));
+        if crosses_cjk_boundary && !punct_at_boundary && gap > -0.5 && gap < font_size * 5.0 {
             return true;
         }
 
@@ -10752,6 +10761,13 @@ impl PdfDocument {
         let mut tables: Vec<crate::structure::Table> = raw_tables
             .into_iter()
             .filter(|t| t.is_real_grid())
+            // Prose-shape filter — applies to line-based detection too: a
+            // PDF with decorative horizontal rules (newsletter mastheads,
+            // press-release banners) can hand `is_real_grid` a "wide data
+            // table" that is actually wrapped paragraphs partitioned by
+            // word x-alignment.  Reject those before they reach the
+            // converter.  See `looks_like_prose_table` for the heuristic.
+            .filter(|t| !looks_like_prose_table(t))
             .collect();
 
         if raw_count != tables.len() {
@@ -10887,7 +10903,20 @@ impl PdfDocument {
             let pre_filter = text_candidates.len();
             let text_tables: Vec<_> = text_candidates
                 .into_iter()
-                .filter(|t| t.is_real_grid())
+                // Text-only detection infers columns from word x-alignment
+                // alone; a title + a wrapped body line (two rows) is the
+                // signature of ordinary prose, not a table.  Require ≥3
+                // rows of evidence before promoting to a table.
+                .filter(|t| t.rows.len() >= 3 && t.is_real_grid())
+                // Prose split across many "columns" is the dominant
+                // false-positive shape for text-only detection on
+                // line-less pages: a paragraph wraps to N lines, words
+                // cluster into N×K cells, and `is_real_grid` accepts the
+                // shape.  Real data-table cells almost never end with a
+                // comma or semicolon (those punctuation marks belong to
+                // running sentences), so a high comma-tail ratio is the
+                // most discriminating prose signal we have.
+                .filter(|t| !looks_like_prose_table(t))
                 .collect();
             if !text_tables.is_empty() {
                 log::debug!(
@@ -12575,6 +12604,69 @@ pub enum ImageFormat {
 /// Extract the /Root reference from a trailer dictionary.
 fn get_root_ref_from_trailer(trailer: &Object) -> Option<ObjectRef> {
     trailer.as_dict()?.get("Root")?.as_reference()
+}
+
+/// Heuristic: does this candidate table actually look like wrapped prose
+/// clustered into x-columns rather than a real grid?
+///
+/// Cell contents in real data tables are atomic units (numbers, codes,
+/// names, short labels): they almost always start with an uppercase
+/// letter, a digit, or a symbol (currency, +/-, punctuation marker) and
+/// rarely end with a mid-sentence comma or semicolon.  Prose-as-table
+/// cells, by contrast, are fragments of running sentences — they
+/// frequently start with a lowercase stopword ("and", "the", "to") because
+/// the column boundary fell mid-clause, and frequently end with `,` or
+/// `;` for the same reason.
+///
+/// We reject the candidate when either signal exceeds its threshold:
+///   • > 12 % of cells end in `,` or `;` (mid-sentence tails), or
+///   • > 25 % of cells start with a lowercase ASCII letter
+///     (continuation fragments).
+///
+/// Thresholds chosen to clear the false positives flagged in the 88-PDF
+/// regression (`searchable.pdf`, the WFMYY press-release, several arxiv
+/// preprints) without disturbing legitimate data tables — sailing scores,
+/// IRS forms, and the CJK traffic-volume grid all stay well below both
+/// bars.
+fn looks_like_prose_table(table: &crate::structure::Table) -> bool {
+    let mut total = 0usize;
+    let mut sentence_tails = 0usize;
+    let mut lower_starts = 0usize;
+    let mut leader_dots = 0usize;
+    for row in &table.rows {
+        for cell in &row.cells {
+            let trimmed = cell.text.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            total += 1;
+            if let Some(last) = trimmed.chars().last() {
+                if matches!(last, ',' | ';') {
+                    sentence_tails += 1;
+                }
+            }
+            if let Some(first) = trimmed.chars().next() {
+                if first.is_ascii_lowercase() {
+                    lower_starts += 1;
+                }
+            }
+            // Table-of-contents leader runs (". . . . . . ." between an
+            // entry's title and its page number) cluster into their own
+            // x-columns and create phantom 10–12-column "tables" out of
+            // an ordinary three-column TOC.  A cell whose content is
+            // exclusively dots and spaces is the leader, not data.
+            if trimmed.chars().all(|c| c == '.' || c == ' ') {
+                leader_dots += 1;
+            }
+        }
+    }
+    if total < 10 {
+        return false;
+    }
+    let tail_ratio = sentence_tails as f32 / total as f32;
+    let lower_ratio = lower_starts as f32 / total as f32;
+    let leader_ratio = leader_dots as f32 / total as f32;
+    tail_ratio > 0.12 || lower_ratio > 0.25 || leader_ratio > 0.10
 }
 
 /// Check whether the object at the xref offset for `obj_ref` looks like a valid header.

--- a/src/document.rs
+++ b/src/document.rs
@@ -5720,9 +5720,14 @@ impl PdfDocument {
         // This aligns with the text extractor's font-aware threshold (~50% of space width).
         let space_threshold = font_size * 0.15;
 
-        // Insert space if gap is significant
-        // Also check that gap is not too large (might indicate column boundary)
-        gap > space_threshold && gap < font_size * 5.0
+        // Insert space if gap is significant.  Previously the upper bound was
+        // `gap < font_size * 5.0` on the rationale that very large gaps mean
+        // "column boundary, no space needed" — but downstream the caller
+        // concatenates the two spans together when this returns false, so
+        // "column boundary" actually rendered as `3.80%4.41%` on wide rate
+        // tables (issue 487 pr-138-example.pdf).  Drop the upper bound so any
+        // gap above the inter-glyph threshold gets at least a single space.
+        gap > space_threshold
     }
 
     /// Detect a span whose text is `N.M` (all-digit groups around one dot) and whose
@@ -13725,8 +13730,13 @@ mod tests {
     fn test_should_insert_space_column_gap() {
         let prev = make_test_span("Hello", 0.0, 100.0, 50.0, 12.0);
         let current = make_test_span("World", 200.0, 100.0, 50.0, 12.0);
-        // Column boundary gap is too large (>5x font), should return false
-        assert!(!PdfDocument::should_insert_space(&prev, &current));
+        // Issue 487 (pr-138-example.pdf rate tables): a very large
+        // same-line gap (here 150 pt > 5 em) must still produce a single
+        // space.  The earlier `gap < font_size * 5.0` upper bound made
+        // this return false, after which the caller concatenated the two
+        // spans without a separator and `3.80%` + `4.41%` came out as
+        // `3.80%4.41%`.  Large gap = different column = still a space.
+        assert!(PdfDocument::should_insert_space(&prev, &current));
     }
 
     // ========================================================================

--- a/src/document.rs
+++ b/src/document.rs
@@ -4701,19 +4701,14 @@ impl PdfDocument {
         let final_text = Self::normalize_arabic_presentation_forms(&final_text);
 
         // Apply whitespace cleanup
-        let mut cleaned_text = crate::converters::whitespace::cleanup_plain_text(&final_text);
+        let cleaned_text = crate::converters::whitespace::cleanup_plain_text(&final_text);
 
-        // Tagged PDFs use their own structure-tree traversal path and
-        // still need the historical end-of-page table block. Untagged
-        // PDFs now inline tables with the flow spans above, so the
-        // end-of-page dump is only run when we came through the
-        // structure-tree branch.
-        if cached_tree.is_some() && !tables.is_empty() {
-            for table in tables {
-                cleaned_text.push_str("\n\n");
-                cleaned_text.push_str(&table.render_text());
-            }
-        }
+        // For tagged PDFs, the structure-tree traversal at line 4306 already
+        // captures all table-cell content via MCIDs. Appending tables here
+        // would double-emit that content (structure-tree text + table render),
+        // dropping precision. For untagged PDFs, tables are inlined via
+        // pending_tables above, so this block is never reached (cached_tree
+        // is None → condition would be false). The block is removed.
 
         // #317 UTF-8 mojibake repair: a run of Latin-1 Supplement chars
         // whose raw bytes form valid UTF-8 decoding to non-Latin-1 code
@@ -7810,6 +7805,13 @@ impl PdfDocument {
             std::collections::HashMap::new();
         let mut first_seen_any: std::collections::HashMap<String, usize> =
             std::collections::HashMap::new();
+        // Track distinct literal texts per signature.  A signature whose digits
+        // are stable across every page (i.e. the literal text never changes) is
+        // NOT a page-number-containing header — it is substantive content that
+        // happens to repeat.  Only suppress signatures where the literal text
+        // varies (at least two distinct forms) meaning digits change per page.
+        let mut literal_variants: std::collections::HashMap<String, std::collections::HashSet<String>> =
+            std::collections::HashMap::new();
         for pi in 0..page_count {
             let spans = match self.extract_spans_raw(pi) {
                 Ok(s) => s,
@@ -7836,7 +7838,8 @@ impl PdfDocument {
             // Collect per-page unique signatures from the chrome bands.
             // Runs even when there's no body content so `first_seen_any`
             // registers the cover page even if it's all-chrome.
-            let mut seen_this_page = std::collections::HashSet::new();
+            let mut seen_this_page: std::collections::HashMap<String, String> =
+                std::collections::HashMap::new();
             for s in spans.iter() {
                 let trimmed = s.text.trim();
                 if trimmed.is_empty() {
@@ -7851,17 +7854,25 @@ impl PdfDocument {
                 if sig.is_empty() || sig.chars().count() < 2 {
                     continue;
                 }
-                seen_this_page.insert(sig);
+                seen_this_page.entry(sig).or_insert_with(|| trimmed.to_string());
             }
             // Track first-seen across ALL pages (even body-content-skipped)
-            for sig in &seen_this_page {
+            for sig in seen_this_page.keys() {
                 first_seen_any.entry(sig.clone()).or_insert(pi);
+            }
+            // Track literal variants — if the literal text for a signature
+            // differs across pages, the digits are varying (page numbers).
+            for (sig, literal) in &seen_this_page {
+                literal_variants
+                    .entry(sig.clone())
+                    .or_default()
+                    .insert(literal.clone());
             }
             if !has_body_content {
                 continue;
             }
             // Count only pages with body content for the recurrence threshold
-            for sig in seen_this_page {
+            for sig in seen_this_page.into_keys() {
                 let entry = occurrences.entry(sig).or_insert((0, pi));
                 entry.0 += 1;
                 if pi < entry.1 {
@@ -7872,7 +7883,18 @@ impl PdfDocument {
         let threshold = (page_count as f32 * 0.5).ceil() as usize;
         let signatures: std::collections::HashMap<String, usize> = occurrences
             .into_iter()
-            .filter(|(_, (count, _))| *count >= threshold.max(2))
+            .filter(|(sig, (count, _))| {
+                if *count < threshold.max(2) {
+                    return false;
+                }
+                // Only suppress if the literal text varied across pages — i.e., the
+                // digits changed, indicating a page number or date that updates per page.
+                // Signatures where all occurrences have the same literal text are
+                // substantive content (facility names, document IDs, etc.) that pdftotext
+                // and pdfium both preserve; suppressing them hurts word-F1 scores.
+                let variants = literal_variants.get(sig).map(|s| s.len()).unwrap_or(0);
+                variants >= 2
+            })
             .map(|(sig, _)| {
                 // Use the earliest page the signature appeared on — which
                 // may be a body-content-skipped cover page that `occurrences`

--- a/src/document.rs
+++ b/src/document.rs
@@ -393,9 +393,12 @@ pub struct PdfDocument {
     pub(crate) xobject_stream_cache_bytes: AtomicUsize,
     /// Cache of extracted TextSpan results from self-contained Form XObjects
     /// (those with own /Resources/Font). None = processed but no spans.
+    /// Key is `(ObjectRef, [i64; 6])` where the array encodes the caller's CTM
+    /// as millipoint-rounded integers, allowing the same Form XObject to cache
+    /// distinct results for each unique CTM it is painted with.
     /// Bounded at [`DEFAULT_XOBJECT_CACHE_MAX_ENTRIES`] entries with FIFO eviction.
     pub(crate) xobject_spans_cache:
-        Mutex<BoundedEntryCache<ObjectRef, Option<Vec<crate::layout::TextSpan>>>>,
+        Mutex<BoundedEntryCache<(ObjectRef, [i64; 6]), Option<Vec<crate::layout::TextSpan>>>>,
     /// Cache of extracted images from Form XObjects (keyed by ObjectRef).
     /// Images are stored without CTM applied — caller applies its own CTM.
     /// Bounded at [`DEFAULT_XOBJECT_CACHE_MAX_ENTRIES`] entries with FIFO eviction.

--- a/src/document.rs
+++ b/src/document.rs
@@ -4245,11 +4245,12 @@ impl PdfDocument {
                     // Fall back to checking the catalog directly when MarkInfo is
                     // absent or /Marked is false — presence of /StructTreeRoot is
                     // authoritative for "is this a tagged PDF" per the spec.
-                    let has_struct_tree_root = !is_marked && self
-                        .catalog()
-                        .ok()
-                        .and_then(|cat| cat.as_dict().map(|d| d.contains_key("StructTreeRoot")))
-                        .unwrap_or(false);
+                    let has_struct_tree_root = !is_marked
+                        && self
+                            .catalog()
+                            .ok()
+                            .and_then(|cat| cat.as_dict().map(|d| d.contains_key("StructTreeRoot")))
+                            .unwrap_or(false);
                     let tree = if is_marked || has_struct_tree_root {
                         self.structure_tree().ok().flatten().map(Arc::new)
                     } else {
@@ -5710,10 +5711,7 @@ impl PdfDocument {
             (Some(p), Some(c)) => is_cjk_script(p) != is_cjk_script(c),
             _ => false,
         };
-        if crosses_cjk_boundary
-            && gap > -0.5
-            && gap < font_size * 5.0
-        {
+        if crosses_cjk_boundary && gap > -0.5 && gap < font_size * 5.0 {
             return true;
         }
 
@@ -6406,7 +6404,11 @@ impl PdfDocument {
             let text = {
                 let from_contents = if let Some(Object::String(s)) = dict.get("Contents") {
                     let decoded = Self::decode_pdf_text_string(s).trim().to_string();
-                    if decoded.is_empty() { None } else { Some(decoded) }
+                    if decoded.is_empty() {
+                        None
+                    } else {
+                        Some(decoded)
+                    }
                 } else {
                     None
                 };
@@ -7887,8 +7889,10 @@ impl PdfDocument {
         // NOT a page-number-containing header — it is substantive content that
         // happens to repeat.  Only suppress signatures where the literal text
         // varies (at least two distinct forms) meaning digits change per page.
-        let mut literal_variants: std::collections::HashMap<String, std::collections::HashSet<String>> =
-            std::collections::HashMap::new();
+        let mut literal_variants: std::collections::HashMap<
+            String,
+            std::collections::HashSet<String>,
+        > = std::collections::HashMap::new();
         for pi in 0..page_count {
             let spans = match self.extract_spans_raw(pi) {
                 Ok(s) => s,
@@ -7931,7 +7935,9 @@ impl PdfDocument {
                 if sig.is_empty() || sig.chars().count() < 2 {
                     continue;
                 }
-                seen_this_page.entry(sig).or_insert_with(|| trimmed.to_string());
+                seen_this_page
+                    .entry(sig)
+                    .or_insert_with(|| trimmed.to_string());
             }
             // Track first-seen across ALL pages (even body-content-skipped)
             for sig in seen_this_page.keys() {
@@ -10549,11 +10555,12 @@ impl PdfDocument {
                 Some(tree) => tree,
                 None => {
                     let is_marked = self.mark_info().map(|m| m.marked).unwrap_or(false);
-                    let has_struct_tree_root = !is_marked && self
-                        .catalog()
-                        .ok()
-                        .and_then(|cat| cat.as_dict().map(|d| d.contains_key("StructTreeRoot")))
-                        .unwrap_or(false);
+                    let has_struct_tree_root = !is_marked
+                        && self
+                            .catalog()
+                            .ok()
+                            .and_then(|cat| cat.as_dict().map(|d| d.contains_key("StructTreeRoot")))
+                            .unwrap_or(false);
                     let tree = if is_marked || has_struct_tree_root {
                         self.structure_tree().ok().flatten().map(Arc::new)
                     } else {
@@ -10810,15 +10817,12 @@ impl PdfDocument {
             // while V-lines are confined to the interior table region.
             let candidate_spans: Vec<crate::layout::TextSpan>;
             let fallback_spans: &[crate::layout::TextSpan] = {
-                let v_lines: Vec<_> = paths
-                    .iter()
-                    .filter(|p| {
-                        p.is_vertical_line(2.0)
-                    })
-                    .collect();
+                let v_lines: Vec<_> = paths.iter().filter(|p| p.is_vertical_line(2.0)).collect();
                 if !v_lines.is_empty() {
-                    let vline_y_min =
-                        v_lines.iter().map(|p| p.bbox.y).fold(f32::INFINITY, f32::min);
+                    let vline_y_min = v_lines
+                        .iter()
+                        .map(|p| p.bbox.y)
+                        .fold(f32::INFINITY, f32::min);
                     let vline_y_max = v_lines
                         .iter()
                         .map(|p| p.bbox.y + p.bbox.height)

--- a/src/document.rs
+++ b/src/document.rs
@@ -10643,9 +10643,45 @@ impl PdfDocument {
         // Safety guards:
         // - Only fires when the main pipeline returned no tables (avoids double-counting).
         // - Only fires when the caller is a converter (text_fallback=true).
+        // - Skipped for tagged PDFs: the structure tree already provides the authoritative
+        //   layout; spatial heuristics produce false-positive tables from structure elements
+        //   (e.g. headings detected as single-row tables — issue #486 regression).
+        // - Skipped for predominantly-RTL pages: Arabic/Hebrew text alignment patterns
+        //   mimic table columns in spatial heuristics — issue #486 regression.
         // - When ruling lines exist, spans are filtered to the line-bounded region to
         //   prevent page headers/footers from being erroneously included in the table.
         // - Results must pass is_real_grid() just like main-pipeline tables.
+
+        // Guard 1 — Tagged PDFs: presence of a structure tree means the document has an
+        // explicit semantic layout.  Spatial text-only detection would misfire on
+        // structure elements (headings, paragraphs) that happen to share a Y band.
+        if config.text_fallback && struct_tree_opt.is_some() {
+            log::debug!(
+                "Text-only spatial fallback skipped for page {} — document has a structure tree (tagged PDF)",
+                page_index
+            );
+            return tables;
+        }
+
+        // Guard 2 — RTL pages: Arabic and Hebrew text naturally aligns horizontally in
+        // patterns that the column-clustering algorithm mistakes for table columns.
+        // Skip spatial detection when more than 30 % of the input spans are RTL.
+        if config.text_fallback {
+            let rtl_count = input_spans
+                .iter()
+                .filter(|s| crate::text::bidi::looks_rtl(&s.text))
+                .count();
+            let rtl_fraction = rtl_count as f32 / input_spans.len().max(1) as f32;
+            if rtl_fraction > 0.30 {
+                log::debug!(
+                    "Text-only spatial fallback skipped for page {} — {:.0}% RTL spans (threshold 30%)",
+                    page_index,
+                    rtl_fraction * 100.0
+                );
+                return tables;
+            }
+        }
+
         if config.text_fallback && tables.is_empty() {
             use crate::structure::spatial_table_detector::detect_tables_from_spans_column_aware;
             // Build a relaxed config derived from the caller's config.

--- a/src/document.rs
+++ b/src/document.rs
@@ -5679,17 +5679,35 @@ impl PdfDocument {
         let prev_end_x = prev.bbox.x + prev.bbox.width;
         let gap = current.bbox.x - prev_end_x;
 
-        // CJK ↔ non-CJK boundary: pdftotext (and the GT it produces) inserts
-        // a space wherever a CJK ideograph meets a Latin/digit character on
-        // the same line, regardless of how tightly the two glyphs were
-        // typeset.  Without this, mixed-script content like "神鹰集团" + "2015"
-        // collapses into one word-F1 token "神鹰集团2015", which never matches
-        // GT's separate "神鹰集团" and "2015" tokens (issue 484, pr-136).
-        // Force a space at the script boundary as long as the two glyphs are
-        // not horizontally overlapping (genuine kerning) and the gap is
-        // within the same-line column.
+        // CJK script ↔ non-CJK boundary: pdftotext (and the GT it produces)
+        // inserts a space wherever a CJK *script* glyph (ideograph, kana, or
+        // hangul) meets a Latin/digit character on the same line, regardless
+        // of how tightly the two were typeset.  Without this, mixed-script
+        // content like "神鹰集团" + "2015" collapses into one token
+        // "神鹰集团2015", which never matches GT's separate "神鹰集团" and
+        // "2015" tokens (issue 484, pr-136).
+        //
+        // IMPORTANT: this MUST exclude fullwidth ASCII variants (U+FF01..FF5E
+        // — ＜＞＝＠ etc.) and CJK Symbols and Punctuation (U+3000..303F) even
+        // though they are technically "CJK characters".  Those are *operator*
+        // glyphs that sit inline with adjacent digits and Latin in CJK
+        // technical documents — pdftotext keeps "60000≤Q＜80000" and
+        // "20＜μ≤30" as compound tokens (issue 484, issue-336).  Forcing a
+        // boundary space there destroys the compound and regresses Jaccard.
+        let is_cjk_script = |c: char| {
+            matches!(
+                c as u32,
+                0x3040..=0x309F      // Hiragana
+                | 0x30A0..=0x30FF    // Katakana
+                | 0x3400..=0x4DBF    // CJK Unified Ideographs Extension A
+                | 0x4E00..=0x9FFF    // CJK Unified Ideographs
+                | 0xAC00..=0xD7AF    // Hangul Syllables
+                | 0x20000..=0x2A6DF  // CJK Unified Ideographs Extension B
+                | 0xFF66..=0xFF9F    // Halfwidth Katakana
+            )
+        };
         let crosses_cjk_boundary = match (prev_tail, curr_head) {
-            (Some(p), Some(c)) => is_cjk(p) != is_cjk(c),
+            (Some(p), Some(c)) => is_cjk_script(p) != is_cjk_script(c),
             _ => false,
         };
         if crosses_cjk_boundary

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -622,9 +622,19 @@ pub fn generate_file_id() -> (Vec<u8>, Vec<u8>) {
     let uuid = uuid::Uuid::new_v4();
     let uuid_bytes = uuid.as_bytes();
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    // SystemTime::now() is not available on wasm32-unknown-unknown.
+    // The UUID v4 already provides sufficient entropy for a unique opaque
+    // file identifier (ISO 32000-1 §14.4), so we skip the time contribution
+    // on that target.
+    #[cfg(not(target_arch = "wasm32"))]
+    let now_bytes: Option<[u8; 16]> = {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default();
+        Some(now.as_nanos().to_le_bytes())
+    };
+    #[cfg(target_arch = "wasm32")]
+    let now_bytes: Option<[u8; 16]> = None;
 
     // PDF spec (ISO 32000-1 §14.4) specifies MD5; when legacy-crypto is off
     // we use SHA-256 truncated to 16 bytes — still a unique opaque identifier.
@@ -633,7 +643,9 @@ pub fn generate_file_id() -> (Vec<u8>, Vec<u8>) {
         use md5::{Digest, Md5};
         let mut h = Md5::new();
         h.update(uuid_bytes);
-        h.update(now.as_nanos().to_le_bytes());
+        if let Some(b) = now_bytes {
+            h.update(b);
+        }
         h.finalize().to_vec()
     };
 
@@ -642,7 +654,9 @@ pub fn generate_file_id() -> (Vec<u8>, Vec<u8>) {
         use sha2::{Digest, Sha256};
         let mut h = Sha256::new();
         h.update(uuid_bytes);
-        h.update(now.as_nanos().to_le_bytes());
+        if let Some(b) = now_bytes {
+            h.update(b);
+        }
         h.finalize()[..16].to_vec()
     };
 
@@ -1337,6 +1351,13 @@ mod tests {
         let (id2, _) = generate_file_id();
         // It's extremely unlikely these would be equal
         assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_generate_file_id_uniqueness() {
+        let id1 = generate_file_id();
+        let id2 = generate_file_id();
+        assert_ne!(id1, id2, "file IDs must be unique across calls");
     }
 
     // === EncryptDict roundtrip tests ===

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -1766,6 +1766,17 @@ enum ByteMode {
 fn get_byte_mode(font: Option<&FontInfo>) -> ByteMode {
     if let Some(font) = font {
         if font.subtype == "Type0" {
+            // If the ToUnicode CMap declares a 2-byte codespace range, always use
+            // TwoByte mode regardless of the encoding name.  This handles CJK fonts
+            // whose /Encoding name is a custom CMap stream that doesn't match the
+            // well-known keyword patterns below (e.g. "H", "V", "UniCNS-H", …).
+            // See PDF Spec §9.7.5 — `begincodespacerange` is authoritative.
+            if let Some(ref lazy_cmap) = font.to_unicode {
+                if lazy_cmap.code_width() == 2 {
+                    return ByteMode::TwoByte;
+                }
+            }
+
             match &font.encoding {
                 crate::fonts::Encoding::Identity => ByteMode::TwoByte,
                 crate::fonts::Encoding::Standard(name) => {
@@ -5975,15 +5986,11 @@ impl<'doc> TextExtractor<'doc> {
                 }
                 w_sum
             } else {
-                // Type0/CID font: process 2-byte CID codes (Identity-H encoding)
-                // Per ISO 32000-1:2008 Section 9.7.6.2, composite fonts use multi-byte codes
+                // Type0/CID font: use TextCharIter so that the byte-width (1 or 2)
+                // is determined by the font's encoding / ToUnicode CMap codespace,
+                // not hardcoded to 2.  Per ISO 32000-1:2008 §9.7.6.2.
                 let mut w_sum = 0.0f32;
-                for chunk in text.chunks(2) {
-                    let cid = if chunk.len() == 2 {
-                        ((chunk[0] as u16) << 8) | (chunk[1] as u16)
-                    } else {
-                        chunk[0] as u16
-                    };
+                for (cid, _) in TextCharIter::new(text, Some(font)) {
                     let mut w = font.get_glyph_width(cid) * fs_factor * hs_factor;
                     w += cs_hs;
                     // Per ISO 32000-1:2008 Section 9.3.3: Tw applied when CID == 32
@@ -6318,14 +6325,13 @@ impl<'doc> TextExtractor<'doc> {
                 w_sum
             } else {
                 buffer.append(text)?;
-                // Width calculation: process 2-byte CID codes (Identity-H encoding)
+                // Width calculation: use TextCharIter so byte-width respects the
+                // CMap codespace (1 or 2 bytes per character).  Fixes CJK fonts
+                // whose encoding name doesn't match the well-known Identity-H/EUC/…
+                // keyword patterns but whose ToUnicode CMap declares a 2-byte
+                // codespace range (§9.7.5).
                 let mut w_sum = 0.0f32;
-                for chunk in text.chunks(2) {
-                    let cid = if chunk.len() == 2 {
-                        ((chunk[0] as u16) << 8) | (chunk[1] as u16)
-                    } else {
-                        chunk[0] as u16
-                    };
+                for (cid, _) in TextCharIter::new(text, Some(font)) {
                     let mut w = font.get_glyph_width(cid) * fs_factor * hs_factor;
                     w += cs_hs;
                     if cid == 32 {

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -516,6 +516,19 @@ pub struct SpanMergingConfig {
     /// - Typical citation markers: 70-80% of text font size
     /// - Superscript usually: 50-80% of base font
     pub citation_font_size_ratio: f32,
+
+    /// When `false`, each `Tm` operator starts a fresh span regardless of position.
+    /// Use this to preserve column boundaries for callers that need per-positioned-run spans
+    /// (e.g. pdftotext `-bbox-layout` parity).
+    ///
+    /// # Warning
+    /// Disabling this on character-by-character-positioned PDFs (common in academic typesetting)
+    /// can produce very large span counts per page (100× or more).
+    ///
+    /// Default: `true` (existing behaviour preserved).
+    ///
+    /// Reference: ISO 32000-1 §9.4.2 / §9.4.4 NOTE 6.
+    pub merge_tm_tj_runs: bool,
 }
 
 impl Default for SpanMergingConfig {
@@ -531,6 +544,7 @@ impl Default for SpanMergingConfig {
             email_threshold_multiplier: 2.5,
             detect_citation_markers: false,
             citation_font_size_ratio: 0.75,
+            merge_tm_tj_runs: true,
         }
     }
 }
@@ -577,6 +591,7 @@ impl SpanMergingConfig {
             email_threshold_multiplier: 2.5,
             detect_citation_markers: false,
             citation_font_size_ratio: 0.75,
+            merge_tm_tj_runs: true,
         }
     }
 
@@ -610,6 +625,7 @@ impl SpanMergingConfig {
             email_threshold_multiplier: 2.5,
             detect_citation_markers: false,
             citation_font_size_ratio: 0.75,
+            merge_tm_tj_runs: true,
         }
     }
 
@@ -646,6 +662,7 @@ impl SpanMergingConfig {
             email_threshold_multiplier: 2.5,
             detect_citation_markers: false,
             citation_font_size_ratio: 0.75,
+            merge_tm_tj_runs: true,
         }
     }
 
@@ -690,6 +707,7 @@ impl SpanMergingConfig {
             email_threshold_multiplier: 2.5,
             detect_citation_markers: false,
             citation_font_size_ratio: 0.75,
+            merge_tm_tj_runs: true,
         }
     }
 
@@ -723,6 +741,7 @@ impl SpanMergingConfig {
             email_threshold_multiplier: 2.5,
             detect_citation_markers: false,
             citation_font_size_ratio: 0.75,
+            merge_tm_tj_runs: true,
         }
     }
 
@@ -766,6 +785,7 @@ impl SpanMergingConfig {
             email_threshold_multiplier: 2.5,
             detect_citation_markers: false,
             citation_font_size_ratio: 0.75,
+            merge_tm_tj_runs: true,
         }
     }
 }
@@ -3734,7 +3754,8 @@ impl<'doc> TextExtractor<'doc> {
                 // If the new Tm is on the same line with the same transform,
                 // keep accumulating into the existing buffer instead of flushing
                 // (avoids creating thousands of 1-char TextSpans per page).
-                let is_continuation = match self.tj_span_buffer {
+                // When merge_tm_tj_runs is false, every Tm always starts a fresh span.
+                let is_continuation = self.merging_config.merge_tm_tj_runs && match self.tj_span_buffer {
                     Some(ref mut buffer)
                         if !buffer.is_empty()
                             && f.round() as i32 == buffer.start_matrix.f.round() as i32
@@ -9839,6 +9860,70 @@ mod tests {
                     .join("");
                 text.contains("A") && text.contains("B")
             }
+        );
+    }
+
+    // ========================================================================
+    // TESTS: merge_tm_tj_runs opt-out (#488)
+    // ========================================================================
+
+    /// With the default config (merge_tm_tj_runs = true), multiple Tm+Tj operators
+    /// on the same line are batched into a single span.
+    #[test]
+    fn test_merge_tm_tj_runs_default_merges() {
+        let mut extractor = TextExtractor::new();
+        extractor.merging_config = SpanMergingConfig::legacy(); // fixed thresholds, merging on
+        let font = create_test_font();
+        extractor.add_font("F1".to_string(), font);
+
+        // Three separate Tm+Tj on the same baseline (same Y, same a/b/c/d, ascending e)
+        let stream =
+            b"BT /F1 12 Tf 1 0 0 1 100 700 Tm (A) Tj 1 0 0 1 107 700 Tm (B) Tj 1 0 0 1 114 700 Tm (C) Tj ET";
+        let spans = extractor.extract_text_spans(stream).unwrap();
+
+        // All three characters must be present
+        let text: String = spans.iter().map(|s| s.text.as_str()).collect();
+        assert!(text.contains('A') && text.contains('B') && text.contains('C'),
+            "All chars must be extracted, got: {:?}", text);
+
+        // The default merging should combine them into fewer spans than the number
+        // of Tm operators (3 Tms should not produce 3 separate spans)
+        assert!(
+            spans.len() < 3,
+            "Default merge_tm_tj_runs=true should combine same-line Tm+Tj into fewer than 3 spans, got {} spans",
+            spans.len()
+        );
+    }
+
+    /// With merge_tm_tj_runs = false, each Tm operator starts a fresh span.
+    #[test]
+    fn test_merge_tm_tj_runs_disabled_splits() {
+        let mut extractor = TextExtractor::new();
+        extractor.merging_config = SpanMergingConfig {
+            merge_tm_tj_runs: false,
+            ..SpanMergingConfig::legacy()
+        };
+        let font = create_test_font();
+        extractor.add_font("F1".to_string(), font);
+
+        // Three separate Tm+Tj on the same baseline
+        let stream =
+            b"BT /F1 12 Tf 1 0 0 1 100 700 Tm (A) Tj 1 0 0 1 107 700 Tm (B) Tj 1 0 0 1 114 700 Tm (C) Tj ET";
+        let spans = extractor.extract_text_spans(stream).unwrap();
+
+        // All three characters must still be present
+        let text: String = spans.iter().map(|s| s.text.as_str()).collect();
+        assert!(text.contains('A') && text.contains('B') && text.contains('C'),
+            "All chars must be extracted even with merging disabled, got: {:?}", text);
+
+        // With merge disabled, each Tm flushes the buffer, so we get more spans
+        // than with merging enabled (post-processing merge_adjacent_spans may combine
+        // some, but at minimum we should get spans >= 1; the key invariant is that
+        // the span count here is NOT reduced by the Tm-continuation shortcut)
+        assert!(
+            spans.len() >= 2,
+            "merge_tm_tj_runs=false should not batch same-line runs; expected >= 2 spans, got {}",
+            spans.len()
         );
     }
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -1975,8 +1975,14 @@ pub struct TextExtractor<'doc> {
     resources: Option<Object>,
     /// Reference to the document (for loading XObjects)
     document: Option<&'doc crate::document::PdfDocument>,
-    /// Set of processed XObject references to avoid duplicates
-    processed_xobjects: HashSet<ObjectRef>,
+    /// Set of processed XObject references to avoid duplicates.
+    /// Key is `(ObjectRef, ctm_key)` where `ctm_key` is the CTM at the time of
+    /// the `Do` operator call, encoded as 6 millipoint-rounded i64 values.
+    /// Using the CTM as part of the key allows the same Form XObject to be
+    /// processed multiple times when invoked with different transformation
+    /// matrices (e.g., the same XObject stamped at different positions on a page),
+    /// while still preventing infinite recursion (same ref + same CTM).
+    processed_xobjects: HashSet<(ObjectRef, [i64; 6])>,
     /// Cached XObject name → ObjectRef mapping for current resources context.
     /// Avoids expensive repeated resolution of the resources/XObject dict chain.
     cached_xobject_refs: HashMap<String, Option<ObjectRef>>,
@@ -4930,13 +4936,38 @@ impl<'doc> TextExtractor<'doc> {
             None => return Ok(()),
         };
 
-        // Skip already-processed XObjects (permanent set — each unique XObject
-        // is processed at most once per page for text extraction)
-        if self.processed_xobjects.contains(&xobject_ref) {
+        // Build a CTM-aware deduplication key.
+        //
+        // Using just `xobject_ref` as the key incorrectly blocked re-processing
+        // the same Form XObject when it was invoked a second time on the same page
+        // with a different CTM (e.g., same header/footer XObject stamped at two
+        // different Y positions, or the nougat_005 pattern where each page's
+        // content stream sets a different `cm` translation before calling `Do`).
+        //
+        // The CTM is encoded as 6 millipoint-rounded i64 values so it can be
+        // stored in a HashSet without floating-point equality hazards.
+        // Infinite-recursion cycles are still prevented because a truly recursive
+        // call re-enters with the *same* XObject ref AND the same CTM at that
+        // nesting depth; the depth limiter (MAX_XOBJECT_DEPTH) provides a
+        // second backstop.
+        let current_ctm = self.state_stack.current().ctm;
+        let ctm_key = [
+            (current_ctm.a * 1000.0) as i64,
+            (current_ctm.b * 1000.0) as i64,
+            (current_ctm.c * 1000.0) as i64,
+            (current_ctm.d * 1000.0) as i64,
+            (current_ctm.e * 1000.0) as i64,
+            (current_ctm.f * 1000.0) as i64,
+        ];
+        let xobj_key = (xobject_ref, ctm_key);
+
+        // Skip already-processed (XObject, CTM) pairs — each unique combination
+        // is processed at most once per page for text extraction.
+        if self.processed_xobjects.contains(&xobj_key) {
             return Ok(());
         }
 
-        self.processed_xobjects.insert(xobject_ref);
+        self.processed_xobjects.insert(xobj_key);
 
         // Get document reference for loading objects.
         let doc = match self.document {
@@ -4962,25 +4993,21 @@ impl<'doc> TextExtractor<'doc> {
 
         // Span result cache: reuse extracted spans from self-contained Form XObjects.
         //
-        // Spans are stored in CTM-transformed page coordinates, so the cache is
-        // only correct when the caller's CTM matches the one at first extraction.
-        // Issue B1 (nougat_005.pdf): a single Form XObject carries every page's
-        // content, and each page's content stream applies a different CTM
-        // translation to position its viewport into that XObject. Reusing the
-        // cached spans returned page 0's coordinates on every page, so every
-        // page emitted identical cross-page text.
+        // The cache key is (ObjectRef, ctm_key) where ctm_key encodes the caller's
+        // CTM as 6 millipoint-rounded i64 values. This allows the same Form XObject
+        // to have independent cached results for each unique CTM it is painted with,
+        // fixing the issue where cross-page reuse of a single Form XObject with
+        // different per-page CTM translations returned stale page-0 coordinates on
+        // all subsequent pages (nougat_005.pdf, Issue B1).
         //
-        // Safe path: only hit the cache when the current CTM is identity. That
-        // covers the common case (reusable headers/footers stamped at the same
-        // origin) without mixing coordinate systems. For non-identity CTMs we
-        // fall through to the fresh extraction below, which applies the caller's
-        // CTM to each span.
-        if self.extract_spans && self.state_stack.current().ctm.is_identity() {
+        // `ctm_key` was already computed above for the `processed_xobjects` guard.
+        let spans_cache_key = (xobject_ref, ctm_key);
+        if self.extract_spans {
             let cached_spans = {
                 doc.xobject_spans_cache
                     .lock()
                     .unwrap()
-                    .get(&xobject_ref)
+                    .get(&spans_cache_key)
                     .cloned()
             };
             if let Some(cached_spans) = cached_spans {
@@ -5193,21 +5220,18 @@ impl<'doc> TextExtractor<'doc> {
                     );
                 }
 
-                // Cache span results for self-contained Form XObjects. Only
-                // safe when the XObject has its own /Resources (font context
-                // is page-independent) AND the current CTM is identity —
-                // otherwise the stored spans are in caller-specific page
-                // coordinates and would poison identity-CTM hits on other
-                // pages (see issue B1).
+                // Cache span results for self-contained Form XObjects.
                 //
-                // Note: is_identity() is checked AFTER the XObject's
-                // /Matrix is concatenated, so XObjects with their own
-                // /Matrix never cache even when the caller CTM is identity.
-                // That's conservative-safe at the cost of re-extraction;
-                // storing spans in XObject-local coords would fix this but
-                // the complexity isn't justified by the current benchmark.
-                let save_identity_ctm = self.state_stack.current().ctm.is_identity();
-                if has_own_resources && self.extract_spans && save_identity_ctm {
+                // The cache key `spans_cache_key` already encodes (ObjectRef, ctm_key),
+                // so each unique (XObject, CTM) pair gets its own entry. There is no
+                // longer any need to restrict caching to identity-CTM invocations —
+                // different CTMs produce different cache entries and therefore cannot
+                // pollute each other (this was the root cause of issue B1).
+                //
+                // We still require `has_own_resources` so that font lookups are
+                // self-contained; XObjects that inherit page-level fonts would
+                // produce spans whose glyph mappings depend on caller context.
+                if has_own_resources && self.extract_spans {
                     let new_spans = if self.spans.len() > spans_before {
                         Some(self.spans[spans_before..].to_vec())
                     } else {
@@ -5216,7 +5240,7 @@ impl<'doc> TextExtractor<'doc> {
                     doc.xobject_spans_cache
                         .lock()
                         .unwrap()
-                        .insert(xobject_ref, new_spans);
+                        .insert(spans_cache_key, new_spans);
                 }
 
                 // Restore graphics state (implicit Q per ISO 32000-1 §8.10.1)

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -5005,13 +5005,17 @@ impl<'doc> TextExtractor<'doc> {
         // nesting depth; the depth limiter (MAX_XOBJECT_DEPTH) provides a
         // second backstop.
         let current_ctm = self.state_stack.current().ctm;
+        // Round to nearest millipoint instead of truncating with `as i64`,
+        // so floating-point noise in the same logical CTM produces a
+        // stable hash key (truncation alone could send 0.99999... and
+        // 1.00001... to different buckets).
         let ctm_key = [
-            (current_ctm.a * 1000.0) as i64,
-            (current_ctm.b * 1000.0) as i64,
-            (current_ctm.c * 1000.0) as i64,
-            (current_ctm.d * 1000.0) as i64,
-            (current_ctm.e * 1000.0) as i64,
-            (current_ctm.f * 1000.0) as i64,
+            (current_ctm.a * 1000.0).round() as i64,
+            (current_ctm.b * 1000.0).round() as i64,
+            (current_ctm.c * 1000.0).round() as i64,
+            (current_ctm.d * 1000.0).round() as i64,
+            (current_ctm.e * 1000.0).round() as i64,
+            (current_ctm.f * 1000.0).round() as i64,
         ];
         let xobj_key = (xobject_ref, ctm_key);
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -3350,18 +3350,45 @@ impl<'doc> TextExtractor<'doc> {
             // and one side is a single character. Targets the drop-cap /
             // single-letter-small-caps typography pattern where per-
             // letter emphasis runs would corrupt proper nouns.
+            //
+            // Issue 484 (pr-136-example.pdf): CJK ideographs satisfy
+            // `is_alphabetic()` per Unicode, so a CJK→Latin (or Latin→CJK)
+            // transition between adjacent characters in different fonts —
+            // the standard mixed-script PDF layout pattern — was triggering
+            // cross-font glue and concatenating "神鹰集团" + "Z" into
+            // "神鹰集团Z" with no separator.  Word-F1 against pdftotext
+            // ground truth (which inserts a space at every CJK↔non-CJK
+            // boundary) then loses both the trailing CJK token and the
+            // leading Latin/digit token.  Skip cross-font glue when the
+            // boundary crosses CJK / non-CJK scripts.
+            let is_cjk_char = |c: char| {
+                matches!(
+                    c as u32,
+                    0x3040..=0x309F      // Hiragana
+                    | 0x30A0..=0x30FF    // Katakana
+                    | 0x3400..=0x4DBF    // CJK Unified Ideographs Extension A
+                    | 0x4E00..=0x9FFF    // CJK Unified Ideographs
+                    | 0xAC00..=0xD7AF    // Hangul Syllables
+                    | 0x20000..=0x2A6DF  // CJK Unified Ideographs Extension B
+                    | 0xFF00..=0xFFEF    // Halfwidth and Fullwidth Forms
+                    | 0x3000..=0x303F    // CJK Symbols and Punctuation
+                )
+            };
+            let prev_tail_char = current.text.chars().last();
+            let curr_head_char = span.text.chars().next();
+            let crosses_cjk_boundary = match (prev_tail_char, curr_head_char) {
+                (Some(p), Some(c)) => is_cjk_char(p) != is_cjk_char(c),
+                _ => false,
+            };
             let cross_font_word_glue = !is_same_font
                 && same_line
                 && gap > -1.0
                 && gap < font_size_ref * 0.25
                 && !current.text.is_empty()
                 && !span.text.is_empty()
-                && current
-                    .text
-                    .chars()
-                    .last()
-                    .is_some_and(|c| c.is_alphabetic())
-                && span.text.chars().next().is_some_and(|c| c.is_alphabetic())
+                && !crosses_cjk_boundary
+                && prev_tail_char.is_some_and(|c| c.is_alphabetic())
+                && curr_head_char.is_some_and(|c| c.is_alphabetic())
                 && (current.text.chars().count() == 1 || span.text.chars().count() == 1);
 
             // Merge threshold: Use configured values
@@ -3389,9 +3416,19 @@ impl<'doc> TextExtractor<'doc> {
             // of dollar amounts in separate fixed-width boxes.
             // e.g., "123456" (integer box) + "72" (cents box) with ~10pt gap.
             // Detect this pattern: both spans are pure digits, the second is
-            // exactly 1-2 digits (cents), same line, and gap < 2x font size.
+            // exactly 1-2 digits (cents), same line, and there's a meaningful
+            // column-boundary-sized gap between them.
+            //
+            // Issue 484 (pr-136-example.pdf): without a minimum-gap floor this
+            // also matches tightly-packed adjacent digit characters from CJK
+            // documents that emit each glyph as its own Tj — e.g. the year
+            // "2013" rendered as four separate TjL operators with sub-pixel
+            // gaps was being mangled into "201.3", losing the year token from
+            // word-F1 scoring.  Real "$123 _ 45" split-box layouts always have
+            // a gap > ~half the font size; tight letter spacing is < 0.1 em.
+            let min_decimal_gap = current.font_size * 0.4;
             let decimal_merge = same_line
-                && gap > 0.0
+                && gap > min_decimal_gap
                 && gap < current.font_size * 2.0
                 && !current.text.is_empty()
                 && !span.text.is_empty()

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -3361,6 +3361,12 @@ impl<'doc> TextExtractor<'doc> {
             // boundary) then loses both the trailing CJK token and the
             // leading Latin/digit token.  Skip cross-font glue when the
             // boundary crosses CJK / non-CJK scripts.
+            //
+            // EXCLUDES fullwidth ASCII (U+FF01..FF5E) and CJK Symbols and
+            // Punctuation (U+3000..303F) — those operator-style glyphs sit
+            // inline with adjacent Latin/digit in CJK technical writing
+            // (e.g. "60000≤Q＜80000" in issue-336).  Treating them as a CJK
+            // boundary would split the compound token.
             let is_cjk_char = |c: char| {
                 matches!(
                     c as u32,
@@ -3370,8 +3376,7 @@ impl<'doc> TextExtractor<'doc> {
                     | 0x4E00..=0x9FFF    // CJK Unified Ideographs
                     | 0xAC00..=0xD7AF    // Hangul Syllables
                     | 0x20000..=0x2A6DF  // CJK Unified Ideographs Extension B
-                    | 0xFF00..=0xFFEF    // Halfwidth and Fullwidth Forms
-                    | 0x3000..=0x303F    // CJK Symbols and Punctuation
+                    | 0xFF66..=0xFF9F    // Halfwidth Katakana
                 )
             };
             let prev_tail_char = current.text.chars().last();

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -3814,23 +3814,24 @@ impl<'doc> TextExtractor<'doc> {
                 // keep accumulating into the existing buffer instead of flushing
                 // (avoids creating thousands of 1-char TextSpans per page).
                 // When merge_tm_tj_runs is false, every Tm always starts a fresh span.
-                let is_continuation = self.merging_config.merge_tm_tj_runs && match self.tj_span_buffer {
-                    Some(ref mut buffer)
-                        if !buffer.is_empty()
-                            && f.round() as i32 == buffer.start_matrix.f.round() as i32
-                            && a == buffer.start_matrix.a
-                            && b == buffer.start_matrix.b
-                            && c == buffer.start_matrix.c
-                            && d == buffer.start_matrix.d
-                            && e >= buffer.start_matrix.e =>
-                    {
-                        // Same line, same transform, LTR progression →
-                        // update width to reflect actual visual extent
-                        buffer.accumulated_width = e - buffer.start_matrix.e;
-                        true
-                    },
-                    _ => false,
-                };
+                let is_continuation = self.merging_config.merge_tm_tj_runs
+                    && match self.tj_span_buffer {
+                        Some(ref mut buffer)
+                            if !buffer.is_empty()
+                                && f.round() as i32 == buffer.start_matrix.f.round() as i32
+                                && a == buffer.start_matrix.a
+                                && b == buffer.start_matrix.b
+                                && c == buffer.start_matrix.c
+                                && d == buffer.start_matrix.d
+                                && e >= buffer.start_matrix.e =>
+                        {
+                            // Same line, same transform, LTR progression →
+                            // update width to reflect actual visual extent
+                            buffer.accumulated_width = e - buffer.start_matrix.e;
+                            true
+                        },
+                        _ => false,
+                    };
 
                 if !is_continuation {
                     self.flush_tj_span_buffer()?;
@@ -9955,8 +9956,11 @@ mod tests {
 
         // All three characters must be present
         let text: String = spans.iter().map(|s| s.text.as_str()).collect();
-        assert!(text.contains('A') && text.contains('B') && text.contains('C'),
-            "All chars must be extracted, got: {:?}", text);
+        assert!(
+            text.contains('A') && text.contains('B') && text.contains('C'),
+            "All chars must be extracted, got: {:?}",
+            text
+        );
 
         // The default merging should combine them into fewer spans than the number
         // of Tm operators (3 Tms should not produce 3 separate spans)
@@ -9985,8 +9989,11 @@ mod tests {
 
         // All three characters must still be present
         let text: String = spans.iter().map(|s| s.text.as_str()).collect();
-        assert!(text.contains('A') && text.contains('B') && text.contains('C'),
-            "All chars must be extracted even with merging disabled, got: {:?}", text);
+        assert!(
+            text.contains('A') && text.contains('B') && text.contains('C'),
+            "All chars must be extracted even with merging disabled, got: {:?}",
+            text
+        );
 
         // With merge disabled, each Tm flushes the buffer, so we get more spans
         // than with merging enabled (post-processing merge_adjacent_spans may combine

--- a/src/fonts/cmap.rs
+++ b/src/fonts/cmap.rs
@@ -47,6 +47,7 @@ struct RangeEntry {
 /// - `chars`: HashMap for individual bfchar mappings (direct lookup O(1))
 /// - `ranges`: Sorted Vec of range entries for binary search (O(log n))
 /// - `notdef_ranges`: Sorted Vec for fallback mappings
+/// - `code_width`: Maximum code width in bytes (1 or 2), from `begincodespacerange`
 ///
 /// Keys are character codes (typically 1-4 bytes), values are Unicode strings.
 /// We use u32 to support multi-byte character codes found in CID fonts.
@@ -58,6 +59,15 @@ pub struct CMap {
     ranges: Vec<RangeEntry>,
     /// Undefined range fallbacks for unmapped codes
     notdef_ranges: Vec<RangeEntry>,
+    /// Maximum character code width in bytes, derived from `begincodespacerange`.
+    ///
+    /// - `1` (default) means single-byte codes (standard simple fonts).
+    /// - `2` means two-byte codes (CJK composite fonts, Identity-H CMaps).
+    ///
+    /// Set during parsing if any codespace entry has a 2-byte (4-hex-digit) hex string.
+    /// Used by the text extractor to decide whether to read 1 or 2 bytes per character
+    /// from the PDF content stream (§9.7.5 "CMaps").
+    pub code_width: u8,
 }
 
 impl CMap {
@@ -121,6 +131,7 @@ impl CMap {
             chars: HashMap::new(),
             ranges: Vec::new(),
             notdef_ranges: Vec::new(),
+            code_width: 1,
         }
     }
 
@@ -275,6 +286,16 @@ impl LazyCMap {
     /// Get the raw CMap stream bytes.
     pub fn raw_data(&self) -> &[u8] {
         &self.raw_stream
+    }
+
+    /// Return the character code width (1 or 2) declared by `begincodespacerange`.
+    ///
+    /// Parses and caches the CMap if not already done.
+    /// Returns `1` when the CMap is missing or unparseable (safe default for simple fonts).
+    /// Returns `2` when the codespace declares 2-byte codes, indicating a CJK composite font
+    /// whose content stream must be read two bytes at a time.
+    pub fn code_width(&self) -> u8 {
+        self.get().map(|cmap| cmap.code_width).unwrap_or(1)
     }
 
     /// Returns the parsed CMap, loading and caching it on first access.
@@ -442,6 +463,27 @@ pub fn parse_tounicode_cmap(data: &[u8]) -> Result<CMap> {
     let mut cmap = CMap::new();
     let content = String::from_utf8_lossy(data);
 
+    // Parse begincodespacerange sections (PDF Spec §9.7.5 / §9.10.3)
+    //
+    // The codespace range declares the valid domain of character codes and,
+    // critically, **their byte width**.  A range like `<00> <FF>` is 1-byte;
+    // `<0000> <FFFF>` is 2-byte.  We use the widest range found to set
+    // `cmap.code_width`, which the text extractor uses to decide how many
+    // bytes to consume per character from the PDF content stream.
+    //
+    // Without this, any CJK ToUnicode CMap that does not use one of the
+    // well-known encoding names (Identity-H, EUC, GBK, …) would be read
+    // one byte at a time, splitting every 2-byte CID into two wrong codes.
+    for section in extract_sections(&content, "begincodespacerange", "endcodespacerange") {
+        for line in section.lines() {
+            let width = parse_codespacerange_line_width(line);
+            if width > cmap.code_width {
+                cmap.code_width = width;
+                log::trace!("ToUnicode codespacerange: code_width set to {}", cmap.code_width);
+            }
+        }
+    }
+
     // Parse bfchar sections
     // PDF Spec: ISO 32000-1:2008, Section 9.10.3 - ToUnicode CMaps
     // Format: <srcCode> <dstString>
@@ -507,6 +549,31 @@ fn extract_sections<'a>(content: &'a str, begin: &str, end: &str) -> Vec<&'a str
     }
 
     sections
+}
+
+/// Parse a `begincodespacerange` line and return the maximum code byte-width found.
+///
+/// Each entry is a pair of hex strings: `<lo> <hi>`.  The number of hex digits
+/// in each string determines the byte width of the character codes:
+/// - 2 hex digits  → 1-byte code  (e.g. `<00> <FF>`)
+/// - 4 hex digits  → 2-byte code  (e.g. `<0000> <FFFF>`)
+///
+/// Returns 1 if the line does not contain a valid codespace pair, or 2 if at
+/// least one 2-byte (4-hex-digit) entry is found.
+fn parse_codespacerange_line_width(line: &str) -> u8 {
+    static RE: std::sync::LazyLock<Regex> =
+        std::sync::LazyLock::new(|| Regex::new(r"<([^>]*)>\s*<([^>]*)>").unwrap());
+
+    let mut max_width: u8 = 1;
+    for caps in RE.captures_iter(line) {
+        let lo_hex = caps[1].trim().replace(char::is_whitespace, "");
+        let hi_hex = caps[2].trim().replace(char::is_whitespace, "");
+        // 4 or more hex digits mean ≥2-byte codes.
+        if lo_hex.len() >= 4 || hi_hex.len() >= 4 {
+            max_width = 2;
+        }
+    }
+    max_width
 }
 
 /// Parse a bfchar line, returning all `<src> <dst>` pairs found on the line.

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -2418,23 +2418,46 @@ impl FontInfo {
         // ==================================================================================
         // PRIORITY 1: ToUnicode CMap (PDF Spec Section 9.10.2, Method 1)
         // ==================================================================================
+        //
+        // Per §9.10.2: if a ToUnicode CMap is PRESENT it is the authoritative source.
+        // For composite (Type0) fonts a present-but-incomplete ToUnicode means the
+        // unmapped codes genuinely have no Unicode equivalent.  Falling through to the
+        // predefined-CMap path (Priority 3 §9.10.2) for Type0 would guess wrong CJK
+        // characters and score near zero versus ground truth.  Therefore:
+        //
+        //   • ToUnicode hit → return the mapped string (or U+FFFD if it maps to FFFD
+        //     or a bare C0 control character).
+        //   • ToUnicode miss AND font is Type0 → return U+FFFD, do NOT fall through.
+        //   • ToUnicode miss AND font is NOT Type0 → fall through to lower priorities
+        //     (simple fonts with standard encoding still benefit from further lookup).
+        //
+        // Fix A (§9.10.2 Priority-3 guard): implemented in the CMap-miss branch below.
+        // Fix B (control-character filter): applied on CMap hits.
         if let Some(lazy_cmap) = &self.to_unicode {
             if let Some(cmap) = lazy_cmap.get() {
                 if let Some(unicode) = cmap.get(&char_code) {
-                    if unicode == "\u{FFFD}" {
-                        log::warn!(
-                            "ToUnicode CMap has U+FFFD for code 0x{:02X} in font '{}' - falling back to Priority 2",
-                            char_code, self.base_font
-                        );
-                    } else if unicode
+                    // Fix B: filter bare C0 control characters (U+0000–U+001F except
+                    // tab/LF/CR which are legitimate whitespace in extracted text).
+                    // These are never valid visible text and typically indicate a
+                    // broken ToUnicode entry.  Return U+FFFD and do NOT fall through
+                    // even for simple fonts — the CMap explicitly mapped this code.
+                    let is_c0_control = unicode
                         .chars()
-                        .all(|c| c.is_control() && c != '\t' && c != '\n' && c != '\r')
-                        && !unicode.is_empty()
-                    {
-                        log::warn!(
-                            "ToUnicode CMap maps code 0x{:04X} to control char(s) in font '{}' - falling back",
+                        .all(|c| matches!(c as u32, 0x00..=0x08 | 0x0B..=0x0C | 0x0E..=0x1F))
+                        && !unicode.is_empty();
+
+                    if unicode == "\u{FFFD}" {
+                        log::debug!(
+                            "ToUnicode CMap has U+FFFD for code 0x{:02X} in font '{}' - returning U+FFFD",
                             char_code, self.base_font
                         );
+                        return Some("\u{FFFD}".to_string());
+                    } else if is_c0_control {
+                        log::debug!(
+                            "ToUnicode CMap maps code 0x{:04X} to C0 control char(s) in font '{}' - returning U+FFFD",
+                            char_code, self.base_font
+                        );
+                        return Some("\u{FFFD}".to_string());
                     } else {
                         return Some(unicode.clone());
                     }
@@ -2444,36 +2467,17 @@ impl FontInfo {
                         self.base_font, self.subtype, char_code, cmap.len()
                     );
 
-                    // #363: subset Type0 + Identity-H + Adobe-Identity ordering.
-                    // The font's CIDs are insertion-ordered and have no relation
-                    // to Unicode code points, so the Priority 2 Identity-H
-                    // CID-as-Unicode fallback (`char::from_u32(cid)`) produces
-                    // ASCII-shifted ciphertext (e.g. `%B+$%8A` on nougat_035.pdf).
-                    // Per ISO 32000-1 §9.10.2, a present ToUnicode CMap is the
-                    // authoritative char→Unicode mapping; a miss means the
-                    // glyph has no Unicode equivalent, so return U+FFFD rather
-                    // than fall through.
-                    //
-                    // Narrow on purpose: simple fonts (Type1/TrueType with
-                    // standard encoding) still fall through — their encoding
-                    // is a real mapping. CJK Type0 (Adobe-GB1/Japan1/etc.) also
-                    // falls through to the predefined-CMap path.
+                    // Fix A (§9.10.2): for composite (Type0) fonts a present ToUnicode
+                    // CMap is the authoritative mapping.  A miss means the glyph has no
+                    // Unicode equivalent — do NOT fall through to the predefined-CMap
+                    // path which would produce plausible-looking but wrong CJK chars.
+                    // This applies regardless of encoding name or CIDSystemInfo ordering.
                     if self.subtype == "Type0" {
-                        let is_identity_encoding = matches!(
-                            &self.encoding,
-                            Encoding::Standard(name) if name == "Identity-H" || name == "Identity-V"
-                        ) || matches!(
-                            &self.encoding,
-                            Encoding::Identity
+                        log::debug!(
+                            "Type0 font '{}': ToUnicode present but code 0x{:04X} not covered → U+FFFD (no Priority-3 fallback per §9.10.2)",
+                            self.base_font, char_code
                         );
-                        let is_identity_ordering = self
-                            .cid_system_info
-                            .as_ref()
-                            .map(|info| info.ordering == "Identity")
-                            .unwrap_or(false);
-                        if is_identity_encoding && is_identity_ordering {
-                            return Some("\u{FFFD}".to_string());
-                        }
+                        return Some("\u{FFFD}".to_string());
                     }
                 }
             } else {
@@ -4311,6 +4315,21 @@ fn decode_cjk_raw_charcode(
 /// - UniJIS-UCS2-H: Adobe-Japan1 (Japanese)
 /// - UniCNS-UCS2-H: Adobe-CNS1 (Traditional Chinese)
 /// - UniKS-UCS2-H: Adobe-Korea1 (Korean)
+
+/// Maximum valid CID for each Adobe character collection (Fix C – OOB guard).
+/// CIDs beyond these values have no defined Unicode mapping; return None early
+/// to avoid accidental wrap-around in future table expansions.
+///
+/// Sources:
+///   Adobe-GB1-5   (TN #5079): 30,283 CIDs (0–30,283)
+///   Adobe-Japan1-7 (TN #5078): 23,059 CIDs (0–23,059)
+///   Adobe-CNS1-7  (TN #5080): 20,316 CIDs (0–20,316)
+///   Adobe-Korea1-2 (TN #5093): 18,351 CIDs (0–18,351)
+const CID_MAX_GB1: u16 = 30_283;
+const CID_MAX_JAPAN1: u16 = 23_059;
+const CID_MAX_CNS1: u16 = 20_316;
+const CID_MAX_KOREA1: u16 = 18_351;
+
 fn lookup_predefined_cmap(
     cmap_name: &str,
     cid_system_info: &Option<CIDSystemInfo>,
@@ -4318,6 +4337,23 @@ fn lookup_predefined_cmap(
 ) -> Option<u32> {
     // Verify that we have CIDSystemInfo to match against the CMap
     let system_info = cid_system_info.as_ref()?;
+
+    // Fix C: guard out-of-bounds CIDs before hitting the lookup table.
+    // CIDs beyond the collection maximum have no defined Unicode mapping.
+    let max_cid = match system_info.ordering.as_str() {
+        "GB1" => CID_MAX_GB1,
+        "Japan1" => CID_MAX_JAPAN1,
+        "CNS1" => CID_MAX_CNS1,
+        "Korea1" => CID_MAX_KOREA1,
+        _ => return None,
+    };
+    if cid > max_cid {
+        log::debug!(
+            "CID {} exceeds max {} for ordering '{}' → returning None (OOB)",
+            cid, max_cid, system_info.ordering
+        );
+        return None;
+    }
 
     // Route to the appropriate CMap lookup based on name and character collection
     match (cmap_name, system_info.ordering.as_str()) {
@@ -6640,27 +6676,29 @@ mod tests {
 
     #[test]
     fn test_char_to_unicode_tounicode_fffd_fallback() {
-        // A ToUnicode mapping to U+FFFD should be treated as missing
-        // and fall back to encoding
+        // A ToUnicode mapping to U+FFFD means the font author explicitly declared
+        // "no Unicode equivalent" for this code.  Per Fix B (§9.10.2) the function
+        // must return U+FFFD and NOT fall through to the encoding-based path.
         let cmap_data = b"beginbfchar\n<0041> <FFFD>\nendbfchar";
         let font = make_font(|f| {
             f.to_unicode = Some(LazyCMap::new(cmap_data.to_vec()));
             f.encoding = Encoding::Standard("WinAnsiEncoding".to_string());
         });
-        // Should fall through FFFD and use WinAnsi → 'A'
-        assert_eq!(font.char_to_unicode(0x41), Some("A".to_string()));
+        // ToUnicode says U+FFFD → return U+FFFD, do NOT fall through to WinAnsi 'A'
+        assert_eq!(font.char_to_unicode(0x41), Some("\u{FFFD}".to_string()));
     }
 
     #[test]
     fn test_char_to_unicode_tounicode_control_char_fallback() {
-        // A ToUnicode mapping to control characters should be treated as missing
+        // A ToUnicode mapping to a C0 control character is filtered by Fix B.
+        // The function must return U+FFFD and NOT fall through to the encoding.
         let cmap_data = b"beginbfchar\n<0041> <0001>\nendbfchar";
         let font = make_font(|f| {
             f.to_unicode = Some(LazyCMap::new(cmap_data.to_vec()));
             f.encoding = Encoding::Standard("WinAnsiEncoding".to_string());
         });
-        // Control char mapping → fallback to WinAnsi → 'A'
-        assert_eq!(font.char_to_unicode(0x41), Some("A".to_string()));
+        // C0 control char (U+0001) → U+FFFD, do NOT fall through to WinAnsi 'A'
+        assert_eq!(font.char_to_unicode(0x41), Some("\u{FFFD}".to_string()));
     }
 
     // =========================================================================
@@ -7530,5 +7568,234 @@ mod tests {
 
         // Byte codes not in the standard-14 table fall back to default_width.
         assert_eq!(table[0], 1000.0, "NUL -> default_width fallback");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+    // Fix A / B / C tests  (§9.10.2 Priority-3 guard + control filter + OOB CID)
+    // ────────────────────────────────────────────────────────────────────────────
+
+    /// Build a minimal ToUnicode CMap stream that maps codes 0x0041–0x005A
+    /// (hex 2-byte keys) to U+0041–U+005A (A–Z).
+    fn make_tounicode_az() -> Vec<u8> {
+        let stream = concat!(
+            "/CIDInit /ProcSet findresource begin\n",
+            "12 dict begin\n",
+            "begincmap\n",
+            "/CIDSystemInfo 3 dict dup begin\n",
+            "  /Registry (Adobe) def\n",
+            "  /Ordering (UCS) def\n",
+            "  /Supplement 0 def\n",
+            "end def\n",
+            "/CMapName /Adobe-Identity-UCS def\n",
+            "/CMapType 2 def\n",
+            "1 begincodespacerange\n",
+            "<0000> <FFFF>\n",
+            "endcodespacerange\n",
+            "26 beginbfchar\n",
+            "<0041> <0041>\n",   // A
+            "<0042> <0042>\n",
+            "<0043> <0043>\n",
+            "<0044> <0044>\n",
+            "<0045> <0045>\n",
+            "<0046> <0046>\n",
+            "<0047> <0047>\n",
+            "<0048> <0048>\n",
+            "<0049> <0049>\n",
+            "<004A> <004A>\n",
+            "<004B> <004B>\n",
+            "<004C> <004C>\n",
+            "<004D> <004D>\n",
+            "<004E> <004E>\n",
+            "<004F> <004F>\n",
+            "<0050> <0050>\n",
+            "<0051> <0051>\n",
+            "<0052> <0052>\n",
+            "<0053> <0053>\n",
+            "<0054> <0054>\n",
+            "<0055> <0055>\n",
+            "<0056> <0056>\n",
+            "<0057> <0057>\n",
+            "<0058> <0058>\n",
+            "<0059> <0059>\n",
+            "<005A> <005A>\n",   // Z
+            "endbfchar\n",
+            "endcmap\n",
+            "CMapName currentdict /CMap defineresource pop\n",
+            "end\n",
+            "end\n",
+        );
+        stream.as_bytes().to_vec()
+    }
+
+    /// Build a minimal ToUnicode CMap that maps code 0x0001 to U+0007 (BEL).
+    fn make_tounicode_bel() -> Vec<u8> {
+        let stream = concat!(
+            "/CIDInit /ProcSet findresource begin\n",
+            "12 dict begin\n",
+            "begincmap\n",
+            "/CIDSystemInfo 3 dict dup begin\n",
+            "  /Registry (Adobe) def\n",
+            "  /Ordering (UCS) def\n",
+            "  /Supplement 0 def\n",
+            "end def\n",
+            "/CMapName /Test-BEL def\n",
+            "/CMapType 2 def\n",
+            "1 begincodespacerange\n",
+            "<0000> <FFFF>\n",
+            "endcodespacerange\n",
+            "1 beginbfchar\n",
+            "<0001> <0007>\n",   // BEL control character
+            "endbfchar\n",
+            "endcmap\n",
+            "CMapName currentdict /CMap defineresource pop\n",
+            "end\n",
+            "end\n",
+        );
+        stream.as_bytes().to_vec()
+    }
+
+    /// Construct a minimal Type0 FontInfo with the given ToUnicode stream and CIDSystemInfo.
+    fn make_type0_font(
+        to_unicode_stream: Option<Vec<u8>>,
+        encoding_name: &str,
+        cid_system_info: Option<CIDSystemInfo>,
+    ) -> FontInfo {
+        FontInfo {
+            base_font: "TestType0Font".to_string(),
+            subtype: "Type0".to_string(),
+            encoding: Encoding::Standard(encoding_name.to_string()),
+            to_unicode: to_unicode_stream.map(LazyCMap::new),
+            font_weight: None,
+            flags: None,
+            stem_v: None,
+            embedded_font_data: None,
+            truetype_cmap: std::sync::OnceLock::new(),
+            is_truetype_font: false,
+            widths: None,
+            first_char: None,
+            last_char: None,
+            default_width: 1000.0,
+            cid_to_gid_map: None,
+            cid_system_info,
+            cid_font_type: None,
+            cid_widths: None,
+            cid_default_width: 1000.0,
+            has_explicit_dw: false,
+            cff_gid_map: None,
+            multi_char_map: HashMap::new(),
+            byte_to_char_table: std::sync::OnceLock::new(),
+            byte_to_width_table: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Fix A — ToUnicode present but code not covered → U+FFFD (no Priority-3 fallback).
+    ///
+    /// A Type0 font with Adobe-GB1 ordering and a ToUnicode CMap covering only A–Z.
+    /// Querying code 0x0061 (not in CMap) must return U+FFFD, NOT a CJK character
+    /// that would result from the Priority-3 predefined CMap lookup.
+    #[test]
+    fn test_fix_a_tounicode_present_miss_returns_fffd_not_cjk() {
+        let cid_system_info = Some(CIDSystemInfo {
+            registry: "Adobe".to_string(),
+            ordering: "GB1".to_string(),
+            supplement: 2,
+        });
+        let font = make_type0_font(
+            Some(make_tounicode_az()),
+            "Identity-H",
+            cid_system_info,
+        );
+
+        // Code 0x0061 ('a') is NOT in the ToUnicode CMap (which only covers A–Z).
+        // The Priority-3 predefined CMap for Adobe-GB1 would map CID 97 to some
+        // Latin character.  With Fix A, the function must return U+FFFD instead.
+        let result = font.char_to_unicode(0x0061);
+        assert_eq!(
+            result,
+            Some("\u{FFFD}".to_string()),
+            "Type0 font with ToUnicode present but missing code 0x61 must return U+FFFD, \
+             not fall through to predefined CMap"
+        );
+
+        // Codes that ARE in the CMap (A–Z) must still work correctly.
+        assert_eq!(font.char_to_unicode(0x0041), Some("A".to_string()));
+        assert_eq!(font.char_to_unicode(0x005A), Some("Z".to_string()));
+    }
+
+    /// Fix A — ToUnicode absent, Priority-3 predefined CMap is triggered.
+    ///
+    /// A Type0 font with Adobe-Japan1 ordering and NO ToUnicode CMap.
+    /// Querying CID 843 must return U+3042 (あ) via the predefined CMap.
+    ///
+    /// The encoding must be Identity-H (not a UCS2/UTF16 variant) combined with a
+    /// non-Identity CIDSystemInfo ordering so the code reaches the
+    /// `!is_ucs2_or_utf16 && is_non_identity_ordering` branch (line ~2568) that
+    /// calls lookup_predefined_cmap directly.
+    #[test]
+    fn test_fix_a_no_tounicode_priority3_triggered() {
+        let cid_system_info = Some(CIDSystemInfo {
+            registry: "Adobe".to_string(),
+            ordering: "Japan1".to_string(),
+            supplement: 4,
+        });
+        // Identity-H with a non-Identity (Japan1) ordering: CIDs route through
+        // lookup_predefined_cmap, NOT treated as raw Unicode code points.
+        let font = make_type0_font(None, "Identity-H", cid_system_info);
+
+        // CID 843 maps to U+3042 (あ) per the Adobe-Japan1 collection.
+        let result = font.char_to_unicode(843);
+        assert_eq!(
+            result,
+            Some("\u{3042}".to_string()),
+            "Type0 font without ToUnicode must use predefined CMap for CID 843 → U+3042"
+        );
+    }
+
+    /// Fix C — OOB CID guard: CID well beyond the Adobe-GB1 maximum → None.
+    ///
+    /// lookup_predefined_cmap with an OOB CID must return None without panicking.
+    #[test]
+    fn test_fix_c_oob_cid_returns_none() {
+        let cid_system_info = Some(CIDSystemInfo {
+            registry: "Adobe".to_string(),
+            ordering: "GB1".to_string(),
+            supplement: 2,
+        });
+        // CID 99_999 is far beyond CID_MAX_GB1 (30_283).
+        // The function takes u16, so we use the max u16 value (65535) which still
+        // exceeds CID_MAX_GB1.
+        let result = lookup_predefined_cmap("UniGB-UCS2-H", &cid_system_info, 65535);
+        assert_eq!(result, None, "OOB CID (65535 > CID_MAX_GB1 30283) must return None");
+
+        // Same for Japan1.
+        let cid_japan = Some(CIDSystemInfo {
+            registry: "Adobe".to_string(),
+            ordering: "Japan1".to_string(),
+            supplement: 4,
+        });
+        let result_j = lookup_predefined_cmap("UniJIS-UCS2-H", &cid_japan, 65535);
+        assert_eq!(result_j, None, "OOB CID (65535 > CID_MAX_JAPAN1 23059) must return None");
+    }
+
+    /// Fix B — C0 control character filter: ToUnicode mapping to U+0007 (BEL) → U+FFFD.
+    ///
+    /// A ToUnicode CMap that explicitly maps code 0x0001 to U+0007 (BEL).
+    /// The function must return U+FFFD, not the BEL character.
+    #[test]
+    fn test_fix_b_control_char_filter_returns_fffd() {
+        let font = make_type0_font(
+            Some(make_tounicode_bel()),
+            "Identity-H",
+            None,
+        );
+
+        // Code 0x0001 maps to U+0007 (BEL) in the ToUnicode CMap.
+        // Fix B must intercept this and return U+FFFD.
+        let result = font.char_to_unicode(0x0001);
+        assert_eq!(
+            result,
+            Some("\u{FFFD}".to_string()),
+            "Code mapping to U+0007 (BEL) must be filtered to U+FFFD by Fix B"
+        );
     }
 }

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -2435,7 +2435,17 @@ impl FontInfo {
         // Fix B (control-character filter): applied on CMap hits.
         if let Some(lazy_cmap) = &self.to_unicode {
             if let Some(cmap) = lazy_cmap.get() {
-                if let Some(unicode) = cmap.get(&char_code) {
+                let raw_unicode = cmap.get(&char_code);
+
+                // For Identity-encoded fonts, a U+FFFD result coming from a notdefrange
+                // entry is NOT a definitive mapping — the CID-as-Unicode path gives the
+                // correct character (CID == Unicode codepoint).  Treat it as a CMap miss
+                // so we fall through to the Identity fallback below.
+                let effective_hit = raw_unicode.filter(|u| {
+                    *u != "\u{FFFD}" || !matches!(self.encoding, Encoding::Identity)
+                });
+
+                if let Some(unicode) = effective_hit {
                     // Fix B: filter bare C0 control characters (U+0000–U+001F except
                     // tab/LF/CR which are legitimate whitespace in extracted text).
                     // These are never valid visible text and typically indicate a
@@ -2462,17 +2472,26 @@ impl FontInfo {
                         return Some(unicode.clone());
                     }
                 } else {
-                    log::debug!(
-                        "ToUnicode CMap MISS: font='{}' subtype='{}' code=0x{:04X} (cmap has {} entries)",
-                        self.base_font, self.subtype, char_code, cmap.len()
-                    );
+                    if raw_unicode.is_some() {
+                        log::debug!(
+                            "Identity font '{}': notdefrange U+FFFD treated as miss for code 0x{:04X} — falling through to CID-as-Unicode",
+                            self.base_font, char_code
+                        );
+                    } else {
+                        log::debug!(
+                            "ToUnicode CMap MISS: font='{}' subtype='{}' code=0x{:04X} (cmap has {} entries)",
+                            self.base_font, self.subtype, char_code, cmap.len()
+                        );
+                    }
 
                     // Fix A (§9.10.2): for composite (Type0) fonts a present ToUnicode
                     // CMap is the authoritative mapping.  A miss means the glyph has no
                     // Unicode equivalent — do NOT fall through to the predefined-CMap
                     // path which would produce plausible-looking but wrong CJK chars.
-                    // This applies regardless of encoding name or CIDSystemInfo ordering.
-                    if self.subtype == "Type0" {
+                    // Exception: Identity-encoded fonts map CID directly to Unicode, so
+                    // a CMap miss still has a valid fallback (CID == Unicode codepoint).
+                    // Blocking them here would suppress spaces and Latin characters.
+                    if self.subtype == "Type0" && !matches!(self.encoding, Encoding::Identity) {
                         log::debug!(
                             "Type0 font '{}': ToUnicode present but code 0x{:04X} not covered → U+FFFD (no Priority-3 fallback per §9.10.2)",
                             self.base_font, char_code

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -4312,6 +4312,20 @@ fn decode_cjk_raw_charcode(
     }
 }
 
+// Maximum valid CID for each Adobe character collection (Fix C – OOB guard).
+// CIDs beyond these values have no defined Unicode mapping; return None early
+// to avoid accidental wrap-around in future table expansions.
+//
+// Sources:
+//   Adobe-GB1-5    (TN #5079): 30,283 CIDs (0–30,283)
+//   Adobe-Japan1-7 (TN #5078): 23,059 CIDs (0–23,059)
+//   Adobe-CNS1-7   (TN #5080): 20,316 CIDs (0–20,316)
+//   Adobe-Korea1-2 (TN #5093): 18,351 CIDs (0–18,351)
+const CID_MAX_GB1: u16 = 30_283;
+const CID_MAX_JAPAN1: u16 = 23_059;
+const CID_MAX_CNS1: u16 = 20_316;
+const CID_MAX_KOREA1: u16 = 18_351;
+
 /// Lookup Unicode code point for a CID in a predefined Unicode-based CMap.
 ///
 /// Predefined CMaps for CJK fonts map CID values from Adobe character collections to Unicode.
@@ -4333,21 +4347,6 @@ fn decode_cjk_raw_charcode(
 /// - UniJIS-UCS2-H: Adobe-Japan1 (Japanese)
 /// - UniCNS-UCS2-H: Adobe-CNS1 (Traditional Chinese)
 /// - UniKS-UCS2-H: Adobe-Korea1 (Korean)
-
-/// Maximum valid CID for each Adobe character collection (Fix C – OOB guard).
-/// CIDs beyond these values have no defined Unicode mapping; return None early
-/// to avoid accidental wrap-around in future table expansions.
-///
-/// Sources:
-///   Adobe-GB1-5   (TN #5079): 30,283 CIDs (0–30,283)
-///   Adobe-Japan1-7 (TN #5078): 23,059 CIDs (0–23,059)
-///   Adobe-CNS1-7  (TN #5080): 20,316 CIDs (0–20,316)
-///   Adobe-Korea1-2 (TN #5093): 18,351 CIDs (0–18,351)
-const CID_MAX_GB1: u16 = 30_283;
-const CID_MAX_JAPAN1: u16 = 23_059;
-const CID_MAX_CNS1: u16 = 20_316;
-const CID_MAX_KOREA1: u16 = 18_351;
-
 fn lookup_predefined_cmap(
     cmap_name: &str,
     cid_system_info: &Option<CIDSystemInfo>,

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -2441,9 +2441,8 @@ impl FontInfo {
                 // entry is NOT a definitive mapping — the CID-as-Unicode path gives the
                 // correct character (CID == Unicode codepoint).  Treat it as a CMap miss
                 // so we fall through to the Identity fallback below.
-                let effective_hit = raw_unicode.filter(|u| {
-                    *u != "\u{FFFD}" || !matches!(self.encoding, Encoding::Identity)
-                });
+                let effective_hit = raw_unicode
+                    .filter(|u| *u != "\u{FFFD}" || !matches!(self.encoding, Encoding::Identity));
 
                 if let Some(unicode) = effective_hit {
                     // Fix B: filter bare C0 control characters (U+0000–U+001F except
@@ -4369,7 +4368,9 @@ fn lookup_predefined_cmap(
     if cid > max_cid {
         log::debug!(
             "CID {} exceeds max {} for ordering '{}' → returning None (OOB)",
-            cid, max_cid, system_info.ordering
+            cid,
+            max_cid,
+            system_info.ordering
         );
         return None;
     }
@@ -7611,7 +7612,7 @@ mod tests {
             "<0000> <FFFF>\n",
             "endcodespacerange\n",
             "26 beginbfchar\n",
-            "<0041> <0041>\n",   // A
+            "<0041> <0041>\n", // A
             "<0042> <0042>\n",
             "<0043> <0043>\n",
             "<0044> <0044>\n",
@@ -7636,7 +7637,7 @@ mod tests {
             "<0057> <0057>\n",
             "<0058> <0058>\n",
             "<0059> <0059>\n",
-            "<005A> <005A>\n",   // Z
+            "<005A> <005A>\n", // Z
             "endbfchar\n",
             "endcmap\n",
             "CMapName currentdict /CMap defineresource pop\n",
@@ -7663,7 +7664,7 @@ mod tests {
             "<0000> <FFFF>\n",
             "endcodespacerange\n",
             "1 beginbfchar\n",
-            "<0001> <0007>\n",   // BEL control character
+            "<0001> <0007>\n", // BEL control character
             "endbfchar\n",
             "endcmap\n",
             "CMapName currentdict /CMap defineresource pop\n",
@@ -7719,11 +7720,7 @@ mod tests {
             ordering: "GB1".to_string(),
             supplement: 2,
         });
-        let font = make_type0_font(
-            Some(make_tounicode_az()),
-            "Identity-H",
-            cid_system_info,
-        );
+        let font = make_type0_font(Some(make_tounicode_az()), "Identity-H", cid_system_info);
 
         // Code 0x0061 ('a') is NOT in the ToUnicode CMap (which only covers A–Z).
         // The Priority-3 predefined CMap for Adobe-GB1 would map CID 97 to some
@@ -7802,11 +7799,7 @@ mod tests {
     /// The function must return U+FFFD, not the BEL character.
     #[test]
     fn test_fix_b_control_char_filter_returns_fffd() {
-        let font = make_type0_font(
-            Some(make_tounicode_bel()),
-            "Identity-H",
-            None,
-        );
+        let font = make_type0_font(Some(make_tounicode_bel()), "Identity-H", None);
 
         // Code 0x0001 maps to U+0007 (BEL) in the ToUnicode CMap.
         // Fix B must intercept this and return U+FFFD.

--- a/src/pipeline/converters/html.rs
+++ b/src/pipeline/converters/html.rs
@@ -184,7 +184,19 @@ impl HtmlOutputConverter {
     ///
     /// Applies bold (<strong>) and italic (<em>) tags as needed.
     fn format_span_with_styles(&self, span: &OrderedTextSpan, text: &str) -> String {
-        let escaped = Self::escape_html(text);
+        // Apply the same column-spanning-decimal / char_widths-boundary
+        // split that the text extractor's `push_span_text` uses.  For
+        // sailing-score PDFs (issue 487 nougat_018) the producer emits two
+        // adjacent score cells as a single Tj like "1.10" with cw=[w].
+        // Without this step, markdown / HTML keep them glued as `1.10`
+        // instead of splitting into the two GT tokens `1` and `10`.
+        let mut processed = String::new();
+        let synthetic = crate::layout::TextSpan {
+            text: text.to_string(),
+            ..span.span.clone()
+        };
+        crate::document::PdfDocument::push_span_text(&mut processed, &synthetic);
+        let escaped = Self::escape_html(&processed);
 
         let mut result = escaped;
 
@@ -493,7 +505,12 @@ impl HtmlOutputConverter {
                 }
             }
 
-            let escaped = Self::escape_html(&span.text);
+            // Apply column-spanning-decimal split (issue 487 nougat_018):
+            // sailing-score cells emitted as "1.10" with sparse char_widths
+            // split into two tokens "1 10".
+            let mut processed = String::new();
+            crate::document::PdfDocument::push_span_text(&mut processed, span);
+            let escaped = Self::escape_html(&processed);
 
             let styled = match (is_bold, is_italic) {
                 (true, true) => format!("<strong><em>{}</em></strong>", escaped),

--- a/src/pipeline/converters/html.rs
+++ b/src/pipeline/converters/html.rs
@@ -395,17 +395,30 @@ impl HtmlOutputConverter {
                 in_paragraph = true;
             }
 
-            // Insert a space when same-line spans have a meaningful horizontal
-            // gap, preventing label+value concatenation (e.g. "Subtotal$500.00").
+            // Insert a space when adjacent spans should be separated:
+            //   1. Same-line spans with a meaningful horizontal gap
+            //      (prevents label+value concatenation like "Subtotal$500.00").
+            //   2. Different-line spans within the same paragraph (multi-line
+            //      column headers, e.g. "Inpatient" / "Bed" stacked across two
+            //      visual lines — issue 487 nougat_026).  Without this, the two
+            //      tokens come out as "InpatientBed" because the same_line gate
+            //      above skips the space-insertion check whenever y_diff >
+            //      0.5 × font_size.
             if let Some(prev) = prev_span {
-                let same_line =
-                    (span.span.bbox.y - prev.span.bbox.y).abs() < span.span.font_size * 0.5;
-                if same_line
+                let y_diff = (span.span.bbox.y - prev.span.bbox.y).abs();
+                let same_line = y_diff < span.span.font_size * 0.5;
+                let need_space_between_lines = !same_line
+                    && y_diff > 0.0
+                    && !current_content.is_empty()
+                    && !current_content.ends_with(' ')
+                    && !current_content.ends_with('\n')
+                    && !span.span.text.starts_with(' ');
+                let need_space_same_line = same_line
                     && !current_content.is_empty()
                     && !current_content.ends_with(' ')
                     && !span.span.text.starts_with(' ')
-                    && super::has_horizontal_gap(&prev.span, &span.span)
-                {
+                    && super::has_horizontal_gap(&prev.span, &span.span);
+                if need_space_same_line || need_space_between_lines {
                     current_content.push(' ');
                 }
             }

--- a/src/pipeline/converters/html.rs
+++ b/src/pipeline/converters/html.rs
@@ -442,6 +442,59 @@ impl HtmlOutputConverter {
         Ok(result)
     }
 
+    /// Render the text content of a single table cell as HTML.
+    ///
+    /// When the cell has `spans`, this walks them in order — mirroring the
+    /// `render_table_markdown` path — so that:
+    /// - Adjacent spans with a meaningful horizontal gap get a space between them
+    ///   (prevents "Label$500.00"-style concatenation).
+    /// - Bold spans are wrapped in `<strong>`, italic spans in `<em>`.
+    ///
+    /// When `spans` is empty the function falls back to `cell.text`.
+    fn render_cell_html(cell: &crate::structure::table_extractor::TableCell) -> String {
+        use crate::layout::FontWeight;
+
+        if cell.spans.is_empty() {
+            // Fallback: no span metadata available — use the pre-built text field.
+            return Self::escape_html(cell.text.trim());
+        }
+
+        let mut out = String::new();
+
+        for (i, span) in cell.spans.iter().enumerate() {
+            let is_bold = matches!(
+                span.font_weight,
+                FontWeight::Bold | FontWeight::Black | FontWeight::ExtraBold | FontWeight::SemiBold
+            );
+            let is_italic = span.is_italic;
+
+            // Insert a space when adjacent same-row spans have a meaningful
+            // horizontal gap (mirrors the body-span logic in convert_semantic_mode
+            // and the span-gap logic in render_table_markdown).
+            if i > 0 {
+                let prev = &cell.spans[i - 1];
+                let has_gap = super::has_horizontal_gap(prev, span);
+                let already_has_space =
+                    out.ends_with(' ') || span.text.starts_with(' ');
+                if has_gap && !already_has_space {
+                    out.push(' ');
+                }
+            }
+
+            let escaped = Self::escape_html(&span.text);
+
+            let styled = match (is_bold, is_italic) {
+                (true, true) => format!("<strong><em>{}</em></strong>", escaped),
+                (true, false) => format!("<strong>{}</strong>", escaped),
+                (false, true) => format!("<em>{}</em>", escaped),
+                (false, false) => escaped,
+            };
+            out.push_str(&styled);
+        }
+
+        out
+    }
+
     /// Render a Table as an HTML table string.
     fn render_table_html(table: &Table) -> String {
         if table.rows.is_empty() {
@@ -475,7 +528,7 @@ impl HtmlOutputConverter {
                     if cell.rowspan > 1 {
                         attrs.push_str(&format!(" rowspan=\"{}\"", cell.rowspan));
                     }
-                    let text = Self::escape_html(cell.text.trim());
+                    let text = Self::render_cell_html(cell);
                     html.push_str(&format!("<th{}>{}</th>", attrs, text));
                 }
                 html.push_str("</tr>\n");
@@ -497,7 +550,7 @@ impl HtmlOutputConverter {
                     if cell.rowspan > 1 {
                         attrs.push_str(&format!(" rowspan=\"{}\"", cell.rowspan));
                     }
-                    let text = Self::escape_html(cell.text.trim());
+                    let text = Self::render_cell_html(cell);
                     html.push_str(&format!("<td{}>{}</td>", attrs, text));
                 }
                 html.push_str("</tr>\n");
@@ -895,5 +948,150 @@ mod tests {
 
         assert_eq!(span_in_table(&inside, &[table.clone()]), Some(0));
         assert_eq!(span_in_table(&outside, &[table]), None);
+    }
+
+    // ============================================================================
+    // render_cell_html() tests — span-walking path (#487)
+    // ============================================================================
+
+    /// Build a raw TextSpan (not OrderedTextSpan) for use in TableCell.spans.
+    fn make_raw_span(
+        text: &str,
+        x: f32,
+        y: f32,
+        width: f32,
+        font_size: f32,
+        weight: FontWeight,
+        italic: bool,
+    ) -> TextSpan {
+        TextSpan {
+            artifact_type: None,
+            text: text.to_string(),
+            bbox: Rect::new(x, y, width, font_size),
+            font_name: "Test".to_string(),
+            font_size,
+            font_weight: weight,
+            is_italic: italic,
+            is_monospace: false,
+            color: Color::black(),
+            mcid: None,
+            sequence: 0,
+            offset_semantic: false,
+            split_boundary_before: false,
+            char_spacing: 0.0,
+            word_spacing: 0.0,
+            horizontal_scaling: 100.0,
+            primary_detected: false,
+            char_widths: vec![],
+        }
+    }
+
+    #[test]
+    fn test_render_cell_html_fallback_to_text_when_no_spans() {
+        // When spans is empty the function returns escaped cell.text (trimmed).
+        use crate::structure::table_extractor::TableCell;
+        let cell = TableCell::new("  hello world  ".to_string(), false);
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_render_cell_html_fallback_escapes_html() {
+        use crate::structure::table_extractor::TableCell;
+        let cell = TableCell::new("<b>bold</b> & more".to_string(), false);
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "&lt;b&gt;bold&lt;/b&gt; &amp; more");
+    }
+
+    #[test]
+    fn test_render_cell_html_plain_spans() {
+        // Two adjacent normal spans with no gap → concatenated without extra space.
+        use crate::structure::table_extractor::TableCell;
+        let mut cell = TableCell::new(String::new(), false);
+        // Place spans directly adjacent: span1 ends at x=50, span2 starts at x=50.
+        cell.spans.push(make_raw_span("hello", 0.0, 0.0, 50.0, 12.0, FontWeight::Normal, false));
+        cell.spans.push(make_raw_span(" world", 50.0, 0.0, 50.0, 12.0, FontWeight::Normal, false));
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        // No gap inserted since span2 already starts with a space.
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_render_cell_html_bold_span() {
+        use crate::structure::table_extractor::TableCell;
+        let mut cell = TableCell::new(String::new(), false);
+        cell.spans.push(make_raw_span("Total", 0.0, 0.0, 30.0, 12.0, FontWeight::Bold, false));
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "<strong>Total</strong>");
+    }
+
+    #[test]
+    fn test_render_cell_html_italic_span() {
+        use crate::structure::table_extractor::TableCell;
+        let mut cell = TableCell::new(String::new(), false);
+        cell.spans.push(make_raw_span("Note", 0.0, 0.0, 25.0, 12.0, FontWeight::Normal, true));
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "<em>Note</em>");
+    }
+
+    #[test]
+    fn test_render_cell_html_bold_italic_span() {
+        use crate::structure::table_extractor::TableCell;
+        let mut cell = TableCell::new(String::new(), false);
+        cell.spans.push(make_raw_span("Warn", 0.0, 0.0, 25.0, 12.0, FontWeight::Bold, true));
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "<strong><em>Warn</em></strong>");
+    }
+
+    #[test]
+    fn test_render_cell_html_gap_inserts_space() {
+        // Span1 ends at x=30, span2 starts at x=35. Gap=5 > 12*0.15=1.8 → space inserted.
+        use crate::structure::table_extractor::TableCell;
+        let mut cell = TableCell::new(String::new(), false);
+        cell.spans.push(make_raw_span("Label", 0.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        cell.spans.push(make_raw_span("Value", 35.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "Label Value", "Gap should produce a space: {}", result);
+    }
+
+    #[test]
+    fn test_render_cell_html_no_gap_no_space() {
+        // Span1 ends at x=30, span2 starts at x=30. Gap=0 → no space inserted.
+        use crate::structure::table_extractor::TableCell;
+        let mut cell = TableCell::new(String::new(), false);
+        cell.spans.push(make_raw_span("foo", 0.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        cell.spans.push(make_raw_span("bar", 30.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "foobar", "No gap should produce no space: {}", result);
+    }
+
+    #[test]
+    fn test_render_cell_html_mixed_bold_and_plain_with_gap() {
+        // A bold label with a gap before a plain value — matches real table cell pattern.
+        use crate::structure::table_extractor::TableCell;
+        let mut cell = TableCell::new(String::new(), false);
+        cell.spans.push(make_raw_span("Subtotal", 0.0, 0.0, 40.0, 12.0, FontWeight::Bold, false));
+        cell.spans.push(make_raw_span("500.00", 50.0, 0.0, 35.0, 12.0, FontWeight::Normal, false));
+        let result = HtmlOutputConverter::render_cell_html(&cell);
+        assert_eq!(result, "<strong>Subtotal</strong> 500.00", "Result: {}", result);
+    }
+
+    #[test]
+    fn test_render_table_html_uses_spans_for_bold() {
+        // End-to-end: a table whose cell has a bold span should emit <strong>.
+        use crate::structure::table_extractor::{TableCell, TableRow};
+        let mut table = Table::new();
+        let mut row = TableRow::new(false);
+        let mut cell = TableCell::new(String::new(), false);
+        cell.spans.push(make_raw_span("Total", 0.0, 0.0, 30.0, 12.0, FontWeight::Bold, false));
+        row.add_cell(cell);
+        table.add_row(row);
+
+        let result = HtmlOutputConverter::render_table_html(&table);
+        assert!(
+            result.contains("<td><strong>Total</strong></td>"),
+            "Should render bold cell via spans: {}",
+            result
+        );
     }
 }

--- a/src/pipeline/converters/html.rs
+++ b/src/pipeline/converters/html.rs
@@ -474,8 +474,7 @@ impl HtmlOutputConverter {
             if i > 0 {
                 let prev = &cell.spans[i - 1];
                 let has_gap = super::has_horizontal_gap(prev, span);
-                let already_has_space =
-                    out.ends_with(' ') || span.text.starts_with(' ');
+                let already_has_space = out.ends_with(' ') || span.text.starts_with(' ');
                 if has_gap && !already_has_space {
                     out.push(' ');
                 }
@@ -1009,8 +1008,10 @@ mod tests {
         use crate::structure::table_extractor::TableCell;
         let mut cell = TableCell::new(String::new(), false);
         // Place spans directly adjacent: span1 ends at x=50, span2 starts at x=50.
-        cell.spans.push(make_raw_span("hello", 0.0, 0.0, 50.0, 12.0, FontWeight::Normal, false));
-        cell.spans.push(make_raw_span(" world", 50.0, 0.0, 50.0, 12.0, FontWeight::Normal, false));
+        cell.spans
+            .push(make_raw_span("hello", 0.0, 0.0, 50.0, 12.0, FontWeight::Normal, false));
+        cell.spans
+            .push(make_raw_span(" world", 50.0, 0.0, 50.0, 12.0, FontWeight::Normal, false));
         let result = HtmlOutputConverter::render_cell_html(&cell);
         // No gap inserted since span2 already starts with a space.
         assert_eq!(result, "hello world");
@@ -1020,7 +1021,8 @@ mod tests {
     fn test_render_cell_html_bold_span() {
         use crate::structure::table_extractor::TableCell;
         let mut cell = TableCell::new(String::new(), false);
-        cell.spans.push(make_raw_span("Total", 0.0, 0.0, 30.0, 12.0, FontWeight::Bold, false));
+        cell.spans
+            .push(make_raw_span("Total", 0.0, 0.0, 30.0, 12.0, FontWeight::Bold, false));
         let result = HtmlOutputConverter::render_cell_html(&cell);
         assert_eq!(result, "<strong>Total</strong>");
     }
@@ -1029,7 +1031,8 @@ mod tests {
     fn test_render_cell_html_italic_span() {
         use crate::structure::table_extractor::TableCell;
         let mut cell = TableCell::new(String::new(), false);
-        cell.spans.push(make_raw_span("Note", 0.0, 0.0, 25.0, 12.0, FontWeight::Normal, true));
+        cell.spans
+            .push(make_raw_span("Note", 0.0, 0.0, 25.0, 12.0, FontWeight::Normal, true));
         let result = HtmlOutputConverter::render_cell_html(&cell);
         assert_eq!(result, "<em>Note</em>");
     }
@@ -1038,7 +1041,8 @@ mod tests {
     fn test_render_cell_html_bold_italic_span() {
         use crate::structure::table_extractor::TableCell;
         let mut cell = TableCell::new(String::new(), false);
-        cell.spans.push(make_raw_span("Warn", 0.0, 0.0, 25.0, 12.0, FontWeight::Bold, true));
+        cell.spans
+            .push(make_raw_span("Warn", 0.0, 0.0, 25.0, 12.0, FontWeight::Bold, true));
         let result = HtmlOutputConverter::render_cell_html(&cell);
         assert_eq!(result, "<strong><em>Warn</em></strong>");
     }
@@ -1048,8 +1052,10 @@ mod tests {
         // Span1 ends at x=30, span2 starts at x=35. Gap=5 > 12*0.15=1.8 → space inserted.
         use crate::structure::table_extractor::TableCell;
         let mut cell = TableCell::new(String::new(), false);
-        cell.spans.push(make_raw_span("Label", 0.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
-        cell.spans.push(make_raw_span("Value", 35.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        cell.spans
+            .push(make_raw_span("Label", 0.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        cell.spans
+            .push(make_raw_span("Value", 35.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
         let result = HtmlOutputConverter::render_cell_html(&cell);
         assert_eq!(result, "Label Value", "Gap should produce a space: {}", result);
     }
@@ -1059,8 +1065,10 @@ mod tests {
         // Span1 ends at x=30, span2 starts at x=30. Gap=0 → no space inserted.
         use crate::structure::table_extractor::TableCell;
         let mut cell = TableCell::new(String::new(), false);
-        cell.spans.push(make_raw_span("foo", 0.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
-        cell.spans.push(make_raw_span("bar", 30.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        cell.spans
+            .push(make_raw_span("foo", 0.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
+        cell.spans
+            .push(make_raw_span("bar", 30.0, 0.0, 30.0, 12.0, FontWeight::Normal, false));
         let result = HtmlOutputConverter::render_cell_html(&cell);
         assert_eq!(result, "foobar", "No gap should produce no space: {}", result);
     }
@@ -1070,8 +1078,10 @@ mod tests {
         // A bold label with a gap before a plain value — matches real table cell pattern.
         use crate::structure::table_extractor::TableCell;
         let mut cell = TableCell::new(String::new(), false);
-        cell.spans.push(make_raw_span("Subtotal", 0.0, 0.0, 40.0, 12.0, FontWeight::Bold, false));
-        cell.spans.push(make_raw_span("500.00", 50.0, 0.0, 35.0, 12.0, FontWeight::Normal, false));
+        cell.spans
+            .push(make_raw_span("Subtotal", 0.0, 0.0, 40.0, 12.0, FontWeight::Bold, false));
+        cell.spans
+            .push(make_raw_span("500.00", 50.0, 0.0, 35.0, 12.0, FontWeight::Normal, false));
         let result = HtmlOutputConverter::render_cell_html(&cell);
         assert_eq!(result, "<strong>Subtotal</strong> 500.00", "Result: {}", result);
     }
@@ -1083,7 +1093,8 @@ mod tests {
         let mut table = Table::new();
         let mut row = TableRow::new(false);
         let mut cell = TableCell::new(String::new(), false);
-        cell.spans.push(make_raw_span("Total", 0.0, 0.0, 30.0, 12.0, FontWeight::Bold, false));
+        cell.spans
+            .push(make_raw_span("Total", 0.0, 0.0, 30.0, 12.0, FontWeight::Bold, false));
         row.add_cell(cell);
         table.add_row(row);
 

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -463,7 +463,13 @@ impl MarkdownOutputConverter {
                             active_italic = is_italic;
                         }
 
-                        let mut text = span.text.replace('|', "\\|").replace('\n', " ");
+                        // Apply column-spanning-decimal split (issue 487
+                        // nougat_018): sailing-score cells emitted as a
+                        // single Tj "1.10" with sparse char_widths split
+                        // into two tokens "1 10".
+                        let mut processed_text = String::new();
+                        crate::document::PdfDocument::push_span_text(&mut processed_text, span);
+                        let mut text = processed_text.replace('|', "\\|").replace('\n', " ");
                         let just_opened = is_bold || is_italic;
                         if just_opened && (cell_md.ends_with("**") || cell_md.ends_with('*')) {
                             while text.starts_with(' ') {
@@ -900,7 +906,13 @@ impl MarkdownOutputConverter {
                 continue;
             }
 
-            let mut text_str = span.span.text.clone();
+            // Apply column-spanning-decimal / char_widths-boundary split
+            // (issue 487 nougat_018).  Mirrors `push_span_text` in the text
+            // extractor so sailing-score cells like "1.10" (sparse cw,
+            // really `1` + `10` in adjacent columns) split into two tokens
+            // for markdown output too.
+            let mut text_str = String::new();
+            crate::document::PdfDocument::push_span_text(&mut text_str, &span.span);
 
             // Normalize known mis-extracted bullet glyphs (DEL from Zapf
             // Dingbats mappings, ❍ from ligature remaps) to U+2022 so the
@@ -1027,7 +1039,15 @@ impl MarkdownOutputConverter {
                     if !result.ends_with(' ') && !result.ends_with('\n') {
                         result.push(' ');
                     }
-                    result.push_str(&orphan.span.text);
+                    // Apply column-spanning-decimal / char_widths-boundary
+                    // split (issue 487 nougat_018): orphan score spans
+                    // emitted as "25.10" with sparse cw split into "25 10".
+                    let mut processed = String::new();
+                    crate::document::PdfDocument::push_span_text(
+                        &mut processed,
+                        &orphan.span,
+                    );
+                    result.push_str(&processed);
                 }
             }
         }

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -1108,6 +1108,18 @@ impl MarkdownOutputConverter {
         // detector emits around Arabic contextual glyph forms — is
         // safe and stays.
         if crate::text::bidi::looks_rtl(&final_result) {
+            // `str::lines()` strips trailing newlines, so `join("\n")` would
+            // silently drop a terminal `\n` (or `\n\n`) that the whitespace
+            // normalisation step above carefully preserved.  Restore the
+            // suffix after reassembly so callers see a consistent document.
+            let trailing_newlines: String = final_result
+                .chars()
+                .rev()
+                .take_while(|&c| c == '\n')
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
             final_result = final_result
                 .lines()
                 .map(|line| {
@@ -1119,6 +1131,9 @@ impl MarkdownOutputConverter {
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
+            if !trailing_newlines.is_empty() {
+                final_result.push_str(&trailing_newlines);
+            }
         }
 
         Ok(final_result)
@@ -3179,6 +3194,122 @@ mod tests {
             result.contains("Grand Total $750.00"),
             "Should merge label with value on same line: {:?}",
             result,
+        );
+    }
+
+    /// D7 — Arabic text with Bold font-weight must NOT produce `**` markers in
+    /// the markdown output.  Reproduces the right_to_left_02 fixture where
+    /// contextual glyph forms (initial/medial/final) triggered the bold
+    /// detector, inserting spurious `**مرح**با` fragments.
+    #[test]
+    fn test_arabic_bold_span_no_spurious_bold_markers() {
+        let converter = MarkdownOutputConverter::new();
+        let config = TextPipelineConfig::default();
+        // Even when the font is reported as Bold, Arabic text must NOT be
+        // wrapped in `**…**` in the final markdown (the bold detector fires on
+        // Latin-font-weight heuristics that are unreliable for Arabic glyphs).
+        let span = make_span("مرحبا", 0.0, 100.0, 12.0, FontWeight::Bold);
+        let result = converter.convert(&[span], &config).unwrap();
+        assert!(
+            !result.contains("**"),
+            "spurious bold markers found in Arabic output: {:?}",
+            result
+        );
+        assert!(
+            result.contains("مرحبا"),
+            "Arabic text lost in output: {:?}",
+            result
+        );
+    }
+
+    /// D7 — is_rtl_text / looks_rtl must return true for Arabic Unicode ranges
+    /// and false for ASCII.  Pins the detector contract used by the converter.
+    #[test]
+    fn test_rtl_detection_arabic_and_ascii() {
+        // Arabic main block
+        assert!(
+            crate::text::bidi::looks_rtl("مرحبا"),
+            "Arabic U+0600-U+06FF must be RTL"
+        );
+        // Arabic Presentation Forms-B (common in PDFs using contextual forms)
+        assert!(
+            crate::text::bidi::looks_rtl("\u{FE80}"),
+            "Arabic Presentation Forms-B U+FE80 must be RTL"
+        );
+        // Hebrew
+        assert!(
+            crate::text::bidi::looks_rtl("שלום"),
+            "Hebrew U+0590-U+05FF must be RTL"
+        );
+        // Pure ASCII must not trigger the RTL path.
+        assert!(
+            !crate::text::bidi::looks_rtl("hello world"),
+            "ASCII must not be RTL"
+        );
+        assert!(
+            !crate::text::bidi::looks_rtl(""),
+            "empty string must not be RTL"
+        );
+    }
+
+    /// D7 — strip_inline_emphasis_in_rtl must remove `**…**` and `*…*`
+    /// markers when the inner content is RTL (Arabic / Hebrew) and preserve
+    /// them when the inner content is LTR.
+    #[test]
+    fn test_strip_inline_emphasis_removes_rtl_markers() {
+        // `**bold**` around Arabic text → markers stripped
+        let out = strip_inline_emphasis_in_rtl("**مرح**با");
+        assert!(
+            !out.contains("**"),
+            "bold markers must be stripped from Arabic: {:?}",
+            out
+        );
+        assert!(
+            out.contains("مرح") && out.contains("با"),
+            "Arabic chars must survive stripping: {:?}",
+            out
+        );
+
+        // `*italic*` around Arabic text → markers stripped
+        let out2 = strip_inline_emphasis_in_rtl("*مرحبا*");
+        assert!(
+            !out2.contains('*'),
+            "italic markers must be stripped from Arabic: {:?}",
+            out2
+        );
+        assert!(out2.contains("مرحبا"), "Arabic text lost: {:?}", out2);
+
+        // Emphasis around LTR content must be preserved.
+        let out3 = strip_inline_emphasis_in_rtl("*Hello*");
+        assert_eq!(out3, "*Hello*", "LTR emphasis must be preserved: {:?}", out3);
+
+        // No asterisks → identity.
+        let out4 = strip_inline_emphasis_in_rtl("مرحبا");
+        assert_eq!(out4, "مرحبا", "no-asterisk path must be identity: {:?}", out4);
+    }
+
+    /// D7 — the RTL emphasis cleanup block must preserve the trailing newline
+    /// that the whitespace-normalisation pass added.  Previously `lines().join()`
+    /// silently dropped the terminal `\n`, corrupting multi-paragraph documents.
+    #[test]
+    fn test_rtl_cleanup_preserves_trailing_newline() {
+        let converter = MarkdownOutputConverter::new();
+        let config = TextPipelineConfig::default();
+        // Two Arabic paragraphs separated by `\n\n`.  The result must end with
+        // the same suffix the normaliser emits (a single `\n` in default mode).
+        let mut s1 = make_span("مرحبا", 0.0, 200.0, 12.0, FontWeight::Normal);
+        s1.block_id = Some(1);
+        let mut s2 = make_span("عالم", 0.0, 100.0, 12.0, FontWeight::Normal);
+        s2.block_id = Some(2);
+        let result = converter.convert(&[s1, s2], &config).unwrap();
+        // Must contain both words.
+        assert!(result.contains("مرحبا"), "first Arabic word lost: {:?}", result);
+        assert!(result.contains("عالم"), "second Arabic word lost: {:?}", result);
+        // Result must end with a newline (the document-level trailing `\n`).
+        assert!(
+            result.ends_with('\n'),
+            "trailing newline was dropped by RTL cleanup: {:?}",
+            result
         );
     }
 }

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -1043,10 +1043,7 @@ impl MarkdownOutputConverter {
                     // split (issue 487 nougat_018): orphan score spans
                     // emitted as "25.10" with sparse cw split into "25 10".
                     let mut processed = String::new();
-                    crate::document::PdfDocument::push_span_text(
-                        &mut processed,
-                        &orphan.span,
-                    );
+                    crate::document::PdfDocument::push_span_text(&mut processed, &orphan.span);
                     result.push_str(&processed);
                 }
             }

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -3215,11 +3215,7 @@ mod tests {
             "spurious bold markers found in Arabic output: {:?}",
             result
         );
-        assert!(
-            result.contains("مرحبا"),
-            "Arabic text lost in output: {:?}",
-            result
-        );
+        assert!(result.contains("مرحبا"), "Arabic text lost in output: {:?}", result);
     }
 
     /// D7 — is_rtl_text / looks_rtl must return true for Arabic Unicode ranges
@@ -3227,29 +3223,17 @@ mod tests {
     #[test]
     fn test_rtl_detection_arabic_and_ascii() {
         // Arabic main block
-        assert!(
-            crate::text::bidi::looks_rtl("مرحبا"),
-            "Arabic U+0600-U+06FF must be RTL"
-        );
+        assert!(crate::text::bidi::looks_rtl("مرحبا"), "Arabic U+0600-U+06FF must be RTL");
         // Arabic Presentation Forms-B (common in PDFs using contextual forms)
         assert!(
             crate::text::bidi::looks_rtl("\u{FE80}"),
             "Arabic Presentation Forms-B U+FE80 must be RTL"
         );
         // Hebrew
-        assert!(
-            crate::text::bidi::looks_rtl("שלום"),
-            "Hebrew U+0590-U+05FF must be RTL"
-        );
+        assert!(crate::text::bidi::looks_rtl("שלום"), "Hebrew U+0590-U+05FF must be RTL");
         // Pure ASCII must not trigger the RTL path.
-        assert!(
-            !crate::text::bidi::looks_rtl("hello world"),
-            "ASCII must not be RTL"
-        );
-        assert!(
-            !crate::text::bidi::looks_rtl(""),
-            "empty string must not be RTL"
-        );
+        assert!(!crate::text::bidi::looks_rtl("hello world"), "ASCII must not be RTL");
+        assert!(!crate::text::bidi::looks_rtl(""), "empty string must not be RTL");
     }
 
     /// D7 — strip_inline_emphasis_in_rtl must remove `**…**` and `*…*`
@@ -3259,11 +3243,7 @@ mod tests {
     fn test_strip_inline_emphasis_removes_rtl_markers() {
         // `**bold**` around Arabic text → markers stripped
         let out = strip_inline_emphasis_in_rtl("**مرح**با");
-        assert!(
-            !out.contains("**"),
-            "bold markers must be stripped from Arabic: {:?}",
-            out
-        );
+        assert!(!out.contains("**"), "bold markers must be stripped from Arabic: {:?}", out);
         assert!(
             out.contains("مرح") && out.contains("با"),
             "Arabic chars must survive stripping: {:?}",
@@ -3272,11 +3252,7 @@ mod tests {
 
         // `*italic*` around Arabic text → markers stripped
         let out2 = strip_inline_emphasis_in_rtl("*مرحبا*");
-        assert!(
-            !out2.contains('*'),
-            "italic markers must be stripped from Arabic: {:?}",
-            out2
-        );
+        assert!(!out2.contains('*'), "italic markers must be stripped from Arabic: {:?}", out2);
         assert!(out2.contains("مرحبا"), "Arabic text lost: {:?}", out2);
 
         // Emphasis around LTR content must be preserved.

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -156,23 +156,64 @@ pub(crate) fn has_horizontal_gap(prev: &TextSpan, current: &TextSpan) -> bool {
     true
 }
 
-/// Return the index of the table whose bounding box contains the span's origin,
-/// or `None` if the span does not fall inside any table region.
+/// Return the index of the table whose bounding box contains the span's
+/// origin AND that has a cell whose bbox also contains the span — i.e.
+/// the table is actually going to render this span as part of a cell.
+///
+/// Returning `Some(idx)` causes `convert_semantic_mode` (md/html) to skip
+/// the span from paragraph flow on the assumption that the table render
+/// will emit it.  If the span sits inside the table's *outer* bbox but
+/// the spatial column-clustering missed the column it belongs to (a
+/// sparse / variable-width score column on wide sailing-results grids
+/// — issue 486 / 487), no cell will contain it and the table render
+/// drops the content.  Treating that span as "outside the table" lets
+/// the paragraph flow pick it up so the text is not lost.
 pub(crate) fn span_in_table(span: &OrderedTextSpan, tables: &[Table]) -> Option<usize> {
     let sx = span.span.bbox.x;
     let sy = span.span.bbox.y;
 
     for (i, table) in tables.iter().enumerate() {
-        if let Some(ref bbox) = table.bbox {
-            let tolerance = 2.0;
-            if sx >= bbox.x - tolerance
-                && sx <= bbox.x + bbox.width + tolerance
-                && sy >= bbox.y - tolerance
-                && sy <= bbox.y + bbox.height + tolerance
-            {
-                return Some(i);
-            }
+        let Some(ref bbox) = table.bbox else { continue };
+        let tolerance = 2.0;
+        let in_outer_bbox = sx >= bbox.x - tolerance
+            && sx <= bbox.x + bbox.width + tolerance
+            && sy >= bbox.y - tolerance
+            && sy <= bbox.y + bbox.height + tolerance;
+        if !in_outer_bbox {
+            continue;
         }
+        // Span is geometrically inside the table — verify a cell will
+        // own it.  Walks all rows / cells once; tables that get through
+        // is_real_grid are typically small enough (≤30 rows × ≤25 cols)
+        // that this is negligible vs. the cost of running the conversion.
+        //
+        // Special case: a Table with no cell bboxes at all (e.g. when
+        // built from MCID-based tagged-PDF extraction, or in unit-test
+        // fixtures) carries the rendering responsibility wholesale —
+        // there is no per-cell layout to consult.  Fall back to the
+        // outer-bbox containment for that case so we don't silently
+        // skip the table rendering.
+        let has_any_cell_bbox = table
+            .rows
+            .iter()
+            .any(|row| row.cells.iter().any(|c| c.bbox.is_some()));
+        if !has_any_cell_bbox {
+            return Some(i);
+        }
+        let span_owned = table.rows.iter().any(|row| {
+            row.cells.iter().any(|cell| {
+                let Some(cb) = cell.bbox else { return false };
+                sx >= cb.x - tolerance
+                    && sx <= cb.x + cb.width + tolerance
+                    && sy >= cb.y - tolerance
+                    && sy <= cb.y + cb.height + tolerance
+            })
+        });
+        if span_owned {
+            return Some(i);
+        }
+        // Span sits in the outer bbox but no cell claims it; fall through
+        // to paragraph flow so the content is not silently dropped.
     }
     None
 }

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -80,18 +80,80 @@ pub trait OutputConverter: Send + Sync {
     fn mime_type(&self) -> &'static str;
 }
 
+/// Returns `true` if `c` is a CJK character (Chinese, Japanese, or Korean).
+fn is_cjk_char(c: char) -> bool {
+    matches!(c,
+        '\u{3040}'..='\u{309F}' |   // Hiragana
+        '\u{30A0}'..='\u{30FF}' |   // Katakana
+        '\u{4E00}'..='\u{9FFF}' |   // CJK Unified Ideographs
+        '\u{AC00}'..='\u{D7AF}' |   // Hangul
+        '\u{3400}'..='\u{4DBF}' |   // CJK Extension A
+        '\u{20000}'..='\u{2A6DF}'   // CJK Extension B
+    )
+}
+
+/// Returns `true` if `c` is a fullwidth or mathematical operator that is
+/// commonly embedded inside CJK text without surrounding spaces.
+///
+/// These characters have slightly wider advances than typical ASCII characters,
+/// which can trigger the gap heuristic and insert a spurious space when they
+/// appear between CJK glyphs (e.g. `25000≤Q＜40000`).
+fn is_fullwidth_or_math_op(c: char) -> bool {
+    matches!(c,
+        '\u{FF0B}' |                // ＋
+        '\u{FF0D}' |                // －
+        '\u{FF1A}' |                // ：
+        '\u{FF1B}' |                // ；
+        '\u{FF1C}'..='\u{FF1E}' |  // ＜ ＝ ＞
+        '\u{2260}' |               // ≠
+        '\u{2248}' |               // ≈
+        '\u{2264}'..='\u{2265}' |  // ≤ ≥
+        '\u{00B5}' |               // µ
+        '\u{03BC}' |               // μ
+        '\u{00B1}' |               // ±
+        '\u{00D7}' |               // ×
+        '\u{00F7}'                 // ÷
+    )
+}
+
 /// Check whether two horizontally adjacent spans have a visible gap between them.
 ///
 /// Returns `true` when the horizontal distance between the end of `prev` and
 /// the start of `current` exceeds a small fraction of the font size but is not
 /// unreasonably large (which would indicate a column break rather than a word
 /// gap).
+///
+/// CJK scripts do not use spaces between words.  When one side of the boundary
+/// is a CJK character and the other side is CJK or a fullwidth/math operator
+/// (e.g. `≤`, `＜`, `μ`), no space is inserted even if the geometric gap
+/// exceeds the threshold.  This mirrors the CJK-pair suppression in the text
+/// extraction path (`document.rs`).
 pub(crate) fn has_horizontal_gap(prev: &TextSpan, current: &TextSpan) -> bool {
     let font_size = prev.font_size.max(current.font_size).max(1.0);
     let prev_end_x = prev.bbox.x + prev.bbox.width;
     let gap = current.bbox.x - prev_end_x;
     let threshold = font_size * 0.15;
-    gap > threshold && gap < font_size * 5.0
+    if !(gap > threshold && gap < font_size * 5.0) {
+        return false;
+    }
+
+    // Suppress space insertion when one side is CJK and the other is CJK or a
+    // fullwidth/math operator.  This mirrors the CJK-pair suppression in the
+    // text extraction path (document.rs:5587-5605).
+    let prev_last = prev.text.chars().next_back();
+    let curr_first = current.text.chars().next();
+    if let (Some(p), Some(c)) = (prev_last, curr_first) {
+        let p_cjk = is_cjk_char(p);
+        let c_cjk = is_cjk_char(c);
+        if (p_cjk || is_fullwidth_or_math_op(p)) && (c_cjk || is_fullwidth_or_math_op(c)) {
+            // At least one side must actually be CJK (not two pure math ops).
+            if p_cjk || c_cjk {
+                return false;
+            }
+        }
+    }
+
+    true
 }
 
 /// Return the index of the table whose bounding box contains the span's origin,
@@ -328,5 +390,82 @@ mod tests {
     fn test_key_value_pair_merging_empty_input() {
         assert_eq!(merge_key_value_pairs(""), "");
         assert_eq!(merge_key_value_pairs("single line\n"), "single line\n");
+    }
+
+    // ========================================================================
+    // has_horizontal_gap CJK suppression tests (#485)
+    // ========================================================================
+
+    /// Build a minimal TextSpan for gap tests.
+    ///
+    /// `x` is the left edge of the span, `w` is its width, `text` is the
+    /// content.  Font size is set to 10 so that the 0.15em threshold = 1.5.
+    fn make_span(x: f32, w: f32, text: &str) -> crate::layout::TextSpan {
+        crate::layout::TextSpan {
+            text: text.to_string(),
+            bbox: crate::geometry::Rect::new(x, 0.0, w, 10.0),
+            font_size: 10.0,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_has_horizontal_gap_cjk_cjk_suppressed() {
+        // CJK char followed by CJK char with a gap > 0.15em → no space.
+        let prev = make_span(0.0, 10.0, "数");   // ends with CJK
+        let curr = make_span(12.0, 10.0, "学");  // starts with CJK; gap = 2.0 > 1.5
+        assert!(!has_horizontal_gap(&prev, &curr),
+            "CJK→CJK should suppress space insertion");
+    }
+
+    #[test]
+    fn test_has_horizontal_gap_cjk_fullwidth_suppressed() {
+        // CJK char followed by fullwidth operator → no space.
+        let prev = make_span(0.0, 10.0, "Q");    // ends with ASCII (not CJK alone)
+        // override: use a CJK ending character
+        let prev_cjk = make_span(0.0, 10.0, "量");
+        let curr = make_span(12.0, 10.0, "＜");  // starts with fullwidth '<'; gap = 2.0
+        assert!(!has_horizontal_gap(&prev_cjk, &curr),
+            "CJK→fullwidth-op should suppress space insertion");
+        let _ = prev; // silence unused warning
+    }
+
+    #[test]
+    fn test_has_horizontal_gap_fullwidth_cjk_suppressed() {
+        // Fullwidth operator followed by CJK char → no space.
+        let prev = make_span(0.0, 10.0, "≤");   // ends with math op
+        let curr = make_span(12.0, 10.0, "Q");  // pure ASCII start — not suppressed
+        // For suppression we need curr to start with CJK
+        let curr_cjk = make_span(12.0, 10.0, "量");
+        assert!(!has_horizontal_gap(&prev, &curr_cjk),
+            "fullwidth-op→CJK should suppress space insertion");
+        let _ = curr; // silence unused warning
+    }
+
+    #[test]
+    fn test_has_horizontal_gap_latin_latin_unchanged() {
+        // Latin→Latin: gap-based logic unchanged — gap > threshold → true.
+        let prev = make_span(0.0, 10.0, "hello");
+        let curr = make_span(12.0, 10.0, "world"); // gap = 2.0 > 1.5
+        assert!(has_horizontal_gap(&prev, &curr),
+            "Latin→Latin with gap > threshold should still insert space");
+    }
+
+    #[test]
+    fn test_has_horizontal_gap_latin_latin_no_gap() {
+        // Latin→Latin: gap ≤ threshold → false (no change from CJK fix).
+        let prev = make_span(0.0, 10.0, "hello");
+        let curr = make_span(11.0, 10.0, "world"); // gap = 1.0 < 1.5
+        assert!(!has_horizontal_gap(&prev, &curr),
+            "Latin→Latin below threshold should not insert space");
+    }
+
+    #[test]
+    fn test_has_horizontal_gap_two_pure_math_ops_unchanged() {
+        // Two pure math operators (neither is CJK): gap-based logic unchanged.
+        let prev = make_span(0.0, 10.0, "≤");
+        let curr = make_span(12.0, 10.0, "≥"); // gap = 2.0 > 1.5; neither is CJK
+        assert!(has_horizontal_gap(&prev, &curr),
+            "math-op→math-op (no CJK) should still apply gap-based logic");
     }
 }

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -133,7 +133,15 @@ pub(crate) fn has_horizontal_gap(prev: &TextSpan, current: &TextSpan) -> bool {
     let prev_end_x = prev.bbox.x + prev.bbox.width;
     let gap = current.bbox.x - prev_end_x;
     let threshold = font_size * 0.15;
-    if !(gap > threshold && gap < font_size * 5.0) {
+    // Sub-em gaps are inter-glyph kerning — no space needed.  ANY gap
+    // larger than that, including gaps >5 em (column boundaries on
+    // wide tables — issue 487 pr-138-example.pdf), must result in a
+    // space.  The previous `gap < 5 em` upper bound made the caller
+    // concatenate without separator for huge gaps, gluing tokens like
+    // `3.80%` + `4.41%` into `3.80%4.41%` when the rate-table cells
+    // sit ~265 pt apart and the table detector wasn't able to capture
+    // them as a real grid.
+    if gap <= threshold {
         return false;
     }
 

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -116,6 +116,21 @@ fn is_fullwidth_or_math_op(c: char) -> bool {
     )
 }
 
+/// Clause-boundary delimiters that always warrant a space even next to CJK text.
+/// Parentheses, brackets, and quotation marks mark syntactic boundaries and must
+/// not have their surrounding space suppressed by the CJK gap-suppression logic.
+fn is_clause_delimiter(c: char) -> bool {
+    matches!(c,
+        '(' | ')' | '[' | ']' | '{' | '}' |
+        '\u{FF08}' | '\u{FF09}' | // （ ）fullwidth parens
+        '\u{FF3B}' | '\u{FF3D}' | // ［ ］fullwidth brackets
+        '\u{300C}' | '\u{300D}' | // 「 」corner brackets
+        '\u{300E}' | '\u{300F}' | // 『 』white corner brackets
+        '\u{2018}' | '\u{2019}' | // ' ' single smart quotes
+        '\u{201C}' | '\u{201D}'   // " " double smart quotes
+    )
+}
+
 /// Check whether two horizontally adjacent spans have a visible gap between them.
 ///
 /// Returns `true` when the horizontal distance between the end of `prev` and

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -518,4 +518,114 @@ mod tests {
             "math-op→math-op (no CJK) should still apply gap-based logic"
         );
     }
+
+    // ========================================================================
+    // span_in_table cell-aware regression tests (#486 / #487)
+    //
+    // These guarantee that:
+    //   * a span inside the outer table bbox is still "in table" when no cell
+    //     bbox exists (e.g. MCID-based tagged-PDF tables, or unit-test
+    //     fixtures) — preserves the legacy contract
+    //   * a span inside the outer bbox but outside every cell bbox is NOT
+    //     "in table" — sparse score columns whose cells never got detected
+    //     fall through to paragraph flow instead of being silently dropped
+    //     (issue 486 / 487)
+    // ========================================================================
+
+    fn make_table_no_cells(x: f32, y: f32, width: f32, height: f32) -> Table {
+        let mut t = Table::new();
+        t.bbox = Some(crate::geometry::Rect::new(x, y, width, height));
+        t
+    }
+
+    fn make_table_with_cell(
+        table_bbox: (f32, f32, f32, f32),
+        cell_bbox: (f32, f32, f32, f32),
+    ) -> Table {
+        use crate::structure::table_extractor::{TableCell, TableRow};
+        let mut t = Table::new();
+        t.bbox = Some(crate::geometry::Rect::new(
+            table_bbox.0,
+            table_bbox.1,
+            table_bbox.2,
+            table_bbox.3,
+        ));
+        let mut row = TableRow::new(false);
+        let mut cell = TableCell::new(String::new(), false);
+        cell.bbox = Some(crate::geometry::Rect::new(
+            cell_bbox.0,
+            cell_bbox.1,
+            cell_bbox.2,
+            cell_bbox.3,
+        ));
+        row.cells.push(cell);
+        t.rows.push(row);
+        t.col_count = 1;
+        t
+    }
+
+    fn make_ordered_span(x: f32, y: f32) -> crate::pipeline::OrderedTextSpan {
+        let span = crate::layout::TextSpan {
+            text: "test".to_string(),
+            bbox: crate::geometry::Rect::new(x, y, 5.0, 10.0),
+            font_size: 10.0,
+            ..Default::default()
+        };
+        crate::pipeline::OrderedTextSpan::new(span, 0)
+    }
+
+    /// Span inside outer bbox of a Table that has no cells at all — legacy
+    /// passthrough must still return Some.  Covers unit-test fixtures and
+    /// MCID-based tagged-PDF Tables built without per-cell layout.
+    #[test]
+    fn span_in_table_no_cells_legacy_passthrough() {
+        let table = make_table_no_cells(10.0, 50.0, 200.0, 100.0);
+        let span = make_ordered_span(50.0, 70.0); // inside outer bbox
+        assert_eq!(
+            span_in_table(&span, &[table]),
+            Some(0),
+            "no-cell Table preserves legacy outer-bbox contract"
+        );
+    }
+
+    /// Span inside the outer bbox AND owned by a cell → Some.
+    #[test]
+    fn span_in_table_owned_by_cell() {
+        let table = make_table_with_cell(
+            (10.0, 50.0, 200.0, 100.0), // outer
+            (40.0, 60.0, 100.0, 20.0),  // cell at (40..140, 60..80)
+        );
+        let span = make_ordered_span(50.0, 70.0); // inside cell
+        assert_eq!(span_in_table(&span, &[table]), Some(0));
+    }
+
+    /// Span inside outer bbox but outside every cell — sparse score column
+    /// case from issue 486.  Must return None so paragraph flow picks it up.
+    #[test]
+    fn span_in_table_outer_bbox_only_returns_none() {
+        let table = make_table_with_cell(
+            (10.0, 50.0, 200.0, 100.0), // outer: x=10..210, y=50..150
+            (10.0, 50.0, 50.0, 100.0),  // cell only covers x=10..60
+        );
+        // Span at x=150 sits inside outer bbox (10..210) but outside cell
+        // (10..60) — represents a column the detector missed.
+        let span = make_ordered_span(150.0, 70.0);
+        assert_eq!(
+            span_in_table(&span, &[table]),
+            None,
+            "span outside every cell must NOT be marked in_table — \
+             paragraph flow needs to pick it up instead of dropping"
+        );
+    }
+
+    /// Span outside every table's outer bbox → None.
+    #[test]
+    fn span_in_table_outside_all_tables() {
+        let table = make_table_with_cell(
+            (10.0, 50.0, 200.0, 100.0),
+            (40.0, 60.0, 100.0, 20.0),
+        );
+        let span = make_ordered_span(500.0, 500.0);
+        assert_eq!(span_in_table(&span, &[table]), None);
+    }
 }

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -560,12 +560,8 @@ mod tests {
         ));
         let mut row = TableRow::new(false);
         let mut cell = TableCell::new(String::new(), false);
-        cell.bbox = Some(crate::geometry::Rect::new(
-            cell_bbox.0,
-            cell_bbox.1,
-            cell_bbox.2,
-            cell_bbox.3,
-        ));
+        cell.bbox =
+            Some(crate::geometry::Rect::new(cell_bbox.0, cell_bbox.1, cell_bbox.2, cell_bbox.3));
         row.cells.push(cell);
         t.rows.push(row);
         t.col_count = 1;
@@ -629,10 +625,7 @@ mod tests {
     /// Span outside every table's outer bbox → None.
     #[test]
     fn span_in_table_outside_all_tables() {
-        let table = make_table_with_cell(
-            (10.0, 50.0, 200.0, 100.0),
-            (40.0, 60.0, 100.0, 20.0),
-        );
+        let table = make_table_with_cell((10.0, 50.0, 200.0, 100.0), (40.0, 60.0, 100.0, 20.0));
         let span = make_ordered_span(500.0, 500.0);
         assert_eq!(span_in_table(&span, &[table]), None);
     }

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -116,21 +116,6 @@ fn is_fullwidth_or_math_op(c: char) -> bool {
     )
 }
 
-/// Clause-boundary delimiters that always warrant a space even next to CJK text.
-/// Parentheses, brackets, and quotation marks mark syntactic boundaries and must
-/// not have their surrounding space suppressed by the CJK gap-suppression logic.
-fn is_clause_delimiter(c: char) -> bool {
-    matches!(c,
-        '(' | ')' | '[' | ']' | '{' | '}' |
-        '\u{FF08}' | '\u{FF09}' | // （ ）fullwidth parens
-        '\u{FF3B}' | '\u{FF3D}' | // ［ ］fullwidth brackets
-        '\u{300C}' | '\u{300D}' | // 「 」corner brackets
-        '\u{300E}' | '\u{300F}' | // 『 』white corner brackets
-        '\u{2018}' | '\u{2019}' | // ' ' single smart quotes
-        '\u{201C}' | '\u{201D}'   // " " double smart quotes
-    )
-}
-
 /// Check whether two horizontally adjacent spans have a visible gap between them.
 ///
 /// Returns `true` when the horizontal distance between the end of `prev` and
@@ -427,33 +412,36 @@ mod tests {
     #[test]
     fn test_has_horizontal_gap_cjk_cjk_suppressed() {
         // CJK char followed by CJK char with a gap > 0.15em → no space.
-        let prev = make_span(0.0, 10.0, "数");   // ends with CJK
-        let curr = make_span(12.0, 10.0, "学");  // starts with CJK; gap = 2.0 > 1.5
-        assert!(!has_horizontal_gap(&prev, &curr),
-            "CJK→CJK should suppress space insertion");
+        let prev = make_span(0.0, 10.0, "数"); // ends with CJK
+        let curr = make_span(12.0, 10.0, "学"); // starts with CJK; gap = 2.0 > 1.5
+        assert!(!has_horizontal_gap(&prev, &curr), "CJK→CJK should suppress space insertion");
     }
 
     #[test]
     fn test_has_horizontal_gap_cjk_fullwidth_suppressed() {
         // CJK char followed by fullwidth operator → no space.
-        let prev = make_span(0.0, 10.0, "Q");    // ends with ASCII (not CJK alone)
-        // override: use a CJK ending character
+        let prev = make_span(0.0, 10.0, "Q"); // ends with ASCII (not CJK alone)
+                                              // override: use a CJK ending character
         let prev_cjk = make_span(0.0, 10.0, "量");
-        let curr = make_span(12.0, 10.0, "＜");  // starts with fullwidth '<'; gap = 2.0
-        assert!(!has_horizontal_gap(&prev_cjk, &curr),
-            "CJK→fullwidth-op should suppress space insertion");
+        let curr = make_span(12.0, 10.0, "＜"); // starts with fullwidth '<'; gap = 2.0
+        assert!(
+            !has_horizontal_gap(&prev_cjk, &curr),
+            "CJK→fullwidth-op should suppress space insertion"
+        );
         let _ = prev; // silence unused warning
     }
 
     #[test]
     fn test_has_horizontal_gap_fullwidth_cjk_suppressed() {
         // Fullwidth operator followed by CJK char → no space.
-        let prev = make_span(0.0, 10.0, "≤");   // ends with math op
-        let curr = make_span(12.0, 10.0, "Q");  // pure ASCII start — not suppressed
-        // For suppression we need curr to start with CJK
+        let prev = make_span(0.0, 10.0, "≤"); // ends with math op
+        let curr = make_span(12.0, 10.0, "Q"); // pure ASCII start — not suppressed
+                                               // For suppression we need curr to start with CJK
         let curr_cjk = make_span(12.0, 10.0, "量");
-        assert!(!has_horizontal_gap(&prev, &curr_cjk),
-            "fullwidth-op→CJK should suppress space insertion");
+        assert!(
+            !has_horizontal_gap(&prev, &curr_cjk),
+            "fullwidth-op→CJK should suppress space insertion"
+        );
         let _ = curr; // silence unused warning
     }
 
@@ -462,8 +450,10 @@ mod tests {
         // Latin→Latin: gap-based logic unchanged — gap > threshold → true.
         let prev = make_span(0.0, 10.0, "hello");
         let curr = make_span(12.0, 10.0, "world"); // gap = 2.0 > 1.5
-        assert!(has_horizontal_gap(&prev, &curr),
-            "Latin→Latin with gap > threshold should still insert space");
+        assert!(
+            has_horizontal_gap(&prev, &curr),
+            "Latin→Latin with gap > threshold should still insert space"
+        );
     }
 
     #[test]
@@ -471,8 +461,10 @@ mod tests {
         // Latin→Latin: gap ≤ threshold → false (no change from CJK fix).
         let prev = make_span(0.0, 10.0, "hello");
         let curr = make_span(11.0, 10.0, "world"); // gap = 1.0 < 1.5
-        assert!(!has_horizontal_gap(&prev, &curr),
-            "Latin→Latin below threshold should not insert space");
+        assert!(
+            !has_horizontal_gap(&prev, &curr),
+            "Latin→Latin below threshold should not insert space"
+        );
     }
 
     #[test]
@@ -480,7 +472,9 @@ mod tests {
         // Two pure math operators (neither is CJK): gap-based logic unchanged.
         let prev = make_span(0.0, 10.0, "≤");
         let curr = make_span(12.0, 10.0, "≥"); // gap = 2.0 > 1.5; neither is CJK
-        assert!(has_horizontal_gap(&prev, &curr),
-            "math-op→math-op (no CJK) should still apply gap-based logic");
+        assert!(
+            has_horizontal_gap(&prev, &curr),
+            "math-op→math-op (no CJK) should still apply gap-based logic"
+        );
     }
 }

--- a/src/signatures/sign_bytes.rs
+++ b/src/signatures/sign_bytes.rs
@@ -287,6 +287,9 @@ fn pdf_text_hex(s: &str) -> String {
 }
 
 fn format_pdf_date() -> String {
+    // WASM note: if signatures are ever enabled for wasm32, SystemTime::now()
+    // here will also need cfg-gating (currently masked because the `signatures`
+    // feature is not enabled in the wasm build).
     use std::time::SystemTime;
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/signatures/signer.rs
+++ b/src/signatures/signer.rs
@@ -394,6 +394,9 @@ fn escape_pdf_string(s: &str) -> String {
 
 /// Format current time as a PDF date string.
 fn format_pdf_date() -> String {
+    // WASM note: if signatures are ever enabled for wasm32, SystemTime::now()
+    // here will also need cfg-gating (currently masked because the `signatures`
+    // feature is not enabled in the wasm build).
     use std::time::SystemTime;
 
     let now = SystemTime::now()

--- a/src/signatures/tsa_client.rs
+++ b/src/signatures/tsa_client.rs
@@ -197,6 +197,9 @@ fn random_nonce() -> der::asn1::Int {
         // happen on our targets), fall back to a time-derived nonce.
         // Timestamps alone don't give crypto security, but they do
         // prevent the trivial replay case.
+        // WASM note: if signatures are ever enabled for wasm32, SystemTime::now()
+        // here will also need cfg-gating (currently masked because the `signatures`
+        // feature is not enabled in the wasm build).
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos() as u64)

--- a/src/signatures/types.rs
+++ b/src/signatures/types.rs
@@ -234,6 +234,9 @@ impl SigningCredentials {
         use x509_parser::prelude::*;
         let (_, cert) = X509Certificate::from_der(&self.certificate)
             .map_err(|e| Error::InvalidPdf(format!("invalid X.509 DER: {e}")))?;
+        // WASM note: if signatures are ever enabled for wasm32, SystemTime::now()
+        // here will also need cfg-gating (currently masked because the `signatures`
+        // feature is not enabled in the wasm build).
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)

--- a/src/signatures/verifier.rs
+++ b/src/signatures/verifier.rs
@@ -208,6 +208,9 @@ impl SignatureVerifier {
                 .push("Certificate is not trusted".to_string());
         }
 
+        // WASM note: if signatures are ever enabled for wasm32, SystemTime::now()
+        // here will also need cfg-gating (currently masked because the `signatures`
+        // feature is not enabled in the wasm build).
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -371,6 +371,45 @@ fn parse_struct_elem(
     // Check /Type (should be /StructElem, but optional)
     if let Some(type_obj) = dict.get("Type") {
         if let Some(type_name) = type_obj.as_name() {
+            if type_name == "OBJR" {
+                // Per PDF spec §14.7.4 Table 323, an OBJR (Object Reference) dictionary
+                // references a StructElem (or other PDF object) via its /Obj entry.
+                // Transparently dereference it so the caller gets the real StructElem.
+                if let Some(obj_ref_obj) = dict.get("Obj") {
+                    if let Some(obj_ref) = obj_ref_obj.as_reference() {
+                        if !visited.insert(obj_ref.id) {
+                            log::debug!(
+                                "OBJR: cycle detected — object {} already visited, skipping",
+                                obj_ref.id
+                            );
+                            return Ok(None);
+                        }
+                        match document.load_object(obj_ref) {
+                            Ok(resolved) => {
+                                return parse_struct_elem(
+                                    document,
+                                    &resolved,
+                                    role_map,
+                                    page_map,
+                                    deadline,
+                                    element_count,
+                                    visited,
+                                );
+                            },
+                            Err(e) => {
+                                log::warn!(
+                                    "OBJR: failed to load /Obj {} {}: {}",
+                                    obj_ref.id,
+                                    obj_ref.gen,
+                                    e
+                                );
+                                return Ok(None);
+                            },
+                        }
+                    }
+                }
+                return Ok(None);
+            }
             if type_name != "StructElem" {
                 return Ok(None); // Not a StructElem
             }

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -3224,6 +3224,114 @@ fn cell_span_separator(prev: &TextSpan, current: &TextSpan) -> &'static str {
     " "
 }
 
+/// Consolidate vertically-adjacent tables that share an identical column
+/// structure into a single multi-row table.
+///
+/// Issue 484/486/487 root cause: when a logical multi-row table is drawn
+/// with a horizontal ruling line between every pair of rows (rather than
+/// only at the top and bottom), the line-based detector emits one Table
+/// per row strip. Each fragment is a 1- or 2-row table that fails
+/// `is_real_grid()` (which requires ≥2 rows) and gets dropped, after
+/// which the cells fall through to the paragraph flow with column-based
+/// reading order — producing orphan `<p>40000≤Q</p>` / `<p>＜55000</p>`
+/// pairs instead of `<table><td>40000≤Q＜55000</td></tr></table>`.
+///
+/// Two fragments are merge-candidates when:
+///   * both have a `bbox`
+///   * X start matches within `X_TOLERANCE`
+///   * width matches within `X_TOLERANCE`
+///   * column counts are equal
+///   * the lower fragment's top edge (`bbox.y + bbox.height`) is within
+///     `Y_TOLERANCE` of the upper fragment's bottom edge (`bbox.y`)
+///
+/// Sort tables top-down (PDF y-up: largest top-Y first) and merge runs
+/// of consecutive fragments that satisfy the criteria. The merged table
+/// preserves the union of all rows and a bbox spanning both fragments.
+pub fn consolidate_adjacent_table_fragments(tables: Vec<Table>) -> Vec<Table> {
+    if tables.len() < 2 {
+        return tables;
+    }
+    const X_TOLERANCE: f32 = 2.0;
+    const Y_TOLERANCE: f32 = 3.0;
+
+    // Sort by top-Y descending (top of page first in PDF y-up coordinates).
+    let mut sorted = tables;
+    sorted.sort_by(|a, b| {
+        let a_top = a.bbox.map(|b| b.y + b.height).unwrap_or(f32::NEG_INFINITY);
+        let b_top = b.bbox.map(|b| b.y + b.height).unwrap_or(f32::NEG_INFINITY);
+        crate::utils::safe_float_cmp(b_top, a_top)
+    });
+
+    let mut consolidated: Vec<Table> = Vec::with_capacity(sorted.len());
+    for table in sorted {
+        let merge_into_last = consolidated
+            .last()
+            .map(|last| can_merge_tables(last, &table, X_TOLERANCE, Y_TOLERANCE))
+            .unwrap_or(false);
+        if merge_into_last {
+            // Safety: merge_into_last is only true when consolidated.last()
+            // returned Some, so last_mut() must also return Some.
+            if let Some(last) = consolidated.last_mut() {
+                merge_table_into(last, table);
+            }
+        } else {
+            consolidated.push(table);
+        }
+    }
+    consolidated
+}
+
+fn can_merge_tables(upper: &Table, lower: &Table, x_tol: f32, y_tol: f32) -> bool {
+    let (Some(u_bbox), Some(l_bbox)) = (upper.bbox, lower.bbox) else {
+        return false;
+    };
+    if upper.col_count != lower.col_count || upper.col_count == 0 {
+        return false;
+    }
+    if (u_bbox.x - l_bbox.x).abs() > x_tol {
+        return false;
+    }
+    if (u_bbox.width - l_bbox.width).abs() > x_tol {
+        return false;
+    }
+    // upper sits ABOVE lower in PDF y-up: upper.bbox.y is the BOTTOM of
+    // upper, lower.bbox.y + lower.bbox.height is the TOP of lower.
+    // For them to be vertically adjacent, the upper.bottom must be close
+    // to the lower.top.  We allow a small NEGATIVE gap (overlap) up to
+    // half the smaller table's height — the line-based detector
+    // occasionally produces bboxes that overhang the adjacent table by a
+    // few points when ruling-rule strokes have non-zero thickness or
+    // include the line's drawn extent above/below the baseline.  Real
+    // distinct tables almost always have a meaningful positive gap.
+    let upper_bottom = u_bbox.y;
+    let lower_top = l_bbox.y + l_bbox.height;
+    let gap = upper_bottom - lower_top;
+    if gap > y_tol {
+        return false;
+    }
+    let min_height = u_bbox.height.min(l_bbox.height);
+    if -gap > min_height * 0.5 {
+        return false;
+    }
+    true
+}
+
+fn merge_table_into(upper: &mut Table, lower: Table) {
+    if let (Some(ub), Some(lb)) = (upper.bbox, lower.bbox) {
+        let new_y = ub.y.min(lb.y);
+        let new_top = (ub.y + ub.height).max(lb.y + lb.height);
+        let new_x = ub.x.min(lb.x);
+        let new_right = (ub.x + ub.width).max(lb.x + lb.width);
+        upper.bbox = Some(crate::geometry::Rect {
+            x: new_x,
+            y: new_y,
+            width: new_right - new_x,
+            height: new_top - new_y,
+        });
+    }
+    upper.rows.extend(lower.rows);
+}
+
 fn detect_merged_cells(grid: &GridStructure, spans: &[TextSpan]) -> Vec<Vec<CellMergeInfo>> {
     let num_rows = grid.cells.len();
     let num_cols = grid.columns.len();

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -2980,10 +2980,17 @@ pub fn detect_tables_with_lines(
     // spurious line-based tables don't shadow valid text-based ones.
     final_tables.retain(is_valid_table);
 
-    // Only allow text-based fallback if BOTH strategies permit it.
-    // If horizontal_strategy is Lines, we require actual horizontal lines for row detection.
-    // If vertical_strategy is Lines, we require actual vertical lines for column detection.
-    let allow_text_fallback = config.horizontal_strategy != TableStrategy::Lines
+    // Only allow text-based fallback if BOTH strategies permit it AND the caller
+    // explicitly enabled text-only detection (config.text_fallback=true).
+    // This prevents extract_text() callers (text_fallback=false) from
+    // spuriously running span-column detection alongside ruling-line tables:
+    // report-style PDFs with decorative horizontal rules (e.g. swimming results)
+    // would otherwise have all their data detected as a text table that renders
+    // the page content a second time, causing duplicate extraction.
+    // Callers that want text-based table detection (to_markdown, to_html) set
+    // config.text_fallback=true explicitly.
+    let allow_text_fallback = config.text_fallback
+        && config.horizontal_strategy != TableStrategy::Lines
         && config.vertical_strategy != TableStrategy::Lines;
 
     if allow_text_fallback {
@@ -3396,9 +3403,15 @@ mod tests {
             create_test_span("21", 90.0, 140.0, 20.0, 10.0),
         ];
 
-        // With the default Both strategy and NO lines, the text-based fallback
-        // inside detect_tables_with_lines fires and finds the grid.
-        let config = TableDetectionConfig::default();
+        // With the Both strategy, NO lines, and text_fallback explicitly
+        // enabled, the text-based fallback inside detect_tables_with_lines
+        // fires and finds the grid.  Issue 484: the default no longer enables
+        // text_fallback to avoid spurious tables on report-style PDFs that
+        // would otherwise be double-emitted by extract_text.
+        let config = TableDetectionConfig {
+            text_fallback: true,
+            ..TableDetectionConfig::default()
+        };
         let tables = detect_tables_with_lines(&spans, &[], &config);
         assert_eq!(
             tables.len(),

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -117,7 +117,7 @@ impl Default for TableDetectionConfig {
             max_table_columns: 15,
             column_merge_threshold: 25.0,
             v_split_gap: 20.0,
-            text_fallback: false,
+            text_fallback: true,
         }
     }
 }
@@ -137,7 +137,7 @@ impl TableDetectionConfig {
             max_table_columns: 12,
             column_merge_threshold: 10.0,
             v_split_gap: 4.0,
-            text_fallback: false,
+            text_fallback: true,
         }
     }
 
@@ -155,7 +155,7 @@ impl TableDetectionConfig {
             max_table_columns: 20,
             column_merge_threshold: 30.0,
             v_split_gap: 40.0,
-            text_fallback: false,
+            text_fallback: true,
         }
     }
 }
@@ -2974,6 +2974,13 @@ pub fn detect_tables_with_lines(
         if !h_edges.is_empty() && v_edges.is_empty() {
             snap_and_merge(&mut h_edges);
             final_tables = detect_tables_from_horizontal_rules(spans, &h_edges, config);
+            // H-rule bounded detection lacks vertical-line evidence —
+            // columns come from text-edge clustering alone (same shape as
+            // the text-only fallback below).  Two-row results are
+            // virtually always prose that happens to live between
+            // decorative rules (annotation underlines, page borders);
+            // require three rows of evidence before promoting.
+            final_tables.retain(|t| t.rows.len() >= 3);
         }
     }
     // Filter out invalid line-based tables BEFORE overlap checking so that
@@ -2997,6 +3004,14 @@ pub fn detect_tables_with_lines(
         let text_candidates = detect_tables_from_spans_column_aware(spans, config);
         for text_table in text_candidates {
             if !passes_spatial_quality_gate(&text_table) {
+                continue;
+            }
+            // Text-only detection (no ruling lines) infers columns from word
+            // x-alignment alone — two rows of column-aligned words is the
+            // signature of ordinary prose (a title + a wrapped body line),
+            // not a table.  Require at least three rows of evidence before
+            // promoting a span cluster to a table.
+            if text_table.rows.len() < 3 {
                 continue;
             }
             if let Some(text_bbox) = text_table.bbox {

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -95,11 +95,18 @@ pub struct TableDetectionConfig {
     /// When `true` and the page has no table-relevant paths (no ruling lines or
     /// rectangles), the detector falls through to `detect_tables_from_spans_column_aware`
     /// rather than returning an empty result.  This is the right default for structured
-    /// output callers (`to_markdown`, `to_html`) that explicitly want tabular layout,
-    /// but is kept `false` for the public `extract_tables` API to preserve backward
-    /// compatibility (line-less PDFs previously returned no tables).
+    /// output callers (`to_markdown`, `to_html`) that explicitly want tabular layout
+    /// and is also relied on by the public `extract_tables` API for line-less PDFs.
+    /// Set to `false` from callers that want the conservative
+    /// "no ruling lines → no tables" behaviour (e.g. plain-text extraction paths
+    /// that explicitly opt out — see `extract_page_tables`).
     ///
-    /// Default: `false`.
+    /// False-positive prose / TOC / underline tables that this default would
+    /// previously have surfaced are filtered post-detection by the
+    /// `looks_like_prose_table` shape gate and a ≥ 3-row evidence requirement
+    /// on text-only and h-rule paths.
+    ///
+    /// Default: `true`.
     pub text_fallback: bool,
 }
 
@@ -3197,9 +3204,13 @@ fn cell_span_separator(prev: &TextSpan, current: &TextSpan) -> &'static str {
     if gap <= space_threshold {
         return "";
     }
-    if gap >= font_size * 5.0 {
-        return "";
-    }
+    // No upper bound: a very large gap (≥ 5 em) used to be treated as a
+    // column boundary and yield no separator, but the caller concatenates
+    // span text when this returns "" — so tokens like `3.80%` and `4.41%`
+    // were rendered as `3.80%4.41%` on wide rate tables.  Mirroring the
+    // inline-flow rule (`pipeline::converters::has_horizontal_gap`), any
+    // gap above the inter-glyph threshold now gets at least a single
+    // space.
 
     // CJK / fullwidth-operator suppression — same rule as
     // pipeline::converters::has_horizontal_gap.  pdftotext keeps an
@@ -3579,20 +3590,18 @@ mod tests {
 
     /// Regression test for issue #486: text-only spatial fallback for line-less tables.
     ///
-    /// When `text_fallback = false` (the default), `detect_tables_with_lines` with an empty
-    /// lines slice and the default `Both` strategy returns no tables — the text path inside
-    /// `detect_tables_with_lines` does run but the result is gated by `extract_page_tables`
-    /// returning early before even calling it.
+    /// `text_fallback = true` is now the default on `TableDetectionConfig` (the
+    /// prose-shape filter and ≥3-row guard suppress the false positives that
+    /// previously motivated a `false` default).  With the default and the `Both`
+    /// strategy, `detect_tables_with_lines` with an empty lines slice falls
+    /// through to the text-based path and detects the grid from span alignment
+    /// alone.  Callers that explicitly want the conservative
+    /// "no ruling lines → no tables" behaviour set `text_fallback = false` and
+    /// the `extract_page_tables` early-return guard in document.rs short-circuits
+    /// before this code is reached.
     ///
-    /// When `text_fallback = true`, `extract_page_tables` no longer returns early and
-    /// `detect_tables_with_lines` proceeds to the text-based fallback path, detecting the
-    /// grid from span alignment alone.
-    ///
-    /// This test directly calls `detect_tables_with_lines` with an empty lines slice to
-    /// verify that the text-based path inside it finds the table (the "text_fallback" flag
-    /// on `TableDetectionConfig` only affects the early-return guard in
-    /// `extract_page_tables`; at the `detect_tables_with_lines` level the `Both` strategy
-    /// already allows text fallback when no lines are present).
+    /// This test directly calls `detect_tables_with_lines` with an empty lines
+    /// slice to verify that the text-based path inside it finds the table.
     #[test]
     fn test_text_fallback_detects_lineless_grid() {
         // Simulate a 3-column, 4-row sailing-score table with no ruling lines.

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -3099,39 +3099,129 @@ fn extract_cell_text(cell_span_indices: &[usize], spans: &[TextSpan]) -> String 
     if cell_span_indices.is_empty() {
         return String::new();
     }
-    let mut span_entries: Vec<(f32, String)> = cell_span_indices
+    // Keep the span reference (not just text) so we can decide spacing based
+    // on the geometric gap and CJK/fullwidth-operator boundary state, exactly
+    // like the inline-flow path does in pipeline/converters/mod.rs.  Without
+    // this, the previous `line.join(" ")` was unconditionally inserting a
+    // space between every adjacent span on the same row, splitting compound
+    // tokens like `40000≤Q＜55000` into `40000≤Q ＜55000` and dropping word-F1
+    // for table-heavy CJK documents (issue 484, issue-336).
+    let mut span_entries: Vec<(f32, &TextSpan, String)> = cell_span_indices
         .iter()
         .filter_map(|&idx| {
             spans
                 .get(idx)
-                .map(|s| (s.bbox.center().y, span_text_for_cell(s)))
+                .map(|s| (s.bbox.center().y, s, span_text_for_cell(s)))
         })
         .collect();
     if span_entries.is_empty() {
         return String::new();
     }
     if span_entries.len() == 1 {
-        return span_entries.remove(0).1;
+        return span_entries.remove(0).2;
     }
     span_entries.sort_by(|a, b| crate::utils::safe_float_cmp(b.0, a.0));
-    let mut lines: Vec<Vec<String>> = Vec::new();
-    let mut current_line: Vec<String> = vec![span_entries[0].1.clone()];
+
+    // Group into rows by y proximity, then within a row decide separator per
+    // pair of spans using the same gap/CJK rules as inline text assembly.
+    let mut lines: Vec<Vec<(&TextSpan, String)>> = Vec::new();
+    let mut current_line: Vec<(&TextSpan, String)> =
+        vec![(span_entries[0].1, span_entries[0].2.clone())];
     let mut current_y = span_entries[0].0;
-    for (y, text) in &span_entries[1..] {
+    for (y, span, text) in &span_entries[1..] {
         if (current_y - y).abs() <= 2.0 {
-            current_line.push(text.clone());
+            current_line.push((span, text.clone()));
         } else {
             lines.push(current_line);
-            current_line = vec![text.clone()];
+            current_line = vec![(span, text.clone())];
             current_y = *y;
         }
     }
     lines.push(current_line);
+
     lines
         .iter()
-        .map(|line| line.join(" "))
+        .map(|line| {
+            let mut out = String::new();
+            for (i, (span, text)) in line.iter().enumerate() {
+                if i > 0 {
+                    let (prev_span, _) = line[i - 1];
+                    let separator = cell_span_separator(prev_span, span);
+                    out.push_str(separator);
+                }
+                out.push_str(text);
+            }
+            out
+        })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Decide what (if any) separator to put between two spans within the same
+/// table cell row.  Mirrors the inline-flow has_horizontal_gap logic from
+/// pipeline/converters/mod.rs: insert a space only when there is a real
+/// horizontal gap that exceeds the inter-glyph kerning floor AND the
+/// boundary is not a CJK ↔ CJK / CJK ↔ fullwidth-operator pair (issue 485).
+fn cell_span_separator(prev: &TextSpan, current: &TextSpan) -> &'static str {
+    // Already-present whitespace at the join point — never duplicate.
+    if prev.text.ends_with(' ') || current.text.starts_with(' ') {
+        return "";
+    }
+
+    let prev_end_x = prev.bbox.x + prev.bbox.width;
+    let gap = current.bbox.x - prev_end_x;
+    let font_size = prev.font_size.max(current.font_size).max(1.0);
+
+    // Sub-em gap: glyphs are touching or overlapping (typical inter-glyph
+    // advance).  Don't insert a space — adjacent characters in the same
+    // word/expression must stay glued.  This is what `40000≤Q` + `＜55000`
+    // hits: gap is essentially zero (the source PDF emits the operator as
+    // its own positioned Tj) but the two spans are part of one compound
+    // token in pdftotext's output.
+    let space_threshold = font_size * 0.15;
+    if gap <= space_threshold {
+        return "";
+    }
+    if gap >= font_size * 5.0 {
+        return "";
+    }
+
+    // CJK / fullwidth-operator suppression — same rule as
+    // pipeline::converters::has_horizontal_gap.  pdftotext keeps an
+    // ideograph + adjacent fullwidth/math operator without a separator.
+    let is_cjk = |c: char| {
+        matches!(
+            c as u32,
+            0x3040..=0x309F     // Hiragana
+            | 0x30A0..=0x30FF   // Katakana
+            | 0x4E00..=0x9FFF   // CJK Unified Ideographs
+            | 0xAC00..=0xD7AF   // Hangul
+            | 0x3400..=0x4DBF   // CJK Extension A
+            | 0x20000..=0x2A6DF // CJK Extension B
+        )
+    };
+    let is_fw_op = |c: char| {
+        matches!(
+            c as u32,
+            0xFF0B | 0xFF0D | 0xFF1A | 0xFF1B
+            | 0xFF1C..=0xFF1E       // ＜ ＝ ＞
+            | 0x2260 | 0x2248
+            | 0x2264..=0x2265       // ≤ ≥
+            | 0x00B5 | 0x03BC       // µ μ
+            | 0x00B1 | 0x00D7 | 0x00F7
+        )
+    };
+    let prev_tail = prev.text.chars().next_back();
+    let curr_head = current.text.chars().next();
+    if let (Some(p), Some(c)) = (prev_tail, curr_head) {
+        let p_cjk = is_cjk(p);
+        let c_cjk = is_cjk(c);
+        if (p_cjk || is_fw_op(p)) && (c_cjk || is_fw_op(c)) && (p_cjk || c_cjk) {
+            return "";
+        }
+    }
+
+    " "
 }
 
 fn detect_merged_cells(grid: &GridStructure, spans: &[TextSpan]) -> Vec<Vec<CellMergeInfo>> {

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -90,6 +90,17 @@ pub struct TableDetectionConfig {
     /// Default: 20.0. Use smaller values (e.g. 4.0) for strict mode, larger (e.g. 40.0)
     /// for relaxed mode where V-lines at mixed Y-ranges should stay together.
     pub v_split_gap: f32,
+    /// Enable text-only spatial detection as a fallback when no ruling lines are found.
+    ///
+    /// When `true` and the page has no table-relevant paths (no ruling lines or
+    /// rectangles), the detector falls through to `detect_tables_from_spans_column_aware`
+    /// rather than returning an empty result.  This is the right default for structured
+    /// output callers (`to_markdown`, `to_html`) that explicitly want tabular layout,
+    /// but is kept `false` for the public `extract_tables` API to preserve backward
+    /// compatibility (line-less PDFs previously returned no tables).
+    ///
+    /// Default: `false`.
+    pub text_fallback: bool,
 }
 
 impl Default for TableDetectionConfig {
@@ -106,6 +117,7 @@ impl Default for TableDetectionConfig {
             max_table_columns: 15,
             column_merge_threshold: 25.0,
             v_split_gap: 20.0,
+            text_fallback: false,
         }
     }
 }
@@ -125,6 +137,7 @@ impl TableDetectionConfig {
             max_table_columns: 12,
             column_merge_threshold: 10.0,
             v_split_gap: 4.0,
+            text_fallback: false,
         }
     }
 
@@ -142,6 +155,7 @@ impl TableDetectionConfig {
             max_table_columns: 20,
             column_merge_threshold: 30.0,
             v_split_gap: 40.0,
+            text_fallback: false,
         }
     }
 }
@@ -3341,6 +3355,85 @@ mod tests {
         };
         // Should return empty because there are no horizontal lines to define rows
         assert!(detect_tables_with_lines(&spans, &[], &config).is_empty());
+    }
+
+    /// Regression test for issue #486: text-only spatial fallback for line-less tables.
+    ///
+    /// When `text_fallback = false` (the default), `detect_tables_with_lines` with an empty
+    /// lines slice and the default `Both` strategy returns no tables — the text path inside
+    /// `detect_tables_with_lines` does run but the result is gated by `extract_page_tables`
+    /// returning early before even calling it.
+    ///
+    /// When `text_fallback = true`, `extract_page_tables` no longer returns early and
+    /// `detect_tables_with_lines` proceeds to the text-based fallback path, detecting the
+    /// grid from span alignment alone.
+    ///
+    /// This test directly calls `detect_tables_with_lines` with an empty lines slice to
+    /// verify that the text-based path inside it finds the table (the "text_fallback" flag
+    /// on `TableDetectionConfig` only affects the early-return guard in
+    /// `extract_page_tables`; at the `detect_tables_with_lines` level the `Both` strategy
+    /// already allows text fallback when no lines are present).
+    #[test]
+    fn test_text_fallback_detects_lineless_grid() {
+        // Simulate a 3-column, 4-row sailing-score table with no ruling lines.
+        // Columns at x=10, 50, 90; rows at y=200, 180, 160, 140.
+        let spans = vec![
+            // Row 1
+            create_test_span("Pos", 10.0, 200.0, 25.0, 10.0),
+            create_test_span("Boat", 50.0, 200.0, 25.0, 10.0),
+            create_test_span("Pts", 90.0, 200.0, 20.0, 10.0),
+            // Row 2
+            create_test_span("1", 10.0, 180.0, 25.0, 10.0),
+            create_test_span("Alpha", 50.0, 180.0, 25.0, 10.0),
+            create_test_span("14", 90.0, 180.0, 20.0, 10.0),
+            // Row 3
+            create_test_span("2", 10.0, 160.0, 25.0, 10.0),
+            create_test_span("Beta", 50.0, 160.0, 25.0, 10.0),
+            create_test_span("17", 90.0, 160.0, 20.0, 10.0),
+            // Row 4
+            create_test_span("3", 10.0, 140.0, 25.0, 10.0),
+            create_test_span("Gamma", 50.0, 140.0, 25.0, 10.0),
+            create_test_span("21", 90.0, 140.0, 20.0, 10.0),
+        ];
+
+        // With the default Both strategy and NO lines, the text-based fallback
+        // inside detect_tables_with_lines fires and finds the grid.
+        let config = TableDetectionConfig::default();
+        let tables = detect_tables_with_lines(&spans, &[], &config);
+        assert_eq!(
+            tables.len(),
+            1,
+            "Text-only fallback in detect_tables_with_lines should detect the grid (got {:?} tables)",
+            tables.len()
+        );
+        let t = &tables[0];
+        assert_eq!(t.col_count, 3, "Should detect 3 columns");
+        assert_eq!(t.rows.len(), 4, "Should detect 4 rows");
+    }
+
+    /// Verify that when no lines are present and `text_fallback = false` (the default),
+    /// the guard in `extract_page_tables` (outside `detect_tables_with_lines`) would
+    /// prevent the text path from running.  We simulate this at the config level: using
+    /// a `Lines`-only strategy ensures `detect_tables_with_lines` returns nothing when
+    /// paths are empty — confirming the safety contract for the public API path.
+    #[test]
+    fn test_text_fallback_disabled_lines_strategy_returns_empty() {
+        let spans = vec![
+            create_test_span("Pos", 10.0, 200.0, 25.0, 10.0),
+            create_test_span("Boat", 50.0, 200.0, 25.0, 10.0),
+            create_test_span("Pts", 90.0, 200.0, 20.0, 10.0),
+            create_test_span("1", 10.0, 180.0, 25.0, 10.0),
+            create_test_span("Alpha", 50.0, 180.0, 25.0, 10.0),
+            create_test_span("14", 90.0, 180.0, 20.0, 10.0),
+        ];
+        // Lines-only strategy: no lines → no tables.  This is what the public
+        // extract_tables() API uses after the early-return guard fires.
+        let config = TableDetectionConfig::strict(); // strict() uses Lines/Lines
+        let tables = detect_tables_with_lines(&spans, &[], &config);
+        assert!(
+            tables.is_empty(),
+            "Lines-only strategy with no ruling lines should return no tables"
+        );
     }
 
     #[test]

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -5676,4 +5676,176 @@ mod tests {
         let config = TableDetectionConfig::default();
         assert!(validate_table_structure_internal(&grid, &config));
     }
+
+    // ========================================================================
+    // consolidate_adjacent_table_fragments (#485 / #486 / #487 regression)
+    // ========================================================================
+
+    /// Build a minimal Table with a bbox and col_count for consolidation tests.
+    fn make_fragment(x: f32, y: f32, width: f32, height: f32, cols: u32) -> Table {
+        let mut t = Table::new();
+        t.bbox = Some(Rect::new(x, y, width, height));
+        t.col_count = cols as usize;
+        // Push one empty row so consolidation has something to extend; the
+        // row count grows as fragments get merged.
+        t.rows.push(TableRow::new(false));
+        t
+    }
+
+    /// Two vertically-adjacent fragments with identical column structure
+    /// merge into a single multi-row table.  Models the issue-336 / nougat_018
+    /// fragmented-table pattern: every horizontal ruling line produces a
+    /// separate 1-row Table.
+    #[test]
+    fn consolidate_merges_adjacent_aligned_fragments() {
+        let upper = make_fragment(90.0, 480.0, 420.0, 16.0, 8);
+        let lower = make_fragment(90.0, 464.0, 420.0, 16.0, 8); // upper.bottom = 480, lower.top = 480
+        let merged = consolidate_adjacent_table_fragments(vec![upper, lower]);
+        assert_eq!(merged.len(), 1, "two aligned adjacent fragments must merge");
+        assert_eq!(merged[0].rows.len(), 2, "merged rows are concatenated");
+        let bb = merged[0].bbox.expect("merged bbox preserved");
+        assert!((bb.x - 90.0).abs() < 0.1);
+        assert!((bb.width - 420.0).abs() < 0.1);
+        // Total height covers both fragments.
+        assert!((bb.height - 32.0).abs() < 0.1);
+    }
+
+    /// Fragments separated by more than `Y_TOLERANCE = 3pt` must NOT merge —
+    /// they represent two distinct tables (e.g. two unrelated grids on the
+    /// same page).
+    #[test]
+    fn consolidate_does_not_merge_non_adjacent_fragments() {
+        let upper = make_fragment(90.0, 600.0, 420.0, 16.0, 8);
+        let lower = make_fragment(90.0, 400.0, 420.0, 16.0, 8); // 200pt gap
+        let result = consolidate_adjacent_table_fragments(vec![upper, lower]);
+        assert_eq!(result.len(), 2, "well-separated fragments stay distinct");
+    }
+
+    /// Fragments with different column counts must NOT merge even if
+    /// they sit adjacent vertically — they aren't a single logical table.
+    #[test]
+    fn consolidate_does_not_merge_different_col_counts() {
+        let upper = make_fragment(90.0, 480.0, 420.0, 16.0, 8);
+        let lower = make_fragment(90.0, 464.0, 420.0, 16.0, 5); // different col_count
+        let result = consolidate_adjacent_table_fragments(vec![upper, lower]);
+        assert_eq!(result.len(), 2, "different col_count blocks merging");
+    }
+
+    /// Fragments at different x-positions must NOT merge — they're in
+    /// different columns of the page even if their Y ranges are adjacent.
+    #[test]
+    fn consolidate_does_not_merge_misaligned_x() {
+        let upper = make_fragment(90.0, 480.0, 420.0, 16.0, 8);
+        let lower = make_fragment(50.0, 464.0, 420.0, 16.0, 8); // x offset 40pt
+        let result = consolidate_adjacent_table_fragments(vec![upper, lower]);
+        assert_eq!(result.len(), 2, "misaligned-x blocks merging");
+    }
+
+    /// A chain of three+ adjacent fragments should chain-merge into one
+    /// multi-row table.  This is the issue-336 shape: 8 column-aligned
+    /// fragments → one 18-row table after consolidation.
+    #[test]
+    fn consolidate_chains_multiple_adjacent_fragments() {
+        let f1 = make_fragment(90.0, 480.0, 420.0, 16.0, 8);
+        let f2 = make_fragment(90.0, 464.0, 420.0, 16.0, 8);
+        let f3 = make_fragment(90.0, 448.0, 420.0, 16.0, 8);
+        let f4 = make_fragment(90.0, 432.0, 420.0, 16.0, 8);
+        let merged = consolidate_adjacent_table_fragments(vec![f1, f2, f3, f4]);
+        assert_eq!(merged.len(), 1, "chain of 4 adjacent fragments → 1 table");
+        assert_eq!(merged[0].rows.len(), 4, "all rows preserved in chain merge");
+    }
+
+    /// Small vertical overlap (line-detector quirk) up to half the
+    /// smaller fragment's height is still considered adjacent.
+    #[test]
+    fn consolidate_tolerates_small_overlap() {
+        // upper bottom = 480, lower top = 484 (4pt overlap, smaller_h = 16, half = 8)
+        let upper = make_fragment(90.0, 480.0, 420.0, 16.0, 8);
+        let lower = make_fragment(90.0, 468.0, 420.0, 16.0, 8);
+        let merged = consolidate_adjacent_table_fragments(vec![upper, lower]);
+        assert_eq!(merged.len(), 1, "small overlap (< ½ row) still merges");
+    }
+
+    /// Empty input passes through unchanged.
+    #[test]
+    fn consolidate_empty_input() {
+        let merged = consolidate_adjacent_table_fragments(vec![]);
+        assert!(merged.is_empty());
+    }
+
+    /// Single-table input passes through unchanged (nothing to merge).
+    #[test]
+    fn consolidate_single_table_passthrough() {
+        let t = make_fragment(90.0, 480.0, 420.0, 16.0, 8);
+        let merged = consolidate_adjacent_table_fragments(vec![t]);
+        assert_eq!(merged.len(), 1);
+    }
+
+    // ========================================================================
+    // cell_span_separator (#485 / #487 regression)
+    // ========================================================================
+
+    /// Helper to construct a TextSpan with just the fields the separator
+    /// rule actually reads: bbox, font_size, and text.
+    fn ts(text: &str, x: f32, y: f32, width: f32, fs: f32) -> TextSpan {
+        TextSpan {
+            artifact_type: None,
+            text: text.to_string(),
+            bbox: Rect::new(x, y, width, fs),
+            font_size: fs,
+            font_name: String::new(),
+            font_weight: crate::layout::text_block::FontWeight::Normal,
+            color: Color::black(),
+            mcid: None,
+            sequence: 0,
+            split_boundary_before: false,
+            offset_semantic: false,
+            is_italic: false,
+            is_monospace: false,
+            char_spacing: 0.0,
+            word_spacing: 0.0,
+            horizontal_scaling: 100.0,
+            primary_detected: false,
+            char_widths: vec![],
+        }
+    }
+
+    /// Adjacent spans with a sub-em gap must NOT have a separator
+    /// inserted.  Models issue-336's `60000` + `≤` + `Q` + `＜` + `80000`
+    /// where the operator glyphs touch / slightly overlap the digit
+    /// glyphs and must be rendered as a single compound token.
+    #[test]
+    fn cell_span_separator_no_space_for_tight_glyphs() {
+        let prev = ts("60000≤Q", 100.0, 200.0, 39.8, 10.6);
+        let curr = ts("＜", 139.8, 200.0, 10.6, 10.6); // gap = 0
+        assert_eq!(cell_span_separator(&prev, &curr), "");
+    }
+
+    /// Adjacent spans with a real gap (clear word boundary) get a
+    /// single space separator inserted.
+    #[test]
+    fn cell_span_separator_inserts_space_for_real_gap() {
+        let prev = ts("Quarter", 100.0, 200.0, 30.0, 10.0); // ends at x=130
+        let curr = ts("Total", 140.0, 200.0, 25.0, 10.0); // gap = 10pt = 1em
+        assert_eq!(cell_span_separator(&prev, &curr), " ");
+    }
+
+    /// CJK ↔ fullwidth-operator boundary suppresses separator even when
+    /// the geometric gap would otherwise warrant a space.
+    #[test]
+    fn cell_span_separator_suppresses_cjk_fullwidth_boundary() {
+        // "中" (U+4E2D, CJK) followed by "＜" (U+FF1C, fullwidth less-than).
+        let prev = ts("中", 100.0, 200.0, 12.0, 12.0); // ends at 112
+        let curr = ts("＜", 115.0, 200.0, 12.0, 12.0); // gap = 3pt = 0.25 em
+        assert_eq!(cell_span_separator(&prev, &curr), "");
+    }
+
+    /// Trailing whitespace on the preceding span suppresses separator
+    /// (no double-space).
+    #[test]
+    fn cell_span_separator_suppresses_on_existing_trailing_space() {
+        let prev = ts("Quarter ", 100.0, 200.0, 35.0, 10.0); // text ends with ' '
+        let curr = ts("Total", 140.0, 200.0, 25.0, 10.0);
+        assert_eq!(cell_span_separator(&prev, &curr), "");
+    }
 }

--- a/src/structure/table_extractor.rs
+++ b/src/structure/table_extractor.rs
@@ -469,6 +469,16 @@ pub(super) fn span_text_for_cell(span: &crate::layout::TextSpan) -> String {
         return text.clone();
     }
     let char_count = text.chars().count();
+    // Signal 1: sparse char_widths array (cw.len < char_count) means the
+    // span was assembled from two concatenated Tj runs — see the matching
+    // `is_column_spanning_decimal` rule in document.rs.  Catches sailing-
+    // score cells emitted as a single Tj like "1.10" (cw=[w]) where the
+    // PDF actually means "1" followed by "10" in adjacent score columns
+    // (issue 487 nougat_018).  bbox.width can still be tight here, so the
+    // bbox-inflation check below isn't sufficient.
+    if !span.char_widths.is_empty() && span.char_widths.len() < char_count {
+        return format!("{} {}", &text[..dot_pos], &text[dot_pos + 1..]);
+    }
     let expected_width = if !span.char_widths.is_empty() {
         let cw_sum: f32 = span.char_widths.iter().sum();
         cw_sum * (char_count as f32 / span.char_widths.len() as f32)

--- a/src/structure/table_extractor.rs
+++ b/src/structure/table_extractor.rs
@@ -113,6 +113,14 @@ impl Table {
         // prose-split false tables have highly variable row fill counts (some rows
         // have 1-2 filled cells, others have 10+), so the fraction of "dense" rows
         // is well below 70%.
+        //
+        // Exception: a consolidated multi-row table (issue 486) can contain a mix
+        // of dense data rows and sparse header / multi-row-label rows.  The sparse
+        // rows are legitimate table content (column headers split across multiple
+        // visual rows, lane-count labels that only appear on the first row of a
+        // sub-group), so a strict dense-row ratio rejects real tables.  Accept the
+        // table if it has BOTH enough dense rows in absolute terms (≥ half the
+        // column count) AND a meaningful dense-row ratio (≥ 40 %).
         if self.col_count >= 8 {
             let min_dense = ((self.col_count as f32 * 0.6) as usize).max(2);
             let dense_rows = self
@@ -123,7 +131,11 @@ impl Table {
                 })
                 .count();
             let dense_row_ratio = dense_rows as f32 / self.rows.len() as f32;
-            return self.rows.len() >= 3 && ratio >= 0.7 && dense_row_ratio >= 0.70;
+            if self.rows.len() >= 3 && ratio >= 0.7 && dense_row_ratio >= 0.70 {
+                return true;
+            }
+            let min_absolute_dense = (self.col_count / 2).max(3);
+            return dense_rows >= min_absolute_dense && dense_row_ratio >= 0.40;
         }
 
         ratio >= 0.5

--- a/src/structure/table_extractor.rs
+++ b/src/structure/table_extractor.rs
@@ -627,7 +627,49 @@ fn extract_cell(
                                 let gap = block.bbox.x - (prev.bbox.x + prev.bbox.width);
                                 let font_size =
                                     prev.avg_font_size.max(block.avg_font_size).max(1.0);
-                                gap > font_size * 0.15
+                                if !(gap > font_size * 0.15) {
+                                    false
+                                } else {
+                                    // Suppress space insertion when one side is CJK and the
+                                    // other is CJK or a fullwidth/math operator (e.g. ≤, ＜, μ).
+                                    // This mirrors the CJK-pair suppression in document.rs and
+                                    // converters/mod.rs (Issue #485).
+                                    #[inline(always)]
+                                    fn is_cjk(c: char) -> bool {
+                                        matches!(c,
+                                            '\u{3040}'..='\u{309F}' |   // Hiragana
+                                            '\u{30A0}'..='\u{30FF}' |   // Katakana
+                                            '\u{4E00}'..='\u{9FFF}' |   // CJK Unified Ideographs
+                                            '\u{AC00}'..='\u{D7AF}' |   // Hangul
+                                            '\u{3400}'..='\u{4DBF}' |   // CJK Extension A
+                                            '\u{20000}'..='\u{2A6DF}'   // CJK Extension B
+                                        )
+                                    }
+                                    #[inline(always)]
+                                    fn is_fw_math(c: char) -> bool {
+                                        matches!(c,
+                                            '\u{FF0B}' | '\u{FF0D}' |
+                                            '\u{FF1A}' | '\u{FF1B}' |
+                                            '\u{FF1C}'..='\u{FF1E}' |
+                                            '\u{2260}' | '\u{2248}' |
+                                            '\u{2264}'..='\u{2265}' |
+                                            '\u{00B5}' | '\u{03BC}' |
+                                            '\u{00B1}' | '\u{00D7}' | '\u{00F7}'
+                                        )
+                                    }
+                                    let p_last = prev.text.chars().next_back();
+                                    let b_first = block.text.chars().next();
+                                    let suppress = if let (Some(p), Some(b)) = (p_last, b_first) {
+                                        let p_cjk = is_cjk(p);
+                                        let b_cjk = is_cjk(b);
+                                        (p_cjk || is_fw_math(p))
+                                            && (b_cjk || is_fw_math(b))
+                                            && (p_cjk || b_cjk)
+                                    } else {
+                                        false
+                                    };
+                                    !suppress
+                                }
                             }
                         } else {
                             !cell_text.ends_with(' ')

--- a/src/structure/table_extractor.rs
+++ b/src/structure/table_extractor.rs
@@ -651,7 +651,7 @@ fn extract_cell(
                                 let gap = block.bbox.x - (prev.bbox.x + prev.bbox.width);
                                 let font_size =
                                     prev.avg_font_size.max(block.avg_font_size).max(1.0);
-                                if !(gap > font_size * 0.15) {
+                                if gap <= font_size * 0.15 {
                                     false
                                 } else {
                                     // Suppress space insertion when one side is CJK and the

--- a/src/structure/table_extractor.rs
+++ b/src/structure/table_extractor.rs
@@ -134,6 +134,8 @@ impl Table {
             if self.rows.len() >= 3 && ratio >= 0.7 && dense_row_ratio >= 0.70 {
                 return true;
             }
+            // Consolidated-table path: accept tables with many absolutely-dense
+            // rows alongside sparse header/label rows (issue 486).
             let min_absolute_dense = (self.col_count / 2).max(3);
             return dense_rows >= min_absolute_dense && dense_row_ratio >= 0.40;
         }

--- a/src/structure/table_extractor.rs
+++ b/src/structure/table_extractor.rs
@@ -1200,4 +1200,136 @@ mod tests {
         let result = extract_table_from_spans(&table_elem, &spans).unwrap();
         assert_eq!(result.rows[0].cells[0].text, "Hello World");
     }
+
+    /// CJK + fullwidth operator with a gap that *exceeds* the 0.15em threshold must
+    /// still suppress space insertion — this exercises the new CJK-suppression branch
+    /// added in fix #485 (the `test_extract_cell_adjacent_mcid_spans_no_space` test
+    /// above only covers the gap ≤ threshold path, which never reaches this branch).
+    #[test]
+    fn test_extract_cell_cjk_fullwidth_gap_suppresses_space() {
+        use crate::layout::text_block::{Color, FontWeight};
+
+        // Build: TD with three MCIDs: "数" (CJK), "≤" (math op), "量" (CJK)
+        // Place them with a gap of 3.0 pt (> font_size * 0.15 = 1.5 for 10 pt font)
+        // so the gap branch fires, then the CJK suppression should prevent a space.
+        let mut td = StructElem::new(StructType::TD);
+        td.add_child(StructChild::MarkedContentRef { mcid: 10, page: 0 });
+        td.add_child(StructChild::MarkedContentRef { mcid: 11, page: 0 });
+        td.add_child(StructChild::MarkedContentRef { mcid: 12, page: 0 });
+        let mut tr = StructElem::new(StructType::TR);
+        tr.add_child(StructChild::StructElem(Box::new(td)));
+        let mut table_elem = StructElem::new(StructType::Table);
+        table_elem.add_child(StructChild::StructElem(Box::new(tr)));
+
+        let base = crate::layout::TextSpan {
+            artifact_type: None,
+            text: String::new(),
+            bbox: Rect::new(0.0, 100.0, 0.0, 10.0),
+            font_name: "Test".to_string(),
+            font_size: 10.0,
+            font_weight: FontWeight::Normal,
+            is_italic: false,
+            is_monospace: false,
+            color: Color::black(),
+            mcid: None,
+            sequence: 0,
+            split_boundary_before: false,
+            offset_semantic: false,
+            char_spacing: 0.0,
+            word_spacing: 0.0,
+            horizontal_scaling: 1.0,
+            primary_detected: false,
+            char_widths: vec![],
+        };
+        // "数" ends at x=10+10=20; "≤" starts at x=23 → gap=3.0 > 1.5 → gap branch fires
+        // CJK("数")→math_op("≤") with at least one CJK side → suppress space
+        // "≤" ends at x=23+10=33; "量" starts at x=36 → gap=3.0 → suppress space
+        let spans = vec![
+            crate::layout::TextSpan {
+                text: "数".into(),
+                bbox: Rect::new(10.0, 100.0, 10.0, 10.0),
+                mcid: Some(10),
+                ..base.clone()
+            },
+            crate::layout::TextSpan {
+                text: "≤".into(),
+                bbox: Rect::new(23.0, 100.0, 10.0, 10.0),
+                mcid: Some(11),
+                ..base.clone()
+            },
+            crate::layout::TextSpan {
+                text: "量".into(),
+                bbox: Rect::new(36.0, 100.0, 10.0, 10.0),
+                mcid: Some(12),
+                ..base.clone()
+            },
+        ];
+
+        let result = extract_table_from_spans(&table_elem, &spans).unwrap();
+        assert_eq!(
+            result.rows[0].cells[0].text, "数≤量",
+            "CJK + math-op + CJK with gap > 0.15em should not have spaces inserted: \
+             got '{}'",
+            result.rows[0].cells[0].text
+        );
+    }
+
+    /// Counterpart: Latin + Latin with a gap exceeding the threshold MUST insert a space.
+    /// This guards that the CJK-suppression branch does not affect non-CJK pairs.
+    #[test]
+    fn test_extract_cell_latin_gap_inserts_space() {
+        use crate::layout::text_block::{Color, FontWeight};
+
+        let mut td = StructElem::new(StructType::TD);
+        td.add_child(StructChild::MarkedContentRef { mcid: 20, page: 0 });
+        td.add_child(StructChild::MarkedContentRef { mcid: 21, page: 0 });
+        let mut tr = StructElem::new(StructType::TR);
+        tr.add_child(StructChild::StructElem(Box::new(td)));
+        let mut table_elem = StructElem::new(StructType::Table);
+        table_elem.add_child(StructChild::StructElem(Box::new(tr)));
+
+        let base = crate::layout::TextSpan {
+            artifact_type: None,
+            text: String::new(),
+            bbox: Rect::new(0.0, 100.0, 0.0, 10.0),
+            font_name: "Test".to_string(),
+            font_size: 10.0,
+            font_weight: FontWeight::Normal,
+            is_italic: false,
+            is_monospace: false,
+            color: Color::black(),
+            mcid: None,
+            sequence: 0,
+            split_boundary_before: false,
+            offset_semantic: false,
+            char_spacing: 0.0,
+            word_spacing: 0.0,
+            horizontal_scaling: 1.0,
+            primary_detected: false,
+            char_widths: vec![],
+        };
+        // "Hello" ends at 50; "world" starts at 53 → gap=3.0 > 1.5 → space inserted
+        // Neither side is CJK, so the CJK suppression must NOT fire.
+        let spans = vec![
+            crate::layout::TextSpan {
+                text: "Hello".into(),
+                bbox: Rect::new(0.0, 100.0, 50.0, 10.0),
+                mcid: Some(20),
+                ..base.clone()
+            },
+            crate::layout::TextSpan {
+                text: "world".into(),
+                bbox: Rect::new(53.0, 100.0, 30.0, 10.0),
+                mcid: Some(21),
+                ..base.clone()
+            },
+        ];
+
+        let result = extract_table_from_spans(&table_elem, &spans).unwrap();
+        assert_eq!(
+            result.rows[0].cells[0].text, "Hello world",
+            "Latin→Latin with gap > 0.15em should insert a space: got '{}'",
+            result.rows[0].cells[0].text
+        );
+    }
 }

--- a/tests/fixtures/hello_structure.pdf
+++ b/tests/fixtures/hello_structure.pdf
@@ -1,0 +1,176 @@
+%PDF-1.4
+1 0 obj
+  << /Type /Catalog
+     /Outlines 2 0 R
+     /Pages 3 0 R
+     /StructTreeRoot 7 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Outlines
+     /Count 0
+  >>
+endobj
+
+3 0 obj
+  << /Type /Pages
+     /MediaBox [0 0 612 792]
+     /Kids [4 0 R 11 0 R]
+     /Count 2
+  >>
+endobj
+
+4 0 obj
+  << /Type /Page
+     /Parent 3 0 R
+     /Contents 6 0 R
+     /StructParents 0
+     /Resources << /ProcSet [/PDF /Text]
+                   /Font << /F1 5 0 R >>
+                >>
+  >>
+endobj
+
+5 0 obj
+  << /Type /Font
+     /Subtype /Type1
+     /Name /F1
+     /BaseFont /Helvetica
+  >>
+endobj
+
+6 0 obj
+  << /Length 87 >>
+stream
+  /H1 <</MCID 1>> BDC
+  BT
+    /F1 24 Tf
+    100 700 Td
+    (Hello World) Tj
+  ET
+  EMC
+endstream
+endobj
+
+7 0 obj
+  << /Type /StructTreeRoot
+     /ParentTree 8 0 R
+     /RoleMap << /Title /P >>
+     /ClassMap << /C1 << /O /Foo /A1 1 >>
+                  /C2 << /O /Foo /A1 3 >>
+               >>
+     /K [9 0 R
+         << /Type OBJR /Pg 11 0 R /Obj 14 0 R >>]
+  >>
+endobj
+
+8 0 obj
+  << /Nums [
+            0 [10 0 R]
+            1 [13 0 R 14 0 R]
+           ]
+  >>
+endobj
+
+9 0 obj
+  << /Type /StructElem
+     /S /Section
+     /Pg 4 0 R
+     /P 7 0 R
+     /K [10 0 R
+         << /Type OBJR /Pg 11 0 R /Obj 13 0 R >>]
+  >>
+endobj
+
+10 0 obj
+   << /Type /StructElem
+      /S /Title
+      /P 9 0 R
+      /Pg 4 0 R
+      /C /C1
+      /K [15 0 R]
+   >>
+endobj
+
+11 0 obj
+  << /Type /Page
+     /Parent 3 0 R
+     /Contents 12 0 R
+     /StructParents 1
+     /Resources << /ProcSet [/PDF /Text]
+                   /Font << /F1 5 0 R >>
+                >>
+  >>
+endobj
+
+12 0 obj
+  << /Length 190 >>
+stream
+  /H1 <</MCID 1>> BDC
+  BT
+    /F1 24 Tf
+    100 700 Td
+    (Goodbye Cruel World...) Tj
+  ET
+  /P <</MCID 2>> BDC
+  BT
+    /F1 12 Tf
+    100 600 Td
+    (I'll be back shortly!) Tj
+  ET
+  EMC
+endstream
+endobj
+
+13 0 obj
+   << /Type /StructElem
+      /S /Title
+      /P 9 0 R
+      /Pg 11 0 R
+      /K [1]
+      /C /C1
+      /A << /A1 2 /A2 2 >>
+   >>
+endobj
+
+14 0 obj
+   << /Type /StructElem
+      /S /P
+      /P 7 0 R
+      /Pg 11 0 R
+      /K [2]
+      /R 1
+      % /C3 does not exist (coverage)
+      /C [/C1 0 /C2 1 /C3 1]
+      /A [<< /A1 2 /A2 2 >> 0
+          << /A2 3 >> 1]
+   >>
+endobj
+
+15 0 obj
+   <</Type MCR /MCID 1 /Pg 4 0 R>>
+endobj
+
+xref
+0 16
+0000000000 65535 f 
+0000000009 00000 n 
+0000000116 00000 n 
+0000000172 00000 n 
+0000000280 00000 n 
+0000000481 00000 n 
+0000000581 00000 n 
+0000000721 00000 n 
+0000000989 00000 n 
+0000001089 00000 n 
+0000001245 00000 n 
+0000001370 00000 n 
+0000001573 00000 n 
+0000001817 00000 n 
+0000001965 00000 n 
+0000002202 00000 n 
+trailer  << /Size 16 /Root 1 0 R >>
+startxref
+2254
+%%EOF

--- a/tests/test_cmap_multibyte_parsing.rs
+++ b/tests/test_cmap_multibyte_parsing.rs
@@ -1,0 +1,253 @@
+//! CMap multi-byte parsing correctness tests (§9.7.5 / §9.10.3).
+//!
+//! Focuses on three specific parsing correctness requirements:
+//!
+//! 1. **Array-form `beginbfrange`**: `<src_start> <src_end> [<dst1> <dst2> ...]`
+//!    Each array entry maps `src_start + i → dst_i`.  Used for ligatures and
+//!    irregular CJK sub-ranges.
+//!
+//! 2. **Multi-byte hex strings**: `<4E2D>` is a single 2-byte code 0x4E2D, not
+//!    bytes 0x4E and 0x2D read separately.
+//!
+//! 3. **`begincodespacerange` drives byte-width**: When the codespace declares
+//!    2-byte codes (`<0000> <FFFF>`), `LazyCMap::code_width()` must return 2 so
+//!    that the text extractor switches from 1-byte to 2-byte character reading.
+
+use pdf_oxide::fonts::cmap::{parse_tounicode_cmap, LazyCMap};
+
+// ============================================================================
+// Fix 1: Array form of beginbfrange
+// ============================================================================
+
+#[test]
+fn test_bfrange_array_form_basic() {
+    // CMap with: beginbfrange <0041> <0043> [<FF21> <FF22> <FF23>] endbfrange
+    // Code 0x0041 → U+FF21 (Ａ), 0x0042 → U+FF22 (Ｂ), 0x0043 → U+FF23 (Ｃ)
+    let data = b"beginbfrange\n<0041> <0043> [<FF21> <FF22> <FF23>]\nendbfrange";
+    let cmap = parse_tounicode_cmap(data).unwrap();
+
+    assert_eq!(
+        cmap.get(&0x0041),
+        Some(&"\u{FF21}".to_string()),
+        "0x41 → Fullwidth A (U+FF21)"
+    );
+    assert_eq!(
+        cmap.get(&0x0042),
+        Some(&"\u{FF22}".to_string()),
+        "0x42 → Fullwidth B (U+FF22)"
+    );
+    assert_eq!(
+        cmap.get(&0x0043),
+        Some(&"\u{FF23}".to_string()),
+        "0x43 → Fullwidth C (U+FF23)"
+    );
+}
+
+#[test]
+fn test_bfrange_array_form_ligatures() {
+    // PDF spec §9.10.3 example: <005F> <0061> [<00660066> <00660069> <00660066006C>]
+    // Codes 0x5F→"ff", 0x60→"fi", 0x61→"ffl"
+    let data =
+        b"beginbfrange\n<005F> <0061> [<00660066> <00660069> <00660066006C>]\nendbfrange";
+    let cmap = parse_tounicode_cmap(data).unwrap();
+
+    assert_eq!(cmap.get(&0x5F), Some(&"ff".to_string()), "code 0x5F → \"ff\"");
+    assert_eq!(cmap.get(&0x60), Some(&"fi".to_string()), "code 0x60 → \"fi\"");
+    assert_eq!(cmap.get(&0x61), Some(&"ffl".to_string()), "code 0x61 → \"ffl\"");
+}
+
+#[test]
+fn test_bfrange_array_form_cjk() {
+    // 2-byte source codes with 2-byte destinations — typical CJK ToUnicode CMap snippet
+    // beginbfrange <4E00> <4E02> [<4E00> <4E01> <4E02>]
+    let data = b"beginbfrange\n<4E00> <4E02> [<4E00> <4E01> <4E02>]\nendbfrange";
+    let cmap = parse_tounicode_cmap(data).unwrap();
+
+    assert_eq!(cmap.get(&0x4E00), Some(&"\u{4E00}".to_string()), "一 identity");
+    assert_eq!(cmap.get(&0x4E01), Some(&"\u{4E01}".to_string()), "丁 identity");
+    assert_eq!(cmap.get(&0x4E02), Some(&"\u{4E02}".to_string()), "丂 identity");
+}
+
+// ============================================================================
+// Fix 1 complement: Linear form of beginbfrange still works after the change
+// ============================================================================
+
+#[test]
+fn test_bfrange_linear_form_still_works() {
+    // beginbfrange <0041> <0045> <0061> endbfrange
+    // 0x41→'a', 0x42→'b', 0x43→'c', 0x44→'d', 0x45→'e'
+    let data = b"beginbfrange\n<0041> <0045> <0061>\nendbfrange";
+    let cmap = parse_tounicode_cmap(data).unwrap();
+
+    assert_eq!(cmap.get(&0x41), Some(&"a".to_string()));
+    assert_eq!(cmap.get(&0x42), Some(&"b".to_string()));
+    assert_eq!(cmap.get(&0x43), Some(&"c".to_string()));
+    assert_eq!(cmap.get(&0x44), Some(&"d".to_string()));
+    assert_eq!(cmap.get(&0x45), Some(&"e".to_string()));
+}
+
+// ============================================================================
+// Fix 2: Multi-byte hex code parsing in bfchar
+// ============================================================================
+
+#[test]
+fn test_bfchar_two_byte_src_code() {
+    // beginbfchar <4E2D> <4E2D> endbfchar
+    // Character code 0x4E2D maps to U+4E2D (中)
+    let data = b"beginbfchar\n<4E2D> <4E2D>\nendbfchar";
+    let cmap = parse_tounicode_cmap(data).unwrap();
+
+    assert_eq!(
+        cmap.get(&0x4E2D),
+        Some(&"\u{4E2D}".to_string()),
+        "code 0x4E2D → U+4E2D (中)"
+    );
+    // Make sure we did NOT insert the individual bytes as separate entries
+    // (would happen if the src hex `4E2D` were split into bytes 0x4E and 0x2D)
+    assert!(
+        cmap.get(&0x4E).is_none() || cmap.get(&0x4E) != Some(&"\u{4E2D}".to_string()),
+        "byte 0x4E must not produce 中"
+    );
+}
+
+#[test]
+fn test_bfchar_two_byte_src_hiragana() {
+    // beginbfchar <3042> <3042> endbfchar  (hiragana あ)
+    let data = b"beginbfchar\n<3042> <3042>\nendbfchar";
+    let cmap = parse_tounicode_cmap(data).unwrap();
+
+    assert_eq!(
+        cmap.get(&0x3042),
+        Some(&"\u{3042}".to_string()),
+        "code 0x3042 → U+3042 (あ)"
+    );
+}
+
+#[test]
+fn test_bfchar_two_byte_multiple_cjk() {
+    // Several CJK characters as both source and destination
+    let data =
+        b"beginbfchar\n<4E2D> <4E2D>\n<6587> <6587>\n<5B66> <5B66>\nendbfchar";
+    let cmap = parse_tounicode_cmap(data).unwrap();
+
+    assert_eq!(cmap.get(&0x4E2D), Some(&"\u{4E2D}".to_string()), "中 (0x4E2D)");
+    assert_eq!(cmap.get(&0x6587), Some(&"\u{6587}".to_string()), "文 (0x6587)");
+    assert_eq!(cmap.get(&0x5B66), Some(&"\u{5B66}".to_string()), "学 (0x5B66)");
+}
+
+// ============================================================================
+// Fix 3: begincodespacerange drives code_width
+// ============================================================================
+
+#[test]
+fn test_codespacerange_two_byte_sets_code_width() {
+    // begincodespacerange <0000> <FFFF> endcodespacerange declares 2-byte codes
+    let data = b"/CIDInit /ProcSet findresource begin\nbegincmap\n\
+        1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+        1 beginbfchar\n<3042> <3042>\nendbfchar\nendcmap";
+
+    let cmap = parse_tounicode_cmap(data).unwrap();
+    assert_eq!(cmap.code_width, 2, "2-byte codespace must set code_width = 2");
+
+    // Lookup still works
+    assert_eq!(cmap.get(&0x3042), Some(&"\u{3042}".to_string()), "あ lookup");
+}
+
+#[test]
+fn test_codespacerange_one_byte_keeps_default() {
+    // begincodespacerange <00> <FF> endcodespacerange — 1-byte codes
+    let data = b"1 begincodespacerange\n<00> <FF>\nendcodespacerange\n\
+        1 beginbfchar\n<41> <41>\nendbfchar";
+
+    let cmap = parse_tounicode_cmap(data).unwrap();
+    assert_eq!(cmap.code_width, 1, "1-byte codespace keeps code_width = 1");
+    assert_eq!(cmap.get(&0x41), Some(&"A".to_string()), "A lookup");
+}
+
+#[test]
+fn test_lazycmap_code_width_two_byte() {
+    // Verify LazyCMap::code_width() returns 2 for a 2-byte codespace CMap
+    let cmap_data = b"1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+        2 beginbfchar\n<4E2D> <4E2D>\n<6587> <6587>\nendbfchar"
+        .to_vec();
+
+    let lazy = LazyCMap::new(cmap_data);
+    assert_eq!(lazy.code_width(), 2, "LazyCMap::code_width() should return 2");
+}
+
+#[test]
+fn test_lazycmap_code_width_one_byte() {
+    // Verify LazyCMap::code_width() returns 1 for a 1-byte codespace CMap
+    let cmap_data = b"1 begincodespacerange\n<00> <FF>\nendcodespacerange\n\
+        1 beginbfchar\n<41> <41>\nendbfchar"
+        .to_vec();
+
+    let lazy = LazyCMap::new(cmap_data);
+    assert_eq!(lazy.code_width(), 1, "LazyCMap::code_width() should return 1");
+}
+
+#[test]
+fn test_lazycmap_code_width_default_when_no_codespace() {
+    // When begincodespacerange is absent, code_width should default to 1
+    let cmap_data = b"1 beginbfchar\n<41> <41>\nendbfchar".to_vec();
+
+    let lazy = LazyCMap::new(cmap_data);
+    assert_eq!(
+        lazy.code_width(),
+        1,
+        "Missing codespace defaults code_width = 1"
+    );
+}
+
+// ============================================================================
+// Integration: full CMap with 2-byte codespace + 2-byte bfchar + bfrange
+// ============================================================================
+
+#[test]
+fn test_full_cjk_cmap_roundtrip() {
+    // Simulates a realistic ToUnicode CMap for a CJK composite font
+    let cmap_data = br#"
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (Adobe)
+/Ordering (UCS)
+/Supplement 0
+>> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+3 beginbfchar
+<4E2D> <4E2D>
+<6587> <6587>
+<3042> <3042>
+endbfchar
+1 beginbfrange
+<4E00> <4E05> <4E00>
+endbfrange
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+"#;
+
+    let lazy = LazyCMap::new(cmap_data.to_vec());
+
+    // code_width must be 2
+    assert_eq!(lazy.code_width(), 2, "full CJK CMap code_width = 2");
+
+    let cmap = lazy.get().expect("CMap must parse");
+
+    // bfchar lookups
+    assert_eq!(cmap.get(&0x4E2D), Some(&"\u{4E2D}".to_string()), "中");
+    assert_eq!(cmap.get(&0x6587), Some(&"\u{6587}".to_string()), "文");
+    assert_eq!(cmap.get(&0x3042), Some(&"\u{3042}".to_string()), "あ");
+
+    // bfrange lookups
+    assert_eq!(cmap.get(&0x4E00), Some(&"\u{4E00}".to_string()), "一");
+    assert_eq!(cmap.get(&0x4E03), Some(&"\u{4E03}".to_string()), "七");
+    assert_eq!(cmap.get(&0x4E05), Some(&"\u{4E05}".to_string()), "丅");
+}

--- a/tests/test_cmap_multibyte_parsing.rs
+++ b/tests/test_cmap_multibyte_parsing.rs
@@ -26,29 +26,16 @@ fn test_bfrange_array_form_basic() {
     let data = b"beginbfrange\n<0041> <0043> [<FF21> <FF22> <FF23>]\nendbfrange";
     let cmap = parse_tounicode_cmap(data).unwrap();
 
-    assert_eq!(
-        cmap.get(&0x0041),
-        Some(&"\u{FF21}".to_string()),
-        "0x41 → Fullwidth A (U+FF21)"
-    );
-    assert_eq!(
-        cmap.get(&0x0042),
-        Some(&"\u{FF22}".to_string()),
-        "0x42 → Fullwidth B (U+FF22)"
-    );
-    assert_eq!(
-        cmap.get(&0x0043),
-        Some(&"\u{FF23}".to_string()),
-        "0x43 → Fullwidth C (U+FF23)"
-    );
+    assert_eq!(cmap.get(&0x0041), Some(&"\u{FF21}".to_string()), "0x41 → Fullwidth A (U+FF21)");
+    assert_eq!(cmap.get(&0x0042), Some(&"\u{FF22}".to_string()), "0x42 → Fullwidth B (U+FF22)");
+    assert_eq!(cmap.get(&0x0043), Some(&"\u{FF23}".to_string()), "0x43 → Fullwidth C (U+FF23)");
 }
 
 #[test]
 fn test_bfrange_array_form_ligatures() {
     // PDF spec §9.10.3 example: <005F> <0061> [<00660066> <00660069> <00660066006C>]
     // Codes 0x5F→"ff", 0x60→"fi", 0x61→"ffl"
-    let data =
-        b"beginbfrange\n<005F> <0061> [<00660066> <00660069> <00660066006C>]\nendbfrange";
+    let data = b"beginbfrange\n<005F> <0061> [<00660066> <00660069> <00660066006C>]\nendbfrange";
     let cmap = parse_tounicode_cmap(data).unwrap();
 
     assert_eq!(cmap.get(&0x5F), Some(&"ff".to_string()), "code 0x5F → \"ff\"");
@@ -97,11 +84,7 @@ fn test_bfchar_two_byte_src_code() {
     let data = b"beginbfchar\n<4E2D> <4E2D>\nendbfchar";
     let cmap = parse_tounicode_cmap(data).unwrap();
 
-    assert_eq!(
-        cmap.get(&0x4E2D),
-        Some(&"\u{4E2D}".to_string()),
-        "code 0x4E2D → U+4E2D (中)"
-    );
+    assert_eq!(cmap.get(&0x4E2D), Some(&"\u{4E2D}".to_string()), "code 0x4E2D → U+4E2D (中)");
     // Make sure we did NOT insert the individual bytes as separate entries
     // (would happen if the src hex `4E2D` were split into bytes 0x4E and 0x2D)
     assert!(
@@ -116,18 +99,13 @@ fn test_bfchar_two_byte_src_hiragana() {
     let data = b"beginbfchar\n<3042> <3042>\nendbfchar";
     let cmap = parse_tounicode_cmap(data).unwrap();
 
-    assert_eq!(
-        cmap.get(&0x3042),
-        Some(&"\u{3042}".to_string()),
-        "code 0x3042 → U+3042 (あ)"
-    );
+    assert_eq!(cmap.get(&0x3042), Some(&"\u{3042}".to_string()), "code 0x3042 → U+3042 (あ)");
 }
 
 #[test]
 fn test_bfchar_two_byte_multiple_cjk() {
     // Several CJK characters as both source and destination
-    let data =
-        b"beginbfchar\n<4E2D> <4E2D>\n<6587> <6587>\n<5B66> <5B66>\nendbfchar";
+    let data = b"beginbfchar\n<4E2D> <4E2D>\n<6587> <6587>\n<5B66> <5B66>\nendbfchar";
     let cmap = parse_tounicode_cmap(data).unwrap();
 
     assert_eq!(cmap.get(&0x4E2D), Some(&"\u{4E2D}".to_string()), "中 (0x4E2D)");
@@ -192,11 +170,7 @@ fn test_lazycmap_code_width_default_when_no_codespace() {
     let cmap_data = b"1 beginbfchar\n<41> <41>\nendbfchar".to_vec();
 
     let lazy = LazyCMap::new(cmap_data);
-    assert_eq!(
-        lazy.code_width(),
-        1,
-        "Missing codespace defaults code_width = 1"
-    );
+    assert_eq!(lazy.code_width(), 1, "Missing codespace defaults code_width = 1");
 }
 
 // ============================================================================

--- a/tests/test_corpus_extraction_quality.rs
+++ b/tests/test_corpus_extraction_quality.rs
@@ -18,6 +18,7 @@
 //! Jaccard similarity on whitespace-split word tokens.  This differs from
 //! kreuzberg's word-F1 but is a good proxy that avoids the kreuzberg dependency.
 
+use pdf_oxide::converters::ConversionOptions;
 use pdf_oxide::document::PdfDocument;
 use std::collections::HashSet;
 
@@ -188,6 +189,110 @@ fn quality_gate_issue_336() {
         "/tmp/gt_issue-336-example.txt",
         0.69,
     );
+}
+
+// ---------------------------------------------------------------------------
+// issue-336-example.pdf — to_markdown quality gate (#485)
+// Same PDF as quality_gate_issue_336 but exercising the to_markdown path so
+// that the CJK fullwidth-operator space-suppression fix is covered end-to-end.
+// Threshold set to the same floor used for extract_text (0.69).
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "requires /tmp/issue-336-example.pdf and /tmp/gt_issue-336-example.txt"]
+fn quality_gate_issue_336_markdown() {
+    let pdf_path = "/tmp/issue-336-example.pdf";
+    let gt_path = "/tmp/gt_issue-336-example.txt";
+    let bytes = match std::fs::read(pdf_path) {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("SKIP issue-336-example (markdown): {pdf_path} not found");
+            return;
+        },
+    };
+    let gt_text = match std::fs::read_to_string(gt_path) {
+        Ok(t) => t,
+        Err(_) => {
+            eprintln!("SKIP issue-336-example (markdown): ground truth {gt_path} not found");
+            return;
+        },
+    };
+    let doc = PdfDocument::from_bytes(bytes).expect("parse PDF");
+    let _ = doc.authenticate(b"");
+    let options = ConversionOptions::default();
+    let mut text = String::new();
+    for i in 0..doc.page_count().unwrap_or(0) {
+        if let Ok(t) = doc.to_markdown(i, &options) {
+            text.push_str(&t);
+            text.push('\n');
+        }
+    }
+    let j = jaccard(&text, &gt_text);
+    assert!(
+        j >= 0.69,
+        "issue-336-example (markdown): Jaccard {j:.3} < threshold 0.69\n\
+         This is a quality regression — to_markdown score dropped."
+    );
+    eprintln!("PASS issue-336-example (markdown)      j={j:.3}  thr=0.69");
+}
+
+// ---------------------------------------------------------------------------
+// issue-336-example.pdf — to_html quality gate (#485)
+// Same PDF as quality_gate_issue_336 but exercising the to_html path.
+// HTML tags are stripped before computing Jaccard so the score reflects
+// actual text content rather than markup.
+// Threshold set slightly lower than to_markdown (0.65) to account for minor
+// HTML-wrapping differences.
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "requires /tmp/issue-336-example.pdf and /tmp/gt_issue-336-example.txt"]
+fn quality_gate_issue_336_html() {
+    let pdf_path = "/tmp/issue-336-example.pdf";
+    let gt_path = "/tmp/gt_issue-336-example.txt";
+    let bytes = match std::fs::read(pdf_path) {
+        Ok(b) => b,
+        Err(_) => {
+            eprintln!("SKIP issue-336-example (html): {pdf_path} not found");
+            return;
+        },
+    };
+    let gt_text = match std::fs::read_to_string(gt_path) {
+        Ok(t) => t,
+        Err(_) => {
+            eprintln!("SKIP issue-336-example (html): ground truth {gt_path} not found");
+            return;
+        },
+    };
+    let doc = PdfDocument::from_bytes(bytes).expect("parse PDF");
+    let _ = doc.authenticate(b"");
+    let options = ConversionOptions::default();
+    let mut html = String::new();
+    for i in 0..doc.page_count().unwrap_or(0) {
+        if let Ok(t) = doc.to_html(i, &options) {
+            html.push_str(&t);
+            html.push('\n');
+        }
+    }
+    // Strip HTML tags: replace <...> sequences with a space so word tokens survive.
+    let stripped = {
+        let mut out = String::with_capacity(html.len());
+        let mut in_tag = false;
+        for c in html.chars() {
+            match c {
+                '<' => { in_tag = true; out.push(' '); },
+                '>' => { in_tag = false; out.push(' '); },
+                _ if in_tag => {},
+                _ => out.push(c),
+            }
+        }
+        out
+    };
+    let j = jaccard(&stripped, &gt_text);
+    assert!(
+        j >= 0.65,
+        "issue-336-example (html): Jaccard {j:.3} < threshold 0.65\n\
+         This is a quality regression — to_html score dropped."
+    );
+    eprintln!("PASS issue-336-example (html)          j={j:.3}  thr=0.65");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_corpus_extraction_quality.rs
+++ b/tests/test_corpus_extraction_quality.rs
@@ -34,6 +34,82 @@ fn jaccard(a: &str, b: &str) -> f32 {
     }
 }
 
+/// Strip markdown syntax markers from a string so the Jaccard test
+/// compares text content rather than formatting markup.
+///
+/// Removes the same families of tokens that pdftotext's plain-text GT
+/// never contains:
+///   * `**...**` and `*...*` (bold / italic)
+///   * `|` table column separators
+///   * `---|---|---` separator-row sequences
+///   * leading `#` heading markers
+///   * fenced code-block fences
+///
+/// Mirrors the HTML test's tag-stripping rationale: the markdown
+/// converter's job is to produce the right text + structure; whether
+/// it wraps a number in `**...**` is a formatting concern, not a
+/// content-quality regression.
+fn strip_markdown(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    let mut at_line_start = true;
+    while i < chars.len() {
+        let c = chars[i];
+        // `**` bold marker — drop two chars
+        if c == '*' && chars.get(i + 1) == Some(&'*') {
+            i += 2;
+            at_line_start = false;
+            continue;
+        }
+        // standalone `*` italic marker — drop
+        if c == '*' {
+            i += 1;
+            at_line_start = false;
+            continue;
+        }
+        // `|` table column separator — turn into space so neighbouring
+        // cells stay separated by whitespace for split_whitespace()
+        if c == '|' {
+            out.push(' ');
+            i += 1;
+            at_line_start = false;
+            continue;
+        }
+        // `# `, `## ` … heading marker at start of line — drop the run
+        if at_line_start && c == '#' {
+            while i < chars.len() && chars[i] == '#' {
+                i += 1;
+            }
+            continue;
+        }
+        // 3+ consecutive `-` (separator row) — turn into space
+        if c == '-' && chars.get(i + 1) == Some(&'-') && chars.get(i + 2) == Some(&'-') {
+            while i < chars.len() && chars[i] == '-' {
+                i += 1;
+            }
+            out.push(' ');
+            at_line_start = false;
+            continue;
+        }
+        // Fenced code block ``` — drop the line
+        if c == '`' && chars.get(i + 1) == Some(&'`') && chars.get(i + 2) == Some(&'`') {
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+        out.push(c);
+        at_line_start = c == '\n';
+        i += 1;
+    }
+    out
+}
+
+fn jaccard_markdown(md: &str, gt: &str) -> f32 {
+    jaccard(&strip_markdown(md), gt)
+}
+
 /// Extract text from all pages of a PDF at the given path.
 /// Returns None when the PDF file is not present (test skips).
 fn extract_all_text(pdf_path: &str) -> Option<String> {
@@ -226,7 +302,10 @@ fn quality_gate_issue_336_markdown() {
             text.push('\n');
         }
     }
-    let j = jaccard(&text, &gt_text);
+    // Strip markdown formatting markers before Jaccard so we compare
+    // content tokens rather than syntax (matches the HTML test which
+    // strips <...> tags).
+    let j = jaccard_markdown(&text, &gt_text);
     assert!(
         j >= 0.69,
         "issue-336-example (markdown): Jaccard {j:.3} < threshold 0.69\n\
@@ -512,17 +591,12 @@ fn check_markdown(label: &str, pdf: &str, gt: &str, threshold: f32) {
             return;
         },
     };
-    // Strip markdown table syntax (|, --, leading/trailing pipes) before Jaccard
-    // so the score reflects actual text tokens rather than formatting characters.
-    let plain: String = md
-        .lines()
-        .map(|line| {
-            // Replace pipe-separated table cells with spaces
-            line.replace('|', " ")
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let j = jaccard(&plain, &gt_text);
+    // Strip markdown formatting markers (**bold**, *italic*, | table
+    // separators, --- header rule, leading # headings, ``` fences)
+    // before computing Jaccard so the score reflects text content,
+    // not formatting characters that the plain-text GT was never
+    // going to contain.  Mirrors the HTML test's strip_html step.
+    let j = jaccard_markdown(&md, &gt_text);
     assert!(
         j >= threshold,
         "{label}: Jaccard {j:.3} < threshold {threshold:.2}\n\

--- a/tests/test_corpus_extraction_quality.rs
+++ b/tests/test_corpus_extraction_quality.rs
@@ -339,3 +339,128 @@ fn quality_gate_pdfa_004() {
 fn quality_gate_nougat_018() {
     check("nougat_018", "/tmp/nougat_018.pdf", "/tmp/gt_nougat_018.txt", 0.90);
 }
+
+// ---------------------------------------------------------------------------
+// #487 — to_html quality gates for table-heavy PDFs.
+//
+// The root cause was render_table_html using cell.text directly instead of
+// walking cell.spans (as render_table_markdown does), causing inter-span gaps
+// to be lost and losing bold/italic markup from the token set.  Fixed by the
+// new render_cell_html helper that mirrors the span-walking in the markdown path.
+//
+// HTML tags are stripped before Jaccard so the score reflects actual text
+// tokens rather than markup.  HTML entities (&amp;, &lt;, &gt;, &quot;) are
+// also unescaped so they compare correctly against plain-text ground truth.
+// ---------------------------------------------------------------------------
+
+/// Strip HTML tags and unescape common HTML entities, returning plain text
+/// suitable for Jaccard comparison against plain-text ground truth.
+fn strip_html(html: &str) -> String {
+    // First pass: remove tags (replace < ... > with a space).
+    let mut stripped = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for c in html.chars() {
+        match c {
+            '<' => {
+                in_tag = true;
+                stripped.push(' ');
+            },
+            '>' => {
+                in_tag = false;
+                stripped.push(' ');
+            },
+            _ if in_tag => {},
+            _ => stripped.push(c),
+        }
+    }
+    // Second pass: unescape the five XML/HTML predefined entities.
+    stripped
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+}
+
+/// Extract all pages of a PDF as HTML, strip tags, and return plain text.
+/// Returns None when the PDF file is not present (test skips).
+fn extract_all_html(pdf_path: &str) -> Option<String> {
+    let bytes = std::fs::read(pdf_path).ok()?;
+    let doc = PdfDocument::from_bytes(bytes).ok()?;
+    let _ = doc.authenticate(b"");
+    let options = ConversionOptions::default();
+    let mut html = String::new();
+    for i in 0..doc.page_count().unwrap_or(0) {
+        if let Ok(t) = doc.to_html(i, &options) {
+            html.push_str(&t);
+            html.push('\n');
+        }
+    }
+    Some(html)
+}
+
+fn check_html(label: &str, pdf: &str, gt: &str, threshold: f32) {
+    let html = match extract_all_html(pdf) {
+        Some(h) => h,
+        None => {
+            eprintln!("SKIP {label}: {pdf} not found");
+            return;
+        },
+    };
+    let gt_text = match std::fs::read_to_string(gt) {
+        Ok(t) => t,
+        Err(_) => {
+            eprintln!("SKIP {label}: ground truth {gt} not found");
+            return;
+        },
+    };
+    let text = strip_html(&html);
+    let j = jaccard(&text, &gt_text);
+    assert!(
+        j >= threshold,
+        "{label}: Jaccard {j:.3} < threshold {threshold:.2}\n\
+         (PDF: {pdf}, GT: {gt})\n\
+         This is a quality regression — to_html score dropped."
+    );
+    eprintln!("PASS {label:<28} j={j:.3}  thr={threshold:.2}");
+}
+
+// pdfa_036.pdf — to_html quality gate (#487)
+// Same fixture as quality_gate_pdfa_036.  Threshold matches the to_text gate
+// (0.78) since the span-walking fix brings HTML on par with text extraction.
+#[test]
+#[ignore = "requires /tmp/pdfa_036.pdf and /tmp/gt_pdfa_036_kreuzberg.txt"]
+fn quality_gate_pdfa_036_html() {
+    check_html(
+        "pdfa_036 (html)",
+        "/tmp/pdfa_036.pdf",
+        "/tmp/gt_pdfa_036_kreuzberg.txt",
+        0.78,
+    );
+}
+
+// nougat_026.pdf — to_html quality gate (#487)
+// Same fixture as quality_gate_nougat_026.  Threshold 0.87 matches to_text gate.
+#[test]
+#[ignore = "requires /tmp/nougat_026.pdf and /tmp/gt_nougat_026.txt"]
+fn quality_gate_nougat_026_html() {
+    check_html("nougat_026 (html)", "/tmp/nougat_026.pdf", "/tmp/gt_nougat_026.txt", 0.87);
+}
+
+// nougat_040.pdf — to_html quality gate (#487)
+// Same fixture as quality_gate_nougat_040.  Threshold 0.35 matches to_text gate.
+#[test]
+#[ignore = "requires /tmp/nougat_040.pdf and /tmp/gt_nougat_040.txt"]
+fn quality_gate_nougat_040_html() {
+    check_html("nougat_040 (html)", "/tmp/nougat_040.pdf", "/tmp/gt_nougat_040.txt", 0.35);
+}
+
+// nougat_018.pdf — to_html quality gate (#487)
+// Same fixture as quality_gate_nougat_018.  Threshold 0.95 (higher than to_text
+// 0.90) because sailing-score tables with span metadata now render all tokens
+// correctly via the span-walking path.
+#[test]
+#[ignore = "requires /tmp/nougat_018.pdf and /tmp/gt_nougat_018.txt"]
+fn quality_gate_nougat_018_html() {
+    check_html("nougat_018 (html)", "/tmp/nougat_018.pdf", "/tmp/gt_nougat_018.txt", 0.95);
+}

--- a/tests/test_corpus_extraction_quality.rs
+++ b/tests/test_corpus_extraction_quality.rs
@@ -464,3 +464,80 @@ fn quality_gate_nougat_040_html() {
 fn quality_gate_nougat_018_html() {
     check_html("nougat_018 (html)", "/tmp/nougat_018.pdf", "/tmp/gt_nougat_018.txt", 0.95);
 }
+
+// ---------------------------------------------------------------------------
+// #486 — to_markdown quality gate for line-less sailing-score table.
+//
+// nougat_018.pdf is a sailing regatta results document.  The table has no
+// ruling lines, so the old code returned no tables and the converter fell
+// back to flat paragraph rendering (Jaccard ≈ 0.64).  With the text-only
+// spatial fallback enabled for converter paths (to_markdown, to_html), the
+// table is now detected spatially and rendered as a proper markdown table.
+//
+// Source: https://github.com/kreuzberg-dev/kreuzberg/blob/main/test_documents/pdf/nougat_018.pdf
+// GT:     https://github.com/kreuzberg-dev/kreuzberg/blob/main/test_documents/expected_output/nougat_018.txt
+// Achieved ≥ 0.90 after fix (threshold = 0.90).
+// ---------------------------------------------------------------------------
+
+/// Extract all pages of a PDF as Markdown and concatenate into a single string.
+/// Returns None when the PDF file is not present (test skips).
+fn extract_all_markdown(pdf_path: &str) -> Option<String> {
+    let bytes = std::fs::read(pdf_path).ok()?;
+    let doc = PdfDocument::from_bytes(bytes).ok()?;
+    let _ = doc.authenticate(b"");
+    let options = ConversionOptions::default();
+    let mut md = String::new();
+    for i in 0..doc.page_count().unwrap_or(0) {
+        if let Ok(t) = doc.to_markdown(i, &options) {
+            md.push_str(&t);
+            md.push('\n');
+        }
+    }
+    Some(md)
+}
+
+fn check_markdown(label: &str, pdf: &str, gt: &str, threshold: f32) {
+    let md = match extract_all_markdown(pdf) {
+        Some(m) => m,
+        None => {
+            eprintln!("SKIP {label}: {pdf} not found");
+            return;
+        },
+    };
+    let gt_text = match std::fs::read_to_string(gt) {
+        Ok(t) => t,
+        Err(_) => {
+            eprintln!("SKIP {label}: ground truth {gt} not found");
+            return;
+        },
+    };
+    // Strip markdown table syntax (|, --, leading/trailing pipes) before Jaccard
+    // so the score reflects actual text tokens rather than formatting characters.
+    let plain: String = md
+        .lines()
+        .map(|line| {
+            // Replace pipe-separated table cells with spaces
+            line.replace('|', " ")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let j = jaccard(&plain, &gt_text);
+    assert!(
+        j >= threshold,
+        "{label}: Jaccard {j:.3} < threshold {threshold:.2}\n\
+         (PDF: {pdf}, GT: {gt})\n\
+         This is a quality regression — to_markdown score dropped."
+    );
+    eprintln!("PASS {label:<28} j={j:.3}  thr={threshold:.2}");
+}
+
+#[test]
+#[ignore = "requires /tmp/nougat_018.pdf and /tmp/gt_nougat_018.txt"]
+fn quality_gate_nougat_018_markdown() {
+    check_markdown(
+        "nougat_018 (markdown)",
+        "/tmp/nougat_018.pdf",
+        "/tmp/gt_nougat_018.txt",
+        0.90,
+    );
+}

--- a/tests/test_corpus_extraction_quality.rs
+++ b/tests/test_corpus_extraction_quality.rs
@@ -278,8 +278,14 @@ fn quality_gate_issue_336_html() {
         let mut in_tag = false;
         for c in html.chars() {
             match c {
-                '<' => { in_tag = true; out.push(' '); },
-                '>' => { in_tag = false; out.push(' '); },
+                '<' => {
+                    in_tag = true;
+                    out.push(' ');
+                },
+                '>' => {
+                    in_tag = false;
+                    out.push(' ');
+                },
                 _ if in_tag => {},
                 _ => out.push(c),
             }
@@ -431,12 +437,7 @@ fn check_html(label: &str, pdf: &str, gt: &str, threshold: f32) {
 #[test]
 #[ignore = "requires /tmp/pdfa_036.pdf and /tmp/gt_pdfa_036_kreuzberg.txt"]
 fn quality_gate_pdfa_036_html() {
-    check_html(
-        "pdfa_036 (html)",
-        "/tmp/pdfa_036.pdf",
-        "/tmp/gt_pdfa_036_kreuzberg.txt",
-        0.78,
-    );
+    check_html("pdfa_036 (html)", "/tmp/pdfa_036.pdf", "/tmp/gt_pdfa_036_kreuzberg.txt", 0.78);
 }
 
 // nougat_026.pdf — to_html quality gate (#487)
@@ -534,10 +535,5 @@ fn check_markdown(label: &str, pdf: &str, gt: &str, threshold: f32) {
 #[test]
 #[ignore = "requires /tmp/nougat_018.pdf and /tmp/gt_nougat_018.txt"]
 fn quality_gate_nougat_018_markdown() {
-    check_markdown(
-        "nougat_018 (markdown)",
-        "/tmp/nougat_018.pdf",
-        "/tmp/gt_nougat_018.txt",
-        0.90,
-    );
+    check_markdown("nougat_018 (markdown)", "/tmp/nougat_018.pdf", "/tmp/gt_nougat_018.txt", 0.90);
 }

--- a/tests/test_form_xobject_ctm.rs
+++ b/tests/test_form_xobject_ctm.rs
@@ -1,0 +1,293 @@
+//! Tests for CTM-aware Form XObject span extraction.
+//!
+//! The same Form XObject may be painted multiple times on a page (or across
+//! pages) with different caller CTMs, producing text at different positions.
+//! The extractor must re-compute spans for each unique (XObject, CTM) pair
+//! rather than returning a stale cached result from the first invocation.
+//!
+//! Regression for: nougat_005.pdf plain F1 = 0.333 (Issue B1)
+//! Fix: `processed_xobjects` and `xobject_spans_cache` keyed by
+//! `(ObjectRef, ctm_millipoints)` instead of `ObjectRef` alone.
+
+use pdf_oxide::document::PdfDocument;
+
+// ---------------------------------------------------------------------------
+// Helper: build a PDF with a Form XObject invoked twice, each time inside a
+// save/restore block that applies a different y-translation via the `cm`
+// operator.
+//
+// Page content stream:
+//   q  1 0 0 1 0   0 cm  /Fm0 Do  Q   ← paints Form at y+0
+//   q  1 0 0 1 0 400 cm  /Fm0 Do  Q   ← paints Form at y+400
+//
+// The Form XObject contains a single text string "FORM_TEXT" at (50, 50).
+// After the first `cm`:  page-space y ≈  50
+// After the second `cm`: page-space y ≈ 450
+// ---------------------------------------------------------------------------
+fn build_form_xobject_two_ctm_pdf() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Object 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Object 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Object 3: Page — references the content stream and declares fonts/XObjects
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n\
+          << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+             /Contents 4 0 R\n\
+             /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >>\n\
+          >>\nendobj\n\n",
+    );
+
+    // Object 4: Page content stream
+    // Two `q … cm … Do … Q` blocks with different y-translations.
+    let page_content =
+        b"q 1 0 0 1 0 0 cm /Fm0 Do Q q 1 0 0 1 0 400 cm /Fm0 Do Q";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Object 5: Form XObject — text "FORM_TEXT" at (50, 50) in XObject space
+    let form_stream = b"BT /F1 12 Tf 50 50 Td (FORM_TEXT) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n\
+         << /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Object 6: Font (Helvetica — built-in, no encoding needed for ASCII)
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n\
+          << /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+             /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Cross-reference table
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1; // +1 for the free entry 0
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    // Trailer
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+
+    pdf
+}
+
+// ---------------------------------------------------------------------------
+// Same as above but the Form XObject is used across two pages.  Each page
+// applies a different CTM before `Do`.
+// ---------------------------------------------------------------------------
+fn build_form_xobject_two_pages_pdf() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Object 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Object 2: Pages (two pages)
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>\nendobj\n\n",
+    );
+
+    // Object 3: Page 1 — paints Form at y-offset 0 (identity cm)
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n\
+          << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+             /Contents 5 0 R\n\
+             /Resources << /Font << /F1 8 0 R >> /XObject << /Fm0 7 0 R >> >>\n\
+          >>\nendobj\n\n",
+    );
+
+    // Object 4: Page 2 — paints Form at y-offset 300
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"4 0 obj\n\
+          << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+             /Contents 6 0 R\n\
+             /Resources << /Font << /F1 8 0 R >> /XObject << /Fm0 7 0 R >> >>\n\
+          >>\nendobj\n\n",
+    );
+
+    // Object 5: Content for page 1 (identity CTM)
+    let content1 = b"q 1 0 0 1 0 0 cm /Fm0 Do Q";
+    offsets.push(pdf.len());
+    let hdr5 = format!("5 0 obj\n<< /Length {} >>\nstream\n", content1.len());
+    pdf.extend_from_slice(hdr5.as_bytes());
+    pdf.extend_from_slice(content1);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Object 6: Content for page 2 (y-translation 300)
+    let content2 = b"q 1 0 0 1 0 300 cm /Fm0 Do Q";
+    offsets.push(pdf.len());
+    let hdr6 = format!("6 0 obj\n<< /Length {} >>\nstream\n", content2.len());
+    pdf.extend_from_slice(hdr6.as_bytes());
+    pdf.extend_from_slice(content2);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Object 7: Form XObject — "PAGE_TEXT" at (30, 100) in XObject space
+    let form_stream = b"BT /F1 12 Tf 30 100 Td (PAGE_TEXT) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "7 0 obj\n\
+         << /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 8 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Object 8: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"8 0 obj\n\
+          << /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+             /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Cross-reference table
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+
+    pdf
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Verify that when the same Form XObject is painted twice on a single page
+/// with different y-translation CTMs, both invocations produce spans at
+/// distinct y-coordinates.
+///
+/// Before the fix, `processed_xobjects` (keyed only by ObjectRef) would
+/// block the second `Do` call, yielding only one span instead of two.
+#[test]
+fn test_same_form_xobject_twice_different_ctm_same_page() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let pdf = build_form_xobject_two_ctm_pdf();
+    let doc = PdfDocument::from_bytes(pdf).expect("parse PDF");
+
+    let spans = doc.extract_spans(0).expect("extract spans");
+
+    // Collect spans that contain "FORM_TEXT"
+    let matching: Vec<_> = spans.iter().filter(|s| s.text.contains("FORM_TEXT")).collect();
+
+    assert!(
+        matching.len() >= 2,
+        "Expected at least 2 'FORM_TEXT' spans (one per CTM invocation), \
+         got {}: {:?}",
+        matching.len(),
+        matching.iter().map(|s| (s.text.as_str(), s.bbox.y)).collect::<Vec<_>>()
+    );
+
+    // The two spans must be at different y positions — the second invocation
+    // adds 400 units of y-translation, so they should differ by ~400.
+    let y_vals: Vec<f32> = matching.iter().map(|s| s.bbox.y).collect();
+    let y_min = y_vals.iter().cloned().fold(f32::INFINITY, f32::min);
+    let y_max = y_vals.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let y_diff = (y_max - y_min).abs();
+
+    assert!(
+        y_diff > 300.0,
+        "Y-coordinates of the two spans should differ by ~400 (got diff = {}). \
+         Positions: {:?}",
+        y_diff,
+        y_vals
+    );
+}
+
+/// Verify that the same Form XObject used on two different pages with
+/// different CTMs yields correct (distinct) y-coordinates on each page.
+///
+/// Before the fix, the `xobject_spans_cache` keyed only by ObjectRef would
+/// return page-1's coordinates for page 2 if the cache was warmed on page 1.
+#[test]
+fn test_same_form_xobject_two_pages_different_ctm() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let pdf = build_form_xobject_two_pages_pdf();
+    let doc = PdfDocument::from_bytes(pdf).expect("parse PDF");
+
+    // Extract from page 0 first (warms the cache with identity CTM)
+    let spans0 = doc.extract_spans(0).expect("extract page 0 spans");
+    // Then page 1 (should use a fresh extraction with y+300 CTM, not the cached result)
+    let spans1 = doc.extract_spans(1).expect("extract page 1 spans");
+
+    let find_text_span = |spans: &[pdf_oxide::layout::TextSpan]| {
+        spans.iter().find(|s| s.text.contains("PAGE_TEXT")).cloned()
+    };
+
+    let span0 = find_text_span(&spans0);
+    let span1 = find_text_span(&spans1);
+
+    assert!(
+        span0.is_some(),
+        "Page 0 should contain 'PAGE_TEXT', got: {:?}",
+        spans0.iter().map(|s| s.text.as_str()).collect::<Vec<_>>()
+    );
+    assert!(
+        span1.is_some(),
+        "Page 1 should contain 'PAGE_TEXT', got: {:?}",
+        spans1.iter().map(|s| s.text.as_str()).collect::<Vec<_>>()
+    );
+
+    let y0 = span0.unwrap().bbox.y;
+    let y1 = span1.unwrap().bbox.y;
+
+    // Page 1 applies a y-translation of 300, so its span y should be ~300 higher
+    // than page 0's span y (which uses identity CTM).
+    // The Form places text at y=100; after +300 translation y ≈ 400.
+    let diff = (y1 - y0).abs();
+    assert!(
+        diff > 200.0,
+        "Page 1's 'PAGE_TEXT' y ({}) should be ~300 above page 0's y ({}); diff = {}",
+        y1,
+        y0,
+        diff
+    );
+}

--- a/tests/test_form_xobject_ctm.rs
+++ b/tests/test_form_xobject_ctm.rs
@@ -50,8 +50,7 @@ fn build_form_xobject_two_ctm_pdf() -> Vec<u8> {
 
     // Object 4: Page content stream
     // Two `q … cm … Do … Q` blocks with different y-translations.
-    let page_content =
-        b"q 1 0 0 1 0 0 cm /Fm0 Do Q q 1 0 0 1 0 400 cm /Fm0 Do Q";
+    let page_content = b"q 1 0 0 1 0 0 cm /Fm0 Do Q q 1 0 0 1 0 400 cm /Fm0 Do Q";
     offsets.push(pdf.len());
     let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
     pdf.extend_from_slice(hdr.as_bytes());
@@ -116,9 +115,7 @@ fn build_form_xobject_two_pages_pdf() -> Vec<u8> {
 
     // Object 2: Pages (two pages)
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>\nendobj\n\n");
 
     // Object 3: Page 1 — paints Form at y-offset 0 (identity cm)
     offsets.push(pdf.len());
@@ -216,14 +213,20 @@ fn test_same_form_xobject_twice_different_ctm_same_page() {
     let spans = doc.extract_spans(0).expect("extract spans");
 
     // Collect spans that contain "FORM_TEXT"
-    let matching: Vec<_> = spans.iter().filter(|s| s.text.contains("FORM_TEXT")).collect();
+    let matching: Vec<_> = spans
+        .iter()
+        .filter(|s| s.text.contains("FORM_TEXT"))
+        .collect();
 
     assert!(
         matching.len() >= 2,
         "Expected at least 2 'FORM_TEXT' spans (one per CTM invocation), \
          got {}: {:?}",
         matching.len(),
-        matching.iter().map(|s| (s.text.as_str(), s.bbox.y)).collect::<Vec<_>>()
+        matching
+            .iter()
+            .map(|s| (s.text.as_str(), s.bbox.y))
+            .collect::<Vec<_>>()
     );
 
     // The two spans must be at different y positions — the second invocation

--- a/tests/test_mediabox_indirect_ref.rs
+++ b/tests/test_mediabox_indirect_ref.rs
@@ -1,0 +1,218 @@
+//! Regression tests for MediaBox/CropBox stored as indirect references.
+//!
+//! PDF spec ISO 32000-1 §7.3.10 states that any value may be a direct or an
+//! indirect reference; the semantics are equivalent.  Before this fix, the
+//! library crashed with "MediaBox not found or not an array" when a page dict
+//! contained `/MediaBox 174 0 R` instead of a direct array.
+
+use pdf_oxide::document::PdfDocument;
+
+/// Build a minimal PDF with a given number of cross-reference entries and
+/// write the cross-reference table + trailer.
+fn write_xref_and_trailer(pdf: &mut Vec<u8>, offsets: &[usize]) {
+    let xref_offset = pdf.len();
+    let count = offsets.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", count).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<</Size {} /Root 1 0 R>>\nstartxref\n{}\n%%EOF\n", count, xref_offset)
+            .as_bytes(),
+    );
+}
+
+/// Build a minimal 1-page PDF where `/MediaBox` in the page dict is an
+/// indirect reference to a separate array object.
+///
+/// Structure:
+///   1 0 obj  Catalog  → /Pages 2 0 R
+///   2 0 obj  Pages    → /Kids [3 0 R] /Count 1
+///   3 0 obj  Page     → /MediaBox 4 0 R  (indirect reference!)
+///   4 0 obj  Array    → [0 0 612 792]
+fn build_pdf_indirect_mediabox() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n");
+
+    // Page dict: MediaBox is an indirect reference (4 0 R), NOT a direct array.
+    let off3 = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj\n<</Type /Page /Parent 2 0 R /MediaBox 4 0 R /Resources <<>>>>\nendobj\n",
+    );
+
+    // The actual MediaBox array stored as its own object.
+    let off4 = pdf.len();
+    pdf.extend_from_slice(b"4 0 obj\n[0 0 612 792]\nendobj\n");
+
+    write_xref_and_trailer(&mut pdf, &[0, off1, off2, off3, off4]);
+    pdf
+}
+
+/// Build a minimal 1-page PDF where the *parent Pages node* has `/MediaBox`
+/// as an indirect reference.  The page itself has no MediaBox entry, so it
+/// must inherit it from the parent — and the inherited value is still an
+/// indirect reference object.
+///
+/// Structure:
+///   1 0 obj  Catalog  → /Pages 2 0 R
+///   2 0 obj  Pages    → /Kids [3 0 R] /Count 1  /MediaBox 4 0 R  (indirect!)
+///   3 0 obj  Page     → (no MediaBox — inherits from parent)
+///   4 0 obj  Array    → [0 0 595 842]
+fn build_pdf_inherited_indirect_mediabox() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n");
+
+    // Pages node carries the MediaBox as an indirect reference.
+    let off2 = pdf.len();
+    pdf.extend_from_slice(
+        b"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1 /MediaBox 4 0 R>>\nendobj\n",
+    );
+
+    // Page dict has NO MediaBox — relies on inheritance from the Pages node.
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<</Type /Page /Parent 2 0 R /Resources <<>>>>\nendobj\n");
+
+    // The actual MediaBox array — A4 dimensions.
+    let off4 = pdf.len();
+    pdf.extend_from_slice(b"4 0 obj\n[0 0 595 842]\nendobj\n");
+
+    write_xref_and_trailer(&mut pdf, &[0, off1, off2, off3, off4]);
+    pdf
+}
+
+/// Build a minimal 1-page PDF where `/MediaBox` is a direct array (the normal
+/// case).  This is the sanity-check that the common path still works.
+fn build_pdf_direct_mediabox() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n");
+
+    // Direct MediaBox array — the conventional form.
+    let off3 = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj\n<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources <<>>>>\nendobj\n",
+    );
+
+    write_xref_and_trailer(&mut pdf, &[0, off1, off2, off3]);
+    pdf
+}
+
+/// Build a minimal 1-page PDF where `/CropBox` is stored as an indirect reference.
+fn build_pdf_indirect_cropbox() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n");
+
+    // Page dict: direct MediaBox, indirect CropBox.
+    let off3 = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj\n<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /CropBox 4 0 R /Resources <<>>>>\nendobj\n",
+    );
+
+    // Crop to the top-left quadrant.
+    let off4 = pdf.len();
+    pdf.extend_from_slice(b"4 0 obj\n[0 396 306 792]\nendobj\n");
+
+    write_xref_and_trailer(&mut pdf, &[0, off1, off2, off3, off4]);
+    pdf
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A PDF with `/MediaBox 4 0 R` (indirect reference) must not crash.
+/// `get_page_media_box` must return the correct dimensions.
+#[test]
+fn test_indirect_mediabox_direct_on_page() {
+    let pdf = build_pdf_indirect_mediabox();
+    let doc = PdfDocument::from_bytes(pdf).expect("PDF should parse successfully");
+
+    let (llx, lly, urx, ury) = doc
+        .get_page_media_box(0)
+        .expect("get_page_media_box must succeed for indirect MediaBox");
+
+    assert_eq!(
+        (llx, lly, urx, ury),
+        (0.0, 0.0, 612.0, 792.0),
+        "Indirect MediaBox [0 0 612 792] should be resolved correctly"
+    );
+}
+
+/// A PDF where the *parent Pages node* carries an indirect MediaBox reference
+/// that is inherited by child pages.
+#[test]
+fn test_indirect_mediabox_inherited_from_pages_node() {
+    let pdf = build_pdf_inherited_indirect_mediabox();
+    let doc = PdfDocument::from_bytes(pdf).expect("PDF should parse successfully");
+
+    let (llx, lly, urx, ury) = doc
+        .get_page_media_box(0)
+        .expect("get_page_media_box must succeed for inherited indirect MediaBox");
+
+    assert_eq!(
+        (llx, lly, urx, ury),
+        (0.0, 0.0, 595.0, 842.0),
+        "Inherited indirect MediaBox [0 0 595 842] should be resolved correctly"
+    );
+}
+
+/// Sanity check: a PDF with a direct MediaBox array still works correctly.
+#[test]
+fn test_direct_mediabox_still_works() {
+    let pdf = build_pdf_direct_mediabox();
+    let doc = PdfDocument::from_bytes(pdf).expect("PDF should parse successfully");
+
+    let (llx, lly, urx, ury) = doc
+        .get_page_media_box(0)
+        .expect("get_page_media_box must succeed for direct MediaBox");
+
+    assert_eq!(
+        (llx, lly, urx, ury),
+        (0.0, 0.0, 612.0, 792.0),
+        "Direct MediaBox [0 0 612 792] should work as before"
+    );
+}
+
+/// A PDF with `/CropBox 4 0 R` (indirect reference) must be handled gracefully.
+/// This test uses `get_page_count` to confirm the document was loaded and does
+/// not panic; CropBox resolution is exercised through `get_page_media_box`
+/// (which parses the page dict) plus a simple page-count sanity check.
+#[test]
+fn test_indirect_cropbox_does_not_crash() {
+    let pdf = build_pdf_indirect_cropbox();
+    let doc = PdfDocument::from_bytes(pdf).expect("PDF should parse successfully");
+
+    // Must not crash when accessing the page.
+    let (llx, lly, urx, ury) = doc
+        .get_page_media_box(0)
+        .expect("get_page_media_box must succeed even when CropBox is indirect");
+
+    assert_eq!(
+        (llx, lly, urx, ury),
+        (0.0, 0.0, 612.0, 792.0),
+        "MediaBox should still be [0 0 612 792] regardless of indirect CropBox"
+    );
+
+    assert_eq!(doc.page_count().unwrap(), 1);
+}

--- a/tests/test_running_header_first_occurrence_kept.rs
+++ b/tests/test_running_header_first_occurrence_kept.rs
@@ -92,21 +92,25 @@ fn first_occurrence_of_running_header_kept_on_page_one() {
     assert!(p1.contains("PageTwoBody"), "page 1 body missing: {p1:?}");
     assert!(p2.contains("PageThreeBody"), "page 2 body missing: {p2:?}");
 
-    // Page 0 — the first occurrence — MUST keep the running-header
-    // title. Pre-fix behaviour would strip it.
+    // v0.3.47 behaviour (commit 3c6562ef): a running header is only
+    // suppressed when its *literal text varies* across pages — i.e. the
+    // digits change, signalling a page number or date.  A header with a
+    // stable literal (a document title that doubles as a per-page
+    // header) is substantive content that pdftotext and pdfium both
+    // preserve, so suppressing it on later pages hurts kreuzberg
+    // word-F1.  "Universal Title" is identical on every page, so it
+    // survives on all three pages.
     assert!(
         p0.contains("Universal Title"),
         "first page should keep the running-header text \
          as it also serves as the cover-page title; got {p0:?}"
     );
-
-    // Pages 1 and 2 drop it as a pagination artifact.
     assert!(
-        !p1.contains("Universal Title"),
-        "page 1 should suppress the running header on second+ occurrences: {p1:?}"
+        p1.contains("Universal Title"),
+        "stable-literal repeats are preserved on page 2 (no digit change); got {p1:?}"
     );
     assert!(
-        !p2.contains("Universal Title"),
-        "page 2 should suppress the running header on second+ occurrences: {p2:?}"
+        p2.contains("Universal Title"),
+        "stable-literal repeats are preserved on page 3 (no digit change); got {p2:?}"
     );
 }

--- a/tests/test_span_merging_config.rs
+++ b/tests/test_span_merging_config.rs
@@ -1,0 +1,73 @@
+//! Integration tests for the `merge_tm_tj_runs` opt-out flag on `SpanMergingConfig` (#488).
+//!
+//! These tests open a real PDF from `tests/fixtures/` and verify that:
+//! - `merge_tm_tj_runs: true` (default) returns a span count at most as large as
+//!   `merge_tm_tj_runs: false`.
+//! - Disabling the flag never loses text content.
+
+use pdf_oxide::document::PdfDocument;
+use pdf_oxide::extractors::SpanMergingConfig;
+
+/// Open `tests/fixtures/1.pdf` (a multi-page PDF with real text runs) and
+/// verify that disabling `merge_tm_tj_runs` yields at least as many spans as
+/// the default (merging-on) configuration.
+///
+/// The invariant: merging collapses consecutive same-line Tm+Tj runs into
+/// fewer spans, so the disabled count must be >= the enabled count.
+#[test]
+fn test_merge_tm_tj_disabled_gives_more_spans() {
+    let fixture = "tests/fixtures/1.pdf";
+    let doc = match PdfDocument::open(fixture) {
+        Ok(d) => d,
+        Err(e) => panic!("Failed to open {fixture}: {e}"),
+    };
+
+    let page_count = doc.page_count().unwrap_or(0);
+    assert!(page_count > 0, "Fixture {fixture} must have at least one page");
+
+    let config_default = SpanMergingConfig::default(); // merge_tm_tj_runs: true
+    let config_no_merge = SpanMergingConfig {
+        merge_tm_tj_runs: false,
+        ..SpanMergingConfig::default()
+    };
+
+    let mut found_text_page = false;
+
+    for page in 0..page_count {
+        let spans_merged = doc
+            .extract_spans_with_config(page, config_default.clone())
+            .expect("extract_spans_with_config (merged) failed");
+        let spans_split = doc
+            .extract_spans_with_config(page, config_no_merge.clone())
+            .expect("extract_spans_with_config (split) failed");
+
+        if spans_merged.is_empty() {
+            // Skip image-only or blank pages.
+            continue;
+        }
+        found_text_page = true;
+
+        // Text content must be identical regardless of merge flag.
+        let text_merged: String = spans_merged.iter().map(|s| s.text.as_str()).collect();
+        let text_split: String = spans_split.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(
+            text_merged, text_split,
+            "Page {page}: text content must not change when merge_tm_tj_runs is toggled"
+        );
+
+        // With merging disabled every Tm starts a fresh span, so the count
+        // must be >= the merged count (merging can only reduce the number of spans).
+        assert!(
+            spans_split.len() >= spans_merged.len(),
+            "Page {page}: expected spans_split ({}) >= spans_merged ({}) \
+             but merge_tm_tj_runs=false produced fewer spans — this is a regression",
+            spans_split.len(),
+            spans_merged.len()
+        );
+    }
+
+    assert!(
+        found_text_page,
+        "Fixture {fixture} had no pages with extractable text — pick a different fixture"
+    );
+}

--- a/tests/test_tagged_pdf_objr.rs
+++ b/tests/test_tagged_pdf_objr.rs
@@ -1,0 +1,128 @@
+//! Tests for OBJR (Object Reference) handling in structure tree parsing.
+//!
+//! PDF spec §14.7.4, Table 323: OBJR (Object Reference) entries in the /K array
+//! of a StructElem or StructTreeRoot indirectly reference StructElems via their
+//! /Obj entry. Previously these were silently dropped, causing content owned by
+//! the referenced StructElems to be missing from text extraction.
+//!
+//! Also tests that the structure tree is used for PDFs that have a /StructTreeRoot
+//! in the catalog even when /MarkInfo /Marked is absent (PDF 1.4 documents).
+
+/// Embedded hello_structure.pdf — a real-world two-page tagged PDF with:
+/// - No /MarkInfo in the catalog (PDF 1.4)
+/// - OBJR entries in both the StructTreeRoot /K array and StructElem /K arrays
+/// - Source: kreuzberg-dev/kreuzberg test corpus (public domain)
+const HELLO_STRUCTURE_PDF: &[u8] = include_bytes!("fixtures/hello_structure.pdf");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that the structure tree is loaded for PDFs without /MarkInfo.
+    /// hello_structure.pdf has a /StructTreeRoot but no /MarkInfo /Marked entry.
+    #[test]
+    fn test_tagged_pdf_without_mark_info_loads_structure_tree() {
+        let doc =
+            pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
+
+        // The document should have a structure tree even though MarkInfo is absent
+        let tree = doc.structure_tree().unwrap();
+        assert!(
+            tree.is_some(),
+            "hello_structure.pdf has a StructTreeRoot and should produce a structure tree"
+        );
+    }
+
+    /// Verify that OBJR references in /K arrays are resolved to their target StructElems.
+    /// The Section (obj 9) in hello_structure.pdf has:
+    ///   /K [10 0 R  << /Type OBJR /Pg 11 0 R /Obj 13 0 R >>]
+    /// Without OBJR handling, obj 13 (Title, MCID 1, page 1) is silently dropped.
+    #[test]
+    fn test_objr_in_struct_elem_k_array_is_resolved() {
+        let doc =
+            pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
+        let tree = doc.structure_tree().unwrap().expect("structure tree present");
+
+        // Walk the tree and collect all MCIDs and pages
+        let mut found_mcids: Vec<(u32, u32)> = Vec::new(); // (page, mcid)
+        collect_mcids(&tree.root_elements, &mut found_mcids);
+
+        // MCID 1 on page 1 (obj 13 — "Goodbye Cruel World" Title) must be found.
+        // Without OBJR fix this was silently dropped.
+        assert!(
+            found_mcids.contains(&(1, 1)),
+            "MCID 1 on page 1 (Goodbye Cruel World) should be in structure tree; \
+             found MCIDs: {:?}",
+            found_mcids
+        );
+    }
+
+    /// Verify that OBJR at the StructTreeRoot /K level is resolved.
+    /// StructTreeRoot /K = [9 0 R  << /Type OBJR /Pg 11 0 R /Obj 14 0 R >>]
+    /// Without OBJR handling, obj 14 (P element with MCID 2) is silently dropped.
+    #[test]
+    fn test_objr_at_struct_tree_root_k_level_is_resolved() {
+        let doc =
+            pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
+        let tree = doc.structure_tree().unwrap().expect("structure tree present");
+
+        let mut found_mcids: Vec<(u32, u32)> = Vec::new();
+        collect_mcids(&tree.root_elements, &mut found_mcids);
+
+        // MCID 2 on page 1 (obj 14 — "I'll be back shortly!" P element) must be found.
+        // Without OBJR fix this was silently dropped from the root K array.
+        assert!(
+            found_mcids.contains(&(1, 2)),
+            "MCID 2 on page 1 (I'll be back shortly!) should be in structure tree; \
+             found MCIDs: {:?}",
+            found_mcids
+        );
+    }
+
+    /// End-to-end: all three text strings from hello_structure.pdf must appear
+    /// in extracted text across both pages.
+    #[test]
+    fn test_hello_structure_full_text_extracted() {
+        let doc =
+            pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
+        let page_count = doc.page_count().unwrap_or(0);
+
+        let all_text: String =
+            (0..page_count).map(|i| doc.extract_text(i).unwrap_or_default()).collect::<Vec<_>>().join("\n");
+
+        assert!(
+            all_text.contains("Hello World"),
+            "page 0 text 'Hello World' missing from: {:?}",
+            all_text
+        );
+        assert!(
+            all_text.contains("Goodbye Cruel World"),
+            "page 1 heading 'Goodbye Cruel World' missing from: {:?}",
+            all_text
+        );
+        assert!(
+            all_text.contains("I'll be back shortly!") || all_text.contains("I\u{2019}ll be back shortly!"),
+            "page 1 paragraph missing from: {:?}",
+            all_text
+        );
+    }
+
+    fn collect_mcids(
+        elems: &[pdf_oxide::structure::types::StructElem],
+        out: &mut Vec<(u32, u32)>,
+    ) {
+        for elem in elems {
+            for child in &elem.children {
+                match child {
+                    pdf_oxide::structure::types::StructChild::MarkedContentRef { mcid, page } => {
+                        out.push((*page, *mcid));
+                    },
+                    pdf_oxide::structure::types::StructChild::StructElem(child_elem) => {
+                        collect_mcids(std::slice::from_ref(child_elem), out);
+                    },
+                    _ => {},
+                }
+            }
+        }
+    }
+}

--- a/tests/test_tagged_pdf_objr.rs
+++ b/tests/test_tagged_pdf_objr.rs
@@ -107,6 +107,77 @@ mod tests {
         );
     }
 
+    /// Regression test for issue #486: text-only spatial table fallback must NOT fire
+    /// on tagged PDFs.  Before the guard was added, `to_markdown` with text_fallback=true
+    /// detected the "Goodbye Cruel World" heading (page 1) as a table row and emitted
+    /// `| | Goodbye | Cruel | World... |` instead of `# Goodbye Cruel World...`.
+    ///
+    /// The fix: `extract_page_tables` returns early (no spatial detection) when the
+    /// document has a structure tree (`struct_tree_opt.is_some()`).
+    #[test]
+    fn test_tagged_pdf_to_markdown_no_false_positive_table() {
+        let doc =
+            pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
+        let options = pdf_oxide::converters::ConversionOptions::default();
+
+        // Page 1 contains "Goodbye Cruel World" as a heading element in the structure tree.
+        // With the text-only spatial fallback guard absent, this heading was mistakenly
+        // rendered as a pipe-delimited table row.
+        let md = doc.to_markdown(1, &options).expect("to_markdown page 1 should succeed");
+
+        assert!(
+            !md.contains('|'),
+            "Page 1 of hello_structure.pdf should NOT contain pipe characters (no false-positive \
+             table from spatial heuristics on a tagged PDF). Got:\n{:?}",
+            md
+        );
+        assert!(
+            md.contains("Goodbye Cruel World"),
+            "Page 1 heading text should be present in markdown. Got:\n{:?}",
+            md
+        );
+    }
+
+    /// Regression test for issue #486: text-only spatial table fallback must NOT fire
+    /// on pages where more than 30% of spans are RTL (Arabic / Hebrew).
+    ///
+    /// The fix: `extract_page_tables` computes `rtl_fraction` over `input_spans` and
+    /// returns early when `rtl_fraction > 0.30`.
+    ///
+    /// This test directly drives the RTL guard path by building a minimal set of
+    /// synthetic spans with predominantly Arabic text and asserting that
+    /// `looks_rtl` agrees they are RTL (i.e. the guard would fire), without
+    /// needing a full RTL PDF fixture.  A PDF-level integration test is gated by
+    /// `quality_gate_right_to_left_02_markdown` in test_corpus_extraction_quality.rs.
+    #[test]
+    fn test_rtl_spans_detected_by_looks_rtl_guard() {
+        // Verify that Arabic-script text is recognised as RTL by the function
+        // used in the guard.  If this fails the guard itself is broken.
+        let arabic_samples = [
+            "مرحبا",           // "Hello" in Arabic
+            "كيف حالك",        // "How are you"
+            "شكراً",           // "Thank you"
+            "\u{0628}\u{064A}\u{062A}", // بيت (house)
+        ];
+        for sample in &arabic_samples {
+            assert!(
+                pdf_oxide::text::bidi::looks_rtl(sample),
+                "looks_rtl should return true for Arabic text {:?} (used in RTL guard)",
+                sample
+            );
+        }
+
+        // Verify that LTR text is NOT flagged as RTL.
+        let ltr_samples = ["hello world", "table data", "123", ""];
+        for sample in &ltr_samples {
+            assert!(
+                !pdf_oxide::text::bidi::looks_rtl(sample),
+                "looks_rtl should return false for LTR text {:?}",
+                sample
+            );
+        }
+    }
+
     fn collect_mcids(
         elems: &[pdf_oxide::structure::types::StructElem],
         out: &mut Vec<(u32, u32)>,

--- a/tests/test_tagged_pdf_objr.rs
+++ b/tests/test_tagged_pdf_objr.rs
@@ -41,7 +41,10 @@ mod tests {
     fn test_objr_in_struct_elem_k_array_is_resolved() {
         let doc =
             pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
-        let tree = doc.structure_tree().unwrap().expect("structure tree present");
+        let tree = doc
+            .structure_tree()
+            .unwrap()
+            .expect("structure tree present");
 
         // Walk the tree and collect all MCIDs and pages
         let mut found_mcids: Vec<(u32, u32)> = Vec::new(); // (page, mcid)
@@ -64,7 +67,10 @@ mod tests {
     fn test_objr_at_struct_tree_root_k_level_is_resolved() {
         let doc =
             pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
-        let tree = doc.structure_tree().unwrap().expect("structure tree present");
+        let tree = doc
+            .structure_tree()
+            .unwrap()
+            .expect("structure tree present");
 
         let mut found_mcids: Vec<(u32, u32)> = Vec::new();
         collect_mcids(&tree.root_elements, &mut found_mcids);
@@ -87,8 +93,10 @@ mod tests {
             pdf_oxide::document::PdfDocument::from_bytes(HELLO_STRUCTURE_PDF.to_vec()).unwrap();
         let page_count = doc.page_count().unwrap_or(0);
 
-        let all_text: String =
-            (0..page_count).map(|i| doc.extract_text(i).unwrap_or_default()).collect::<Vec<_>>().join("\n");
+        let all_text: String = (0..page_count)
+            .map(|i| doc.extract_text(i).unwrap_or_default())
+            .collect::<Vec<_>>()
+            .join("\n");
 
         assert!(
             all_text.contains("Hello World"),
@@ -101,7 +109,8 @@ mod tests {
             all_text
         );
         assert!(
-            all_text.contains("I'll be back shortly!") || all_text.contains("I\u{2019}ll be back shortly!"),
+            all_text.contains("I'll be back shortly!")
+                || all_text.contains("I\u{2019}ll be back shortly!"),
             "page 1 paragraph missing from: {:?}",
             all_text
         );
@@ -123,7 +132,9 @@ mod tests {
         // Page 1 contains "Goodbye Cruel World" as a heading element in the structure tree.
         // With the text-only spatial fallback guard absent, this heading was mistakenly
         // rendered as a pipe-delimited table row.
-        let md = doc.to_markdown(1, &options).expect("to_markdown page 1 should succeed");
+        let md = doc
+            .to_markdown(1, &options)
+            .expect("to_markdown page 1 should succeed");
 
         assert!(
             !md.contains('|'),
@@ -154,9 +165,9 @@ mod tests {
         // Verify that Arabic-script text is recognised as RTL by the function
         // used in the guard.  If this fails the guard itself is broken.
         let arabic_samples = [
-            "مرحبا",           // "Hello" in Arabic
-            "كيف حالك",        // "How are you"
-            "شكراً",           // "Thank you"
+            "مرحبا",                    // "Hello" in Arabic
+            "كيف حالك",                 // "How are you"
+            "شكراً",                     // "Thank you"
             "\u{0628}\u{064A}\u{062A}", // بيت (house)
         ];
         for sample in &arabic_samples {
@@ -178,10 +189,7 @@ mod tests {
         }
     }
 
-    fn collect_mcids(
-        elems: &[pdf_oxide::structure::types::StructElem],
-        out: &mut Vec<(u32, u32)>,
-    ) {
+    fn collect_mcids(elems: &[pdf_oxide::structure::types::StructElem], out: &mut Vec<(u32, u32)>) {
         for elem in elems {
             for child in &elem.children {
                 match child {

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

v0.3.47 release branch closing the bugs surfaced by the kreuzberg
integration suite (issue [#484](https://github.com/yfedoseev/pdf_oxide/issues/484))
plus related text-extraction quality work reported by the community.
Word-F1 against the pdftotext-derived ground-truth corpus now meets the
kreuzberg quality floor for every PDF in the issue 484 set, and all 19
quality-gate Jaccard tests in `tests/test_corpus_extraction_quality.rs`
pass.

## Issues addressed

This PR addresses and closes:

- Closes #459 — RTL inline emphasis stripping in markdown extraction
- Closes #484 — kreuzberg regression suite (24 PDFs to F1 floor)
- Closes #485 — CJK fullwidth operator spacing in `to_markdown` / `to_html`
- Closes #486 — Text-only spatial fallback for line-less tables
- Closes #487 — HTML table cell rendering aligned with markdown
- Closes #488 — `extract_spans` `merge_tm_tj_runs` opt-out
- Closes #492 — `saveEncryptedToBytes` WASM `SystemTime` panic

Reported by @Goldziher (kreuzberg), @haberman, @eersis-byte.

## Spec-driven fixes

- `§9.7.5` Multi-byte CMap parsing and array-form `beginbfrange`
- `§9.10.2` `notdefrange` U+FFFD must not block Identity CID-as-Unicode fallback
- `§9.10.2` ToUnicode Priority-3 fallback guarded for composite fonts
- `§14.4` `generate_file_id` cfg-gated for `wasm32-unknown-unknown`
- `§14.7.4` `/StructTreeRoot`-only tagged PDFs (resolves `/OBJR` content items)
- `§14.8.2.3.3` Reverse-Order Show Strings — RTL inline emphasis stripping
- `§7.3.10` / `§7.7.3.4` Indirect references in `/MediaBox` / `/CropBox`

## Late-cycle hardening (post-#484)

- Reject prose / TOC / underline-annotation false-positive tables
  (`looks_like_prose_table` shape filter, ≥3-row guard on text-only
  and h-rule paths, CJK ↔ ASCII-punctuation boundary exception,
  `text_fallback: true` default restored).

## Test plan

- [x] `cargo test --tests` — all unit + integration tests pass
- [x] `tests/test_corpus_extraction_quality.rs` — 19/19 quality gates pass (up from 13)
- [x] Issue 484 corpus F1 scorer — every PDF meets its floor
- [x] 88-PDF main-vs-HEAD regression sweep — net positive (improvements outnumber regressions, no remaining catastrophes)
- [ ] Manual smoke test of `to_markdown` and `to_html` on a representative customer PDF

## Notes

See `CHANGELOG.md` for the user-facing per-bug breakdown.  Branch was
rebased on `origin/main` earlier this cycle; commit history kept
linear (no merge commits in the range).
