### PR TITLE
Release v0.3.49 — Linearized parsing, font & rendering fixes

### DIFF
--- a/.github/scripts/extract-release-notes.sh
+++ b/.github/scripts/extract-release-notes.sh
@@ -1,37 +1,120 @@
 #!/bin/bash
-# Extracts release notes for a given version from CHANGELOG.md
-# Usage: extract-release-notes.sh <version>
-# Outputs:
-#   release-title.txt  — "v0.3.5 | Performance, ..."
-#   release-notes.md   — Full body (changelog section + installation footer)
+# Extracts (or validates) release notes for a given version from CHANGELOG.md.
+#
+# Usage:
+#   extract-release-notes.sh <version>           # write release-title.txt + release-notes.md
+#   extract-release-notes.sh --check <version>   # validate only, write nothing, exit non-zero on problems
+#
+# A well-formed CHANGELOG section looks like:
+#
+#   ## [0.3.49] - 2026-05-15
+#
+#   > One-line (or multi-line) subtitle describing the release.
+#   > Continuation lines are concatenated into a single subtitle.
+#
+#   ### Fixed
+#   - ...
+#
+# The script is STRICT (issue #506): it fails loudly — instead of silently
+# producing a stale or bare title — when, for the requested version:
+#   * the `## [VERSION]` section is missing entirely, or
+#   * no `> ...` subtitle blockquote appears in that section, or
+#   * the section has no `### ` heading (i.e. it's an empty stub).
+#
+# The subtitle scan is BOUNDED to the requested version's own section, so it
+# can never scrape an older version's blockquote (the root cause of v0.3.45–
+# v0.3.47 all inheriting v0.3.44's "FIPS 140-3 compliance" title), and a
+# multi-line blockquote is concatenated rather than truncated at line 1.
 
 set -euo pipefail
 
-VERSION="$1"
+CHECK_ONLY=0
+if [ "${1:-}" = "--check" ]; then
+  CHECK_ONLY=1
+  shift
+fi
+
+VERSION="${1:?usage: extract-release-notes.sh [--check] <version>}"
 CHANGELOG="CHANGELOG.md"
 
 if [ ! -f "$CHANGELOG" ]; then
-  echo "Error: $CHANGELOG not found" >&2
+  echo "::error::$CHANGELOG not found" >&2
   exit 1
 fi
 
-# Extract subtitle from "> ..." line after version header
-SUBTITLE=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^>/{gsub(/^> */, \"\"); print; exit}" "$CHANGELOG")
-
-# Build title
-if [ -n "$SUBTITLE" ]; then
-  echo "v${VERSION} | ${SUBTITLE}" > release-title.txt
-else
-  echo "v${VERSION}" > release-title.txt
+# 1. The version section must exist. Match the bracketed token literally
+#    (string compare, not regex) so dots in the version aren't wildcards.
+if ! awk -v ver="$VERSION" '
+  /^## \[/ { s=$0; sub(/^## \[/,"",s); sub(/\].*/,"",s); if (s==ver) { found=1; exit } }
+  END      { exit(found ? 0 : 1) }
+' "$CHANGELOG"; then
+  echo "::error file=CHANGELOG.md::No '## [$VERSION]' section found in CHANGELOG.md. Add the release section (with a '> subtitle' and '### ' notes) before tagging." >&2
+  exit 1
 fi
 
-# Extract body: everything between this version's ## and the next ##
-awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" "$CHANGELOG" \
-  | sed '/^> /d' \
+# 2. Extract the subtitle: the FIRST contiguous run of '>' lines inside this
+#    version's section only. Bounded by the next '## [' header (or EOF), so a
+#    missing subtitle can never fall through to an older version's blockquote.
+#    Multi-line blockquotes are concatenated into one subtitle.
+SUBTITLE=$(awk -v ver="$VERSION" '
+  function hdrver(line,   s) { s=line; sub(/^## \[/,"",s); sub(/\].*/,"",s); return s }
+  /^## \[/ {
+    if (hdrver($0) == ver) { in_section=1; next }
+    if (in_section) exit            # reached the next version → stop
+    next
+  }
+  in_section {
+    if ($0 ~ /^>/) {
+      l=$0; sub(/^>[ \t]?/,"",l)
+      st = (st=="" ? l : st " " l)
+      seen=1
+    } else if (seen) {
+      exit                          # end of the first blockquote block
+    }
+  }
+  END { if (st != "") print st }
+' "$CHANGELOG")
+
+if [ -z "$SUBTITLE" ]; then
+  echo "::error file=CHANGELOG.md::No '> subtitle' blockquote found under '## [$VERSION]' in CHANGELOG.md. Add a one-line (or multi-line) '> ...' subtitle directly below the version header before tagging." >&2
+  exit 1
+fi
+
+# 3. The section must contain at least one '### ' heading (real notes, not a
+#    bare stub). Bounded to this version's section.
+if ! awk -v ver="$VERSION" '
+  function hdrver(line,   s) { s=line; sub(/^## \[/,"",s); sub(/\].*/,"",s); return s }
+  /^## \[/ { if (hdrver($0)==ver){in_section=1;next} if(in_section) exit; next }
+  in_section && /^### / { found=1; exit }
+  END { exit(found ? 0 : 1) }
+' "$CHANGELOG"; then
+  echo "::error file=CHANGELOG.md::Section '## [$VERSION]' has no '### ' heading — it looks like an empty stub. Add the real release notes before tagging." >&2
+  exit 1
+fi
+
+TITLE="v${VERSION} | ${SUBTITLE}"
+
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  echo "CHANGELOG OK for v${VERSION}: ${TITLE}"
+  exit 0
+fi
+
+echo "$TITLE" > release-title.txt
+
+# Extract body: everything between this version's header and the next '## [',
+# minus the subtitle blockquote lines and any leading blank line.
+awk -v ver="$VERSION" '
+  function hdrver(line,   s) { s=line; sub(/^## \[/,"",s); sub(/\].*/,"",s); return s }
+  /^## \[/ { if (hdrver($0)==ver){in_section=1;next} if(in_section) exit; next }
+  in_section { print }
+' "$CHANGELOG" \
+  | sed '/^>/d' \
   | sed '1{/^$/d}' > changelog-section.md
 
 if [ ! -s changelog-section.md ]; then
-  echo "Warning: No changelog content found for version ${VERSION}" >&2
+  echo "::error file=CHANGELOG.md::No changelog body content found for version ${VERSION}" >&2
+  rm -f changelog-section.md
+  exit 1
 fi
 
 # Build release body = changelog section + installation footer
@@ -104,3 +187,4 @@ FOOTER
 rm -f changelog-section.md
 
 echo "Generated release-title.txt and release-notes.md for v${VERSION}"
+echo "Title: ${TITLE}"

--- a/.github/scripts/extract-release-notes.sh
+++ b/.github/scripts/extract-release-notes.sh
@@ -21,10 +21,16 @@
 #   * no `> ...` subtitle blockquote appears in that section, or
 #   * the section has no `### ` heading (i.e. it's an empty stub).
 #
-# The subtitle scan is BOUNDED to the requested version's own section, so it
-# can never scrape an older version's blockquote (the root cause of v0.3.45–
-# v0.3.47 all inheriting v0.3.44's "FIPS 140-3 compliance" title), and a
+# The subtitle scan is BOUNDED to the requested version's own section AND
+# ANCHORED to the blockquote that immediately follows the version header
+# (only blank lines may sit between). So it can never scrape an older
+# version's blockquote (the root cause of v0.3.45–v0.3.47 all inheriting
+# v0.3.44's "FIPS 140-3 compliance" title), and a section that forgets its
+# top subtitle but has a body blockquote later (e.g. a "> Scope note.")
+# fails loudly instead of silently using that body note as the title. A
 # multi-line blockquote is concatenated rather than truncated at line 1.
+# Body blockquotes are preserved in the release notes — only the leading
+# subtitle block is stripped.
 
 set -euo pipefail
 
@@ -52,24 +58,30 @@ if ! awk -v ver="$VERSION" '
   exit 1
 fi
 
-# 2. Extract the subtitle: the FIRST contiguous run of '>' lines inside this
-#    version's section only. Bounded by the next '## [' header (or EOF), so a
-#    missing subtitle can never fall through to an older version's blockquote.
-#    Multi-line blockquotes are concatenated into one subtitle.
+# 2. Extract the subtitle: the contiguous run of '>' lines that IMMEDIATELY
+#    follows the version header (only blank lines may precede it). Bounded by
+#    the next '## [' header (or EOF). If the first non-blank line in the
+#    section is not a '>' blockquote, the subtitle is treated as MISSING — a
+#    body blockquote appearing later in the section (e.g. a "> Scope note.")
+#    is never mistaken for the title. Multi-line blockquotes are concatenated.
 SUBTITLE=$(awk -v ver="$VERSION" '
   function hdrver(line,   s) { s=line; sub(/^## \[/,"",s); sub(/\].*/,"",s); return s }
   /^## \[/ {
-    if (hdrver($0) == ver) { in_section=1; next }
+    if (hdrver($0) == ver) { in_section=1; pre=1; next }
     if (in_section) exit            # reached the next version → stop
     next
   }
   in_section {
+    if (pre && $0 ~ /^[ \t]*$/) next   # blank lines between header and subtitle
+    if (pre) {                         # first non-blank line in the section
+      if ($0 !~ /^>/) exit             # not a blockquote → no anchored subtitle
+      pre=0
+    }
     if ($0 ~ /^>/) {
       l=$0; sub(/^>[ \t]?/,"",l)
       st = (st=="" ? l : st " " l)
-      seen=1
-    } else if (seen) {
-      exit                          # end of the first blockquote block
+    } else {
+      exit                             # end of the subtitle blockquote
     }
   }
   END { if (st != "") print st }
@@ -102,13 +114,25 @@ fi
 echo "$TITLE" > release-title.txt
 
 # Extract body: everything between this version's header and the next '## [',
-# minus the subtitle blockquote lines and any leading blank line.
+# minus ONLY the leading subtitle block (the blank lines + the contiguous '>'
+# run immediately under the header). Body blockquotes that appear later in the
+# section (scope notes, callouts) are preserved verbatim.
 awk -v ver="$VERSION" '
   function hdrver(line,   s) { s=line; sub(/^## \[/,"",s); sub(/\].*/,"",s); return s }
-  /^## \[/ { if (hdrver($0)==ver){in_section=1;next} if(in_section) exit; next }
-  in_section { print }
+  /^## \[/ { if (hdrver($0)==ver){in_section=1;phase="lead";next} if(in_section) exit; next }
+  in_section {
+    if (phase=="lead") {
+      if ($0 ~ /^[ \t]*$/) next        # blank lines above the subtitle
+      if ($0 ~ /^>/) { phase="sub"; next }
+      phase="body"                     # defensive: no anchored subtitle
+    }
+    if (phase=="sub") {
+      if ($0 ~ /^>/) next              # subtitle blockquote line — strip
+      phase="body"                     # subtitle ended; print this line onward
+    }
+    print
+  }
 ' "$CHANGELOG" \
-  | sed '/^>/d' \
   | sed '1{/^$/d}' > changelog-section.md
 
 if [ ! -s changelog-section.md ]; then

--- a/.github/scripts/test-extract-release-notes.sh
+++ b/.github/scripts/test-extract-release-notes.sh
@@ -56,8 +56,8 @@ run_case() {
       echo "FAIL [$name]: --check disagreed (expected ok)"
       FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
     fi
-    if [ -f "$workdir/release-title.txt" ]; then
-      echo "FAIL [$name]: --check wrote release-title.txt (should be no-op)"
+    if [ -f "$workdir/release-title.txt" ] || [ -f "$workdir/release-notes.md" ]; then
+      echo "FAIL [$name]: --check wrote output (release-title.txt / release-notes.md) — should be no-op"
       FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
     fi
     echo "PASS [$name]"

--- a/.github/scripts/test-extract-release-notes.sh
+++ b/.github/scripts/test-extract-release-notes.sh
@@ -22,9 +22,9 @@ SCRIPT="$SCRIPT_DIR/extract-release-notes.sh"
 PASS=0
 FAIL=0
 
-# run_case <name> <version> <expect: ok|fail> <changelog-content-file> [expected-title]
+# run_case <name> <version> <expect: ok|fail> <changelog-content-file> [expected-title] [expected-body-substr]
 run_case() {
-  local name="$1" version="$2" expect="$3" changelog="$4" expected_title="${5:-}"
+  local name="$1" version="$2" expect="$3" changelog="$4" expected_title="${5:-}" expected_body="${6:-}"
   local workdir rc title
 
   workdir="$(mktemp -d)"
@@ -43,6 +43,11 @@ run_case() {
       echo "FAIL [$name]: title mismatch"
       echo "  expected: $expected_title"
       echo "  actual:   $title"
+      FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
+    fi
+    if [ -n "$expected_body" ] && ! grep -qF -- "$expected_body" "$workdir/release-notes.md" 2>/dev/null; then
+      echo "FAIL [$name]: release-notes.md missing expected body content"
+      echo "  expected substring: $expected_body"
       FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
     fi
     # --check must agree and write nothing.
@@ -145,7 +150,8 @@ cat > "$TMP/valid.md" <<'EOF'
 EOF
 
 # A later, separate blockquote in the section (e.g. a "> Scope note.") must
-# NOT be merged into the subtitle — only the first contiguous '>' block is.
+# NOT be merged into the subtitle — only the first contiguous '>' block is —
+# and it must be PRESERVED in the release-notes body (not stripped).
 cat > "$TMP/second_blockquote.md" <<'EOF'
 # Changelog
 
@@ -159,15 +165,30 @@ cat > "$TMP/second_blockquote.md" <<'EOF'
 > **Scope note.** This must not be appended to the subtitle.
 EOF
 
+# A section that forgot its top subtitle but has a body blockquote LATER must
+# fail loudly — the body note must never be anchored as the release title.
+cat > "$TMP/late_blockquote_no_subtitle.md" <<'EOF'
+# Changelog
+
+## [0.3.49] - 2026-05-15
+
+### Fixed
+- A real fix but no subtitle directly under the header.
+
+> **Scope note.** A body blockquote that is NOT the subtitle.
+EOF
+
 run_case "valid-single-line"      "0.3.49" ok   "$TMP/valid.md" \
   "v0.3.49 | Off-byte-0 PDF header recovery and release-automation hardening."
 run_case "multi-line-concat"      "0.3.49" ok   "$TMP/multiline.md" \
   "v0.3.49 | Text-extraction reading-order rewire — fixes [#211] and closes the [#457] refactor."
 run_case "first-block-only"       "0.3.49" ok   "$TMP/second_blockquote.md" \
-  "v0.3.49 | The real subtitle line."
+  "v0.3.49 | The real subtitle line." \
+  "> **Scope note.** This must not be appended to the subtitle."
 run_case "missing-subtitle-no-scrape" "0.3.49" fail "$TMP/no_subtitle.md"
 run_case "missing-version-section"    "0.3.49" fail "$TMP/missing_section.md"
 run_case "empty-stub-no-heading"      "0.3.49" fail "$TMP/stub.md"
+run_case "late-blockquote-not-subtitle" "0.3.49" fail "$TMP/late_blockquote_no_subtitle.md"
 
 echo
 echo "extract-release-notes regression: $PASS passed, $FAIL failed"

--- a/.github/scripts/test-extract-release-notes.sh
+++ b/.github/scripts/test-extract-release-notes.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Regression tests for extract-release-notes.sh (issue #506).
+#
+# Covers the bug classes that shipped three consecutive wrong release titles:
+#   * missing version section            → must fail loudly (not silent)
+#   * missing subtitle                   → must fail loudly (NOT scrape an
+#                                          older version's blockquote)
+#   * cross-version false-scrape         → target version w/o '>' but an
+#                                          older version has one → must fail
+#   * multi-line subtitle                → concatenated, not truncated at L1
+#   * empty stub section (no '### ')     → must fail loudly
+#   * valid single-line subtitle         → correct "vX | subtitle" title
+#   * --check mode                       → same verdicts, writes nothing
+#
+# Self-contained: no network, no cargo. Exits 0 iff every case passes.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/extract-release-notes.sh"
+
+PASS=0
+FAIL=0
+
+# run_case <name> <version> <expect: ok|fail> <changelog-content-file> [expected-title]
+run_case() {
+  local name="$1" version="$2" expect="$3" changelog="$4" expected_title="${5:-}"
+  local workdir rc title
+
+  workdir="$(mktemp -d)"
+  cp "$changelog" "$workdir/CHANGELOG.md"
+
+  ( cd "$workdir" && "$SCRIPT" "$version" ) >/dev/null 2>&1
+  rc=$?
+
+  if [ "$expect" = "ok" ]; then
+    if [ "$rc" -ne 0 ]; then
+      echo "FAIL [$name]: expected success, script exited $rc"
+      FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
+    fi
+    title="$(cat "$workdir/release-title.txt" 2>/dev/null || echo '<no title>')"
+    if [ -n "$expected_title" ] && [ "$title" != "$expected_title" ]; then
+      echo "FAIL [$name]: title mismatch"
+      echo "  expected: $expected_title"
+      echo "  actual:   $title"
+      FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
+    fi
+    # --check must agree and write nothing.
+    ( cd "$workdir" && rm -f release-title.txt release-notes.md && "$SCRIPT" --check "$version" ) >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      echo "FAIL [$name]: --check disagreed (expected ok)"
+      FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
+    fi
+    if [ -f "$workdir/release-title.txt" ]; then
+      echo "FAIL [$name]: --check wrote release-title.txt (should be no-op)"
+      FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
+    fi
+    echo "PASS [$name]"
+    PASS=$((PASS + 1))
+  else
+    if [ "$rc" -eq 0 ]; then
+      echo "FAIL [$name]: expected failure, but script succeeded (title: $(cat "$workdir/release-title.txt" 2>/dev/null))"
+      FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
+    fi
+    ( cd "$workdir" && "$SCRIPT" --check "$version" ) >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      echo "FAIL [$name]: --check should also fail but succeeded"
+      FAIL=$((FAIL + 1)); rm -rf "$workdir"; return
+    fi
+    echo "PASS [$name]"
+    PASS=$((PASS + 1))
+  fi
+  rm -rf "$workdir"
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Fixture: a CHANGELOG with multiple versions; 0.3.49 has NO subtitle but
+#     an older version (0.3.44) does. The buggy script scraped 0.3.44's line.
+cat > "$TMP/no_subtitle.md" <<'EOF'
+# Changelog
+
+## [0.3.49] - 2026-05-15
+
+### Fixed
+- Something without a subtitle blockquote.
+
+## [0.3.44] - 2026-05-05
+
+> Pluggable cryptographic provider — FIPS 140-3 compliance for
+> government / regulated deployments.
+
+### Added
+- Older release that DOES have a subtitle.
+EOF
+
+cat > "$TMP/missing_section.md" <<'EOF'
+# Changelog
+
+## [0.3.48] - 2026-05-14
+
+> Some other version.
+
+### Fixed
+- Not the version we ask for.
+EOF
+
+cat > "$TMP/multiline.md" <<'EOF'
+# Changelog
+
+## [0.3.49] - 2026-05-15
+
+> Text-extraction reading-order rewire — fixes [#211]
+> and closes the [#457] refactor.
+
+### Fixed
+- Multi-line subtitle must be concatenated, not truncated.
+EOF
+
+cat > "$TMP/stub.md" <<'EOF'
+# Changelog
+
+## [0.3.49] - 2026-05-15
+
+> A subtitle but no notes at all.
+EOF
+
+cat > "$TMP/valid.md" <<'EOF'
+# Changelog
+
+## [0.3.49] - 2026-05-15
+
+> Off-byte-0 PDF header recovery and release-automation hardening.
+
+### Fixed
+- A real fix.
+
+## [0.3.48] - 2026-05-14
+
+> An older release subtitle that must never leak upward.
+
+### Added
+- Older content.
+EOF
+
+# A later, separate blockquote in the section (e.g. a "> Scope note.") must
+# NOT be merged into the subtitle — only the first contiguous '>' block is.
+cat > "$TMP/second_blockquote.md" <<'EOF'
+# Changelog
+
+## [0.3.49] - 2026-05-15
+
+> The real subtitle line.
+
+### Added
+- Thing.
+
+> **Scope note.** This must not be appended to the subtitle.
+EOF
+
+run_case "valid-single-line"      "0.3.49" ok   "$TMP/valid.md" \
+  "v0.3.49 | Off-byte-0 PDF header recovery and release-automation hardening."
+run_case "multi-line-concat"      "0.3.49" ok   "$TMP/multiline.md" \
+  "v0.3.49 | Text-extraction reading-order rewire — fixes [#211] and closes the [#457] refactor."
+run_case "first-block-only"       "0.3.49" ok   "$TMP/second_blockquote.md" \
+  "v0.3.49 | The real subtitle line."
+run_case "missing-subtitle-no-scrape" "0.3.49" fail "$TMP/no_subtitle.md"
+run_case "missing-version-section"    "0.3.49" fail "$TMP/missing_section.md"
+run_case "empty-stub-no-heading"      "0.3.49" fail "$TMP/stub.md"
+
+echo
+echo "extract-release-notes regression: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,48 @@
+name: Changelog Gate
+
+# Refuses to merge to main / advance a release branch if the CHANGELOG
+# section for the version in Cargo.toml is missing or malformed (issue #506).
+# This makes it impossible for the release-publish workflow to ever be
+# triggered against a CHANGELOG that would yield a stale or bare release
+# title.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches:
+      - 'release/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-changelog:
+    name: Validate CHANGELOG for Cargo.toml version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Extract version from Cargo.toml
+        id: ver
+        run: |
+          VERSION=$(awk -F'"' '/^\[package\]/{p=1} p&&/^version[[:space:]]*=/{print $2; exit}' Cargo.toml)
+          if [ -z "$VERSION" ]; then
+            echo "::error file=Cargo.toml::Could not parse [package] version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Cargo.toml version: $VERSION"
+
+      - name: Validate CHANGELOG section (strict)
+        run: |
+          chmod +x .github/scripts/extract-release-notes.sh
+          .github/scripts/extract-release-notes.sh --check "${{ steps.ver.outputs.version }}"
+
+      - name: Run extract-release-notes regression tests
+        run: |
+          chmod +x .github/scripts/test-extract-release-notes.sh
+          .github/scripts/test-extract-release-notes.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,8 +755,25 @@ jobs:
       #   exports (`./builders`, `./managers`, `./errors`) don't
       #   simulate cleanly under node10's CJS resolver. Same
       #   justification.
+      #
+      # NON-BLOCKING (continue-on-error) due to an upstream attw bug, NOT a
+      # problem with our types. attw's `extractTarball`
+      # (@arethetypeswrong/core createPackage.js) does
+      # `new Gunzip((chunk) => (unzipped = chunk)).push(tgz, true)` — it keeps
+      # only the LAST fflate gunzip chunk. Any package whose *decompressed*
+      # tarball spans multiple fflate chunks (ours is ~1.16 MB / 118 files of
+      # legit .js + .d.ts) ends with an empty final chunk, so `untar` sees no
+      # files and attw crashes: "Cannot read properties of undefined (reading
+      # 'filename')". Reproduced against every attw 0.15.0–0.18.2 — there is
+      # no good version to pin, and the package can't be shrunk (no maps /
+      # tests / source are shipped; it's all real API surface). It "used to
+      # work" only while the package was small enough to fit one chunk.
+      # Every other Node-binding gate (typecheck, biome, publint, npm audit,
+      # node-gyp build, node tests) still hard-fails the job. Remove
+      # continue-on-error once attw upstream fixes the chunk handling.
       - name: arethetypeswrong (types vs runtime)
         if: matrix.os == 'ubuntu-latest'
+        continue-on-error: true
         working-directory: js
         run: >-
           npx --yes @arethetypeswrong/cli --pack .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,28 +756,41 @@ jobs:
       #   simulate cleanly under node10's CJS resolver. Same
       #   justification.
       #
-      # NON-BLOCKING (continue-on-error) due to an upstream attw bug, NOT a
-      # problem with our types. attw's `extractTarball`
-      # (@arethetypeswrong/core createPackage.js) does
-      # `new Gunzip((chunk) => (unzipped = chunk)).push(tgz, true)` — it keeps
+      # This tolerates ONLY one specific upstream attw crash, not arbitrary
+      # attw failures — a real types-vs-runtime regression still fails CI.
+      # The crash: attw's `extractTarball` (@arethetypeswrong/core
+      # createPackage.js) does
+      # `new Gunzip((chunk) => (unzipped = chunk)).push(tgz, true)`, keeping
       # only the LAST fflate gunzip chunk. Any package whose *decompressed*
       # tarball spans multiple fflate chunks (ours is ~1.16 MB / 118 files of
       # legit .js + .d.ts) ends with an empty final chunk, so `untar` sees no
-      # files and attw crashes: "Cannot read properties of undefined (reading
-      # 'filename')". Reproduced against every attw 0.15.0–0.18.2 — there is
-      # no good version to pin, and the package can't be shrunk (no maps /
-      # tests / source are shipped; it's all real API surface). It "used to
-      # work" only while the package was small enough to fit one chunk.
-      # Every other Node-binding gate (typecheck, biome, publint, npm audit,
-      # node-gyp build, node tests) still hard-fails the job. Remove
-      # continue-on-error once attw upstream fixes the chunk handling.
+      # files and attw aborts with exactly:
+      # "Cannot read properties of undefined (reading 'filename')".
+      # Reproduced against every attw 0.15.0–0.18.2 — no version to pin, and
+      # the package can't be shrunk (no maps/tests/source shipped; all real
+      # API surface). It "used to work" only while the package fit one chunk.
+      # We swallow ONLY that exact signature; any other non-zero exit (i.e. a
+      # genuine export/type problem) still fails the job, as do all other
+      # Node-binding gates. Drop this wrapper once attw fixes chunk handling.
       - name: arethetypeswrong (types vs runtime)
         if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
         working-directory: js
-        run: >-
-          npx --yes @arethetypeswrong/cli --pack .
-          --ignore-rules cjs-resolves-to-esm no-resolution internal-resolution-error
+        shell: bash
+        run: |
+          set +e
+          out="$(npx --yes @arethetypeswrong/cli --pack . \
+            --ignore-rules cjs-resolves-to-esm no-resolution internal-resolution-error 2>&1)"
+          rc=$?
+          printf '%s\n' "$out"
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+          if printf '%s' "$out" | grep -qF "Cannot read properties of undefined (reading 'filename')"; then
+            echo "::warning::attw hit the known upstream tarball-extraction bug (multi-chunk gunzip drops files); tolerated — see the comment above this step in ci.yml."
+            exit 0
+          fi
+          echo "::error::attw reported a real types-vs-runtime problem (not the known upstream crash)."
+          exit "$rc"
 
       # npm audit fails on high+ severity transitive vulns.
       - name: npm audit (prod deps, high severity)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1067,7 +1067,22 @@ jobs:
 
       - name: Read release title
         id: title
-        run: echo "title=$(cat release-title.txt)" >> $GITHUB_OUTPUT
+        # Defense-in-depth (issue #506): the extract script already fails
+        # loudly on a missing/stale subtitle, but re-validate the title shape
+        # here so a script regression can never publish a bare or wrong title.
+        run: |
+          TITLE="$(cat release-title.txt)"
+          VERSION="${{ needs.validate.outputs.version }}"
+          PREFIX="v${VERSION} | "
+          if [ "${TITLE#"$PREFIX"}" = "$TITLE" ]; then
+            echo "::error::Release title '$TITLE' does not start with expected prefix '${PREFIX}'. Check the '> subtitle' under '## [$VERSION]' in CHANGELOG.md." >&2
+            exit 1
+          fi
+          if [ "${#TITLE}" -lt 20 ]; then
+            echo "::error::Release title '$TITLE' is suspiciously short (<20 chars) — likely a missing or stub subtitle." >&2
+            exit 1
+          fi
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1113,6 +1113,9 @@ jobs:
     needs: [validate, create-release]
     runs-on: ubuntu-latest
     if: ${{ !contains(needs.validate.outputs.version, '-') }}
+    environment:
+      name: crates-io
+      url: https://crates.io/crates/pdf_oxide
     permissions:
       contents: read
     steps:
@@ -1143,6 +1146,9 @@ jobs:
     needs: [validate, build-python-wheels, create-release]
     runs-on: ubuntu-latest
     if: ${{ !contains(needs.validate.outputs.version, '-') }}
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pdf_oxide
     permissions:
       contents: read
     steps:
@@ -1171,6 +1177,9 @@ jobs:
     needs: [validate, build-wasm, create-release]
     runs-on: ubuntu-latest
     if: ${{ !contains(needs.validate.outputs.version, '-') }}
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/pdf-oxide-wasm
     permissions:
       contents: read
     steps:
@@ -1210,6 +1219,9 @@ jobs:
     needs: [validate, create-release]
     runs-on: ubuntu-latest
     if: ${{ !contains(needs.validate.outputs.version, '-') }}
+    environment:
+      name: packaging
+      url: https://github.com/yfedoseev/homebrew-tap
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -1304,6 +1316,9 @@ jobs:
     needs: [validate, build-nodejs, create-release]
     runs-on: ubuntu-latest
     if: ${{ !contains(needs.validate.outputs.version, '-') }}
+    environment:
+      name: npm-native
+      url: https://www.npmjs.com/package/pdf-oxide
     permissions:
       contents: read
     steps:
@@ -1369,6 +1384,9 @@ jobs:
     needs: [validate, build-csharp, create-release]
     runs-on: ubuntu-latest
     if: ${{ !contains(needs.validate.outputs.version, '-') }}
+    environment:
+      name: nuget
+      url: https://www.nuget.org/packages/PdfOxide
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,85 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.49] - 2026-05-15
+
+> Off-byte-0 PDF header recovery, sparse-trailer Catalog discovery,
+> a render-path thread-safety fix, and release-automation hardening.
+
+### Fixed
+
+- **Linearized PDFs with a non-zero `%PDF-` header offset
+  ([#509](https://github.com/yfedoseev/pdf_oxide/issues/509))** — files
+  whose `%PDF-` header is preceded by leading bytes (e.g. a captive-
+  portal HTML redirect injected ahead of a Linearized PDF) are now read
+  instead of rejected with `Trailer missing /Root entry`. The xref-
+  offset shift for header-offset PDFs no longer requires the final
+  trailer to carry `/Root`; xref reconstruction now rejects a parsed-
+  but-`/Root`-less trailer and falls through to Catalog discovery; and
+  `catalog()` scans for `/Type /Catalog` when the trailer omits `/Root`
+  (matching Poppler / PDFium behaviour, ISO 32000-2 §7.5.2 / 1.7
+  Implementation Note G.6).
+
+- **Render-path data race under concurrent rendering
+  ([#505](https://github.com/yfedoseev/pdf_oxide/issues/505))** — the
+  process-wide embedded-font classification cache keyed on
+  `Arc::as_ptr` could return a stale `(is_byte_indexed,
+  has_unicode_cmap)` for an unrelated font when an allocation address
+  was recycled across threads, intermittently surfacing as
+  `ParseException [1000]` from `RenderPage` / `RenderPageFit` under
+  `Parallel.ForEach`. The unsound global cache is removed; the cmap
+  classification is now computed locally per call (a cheap `ttf_parser`
+  table probe), so concurrent renders can no longer collide.
+
+- **Test helper `make_type0_font` used a non-production `Encoding`
+  variant ([#504](https://github.com/yfedoseev/pdf_oxide/issues/504))**
+  — the helper now maps `Identity-H` / `Identity-V` to
+  `Encoding::Identity` exactly as the real font parser does, so the
+  affected Type0 tests exercise the production code path instead of a
+  variant production never produces. Purely test-correctness; no user-
+  facing behaviour change.
+
+### CI / Infrastructure
+
+- **Release-notes title extraction hardened
+  ([#506](https://github.com/yfedoseev/pdf_oxide/issues/506))** —
+  `extract-release-notes.sh` now bounds the subtitle scan to the
+  requested version's section (no longer silently inheriting an older
+  version's `>` blockquote), concatenates multi-line blockquotes
+  instead of truncating at the first line, and fails loudly when the
+  version section or its subtitle is missing. A `validate-changelog`
+  PR/release-branch gate plus a release-title sanity check stop a
+  malformed CHANGELOG from ever reaching the publish step, and a self-
+  contained regression test covers the missing-section, missing-
+  subtitle, multi-line, and cross-version false-scrape cases.
+
+- **GitHub Deployments visibility for regular publishes
+  ([#493](https://github.com/yfedoseev/pdf_oxide/issues/493))** — each
+  publish job in `release.yml` (crates.io, PyPI, npm, npm-native,
+  NuGet, Homebrew/Scoop) now declares an `environment:`, so standard-
+  pipeline publishes appear under the Deployments view with their
+  artifact URL, matching what the FIPS pipeline already did.
+
+### Thanks
+
+- [@Goldziher](https://github.com/Goldziher) (kreuzberg-dev) — opened
+  [#509](https://github.com/yfedoseev/pdf_oxide/issues/509) with a clean
+  standalone reproducer (no app code), a pinned test file, a full
+  multi-engine cross-check against Poppler, and a 156-PDF corpus survey
+  that isolated this as the single legitimate file the parser rejected.
+  That report turned a vague "Linearized PDF fails" into a precise
+  header-offset + sparse-trailer root cause.
+
+The remaining fixes ([#506](https://github.com/yfedoseev/pdf_oxide/issues/506),
+[#505](https://github.com/yfedoseev/pdf_oxide/issues/505),
+[#504](https://github.com/yfedoseev/pdf_oxide/issues/504),
+[#493](https://github.com/yfedoseev/pdf_oxide/issues/493)) were surfaced
+internally while reviewing the v0.3.45–v0.3.47 release automation, the
+post-merge `main` CI runs, and the v0.3.47 PR review.
+
 ## [0.3.48] - 2026-05-14
+
+> Bidirectional PDF ↔ DOCX/PPTX/XLSX office converter integration across all seven bindings.
 
 This release lands the **office converter integration**
 ([#159](https://github.com/yfedoseev/pdf_oxide/issues/159)):
@@ -157,6 +235,8 @@ follow-up work).
   `log::log_enabled!(Level::Debug)`.
 
 ## [0.3.47] - 2026-05-11
+
+> Text-extraction quality, CJK + RTL fixes, table-detection hardening, and a WASM SystemTime fix.
 
 This release closes the remaining bugs surfaced by the kreuzberg
 integration (issue [#484](https://github.com/yfedoseev/pdf_oxide/issues/484))
@@ -380,6 +460,8 @@ kreuzberg integration test feedback loop:
 - @eersis-byte — opened #492 with the WASM `SystemTime` panic backtrace
 
 ## [0.3.46] - 2026-05-10
+
+> Extraction quality, raw RGBA output, JBIG2 decode, editor fixes, and FIPS CI hardening.
 
 ### Added
 
@@ -610,6 +692,8 @@ kreuzberg integration test feedback loop:
   regression are resolved.
 
 ## [0.3.45] - 2026-05-07
+
+> legacy-crypto gate, FIPS RSA-PKCS#1 v1.5, CJK font subsetter fix, and render_page_fit precision.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.48"
+version = "0.3.49"
 dependencies = [
  "aes 0.9.0",
  "aws-lc-rs",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.48"
+version = "0.3.49"
 dependencies = [
  "clap",
  "is-terminal",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.48"
+version = "0.3.49"
 dependencies = [
  "pdf_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.48"
+version = "0.3.49"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.48</Version>
+    <Version>0.3.49</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -52,7 +52,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion = "0.3.48"
+	fallbackVersion = "0.3.49"
 	BaseURL         = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	// cacheSubdir lives under os.UserCacheDir() — XDG_CACHE_HOME on Linux,
 	// ~/Library/Caches on macOS (Time-Machine-excluded), %LocalAppData% on

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.48"
+version = "0.3.49"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ doctest = false
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.48", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.49", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.48"
+version = "0.3.49"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.48", path = ".." }
+pdf_oxide = { version = "0.3.49", path = ".." }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.48"
+version = "0.3.49"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/document.rs
+++ b/src/document.rs
@@ -2948,8 +2948,12 @@ impl PdfDocument {
         // trailer legitimately does this (issue #509); discover the Catalog
         // by scanning indirect objects for /Type /Catalog, as Poppler /
         // PDFium do.
-        self.find_catalog_by_scan()
-            .ok_or_else(|| Error::InvalidPdf("Trailer missing /Root entry".to_string()))
+        self.find_catalog_by_scan().ok_or_else(|| {
+            Error::InvalidPdf(
+                "Trailer omits /Root and no /Type /Catalog object could be found by scanning"
+                    .to_string(),
+            )
+        })
     }
 
     /// Scan indirect objects for the document Catalog (`/Type /Catalog`).

--- a/src/document.rs
+++ b/src/document.rs
@@ -2945,9 +2945,17 @@ impl PdfDocument {
     /// Used only as a fallback when the trailer omits `/Root` (issue #509).
     /// Bounded so a pathological xref can't turn this into an unbounded
     /// scan; the Catalog is virtually always one of the first objects.
+    ///
+    /// Object numbers are scanned in ascending order. `all_object_numbers()`
+    /// is `HashMap`-backed, so iterating it directly would be a
+    /// nondeterministic order — a bounded scan over an arbitrary subset can
+    /// miss the Catalog on different runs. Sorting makes discovery
+    /// deterministic and scans low-numbered objects first, where the Catalog
+    /// conventionally lives.
     fn find_catalog_by_scan(&self) -> Option<Object> {
         const MAX_SCAN: usize = 4096;
-        let nums: Vec<u32> = self.xref.all_object_numbers().collect();
+        let mut nums: Vec<u32> = self.xref.all_object_numbers().collect();
+        nums.sort_unstable();
         let mut checked = 0usize;
         for num in nums {
             if checked >= MAX_SCAN {

--- a/src/document.rs
+++ b/src/document.rs
@@ -729,11 +729,18 @@ impl PdfDocument {
         // The xref offsets are relative to the original PDF start, but file positions are
         // shifted by header_offset bytes.
         if header_offset > 0 {
-            if let Some(root_ref) = get_root_ref_from_trailer(&trailer) {
-                if !validate_object_at_offset(&mut reader, &xref, root_ref) {
+            // Probe an object to decide whether xref offsets are off by
+            // header_offset. Prefer /Root (common case, unchanged), but a
+            // Linearized file's sparse final trailer omits it (issue #509) —
+            // fall back to the first in-use uncompressed object so the shift
+            // decision no longer depends on /Root being present.
+            let probe =
+                get_root_ref_from_trailer(&trailer).or_else(|| first_in_use_uncompressed(&xref));
+            if let Some(probe_ref) = probe {
+                if !validate_object_at_offset(&mut reader, &xref, probe_ref) {
                     log::info!(
-                        "Root object not loadable at xref offset, adjusting all offsets by header_offset={}",
-                        header_offset
+                        "Probe object {} not loadable at xref offset, adjusting all offsets by header_offset={}",
+                        probe_ref.id, header_offset
                     );
                     xref.shift_offsets(header_offset);
                 }
@@ -2918,13 +2925,52 @@ impl PdfDocument {
             .as_dict()
             .ok_or_else(|| Error::InvalidPdf("Trailer is not a dictionary".to_string()))?;
 
-        let root_ref = trailer_dict
-            .get("Root")
-            .ok_or_else(|| Error::InvalidPdf("Trailer missing /Root entry".to_string()))?
-            .as_reference()
-            .ok_or_else(|| Error::InvalidPdf("/Root is not a reference".to_string()))?;
+        if let Some(root_obj) = trailer_dict.get("Root") {
+            let root_ref = root_obj
+                .as_reference()
+                .ok_or_else(|| Error::InvalidPdf("/Root is not a reference".to_string()))?;
+            return self.load_object(root_ref);
+        }
 
-        self.load_object(root_ref)
+        // The trailer omits /Root. A Linearized file's sparse end-of-file
+        // trailer legitimately does this (issue #509); discover the Catalog
+        // by scanning indirect objects for /Type /Catalog, as Poppler /
+        // PDFium do.
+        self.find_catalog_by_scan()
+            .ok_or_else(|| Error::InvalidPdf("Trailer missing /Root entry".to_string()))
+    }
+
+    /// Scan indirect objects for the document Catalog (`/Type /Catalog`).
+    ///
+    /// Used only as a fallback when the trailer omits `/Root` (issue #509).
+    /// Bounded so a pathological xref can't turn this into an unbounded
+    /// scan; the Catalog is virtually always one of the first objects.
+    fn find_catalog_by_scan(&self) -> Option<Object> {
+        const MAX_SCAN: usize = 4096;
+        let nums: Vec<u32> = self.xref.all_object_numbers().collect();
+        let mut checked = 0usize;
+        for num in nums {
+            if checked >= MAX_SCAN {
+                break;
+            }
+            let generation = match self.xref.get(num) {
+                Some(e) if e.in_use => e.generation,
+                _ => continue,
+            };
+            checked += 1;
+            if let Ok(obj) = self.load_object(ObjectRef::new(num, generation)) {
+                if obj
+                    .as_dict()
+                    .and_then(|d| d.get("Type"))
+                    .and_then(|t| t.as_name())
+                    == Some("Catalog")
+                {
+                    log::info!("Catalog discovered by object scan: {} {} obj", num, generation);
+                    return Some(obj);
+                }
+            }
+        }
+        None
     }
 
     /// Get the structure tree (logical structure) of the document.
@@ -13231,6 +13277,16 @@ pub enum ImageFormat {
 /// Extract the /Root reference from a trailer dictionary.
 fn get_root_ref_from_trailer(trailer: &Object) -> Option<ObjectRef> {
     trailer.as_dict()?.get("Root")?.as_reference()
+}
+
+/// First in-use *uncompressed* object in the xref, used as a /Root-independent
+/// probe for the garbage-prefix offset-shift decision (issue #509). Compressed
+/// entries can't be seek-validated, so they're skipped.
+fn first_in_use_uncompressed(xref: &crate::xref::CrossRefTable) -> Option<ObjectRef> {
+    xref.all_object_numbers()
+        .filter_map(|n| xref.get(n).map(|e| (n, e)))
+        .find(|(_, e)| e.in_use && e.entry_type == crate::xref::XRefEntryType::Uncompressed)
+        .map(|(n, e)| ObjectRef::new(n, e.generation))
 }
 
 /// Heuristic: does this candidate table actually look like wrapped prose

--- a/src/document.rs
+++ b/src/document.rs
@@ -2907,9 +2907,12 @@ impl PdfDocument {
     /// # Errors
     ///
     /// Returns an error if:
-    /// - The trailer does not contain a /Root entry
-    /// - The /Root entry is not a reference
+    /// - The /Root entry is present but is not a reference
     /// - Loading the catalog object fails
+    /// - The trailer omits /Root **and** no `/Type /Catalog` object can be
+    ///   found by scanning (the issue #509 recovery path: a missing /Root is
+    ///   not itself fatal — the Catalog is discovered by object scan, as
+    ///   Poppler / PDFium do — but it does error if that scan also fails)
     ///
     /// # Example
     ///
@@ -14064,6 +14067,41 @@ mod tests {
         let doc = PdfDocument::from_bytes(pdf).unwrap();
         assert_eq!(doc.version(), (1, 4));
         assert!(doc.trailer().as_dict().is_some());
+    }
+
+    // Issue #509: catalog() must fall back to scanning indirect objects for
+    // `/Type /Catalog` when the trailer omits /Root. The public open path
+    // can't reach this — a /Root-less parsed trailer fails root validation
+    // and xref reconstruction synthesizes a /Root-bearing trailer before
+    // catalog() ever runs — so cover find_catalog_by_scan() directly: open a
+    // valid PDF, then strip /Root from the in-memory trailer and confirm
+    // catalog() still resolves the Catalog by object scan.
+    #[test]
+    fn test_catalog_recovers_when_trailer_omits_root() {
+        let mut doc = PdfDocument::from_bytes(build_minimal_pdf(b"")).unwrap();
+        // Sanity: the normal /Root path resolves the Catalog.
+        assert!(doc.catalog().is_ok());
+
+        // Drop /Root so only the indirect-object scan can find the Catalog.
+        match doc.trailer {
+            Object::Dictionary(ref mut d) => {
+                d.remove("Root");
+                assert!(d.get("Root").is_none());
+            },
+            _ => panic!("trailer is not a dictionary"),
+        }
+
+        let catalog = doc.catalog().expect(
+            "catalog() must recover the /Type /Catalog object by scan when /Root is absent",
+        );
+        assert_eq!(
+            catalog
+                .as_dict()
+                .and_then(|d| d.get("Type"))
+                .and_then(|t| t.as_name()),
+            Some("Catalog"),
+            "find_catalog_by_scan must return the actual Catalog object"
+        );
     }
 
     #[test]

--- a/src/document.rs
+++ b/src/document.rs
@@ -730,12 +730,21 @@ impl PdfDocument {
         // shifted by header_offset bytes.
         if header_offset > 0 {
             // Probe an object to decide whether xref offsets are off by
-            // header_offset. Prefer /Root (common case, unchanged), but a
-            // Linearized file's sparse final trailer omits it (issue #509) —
-            // fall back to the first in-use uncompressed object so the shift
-            // decision no longer depends on /Root being present.
-            let probe =
-                get_root_ref_from_trailer(&trailer).or_else(|| first_in_use_uncompressed(&xref));
+            // header_offset. Prefer /Root (common case), but the probe MUST
+            // be seek-validatable: `validate_object_at_offset` returns true
+            // for *compressed* entries without seeking, so a /Root that
+            // lives in an object stream would falsely report "no shift
+            // needed" and leave every uncompressed offset wrong. Use /Root
+            // only when its entry is in-use + uncompressed; otherwise (no
+            // /Root — issue #509 — or a compressed /Root) fall back to the
+            // first in-use uncompressed object.
+            let probe = get_root_ref_from_trailer(&trailer)
+                .filter(|r| {
+                    xref.get(r.id).is_some_and(|e| {
+                        e.in_use && e.entry_type == crate::xref::XRefEntryType::Uncompressed
+                    })
+                })
+                .or_else(|| first_in_use_uncompressed(&xref));
             if let Some(probe_ref) = probe {
                 if !validate_object_at_offset(&mut reader, &xref, probe_ref) {
                     log::info!(
@@ -2949,16 +2958,16 @@ impl PdfDocument {
     /// Bounded so a pathological xref can't turn this into an unbounded
     /// scan; the Catalog is virtually always one of the first objects.
     ///
-    /// Object numbers are scanned in ascending order. `all_object_numbers()`
-    /// is `HashMap`-backed, so iterating it directly would be a
-    /// nondeterministic order — a bounded scan over an arbitrary subset can
-    /// miss the Catalog on different runs. Sorting makes discovery
-    /// deterministic and scans low-numbered objects first, where the Catalog
-    /// conventionally lives.
+    /// The smallest `MAX_SCAN` object numbers are scanned, ascending.
+    /// `all_object_numbers()` is `HashMap`-backed, so iterating it directly
+    /// would be nondeterministic — a bounded scan over an arbitrary subset
+    /// can miss the Catalog on different runs. `smallest_object_numbers`
+    /// makes discovery deterministic, scans low-numbered objects first
+    /// (where the Catalog conventionally lives), and bounds the candidate
+    /// set *before* sorting so a pathological xref stays O(n log MAX_SCAN).
     fn find_catalog_by_scan(&self) -> Option<Object> {
         const MAX_SCAN: usize = 4096;
-        let mut nums: Vec<u32> = self.xref.all_object_numbers().collect();
-        nums.sort_unstable();
+        let nums = self.xref.smallest_object_numbers(MAX_SCAN);
         let mut checked = 0usize;
         for num in nums {
             if checked >= MAX_SCAN {

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -7682,7 +7682,14 @@ mod tests {
         FontInfo {
             base_font: "TestType0Font".to_string(),
             subtype: "Type0".to_string(),
-            encoding: Encoding::Standard(encoding_name.to_string()),
+            // Mirror the real parser (`parse_encoding`): a `/Identity-H` or
+            // `/Identity-V` encoding name resolves to `Encoding::Identity`, not
+            // `Encoding::Standard("Identity-H")` — production never produces the
+            // latter for an Identity name, so tests must not either (#504).
+            encoding: match encoding_name {
+                "Identity-H" | "Identity-V" => Encoding::Identity,
+                name => Encoding::Standard(name.to_string()),
+            },
             to_unicode: to_unicode_stream.map(LazyCMap::new),
             font_weight: None,
             flags: None,
@@ -7709,9 +7716,15 @@ mod tests {
 
     /// Fix A — ToUnicode present but code not covered → U+FFFD (no Priority-3 fallback).
     ///
-    /// A Type0 font with Adobe-GB1 ordering and a ToUnicode CMap covering only A–Z.
-    /// Querying code 0x0061 (not in CMap) must return U+FFFD, NOT a CJK character
-    /// that would result from the Priority-3 predefined CMap lookup.
+    /// A Type0 font with Adobe-GB1 ordering, a *non-Identity* predefined-CMap
+    /// encoding (`UniGB-UCS2-H` → `Encoding::Standard`), and a ToUnicode CMap
+    /// covering only A–Z.  The Fix-A guard is deliberately scoped to
+    /// non-Identity Type0 fonts (Identity fonts map CID→Unicode directly and
+    /// have a valid CMap-miss fallback), so the encoding here must be a real
+    /// predefined CMap — not Identity-H — for this guard to apply in
+    /// production.  Querying code 0x0061 (not in the ToUnicode CMap) must
+    /// return U+FFFD, NOT the CJK character the Priority-3 predefined CMap
+    /// lookup would otherwise produce.
     #[test]
     fn test_fix_a_tounicode_present_miss_returns_fffd_not_cjk() {
         let cid_system_info = Some(CIDSystemInfo {
@@ -7719,7 +7732,7 @@ mod tests {
             ordering: "GB1".to_string(),
             supplement: 2,
         });
-        let font = make_type0_font(Some(make_tounicode_az()), "Identity-H", cid_system_info);
+        let font = make_type0_font(Some(make_tounicode_az()), "UniGB-UCS2-H", cid_system_info);
 
         // Code 0x0061 ('a') is NOT in the ToUnicode CMap (which only covers A–Z).
         // The Priority-3 predefined CMap for Adobe-GB1 would map CID 97 to some
@@ -7742,10 +7755,11 @@ mod tests {
     /// A Type0 font with Adobe-Japan1 ordering and NO ToUnicode CMap.
     /// Querying CID 843 must return U+3042 (あ) via the predefined CMap.
     ///
-    /// The encoding must be Identity-H (not a UCS2/UTF16 variant) combined with a
-    /// non-Identity CIDSystemInfo ordering so the code reaches the
-    /// `!is_ucs2_or_utf16 && is_non_identity_ordering` branch (line ~2568) that
-    /// calls lookup_predefined_cmap directly.
+    /// `Identity-H` resolves to `Encoding::Identity` (as in production);
+    /// combined with a non-Identity CIDSystemInfo ordering (Japan1) and no
+    /// ToUnicode CMap, the lookup routes through the predefined-CMap path
+    /// (`lookup_predefined_cmap`) rather than treating the CID as a raw
+    /// Unicode code point.
     #[test]
     fn test_fix_a_no_tounicode_priority3_triggered() {
         let cid_system_info = Some(CIDSystemInfo {

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -7823,4 +7823,28 @@ mod tests {
             "Code mapping to U+0007 (BEL) must be filtered to U+FFFD by Fix B"
         );
     }
+
+    /// #504: `make_type0_font` must mirror the real `parse_encoding`
+    /// mapping. A direct guard so a future revert of the helper is caught
+    /// tightly (the Fix-A/B tests above only assert it *indirectly* via
+    /// `char_to_unicode` outcomes).
+    #[test]
+    fn test_make_type0_font_encoding_matches_parser() {
+        assert!(
+            matches!(make_type0_font(None, "Identity-H", None).encoding, Encoding::Identity),
+            "Identity-H must map to Encoding::Identity (production never yields Standard(\"Identity-H\"))"
+        );
+        assert!(
+            matches!(make_type0_font(None, "Identity-V", None).encoding, Encoding::Identity),
+            "Identity-V must map to Encoding::Identity"
+        );
+        match make_type0_font(None, "WinAnsiEncoding", None).encoding {
+            Encoding::Standard(ref n) => assert_eq!(n, "WinAnsiEncoding"),
+            other => panic!("non-Identity name must stay Encoding::Standard, got {other:?}"),
+        }
+        match make_type0_font(None, "UniGB-UCS2-H", None).encoding {
+            Encoding::Standard(ref n) => assert_eq!(n, "UniGB-UCS2-H"),
+            other => panic!("predefined CMap name must be Encoding::Standard, got {other:?}"),
+        }
+    }
 }

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -358,8 +358,10 @@ impl TextRasterizer {
                     // for this subtype so the byte→GID route is taken for every
                     // `Tj` / `TJ` call, not just the ones whose decoded Unicode
                     // happens to miss the cmap.
-                    // Classify the embedded font's cmap tables once per Arc lifetime;
-                    // subsequent calls for the same font bytes are a cheap HashMap hit.
+                    // Classify the embedded font's cmap tables. Computed
+                    // locally on every call — a cheap zero-copy `ttf_parser`
+                    // probe; the process-wide memoisation was removed as
+                    // unsound under concurrency (issue #505).
                     let (is_byte_indexed, has_unicode_cmap) = classify_embedded_font(embedded);
                     if info.subtype != "Type0" && is_byte_indexed {
                         log::debug!(

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -43,38 +43,25 @@ impl<'a> OutlineBuilder for SkiaOutlineBuilder<'a> {
     }
 }
 
-/// Classify an embedded font's cmap tables in a single parse pass and cache
-/// the result keyed on the Arc pointer (stable for the document lifetime).
+/// Classify an embedded font's cmap tables in a single parse pass.
 ///
 /// Returns `(is_byte_indexed_only, has_unicode_cmap)`:
-/// - `is_byte_indexed_only`: only Macintosh byte-indexed cmap present → use
-///   `render_cid_direct` rather than Unicode shaping.
+/// - `is_byte_indexed_only`: only a Macintosh byte-indexed cmap present →
+///   use `render_cid_direct` rather than Unicode shaping.
 /// - `has_unicode_cmap`: a Unicode/Windows cmap is present → Unicode shaping
 ///   is likely to produce non-.notdef glyphs; use `render_unicode_text`.
 ///
-/// Before this cache existed, every `render_text` call with an embedded font
-/// ran `has_byte_indexed_cmap` (one `ttf_parser::Face::parse`) **plus** a full
-/// `rustybuzz::shape` probe on the current text — so 1000 text segments on one
-/// page paid for 1000 parse + 1000 shape calls on the same font bytes. Now
-/// those are collapsed to one parse per embedded font per process.
-static EMBEDDED_FONT_CLASS: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<usize, (bool, bool)>>,
-> = std::sync::OnceLock::new();
-
+/// This is a zero-copy `ttf_parser` table probe (no glyph parsing, no
+/// shaping), cheap enough to run per call. It was previously memoised in a
+/// process-wide `HashMap` keyed on `Arc::as_ptr(data)`, but that key is
+/// unsound under concurrency: when an `Arc<Vec<u8>>` font buffer is dropped
+/// (font-cache eviction / per-page renderer reset) and the allocator
+/// recycles its address for an unrelated font, the stale entry was returned,
+/// flipping the render branch and surfacing as an intermittent
+/// `ParseException [1000]` under concurrent rendering (issue #505).
+/// Computing it locally removes the shared mutable state entirely.
 fn classify_embedded_font(data: &Arc<Vec<u8>>) -> (bool, bool) {
-    // Use the Arc's inner-pointer value as a stable key (two Arc::clones of the
-    // same allocation share the same raw pointer, so this is always a cache hit
-    // after the first call for any given font binary).
-    let key = Arc::as_ptr(data) as usize;
-    let cache =
-        EMBEDDED_FONT_CLASS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    {
-        let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(&v) = guard.get(&key) {
-            return v;
-        }
-    }
-    let result = (|| {
+    (|| {
         let face = ttf_parser::Face::parse(data, 0).ok()?;
         let cmap = face.tables().cmap?;
         let mut saw_byte_indexed = false;
@@ -92,12 +79,7 @@ fn classify_embedded_font(data: &Arc<Vec<u8>>) -> (bool, bool) {
         }
         Some((saw_byte_indexed && !saw_unicode, saw_unicode))
     })()
-    .unwrap_or((false, false));
-    cache
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .insert(key, result);
-    result
+    .unwrap_or((false, false))
 }
 
 /// Resolve a single PDF content byte to a GID by consulting the font's

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -133,6 +133,29 @@ impl CrossRefTable {
         self.entries.keys().copied()
     }
 
+    /// The `max` smallest object numbers, ascending.
+    ///
+    /// `entries` is a `HashMap`, so iteration order is nondeterministic; a
+    /// bounded scan over an arbitrary subset can miss the target. Selecting
+    /// the smallest numbers makes scans deterministic and prioritizes
+    /// low-numbered objects (where the Catalog conventionally lives). A
+    /// bounded max-heap keeps this O(n log max) time / O(max) memory rather
+    /// than sorting all n on a pathological or maliciously sparse xref.
+    pub(crate) fn smallest_object_numbers(&self, max: usize) -> Vec<u32> {
+        if max == 0 {
+            return Vec::new();
+        }
+        let mut heap: std::collections::BinaryHeap<u32> =
+            std::collections::BinaryHeap::with_capacity(max + 1);
+        for n in self.entries.keys().copied() {
+            heap.push(n);
+            if heap.len() > max {
+                heap.pop(); // drop the current largest
+            }
+        }
+        heap.into_sorted_vec()
+    }
+
     /// Merge entries from another xref table.
     ///
     /// Entries in self override entries in other (for incremental updates).

--- a/src/xref.rs
+++ b/src/xref.rs
@@ -133,21 +133,30 @@ impl CrossRefTable {
         self.entries.keys().copied()
     }
 
-    /// The `max` smallest object numbers, ascending.
+    /// The `max` smallest **in-use** object numbers, ascending.
     ///
     /// `entries` is a `HashMap`, so iteration order is nondeterministic; a
     /// bounded scan over an arbitrary subset can miss the target. Selecting
-    /// the smallest numbers makes scans deterministic and prioritizes
-    /// low-numbered objects (where the Catalog conventionally lives). A
-    /// bounded max-heap keeps this O(n log max) time / O(max) memory rather
-    /// than sorting all n on a pathological or maliciously sparse xref.
+    /// the smallest in-use numbers makes scans deterministic and prioritizes
+    /// low-numbered live objects (where the Catalog conventionally lives).
+    /// Free entries are excluded so a long low-numbered free list can't
+    /// crowd the bounded set. A bounded max-heap keeps this O(n log max)
+    /// time / O(max) memory rather than sorting all n on a pathological or
+    /// maliciously sparse xref.
     pub(crate) fn smallest_object_numbers(&self, max: usize) -> Vec<u32> {
         if max == 0 {
             return Vec::new();
         }
         let mut heap: std::collections::BinaryHeap<u32> =
             std::collections::BinaryHeap::with_capacity(max + 1);
-        for n in self.entries.keys().copied() {
+        // Only live objects are scan candidates. Traditional xref tables
+        // store free entries (the free list); a file with more than `max`
+        // low-numbered *free* objects would otherwise exhaust the bounded
+        // candidate set before any live Catalog is even considered.
+        for (&n, e) in self.entries.iter() {
+            if !e.in_use {
+                continue;
+            }
             heap.push(n);
             if heap.len() > max {
                 heap.pop(); // drop the current largest

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -202,7 +202,7 @@ fn find_trailer<R: Read + Seek>(
     // from (RE_TRAILER yields matches in ascending file order, so a later
     // offset = a more recent incremental update).
     let mut best_trailer: Option<(Object, usize)> = None;
-    // /Encrypt //ID //Info salvaged from /Root-less parsed trailers, each
+    // /Encrypt /ID /Info salvaged from /Root-less parsed trailers, each
     // tracked with the offset it came from. If no /Root-bearing trailer
     // exists and we synthesize a minimal one, an encrypted file's /Encrypt
     // (and /ID, used for the encryption key) would otherwise be lost, making
@@ -248,7 +248,7 @@ fn find_trailer<R: Read + Seek>(
         }
     }
     if let Some((mut trailer, best_off)) = best_trailer {
-        // Merge salvaged /Encrypt //ID //Info from /Root-less trailers using
+        // Merge salvaged /Encrypt /ID /Info from /Root-less trailers using
         // most-recent-occurrence-wins (ISO 32000-1 §7.5.5): a salvaged value
         // overrides the /Root-bearing trailer's only when it was parsed from
         // a *later* offset (a newer incremental update — e.g. a sparse

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -242,7 +242,20 @@ fn find_trailer<R: Read + Seek>(
             },
         }
     }
-    if let Some(trailer) = best_trailer {
+    if let Some(mut trailer) = best_trailer {
+        // A later /Root-less trailer may carry an /Encrypt //ID //Info that
+        // the chosen /Root-bearing trailer lacks (incremental update that
+        // adds encryption or rotates the file ID in a sparse trailer). Fill
+        // only the gaps so an explicit value in the /Root-bearing trailer is
+        // never clobbered, while encryption info that exists nowhere else is
+        // not lost (it is needed by `ensure_encryption_initialized`).
+        if !salvaged.is_empty() {
+            if let Object::Dictionary(d) = &mut trailer {
+                for (key, value) in &salvaged {
+                    d.entry(key.clone()).or_insert_with(|| value.clone());
+                }
+            }
+        }
         log::info!("Successfully parsed trailer dictionary (last /Root-bearing occurrence)");
         return Ok(trailer);
     }

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -207,7 +207,22 @@ fn find_trailer<R: Read + Seek>(
         let input = &contents[trailer_keyword_end..];
         match parse_object(input) {
             Ok((_, obj)) => {
-                best_trailer = Some(obj);
+                // Only accept a parsed trailer that actually carries /Root.
+                // A Linearized file's sparse end-of-file trailer legitimately
+                // omits /Root — the Catalog is reachable via the linearization
+                // parameters / first xref chain, not the trailing trailer
+                // (issue #509). Accepting a /Root-less trailer here would
+                // short-circuit Catalog discovery and fail downstream with
+                // "Trailer missing /Root entry". The *last* /Root-bearing
+                // trailer still wins, so a later revision's /Encrypt is kept.
+                if obj.as_dict().is_some_and(|d| d.get("Root").is_some()) {
+                    best_trailer = Some(obj);
+                } else {
+                    log::debug!(
+                        "Parsed trailer at offset {} has no /Root — skipping (Catalog will be located by object scan)",
+                        trailer_start
+                    );
+                }
             },
             Err(e) => {
                 log::warn!("Failed to parse trailer dictionary at offset {}: {}", trailer_start, e);
@@ -215,12 +230,16 @@ fn find_trailer<R: Read + Seek>(
         }
     }
     if let Some(trailer) = best_trailer {
-        log::info!("Successfully parsed trailer dictionary (using last valid occurrence)");
+        log::info!("Successfully parsed trailer dictionary (last /Root-bearing occurrence)");
         return Ok(trailer);
     }
 
-    // No trailer found or parsing failed - reconstruct minimal trailer
-    log::info!("Reconstructing minimal trailer dictionary...");
+    // No /Root-bearing trailer found — synthesize one by scanning objects
+    // for /Type /Catalog (handles Linearized files whose only trailer is the
+    // sparse, /Root-less end-of-file trailer).
+    log::info!(
+        "No /Root-bearing trailer found; reconstructing minimal trailer via Catalog scan..."
+    );
     reconstruct_minimal_trailer(reader, xref)
 }
 

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -199,6 +199,12 @@ fn find_trailer<R: Read + Seek>(
     // latest incremental update) takes precedence. Using the first trailer can
     // miss /Encrypt entries added in later revisions.
     let mut best_trailer: Option<Object> = None;
+    // Entries salvaged from /Root-less parsed trailers. If no /Root-bearing
+    // trailer exists and we have to synthesize a minimal one, an encrypted
+    // file's /Encrypt (and /ID, used for the encryption key) would otherwise
+    // be lost, making the document undecryptable. Last occurrence wins, for
+    // the same "latest incremental update" reason as /Root above.
+    let mut salvaged: HashMap<String, Object> = HashMap::new();
     for mat in RE_TRAILER.find_iter(contents) {
         let trailer_start = mat.start();
         log::debug!("Found trailer keyword at offset {}", trailer_start);
@@ -218,8 +224,15 @@ fn find_trailer<R: Read + Seek>(
                 if obj.as_dict().is_some_and(|d| d.get("Root").is_some()) {
                     best_trailer = Some(obj);
                 } else {
+                    if let Some(d) = obj.as_dict() {
+                        for key in ["Encrypt", "ID", "Info"] {
+                            if let Some(v) = d.get(key) {
+                                salvaged.insert(key.to_string(), v.clone());
+                            }
+                        }
+                    }
                     log::debug!(
-                        "Parsed trailer at offset {} has no /Root — skipping (Catalog will be located by object scan)",
+                        "Parsed trailer at offset {} has no /Root — skipping (Catalog located by object scan; /Encrypt /ID /Info preserved)",
                         trailer_start
                     );
                 }
@@ -240,16 +253,19 @@ fn find_trailer<R: Read + Seek>(
     log::info!(
         "No /Root-bearing trailer found; reconstructing minimal trailer via Catalog scan..."
     );
-    reconstruct_minimal_trailer(reader, xref)
+    reconstruct_minimal_trailer(reader, xref, &salvaged)
 }
 
 /// Reconstruct a minimal trailer dictionary.
 ///
 /// Scans objects to find the catalog (object with /Type /Catalog) and
-/// creates a minimal trailer with just the required entries.
+/// creates a minimal trailer with the required entries, plus any
+/// `salvaged` entries (/Encrypt, /ID, /Info) carried over from a
+/// /Root-less parsed trailer so encrypted documents remain decryptable.
 fn reconstruct_minimal_trailer<R: Read + Seek>(
     reader: &mut R,
     xref: &CrossRefTable,
+    salvaged: &HashMap<String, Object>,
 ) -> Result<Object> {
     log::debug!("Scanning objects to find catalog...");
 
@@ -257,10 +273,19 @@ fn reconstruct_minimal_trailer<R: Read + Seek>(
     // The catalog is an object with /Type /Catalog
     let mut catalog_ref = None;
 
-    // Scan through objects looking for the catalog
-    // We'll check a reasonable number of objects (up to 100)
-    for (idx, obj_num) in xref.all_object_numbers().enumerate() {
-        if idx >= 100 {
+    // Scan objects looking for the catalog. `all_object_numbers()` is
+    // `HashMap`-backed, so iterating it directly is a nondeterministic order:
+    // a bounded scan over an arbitrary subset can miss the Catalog on
+    // different runs (even for a ~114-object Linearized file). Sort ascending
+    // so the scan is deterministic and visits low-numbered objects first,
+    // where the Catalog conventionally lives. The bound only guards against a
+    // pathologically large xref.
+    const MAX_SCAN: usize = 4096;
+    let mut obj_nums: Vec<u32> = xref.all_object_numbers().collect();
+    obj_nums.sort_unstable();
+    let mut checked = 0usize;
+    for obj_num in obj_nums {
+        if checked >= MAX_SCAN {
             break;
         }
 
@@ -268,6 +293,7 @@ fn reconstruct_minimal_trailer<R: Read + Seek>(
             if !entry.in_use {
                 continue;
             }
+            checked += 1;
 
             // Try to load and check this object
             match load_object_at_offset(reader, entry.offset) {
@@ -305,6 +331,14 @@ fn reconstruct_minimal_trailer<R: Read + Seek>(
         Object::Reference(crate::object::ObjectRef::new(cat_num, cat_gen)),
     );
     trailer_dict.insert("Size".to_string(), Object::Integer(xref.len() as i64));
+
+    // Carry over /Encrypt, /ID, /Info salvaged from a skipped /Root-less
+    // trailer. Never clobber the Root/Size we just computed.
+    for (key, value) in salvaged {
+        if key != "Root" && key != "Size" {
+            trailer_dict.insert(key.clone(), value.clone());
+        }
+    }
 
     Ok(Object::Dictionary(trailer_dict))
 }

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -243,7 +243,7 @@ fn find_trailer<R: Read + Seek>(
         }
     }
     if let Some(mut trailer) = best_trailer {
-        // A later /Root-less trailer may carry an /Encrypt //ID //Info that
+        // A later /Root-less trailer may carry an /Encrypt /ID /Info that
         // the chosen /Root-bearing trailer lacks (incremental update that
         // adds encryption or rotates the file ID in a sparse trailer). Fill
         // only the gaps so an explicit value in the /Root-bearing trailer is

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -198,13 +198,18 @@ fn find_trailer<R: Read + Seek>(
     // Per ISO 32000-1:2008 Section 7.5.5, the most recent trailer (from the
     // latest incremental update) takes precedence. Using the first trailer can
     // miss /Encrypt entries added in later revisions.
-    let mut best_trailer: Option<Object> = None;
-    // Entries salvaged from /Root-less parsed trailers. If no /Root-bearing
-    // trailer exists and we have to synthesize a minimal one, an encrypted
-    // file's /Encrypt (and /ID, used for the encryption key) would otherwise
-    // be lost, making the document undecryptable. Last occurrence wins, for
-    // the same "latest incremental update" reason as /Root above.
-    let mut salvaged: HashMap<String, Object> = HashMap::new();
+    // The chosen /Root-bearing trailer plus the byte offset it was parsed
+    // from (RE_TRAILER yields matches in ascending file order, so a later
+    // offset = a more recent incremental update).
+    let mut best_trailer: Option<(Object, usize)> = None;
+    // /Encrypt //ID //Info salvaged from /Root-less parsed trailers, each
+    // tracked with the offset it came from. If no /Root-bearing trailer
+    // exists and we synthesize a minimal one, an encrypted file's /Encrypt
+    // (and /ID, used for the encryption key) would otherwise be lost, making
+    // the document undecryptable. Per ISO 32000-1 §7.5.5 the most recent
+    // occurrence wins — including over a /Root-bearing trailer that appears
+    // earlier in the file.
+    let mut salvaged: HashMap<String, (Object, usize)> = HashMap::new();
     for mat in RE_TRAILER.find_iter(contents) {
         let trailer_start = mat.start();
         log::debug!("Found trailer keyword at offset {}", trailer_start);
@@ -220,14 +225,14 @@ fn find_trailer<R: Read + Seek>(
                 // (issue #509). Accepting a /Root-less trailer here would
                 // short-circuit Catalog discovery and fail downstream with
                 // "Trailer missing /Root entry". The *last* /Root-bearing
-                // trailer still wins, so a later revision's /Encrypt is kept.
+                // trailer still wins for /Root itself.
                 if obj.as_dict().is_some_and(|d| d.get("Root").is_some()) {
-                    best_trailer = Some(obj);
+                    best_trailer = Some((obj, trailer_start));
                 } else {
                     if let Some(d) = obj.as_dict() {
                         for key in ["Encrypt", "ID", "Info"] {
                             if let Some(v) = d.get(key) {
-                                salvaged.insert(key.to_string(), v.clone());
+                                salvaged.insert(key.to_string(), (v.clone(), trailer_start));
                             }
                         }
                     }
@@ -242,17 +247,23 @@ fn find_trailer<R: Read + Seek>(
             },
         }
     }
-    if let Some(mut trailer) = best_trailer {
-        // A later /Root-less trailer may carry an /Encrypt /ID /Info that
-        // the chosen /Root-bearing trailer lacks (incremental update that
-        // adds encryption or rotates the file ID in a sparse trailer). Fill
-        // only the gaps so an explicit value in the /Root-bearing trailer is
-        // never clobbered, while encryption info that exists nowhere else is
-        // not lost (it is needed by `ensure_encryption_initialized`).
+    if let Some((mut trailer, best_off)) = best_trailer {
+        // Merge salvaged /Encrypt //ID //Info from /Root-less trailers using
+        // most-recent-occurrence-wins (ISO 32000-1 §7.5.5): a salvaged value
+        // overrides the /Root-bearing trailer's only when it was parsed from
+        // a *later* offset (a newer incremental update — e.g. a sparse
+        // trailer that adds encryption or rotates the file ID), and always
+        // fills a key the /Root-bearing trailer lacks. An earlier /Root-less
+        // value never clobbers a newer explicit one.
         if !salvaged.is_empty() {
             if let Object::Dictionary(d) = &mut trailer {
-                for (key, value) in &salvaged {
-                    d.entry(key.clone()).or_insert_with(|| value.clone());
+                for (key, (value, off)) in &salvaged {
+                    match d.get(key) {
+                        Some(_) if *off <= best_off => {}, // existing is newer/equal
+                        _ => {
+                            d.insert(key.clone(), value.clone());
+                        },
+                    }
                 }
             }
         }
@@ -266,7 +277,9 @@ fn find_trailer<R: Read + Seek>(
     log::info!(
         "No /Root-bearing trailer found; reconstructing minimal trailer via Catalog scan..."
     );
-    reconstruct_minimal_trailer(reader, xref, &salvaged)
+    let salvaged_values: HashMap<String, Object> =
+        salvaged.into_iter().map(|(k, (v, _))| (k, v)).collect();
+    reconstruct_minimal_trailer(reader, xref, &salvaged_values)
 }
 
 /// Reconstruct a minimal trailer dictionary.
@@ -287,15 +300,15 @@ fn reconstruct_minimal_trailer<R: Read + Seek>(
     let mut catalog_ref = None;
 
     // Scan objects looking for the catalog. `all_object_numbers()` is
-    // `HashMap`-backed, so iterating it directly is a nondeterministic order:
-    // a bounded scan over an arbitrary subset can miss the Catalog on
-    // different runs (even for a ~114-object Linearized file). Sort ascending
-    // so the scan is deterministic and visits low-numbered objects first,
-    // where the Catalog conventionally lives. The bound only guards against a
-    // pathologically large xref.
+    // `HashMap`-backed, so iterating it directly is nondeterministic: a
+    // bounded scan over an arbitrary subset can miss the Catalog on
+    // different runs (even for a ~114-object Linearized file).
+    // `smallest_object_numbers` is deterministic, visits low-numbered
+    // objects first (where the Catalog conventionally lives), and bounds the
+    // candidate set *before* sorting so a maliciously sparse/huge xref stays
+    // O(n log MAX_SCAN) time / O(MAX_SCAN) memory.
     const MAX_SCAN: usize = 4096;
-    let mut obj_nums: Vec<u32> = xref.all_object_numbers().collect();
-    obj_nums.sort_unstable();
+    let obj_nums = xref.smallest_object_numbers(MAX_SCAN);
     let mut checked = 0usize;
     for obj_num in obj_nums {
         if checked >= MAX_SCAN {

--- a/tests/test_concurrent_document_reads.rs
+++ b/tests/test_concurrent_document_reads.rs
@@ -209,3 +209,105 @@ fn concurrent_render_page_fit_one_shared_handle_no_spurious_parse() {
 
     assert!(failures.is_empty(), "shared-handle render race (#507): {failures:?}");
 }
+
+/// Regression for #505: concurrent renders of an **embedded-font** PDF must
+/// never raise a spurious `[1000]` parse error.
+///
+/// The C# `ThreadSafetyTests.RenderPageFit_ParallelForEach_DoesNotThrow` /
+/// `RenderPage_ParallelForEach_DoesNotThrow` flaked on `main` CI because the
+/// embedded-font cmap classifier memoised its result in a process-wide map
+/// keyed on `Arc::as_ptr(font_bytes)`. When a font `Arc<Vec<u8>>` was dropped
+/// (font-cache eviction / per-page renderer reset) and the allocator recycled
+/// its address for an unrelated font, a stale `(is_byte_indexed,
+/// has_unicode_cmap)` flipped the render branch and surfaced as
+/// `ParseException [1000]`.
+///
+/// The existing #507 guard above uses `Pdf::from_text` (Helvetica, no
+/// embedded font) so it never reached the classifier. This test mirrors the
+/// C# fixture exactly — `Pdf::from_markdown(...)`, which embeds a font — and
+/// hammers a single shared FFI handle so the classifier runs on every render
+/// across all threads. Any `ERR_PARSE` is the #505 regression.
+#[cfg(feature = "rendering")]
+#[test]
+fn concurrent_render_embedded_font_no_spurious_parse_505() {
+    use pdf_oxide::api::Pdf;
+    use std::sync::Arc;
+
+    const ERR_SUCCESS: i32 = 0;
+    const ERR_PARSE: i32 = 3;
+
+    // Identical to the C# CreateTestDoc(): a 3-page markdown PDF. Markdown
+    // rendering embeds a font, so every render exercises the embedded-font
+    // cmap classifier that #505 is about.
+    let bytes: Vec<u8> =
+        Pdf::from_markdown("# Thread Safety\n\nPage 1.\n\n---\n\nPage 2.\n\n---\n\nPage 3.")
+            .expect("build markdown PDF")
+            .into_bytes();
+
+    let mut ec: i32 = -1;
+    let doc = unsafe { pdf_document_open_from_bytes(bytes.as_ptr(), bytes.len(), &mut ec) };
+    assert_eq!(ec, ERR_SUCCESS, "open_from_bytes failed");
+    assert!(!doc.is_null(), "open_from_bytes returned null");
+    let doc_addr = doc as usize;
+
+    // Use the real page count (the C# test reads doc.PageCount the same way);
+    // markdown pagination isn't guaranteed to be 3 pages.
+    let mut ec: i32 = -1;
+    let pages = unsafe { pdf_document_get_page_count(doc, &mut ec) };
+    assert_eq!(ec, ERR_SUCCESS, "page_count failed");
+    assert!(pages >= 1, "expected at least one page, got {pages}");
+    let pages = pages as usize;
+
+    // Enough concurrent font alloc/drop churn to exercise the classifier
+    // across threads, but small render targets keep CI time bounded.
+    const THREADS: usize = 8;
+    const ITERS: usize = 40;
+
+    let barrier = Arc::new(std::sync::Barrier::new(THREADS));
+    let handles: Vec<_> = (0..THREADS)
+        .map(|t| {
+            let b = Arc::clone(&barrier);
+            std::thread::spawn(move || -> Result<(), String> {
+                let doc = doc_addr as *mut _;
+                b.wait();
+                for i in 0..ITERS {
+                    let page = (i % pages) as i32;
+                    let mut ec: i32 = -1;
+                    // Alternate the two render entry points the C# tests use.
+                    let img = if (t + i) % 2 == 0 {
+                        unsafe { pdf_render_page_fit(doc, page, 200, 260, 0, &mut ec) }
+                    } else {
+                        unsafe { pdf_render_page(doc, page, 0, &mut ec) }
+                    };
+                    if ec == ERR_PARSE {
+                        return Err(format!(
+                            "thread {t} iter {i} page {page}: spurious ERR_PARSE \
+                             ([1000]) — embedded-font classifier race (#505) regressed"
+                        ));
+                    }
+                    if ec != ERR_SUCCESS || img.is_null() {
+                        return Err(format!(
+                            "thread {t} iter {i} page {page}: render failed ec={ec}, null={}",
+                            img.is_null()
+                        ));
+                    }
+                    unsafe { pdf_rendered_image_free(img) };
+                }
+                Ok(())
+            })
+        })
+        .collect();
+
+    let mut failures = Vec::new();
+    for h in handles {
+        match h.join() {
+            Ok(Ok(())) => {},
+            Ok(Err(e)) => failures.push(e),
+            Err(_) => failures.push("render thread panicked".to_string()),
+        }
+    }
+
+    unsafe { pdf_document_free(doc) };
+
+    assert!(failures.is_empty(), "embedded-font render race (#505): {failures:?}");
+}

--- a/tests/test_concurrent_document_reads.rs
+++ b/tests/test_concurrent_document_reads.rs
@@ -258,10 +258,14 @@ fn concurrent_render_embedded_font_no_spurious_parse_505() {
     assert!(pages >= 1, "expected at least one page, got {pages}");
     let pages = pages as usize;
 
-    // Enough concurrent font alloc/drop churn to exercise the classifier
-    // across threads, but small render targets keep CI time bounded.
+    // Keep 8 threads — concurrency is the point: the #505 race only
+    // manifests with simultaneous font alloc/drop across threads. Half the
+    // iterations use `pdf_render_page`, which is a full-page 150-DPI render
+    // (not a small target), so ITERS is kept modest to bound CI cost: 8×16
+    // = 128 renders (~64 full-page of a tiny 3-page markdown doc) is ample
+    // churn for the classifier race without slowing/flaking the suite.
     const THREADS: usize = 8;
-    const ITERS: usize = 40;
+    const ITERS: usize = 16;
 
     let barrier = Arc::new(std::sync::Barrier::new(THREADS));
     let handles: Vec<_> = (0..THREADS)

--- a/tests/test_issue_509_header_offset.rs
+++ b/tests/test_issue_509_header_offset.rs
@@ -182,9 +182,11 @@ fn test_issue_509_linearized_two_trailers_keeps_root_bearing() {
         1
     );
 
-    // Same shape without the garbage prefix: regular xref parse fails on the
-    // duplicated/competing xref so reconstruction still runs; the /Root-bearing
-    // trailer must still win.
+    // Same shape without the garbage prefix: the final `startxref` points at
+    // the second (sparse, valid) xref, so the regular xref parse *succeeds*,
+    // but that final trailer has no /Root, so root validation fails and
+    // reconstruction runs anyway. The earlier /Root-bearing trailer must
+    // still win.
     let doc2 = PdfDocument::from_bytes(build_two_trailer_linearized())
         .expect("two-trailer Linearized PDF (no prefix) must load");
     assert_eq!(doc2.page_count().expect("page_count"), 1);

--- a/tests/test_issue_509_header_offset.rs
+++ b/tests/test_issue_509_header_offset.rs
@@ -115,3 +115,77 @@ fn test_issue_509_garbage_prefix_with_root_still_works() {
     let doc = PdfDocument::from_bytes(bytes).expect("garbage-prefixed /Root PDF must still load");
     assert_eq!(doc.page_count().expect("page_count"), 1);
 }
+
+/// Build a PDF with the **real Linearized shape**: an earlier `trailer`
+/// that carries `/Root` (the first-page xref chain) followed by a later,
+/// sparse end-of-file `trailer` that omits `/Root` (only `/Size` + `/ID`,
+/// exactly like the issue #509 `medium.pdf`: `<</Size 114/ID[...]>>`).
+fn build_two_trailer_linearized() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    let off3 = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> >>\nendobj\n",
+    );
+
+    let xref_off = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 4\n");
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    pdf.extend_from_slice(format!("{off1:010} 00000 n \n").as_bytes());
+    pdf.extend_from_slice(format!("{off2:010} 00000 n \n").as_bytes());
+    pdf.extend_from_slice(format!("{off3:010} 00000 n \n").as_bytes());
+
+    // FIRST trailer — carries /Root (Linearized first-chain trailer).
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n{xref_off}\n%%EOF\n").as_bytes(),
+    );
+
+    // LATER, sparse end-of-file trailer — NO /Root, only /Size + /ID,
+    // appearing *after* the /Root-bearing one in byte order. Pre-fix,
+    // `find_trailer` kept the last parsed trailer regardless of /Root, so
+    // this one clobbered the good one and the load failed with
+    // "Trailer missing /Root entry".
+    let xref2_off = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 1\n0000000000 65535 f \n");
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size 4 /ID[<AAAAAAAA><BBBBBBBB>] >>\nstartxref\n{xref2_off}\n%%EOF\n"
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+/// The discriminating #509 case: two trailers, the *later* one sparse and
+/// `/Root`-less. `find_trailer` must keep the earlier `/Root`-bearing
+/// trailer, not the last-parsed one. This is the exact real-file shape;
+/// the single-trailer tests above do NOT exercise the "skip a later
+/// `/Root`-less trailer, keep the earlier `/Root`-bearing one" logic, so a
+/// future revert of that logic would pass them while silently re-breaking
+/// the real `medium.pdf`. Garbage prefix forces the reconstruction path
+/// where `find_trailer` runs.
+#[test]
+fn test_issue_509_linearized_two_trailers_keeps_root_bearing() {
+    let mut bytes = html_redirect_garbage();
+    bytes.extend_from_slice(&build_two_trailer_linearized());
+
+    let doc = PdfDocument::from_bytes(bytes)
+        .unwrap_or_else(|e| panic!("two-trailer Linearized PDF must load (#509): {e}"));
+    assert_eq!(
+        doc.page_count().unwrap_or_else(|e| panic!(
+            "page_count failed — later /Root-less trailer wrongly won: {e}"
+        )),
+        1
+    );
+
+    // Same shape without the garbage prefix: regular xref parse fails on the
+    // duplicated/competing xref so reconstruction still runs; the /Root-bearing
+    // trailer must still win.
+    let doc2 = PdfDocument::from_bytes(build_two_trailer_linearized())
+        .expect("two-trailer Linearized PDF (no prefix) must load");
+    assert_eq!(doc2.page_count().expect("page_count"), 1);
+}

--- a/tests/test_issue_509_header_offset.rs
+++ b/tests/test_issue_509_header_offset.rs
@@ -1,0 +1,117 @@
+//! Regression tests for issue #509:
+//! "Rejects Linearized PDF when %PDF- header is offset from byte 0".
+//!
+//! Two independent defects, either of which sank the kreuzberg `medium.pdf`
+//! corpus file (a Linearized PDF whose `%PDF-` header is preceded by ~364
+//! bytes of captive-portal HTML, and whose sparse final trailer legitimately
+//! omits `/Root`):
+//!
+//!   1. The garbage-prefix xref-offset shift was gated on the final trailer
+//!      carrying `/Root` — so a `/Root`-less trailer skipped the shift.
+//!   2. xref reconstruction accepted a parsed-but-`/Root`-less trailer
+//!      instead of falling through to Catalog discovery, and `catalog()`
+//!      had no fallback when the trailer omitted `/Root`.
+//!
+//! These build inline PDFs whose xref offsets are *logical* (relative to the
+//! `%PDF-` position), then optionally prepend leading garbage — exactly the
+//! shape of the real file — so no 245 KB external fixture is needed.
+
+use pdf_oxide::document::PdfDocument;
+
+/// Build a minimal single-page PDF whose internal byte offsets are all
+/// relative to the `%PDF-` header (logical byte 0). `with_root` controls
+/// whether the final trailer dict carries `/Root` (a Linearized file's
+/// sparse end-of-file trailer legitimately omits it).
+fn build_logical_pdf(with_root: bool) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> >>\nendobj\n",
+    );
+
+    let xref_off = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 4\n");
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    pdf.extend_from_slice(format!("{:010} 00000 n \n", off1).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 00000 n \n", off2).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 00000 n \n", off3).as_bytes());
+
+    let trailer = if with_root {
+        format!("trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n{xref_off}\n%%EOF\n")
+    } else {
+        // Sparse Linearized-style trailer: NO /Root.
+        format!("trailer\n<< /Size 4 >>\nstartxref\n{xref_off}\n%%EOF\n")
+    };
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+/// ~380 bytes of injected captive-portal HTML, mirroring the real file's
+/// `dnserrorassist.att.net` redirect blob. Long enough that the xref
+/// keyword-tolerance scan cannot bridge it.
+fn html_redirect_garbage() -> Vec<u8> {
+    let mut g = Vec::new();
+    g.extend_from_slice(
+        b"<html><head><meta http-equiv=\"refresh\" content=\"0;url=http://dnserrorassist.example.net/redirect?\
+          orig=http://example.org/medium.pdf\"></head><body>\
+          <script type=\"text/javascript\">window.location=\"http://dnserrorassist.example.net/redirect\";</script>\
+          <p>Your DNS request has been redirected by your network provider. \
+          If you are not redirected automatically, follow the link.</p>\
+          </body></html>\n",
+    );
+    g
+}
+
+/// The full #509 scenario: leading garbage AND a sparse final trailer that
+/// omits `/Root`. Before the fix this failed with
+/// "Invalid PDF: Trailer missing /Root entry".
+#[test]
+fn test_issue_509_garbage_prefix_sparse_trailer() {
+    let mut bytes = html_redirect_garbage();
+    let offset = bytes.len();
+    bytes.extend_from_slice(&build_logical_pdf(false));
+
+    let doc = PdfDocument::from_bytes(bytes)
+        .unwrap_or_else(|e| panic!("from_bytes failed for garbage-prefixed PDF: {e}"));
+
+    let (major, minor) = doc.version();
+    assert_eq!((major, minor), (1, 4), "header parsed from offset {offset}");
+
+    let pages = doc
+        .page_count()
+        .unwrap_or_else(|e| panic!("page_count failed (issue #509 regression): {e}"));
+    assert_eq!(pages, 1, "single-page PDF must report 1 page");
+}
+
+/// Isolates the `catalog()` Catalog-discovery fallback: a well-formed PDF
+/// (no leading garbage) whose final trailer omits `/Root`. The Catalog is
+/// still discoverable by scanning objects for `/Type /Catalog`, which is
+/// what Poppler / PDFium do.
+#[test]
+fn test_issue_509_catalog_fallback_when_trailer_omits_root() {
+    let doc = PdfDocument::from_bytes(build_logical_pdf(false))
+        .expect("from_bytes failed for /Root-less trailer PDF");
+
+    let pages = doc
+        .page_count()
+        .expect("page_count must recover via /Type /Catalog scan when trailer omits /Root");
+    assert_eq!(pages, 1);
+}
+
+/// Regression guard: a garbage-prefixed PDF whose trailer DOES carry `/Root`
+/// must keep working (the existing header-offset path must not regress).
+#[test]
+fn test_issue_509_garbage_prefix_with_root_still_works() {
+    let mut bytes = html_redirect_garbage();
+    bytes.extend_from_slice(&build_logical_pdf(true));
+
+    let doc = PdfDocument::from_bytes(bytes).expect("garbage-prefixed /Root PDF must still load");
+    assert_eq!(doc.page_count().expect("page_count"), 1);
+}

--- a/tests/test_issue_509_header_offset.rs
+++ b/tests/test_issue_509_header_offset.rs
@@ -90,10 +90,15 @@ fn test_issue_509_garbage_prefix_sparse_trailer() {
     assert_eq!(pages, 1, "single-page PDF must report 1 page");
 }
 
-/// Isolates the `catalog()` Catalog-discovery fallback: a well-formed PDF
-/// (no leading garbage) whose final trailer omits `/Root`. The Catalog is
-/// still discoverable by scanning objects for `/Type /Catalog`, which is
-/// what Poppler / PDFium do.
+/// A well-formed PDF (no leading garbage) whose final trailer omits
+/// `/Root`. NOTE: this exercises the *xref-reconstruction* Catalog
+/// synthesis path, not `catalog()`'s `find_catalog_by_scan` fallback —
+/// the public open path fails root validation on the `/Root`-less trailer
+/// and reconstructs a `/Root`-bearing trailer before `catalog()` runs
+/// (the `catalog()` fallback itself is covered by the unit test
+/// `document::tests::test_catalog_recovers_when_trailer_omits_root`).
+/// Either way the Catalog is discovered by scanning objects for
+/// `/Type /Catalog`, which is what Poppler / PDFium do.
 #[test]
 fn test_issue_509_catalog_fallback_when_trailer_omits_root() {
     let doc = PdfDocument::from_bytes(build_logical_pdf(false))

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Release **v0.3.49**: workspace bumped 0.3.48 → 0.3.49 across all manifests, plus fixes for 5 GitHub issues (TDD, full local CI verification).

## Closes

Merging this PR into `main` closes:

- Closes #509
- Closes #505
- Closes #504
- Closes #506
- Closes #493

| Issue | Area | Fix |
|------|------|-----|
| **#509** | parser | Accept Linearized PDFs with garbage-before-`%PDF-` / sparse `/Root`-less trailer: `/Root`-independent offset-shift probe, `find_trailer` skips `/Root`-less parsed trailers → Catalog scan, bounded `/Type /Catalog` discovery fallback. Verified against the real ticket file. |
| **#505** | rendering | Remove the unsound `Arc::as_ptr`-keyed process-wide `EMBEDDED_FONT_CLASS` cache; classification now computed locally. |
| **#504** | fonts | `make_type0_font` test helper now maps `Identity-H/V` → `Encoding::Identity` like the real parser. |
| **#506** | ci | Rewrote `extract-release-notes.sh` (bounded scan, fail-loud, `--check`), added regression suite + changelog PR gate + release title sanity check. |
| **#493** | ci | Added `environment:` blocks to all 6 publish jobs in `release.yml`. |

## Commits

- `chore(release)` bump workspace to 0.3.49
- `fix(fonts)` map Identity-H/V to Encoding::Identity in test helper (#504)
- `fix(rendering)` remove unsound Arc-pointer font-class cache (#505)
- `fix(parser)` accept Linearized PDFs with offset header / sparse trailer (#509)
- `ci(release-notes)` bound subtitle scan + fail-loud + PR gate (#506)
- `ci(release)` add environment: to regular publish jobs (#493)
- `docs(changelog)` 0.3.49 release notes + contributor credits
- `test(parser)` cover the multi-trailer Linearized shape (#509)
- `test(fonts)` direct guard that make_type0_font mirrors parse_encoding (#504)

## Test plan

- [ ] All 5 required checks green (Format Check, Clippy, Test ubuntu-latest stable, Security Audit, Dependency Check cargo-deny)
- [ ] `cargo test --lib` passes (locally 5023/0)
- [ ] #509 header-offset suite 3/3 + multi-trailer regression
- [ ] Concurrency stress (#505) 4/4
- [ ] Release-notes extraction regression 6/6
- [ ] CHANGELOG `> ` subtitle present for 0.3.49 (becomes the GitHub Release title)
