### PR TITLE
feat(extractors): expose Optional Content Group (PDF layer) name on extracted paths

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -9854,12 +9854,108 @@ impl PdfDocument {
                     }
                 },
 
+                // Marked content operators — maintain the active Optional
+                // Content Group (PDF "layer") so each finalized path gets
+                // tagged with the OCG it was emitted under. Per ISO 32000-1
+                // §14.6, every `BDC`/`BMC` must be balanced by an `EMC`,
+                // so we always push (with `None` for non-`/OC` tags) and
+                // always pop — keeps the stack depth in sync with the
+                // marked-content nesting.
+                Operator::BeginMarkedContent { .. } => {
+                    extractor.push_oc_layer(None);
+                },
+                Operator::BeginMarkedContentDict { tag, properties } => {
+                    let layer = if tag == "OC" {
+                        self.resolve_oc_layer_name(page_dict, &properties)
+                    } else {
+                        None
+                    };
+                    extractor.push_oc_layer(layer);
+                },
+                Operator::EndMarkedContent => {
+                    extractor.pop_oc_layer();
+                },
+
                 // Skip other operators (text, images, etc.)
                 _ => {},
             }
         }
 
         Ok(extractor.finish())
+    }
+
+    /// Resolve a `BDC /OC <properties>` property operand to the human-readable
+    /// `/Name` of the Optional Content Group it refers to (PDF spec
+    /// ISO 32000-1:2008 §8.11, §14.6).
+    ///
+    /// `properties` is the operand parsed by `Operator::BeginMarkedContentDict`
+    /// — per spec it is either:
+    ///
+    /// 1. An inline dictionary: read its `/Name` entry directly.
+    /// 2. A name (e.g. `/MC0`) that references `page_dict /Resources
+    ///    /Properties <name>` → an indirect ref to an OCG dictionary → read
+    ///    its `/Name` entry.
+    ///
+    /// Returns `None` for malformed PDFs, missing `/Resources /Properties`
+    /// entries, or OCG objects without a `/Name`. Callers treat `None` as
+    /// "path belongs to no named layer" — extraction continues normally.
+    fn resolve_oc_layer_name(
+        &self,
+        page_dict: &std::collections::HashMap<String, crate::object::Object>,
+        properties: &crate::object::Object,
+    ) -> Option<String> {
+        use crate::object::Object;
+
+        // Helper to pull a UTF-8 `/Name` (decoded as a PDF text string) out
+        // of an OCG-like dictionary. OCG `/Name` is a string (§8.11.2.1),
+        // not a `/Name` PDF name.
+        fn read_name_field(dict: &std::collections::HashMap<String, Object>) -> Option<String> {
+            let name_obj = dict.get("Name")?;
+            match name_obj {
+                Object::String(bytes) => {
+                    // PDF spec: text strings may be PDFDocEncoding or UTF-16BE
+                    // with BOM. Detect BOM; otherwise treat as latin-1.
+                    if bytes.starts_with(&[0xFE, 0xFF]) {
+                        let u16s: Vec<u16> = bytes[2..]
+                            .chunks_exact(2)
+                            .map(|c| u16::from_be_bytes([c[0], c[1]]))
+                            .collect();
+                        String::from_utf16(&u16s).ok()
+                    } else {
+                        Some(bytes.iter().map(|&b| b as char).collect())
+                    }
+                },
+                Object::Name(s) => Some(s.clone()),
+                _ => None,
+            }
+        }
+
+        // Case 1: inline dictionary — read /Name directly.
+        if let Some(dict) = properties.as_dict() {
+            return read_name_field(dict);
+        }
+
+        // Case 2: name reference — look up page /Resources /Properties.
+        let prop_name = properties.as_name()?;
+        let resources = page_dict.get("Resources")?;
+        let resources_obj = if let Some(r) = resources.as_reference() {
+            self.load_object(r).ok()?
+        } else {
+            resources.clone()
+        };
+        let properties_dict = resources_obj.as_dict()?.get("Properties")?;
+        let properties_obj = if let Some(r) = properties_dict.as_reference() {
+            self.load_object(r).ok()?
+        } else {
+            properties_dict.clone()
+        };
+        let target = properties_obj.as_dict()?.get(prop_name)?;
+        let target_obj = if let Some(r) = target.as_reference() {
+            self.load_object(r).ok()?
+        } else {
+            target.clone()
+        };
+        read_name_field(target_obj.as_dict()?)
     }
 
     /// Extract rectangles from a page (v0.3.14).

--- a/src/document.rs
+++ b/src/document.rs
@@ -9866,7 +9866,7 @@ impl PdfDocument {
                 },
                 Operator::BeginMarkedContentDict { tag, properties } => {
                     let layer = if tag == "OC" {
-                        self.resolve_oc_layer_name(page_dict, &properties)
+                        self.resolve_oc_layer_name(extractor.current_resources(), &properties)
                     } else {
                         None
                     };
@@ -9885,77 +9885,106 @@ impl PdfDocument {
     }
 
     /// Resolve a `BDC /OC <properties>` property operand to the human-readable
-    /// `/Name` of the Optional Content Group it refers to (PDF spec
+    /// layer name of the Optional Content it refers to (PDF spec
     /// ISO 32000-1:2008 §8.11, §14.6).
     ///
     /// `properties` is the operand parsed by `Operator::BeginMarkedContentDict`
     /// — per spec it is either:
     ///
-    /// 1. An inline dictionary: read its `/Name` entry directly.
-    /// 2. A name (e.g. `/MC0`) that references `page_dict /Resources
-    ///    /Properties <name>` → an indirect ref to an OCG dictionary → read
-    ///    its `/Name` entry.
+    /// 1. An inline dictionary: an OCG (or OCMD) — read its name directly.
+    /// 2. A name (e.g. `/MC0`) that references `<resources> /Properties
+    ///    <name>` → an OCG or OCMD dictionary → read its name.
+    ///
+    /// `resources` is the resource dictionary currently in scope: the page
+    /// `/Resources` at page level, or the active Form XObject's own
+    /// `/Resources` when extracting inside an XObject (§14.6.2, §8.10.1).
     ///
     /// Returns `None` for malformed PDFs, missing `/Resources /Properties`
-    /// entries, or OCG objects without a `/Name`. Callers treat `None` as
-    /// "path belongs to no named layer" — extraction continues normally.
+    /// entries, or optional-content objects without a resolvable name.
+    /// Callers treat `None` as "path belongs to no named layer" — extraction
+    /// continues normally.
     fn resolve_oc_layer_name(
         &self,
-        page_dict: &std::collections::HashMap<String, crate::object::Object>,
+        resources: Option<&crate::object::Object>,
         properties: &crate::object::Object,
+    ) -> Option<String> {
+        const OC_NAME_MAX_DEPTH: u8 = 8;
+
+        // Case 1: inline dictionary — the property list itself is the OCG (or
+        // OCMD) dictionary.
+        if let Some(dict) = properties.as_dict() {
+            return self.read_oc_name(dict, OC_NAME_MAX_DEPTH);
+        }
+
+        // Case 2: name reference (e.g. `/MC0`) — resolve through the current
+        // resource dict's `/Properties` subdictionary.
+        let prop_name = properties.as_name()?;
+        let resources_obj = self.deref_object(resources?)?;
+        let properties_dict = resources_obj.as_dict()?.get("Properties")?;
+        let properties_obj = self.deref_object(properties_dict)?;
+        let target = properties_obj.as_dict()?.get(prop_name)?;
+        let target_obj = self.deref_object(target)?;
+        self.read_oc_name(target_obj.as_dict()?, OC_NAME_MAX_DEPTH)
+    }
+
+    /// Read the human-readable layer name from an Optional Content dictionary.
+    ///
+    /// - An **OCG** (§8.11.2.1) carries its label in `/Name` — a PDF *text
+    ///   string*, decoded via [`Self::decode_pdf_text_string`] so
+    ///   PDFDocEncoding (Annex D) and UTF-16 (BE/LE, with BOM) layer names
+    ///   round-trip identically to the rest of the library.
+    /// - An **OCMD** (§8.11.3.2, Table 99) has no `/Name` of its own; its
+    ///   member OCGs live in `/OCGs`, which is *either* a single OCG *or* an
+    ///   array of them (array entries may be `null`). We follow the first
+    ///   entry that resolves to a dictionary and read its name.
+    ///
+    /// `depth` bounds the `/OCGs` chain so a malformed PDF whose membership
+    /// dictionary points back to another OCMD cannot recurse forever.
+    /// Returns `None` for missing / non-dictionary / nameless inputs — the
+    /// path is simply left unlabelled.
+    fn read_oc_name(
+        &self,
+        dict: &std::collections::HashMap<String, crate::object::Object>,
+        depth: u8,
     ) -> Option<String> {
         use crate::object::Object;
 
-        // Helper to pull a UTF-8 `/Name` (decoded as a PDF text string) out
-        // of an OCG-like dictionary. OCG `/Name` is a string (§8.11.2.1),
-        // not a `/Name` PDF name.
-        fn read_name_field(dict: &std::collections::HashMap<String, Object>) -> Option<String> {
-            let name_obj = dict.get("Name")?;
-            match name_obj {
-                Object::String(bytes) => {
-                    // PDF spec: text strings may be PDFDocEncoding or UTF-16BE
-                    // with BOM. Detect BOM; otherwise treat as latin-1.
-                    if bytes.starts_with(&[0xFE, 0xFF]) {
-                        let u16s: Vec<u16> = bytes[2..]
-                            .chunks_exact(2)
-                            .map(|c| u16::from_be_bytes([c[0], c[1]]))
-                            .collect();
-                        String::from_utf16(&u16s).ok()
-                    } else {
-                        Some(bytes.iter().map(|&b| b as char).collect())
-                    }
-                },
-                Object::Name(s) => Some(s.clone()),
-                _ => None,
-            }
+        if depth == 0 {
+            return None;
         }
 
-        // Case 1: inline dictionary — read /Name directly.
-        if let Some(dict) = properties.as_dict() {
-            return read_name_field(dict);
+        // OCMD: no /Name of its own — follow /OCGs to the first member OCG.
+        if matches!(dict.get("Type").and_then(|t| t.as_name()), Some("OCMD")) {
+            let ocgs = self.deref_object(dict.get("OCGs")?)?;
+            let first_ocg = match ocgs.as_array() {
+                // /OCGs as an array: first entry that derefs to a dictionary.
+                Some(entries) => entries
+                    .iter()
+                    .find_map(|e| self.deref_object(e).filter(|o| o.as_dict().is_some())),
+                // /OCGs as a single OCG (already a dictionary).
+                None => Some(ocgs.clone()),
+            };
+            return self.read_oc_name(first_ocg?.as_dict()?, depth - 1);
         }
 
-        // Case 2: name reference — look up page /Resources /Properties.
-        let prop_name = properties.as_name()?;
-        let resources = page_dict.get("Resources")?;
-        let resources_obj = if let Some(r) = resources.as_reference() {
-            self.load_object(r).ok()?
-        } else {
-            resources.clone()
-        };
-        let properties_dict = resources_obj.as_dict()?.get("Properties")?;
-        let properties_obj = if let Some(r) = properties_dict.as_reference() {
-            self.load_object(r).ok()?
-        } else {
-            properties_dict.clone()
-        };
-        let target = properties_obj.as_dict()?.get(prop_name)?;
-        let target_obj = if let Some(r) = target.as_reference() {
-            self.load_object(r).ok()?
-        } else {
-            target.clone()
-        };
-        read_name_field(target_obj.as_dict()?)
+        // OCG (or inline property dict): /Name is a PDF text string.
+        match dict.get("Name")? {
+            Object::String(bytes) => Some(Self::decode_pdf_text_string(bytes)),
+            // Tolerate a /Name written as a PDF name object (non-conformant,
+            // but seen in real exports).
+            Object::Name(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+
+    /// Dereference one level of indirection, loading the target object;
+    /// pass direct objects through unchanged. `None` if a reference fails to
+    /// load — callers treat that as "unresolvable, leave unlabelled".
+    fn deref_object(&self, obj: &crate::object::Object) -> Option<crate::object::Object> {
+        match obj.as_reference() {
+            Some(r) => self.load_object(r).ok(),
+            None => Some(obj.clone()),
+        }
     }
 
     /// Extract rectangles from a page (v0.3.14).
@@ -10236,6 +10265,10 @@ impl PdfDocument {
             None
         };
 
+        // Remember the marked-content nesting depth on entry so we can drop
+        // anything this XObject leaves unbalanced (see truncate below).
+        let oc_base_depth = extractor.oc_layer_depth();
+
         // Process operators from the XObject
         for op in operators {
             match op {
@@ -10361,6 +10394,28 @@ impl PdfDocument {
                     }
                 },
 
+                // Marked content — same Optional Content Group ("layer")
+                // tracking as the page-level loop, but `/OC` property
+                // references resolve against *this* XObject's resource scope
+                // (swapped in above), per §14.6.2 + §8.10.1. CAD exports that
+                // reuse Form XObjects for repeated symbols (gridline labels,
+                // callouts) carry their `/OC` markers and local `/Properties`
+                // here rather than on the page.
+                Operator::BeginMarkedContent { .. } => {
+                    extractor.push_oc_layer(None);
+                },
+                Operator::BeginMarkedContentDict { tag, properties } => {
+                    let layer = if tag == "OC" {
+                        self.resolve_oc_layer_name(extractor.current_resources(), &properties)
+                    } else {
+                        None
+                    };
+                    extractor.push_oc_layer(layer);
+                },
+                Operator::EndMarkedContent => {
+                    extractor.pop_oc_layer();
+                },
+
                 // Skip other operators
                 _ => {},
             }
@@ -10370,6 +10425,10 @@ impl PdfDocument {
         if extractor.has_current_path() {
             extractor.end_path();
         }
+
+        // Drop any marked-content entries this XObject left open so an
+        // unbalanced `BDC` cannot leak its layer onto the caller's paths.
+        extractor.truncate_oc_layers(oc_base_depth);
 
         // Restore the caller's resource scope before popping the cycle guard.
         if let Some(saved) = saved_scope {
@@ -18956,5 +19015,156 @@ mod tests {
 
         let texts: Vec<&str> = spans.iter().map(|s| s.text.as_str()).collect();
         assert_eq!(texts, vec!["September", "11", "th"]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Optional Content (PDF "layer") name resolution — OCG `/Name` decoding,
+    // OCMD `/OCGs` following, and the `/Properties` name-reference path
+    // against the current resource scope. ISO 32000-1:2008 §8.11, §14.6.
+    //
+    // The resolver methods are `&self` only to reach `load_object` for
+    // indirect references; these tests use direct objects, so a throwaway
+    // minimal PDF serves purely as the method receiver.
+    // ─────────────────────────────────────────────────────────────────────
+
+    fn oc_test_doc() -> PdfDocument {
+        PdfDocument::from_bytes(build_minimal_pdf(b"")).unwrap()
+    }
+
+    fn ocg_dict(name: Object) -> Object {
+        let mut d = std::collections::HashMap::new();
+        d.insert("Type".to_string(), Object::Name("OCG".to_string()));
+        d.insert("Name".to_string(), name);
+        Object::Dictionary(d)
+    }
+
+    fn ocmd_dict(ocgs: Object) -> Object {
+        let mut d = std::collections::HashMap::new();
+        d.insert("Type".to_string(), Object::Name("OCMD".to_string()));
+        d.insert("OCGs".to_string(), ocgs);
+        Object::Dictionary(d)
+    }
+
+    fn utf16_string(s: &str, big_endian: bool) -> Object {
+        let mut bytes = if big_endian {
+            vec![0xFE, 0xFF]
+        } else {
+            vec![0xFF, 0xFE]
+        };
+        for u in s.encode_utf16() {
+            if big_endian {
+                bytes.extend_from_slice(&u.to_be_bytes());
+            } else {
+                bytes.extend_from_slice(&u.to_le_bytes());
+            }
+        }
+        Object::String(bytes)
+    }
+
+    #[test]
+    fn test_oc_name_ocg_ascii() {
+        let doc = oc_test_doc();
+        let dict = ocg_dict(Object::String(b"A-GRID".to_vec()));
+        assert_eq!(doc.read_oc_name(dict.as_dict().unwrap(), 8).as_deref(), Some("A-GRID"));
+    }
+
+    #[test]
+    fn test_oc_name_ocg_utf16le_bom() {
+        // Regression for the reuse of decode_pdf_text_string: the previous
+        // inline reader only handled UTF-16BE and fell back to latin-1,
+        // mangling UTF-16LE-encoded layer names. The shared helper decodes
+        // the LE BOM correctly.
+        let doc = oc_test_doc();
+        let dict = ocg_dict(utf16_string("ÁREA-Ø", false));
+        assert_eq!(doc.read_oc_name(dict.as_dict().unwrap(), 8).as_deref(), Some("ÁREA-Ø"));
+    }
+
+    #[test]
+    fn test_oc_name_ocg_utf16be_bom() {
+        let doc = oc_test_doc();
+        let dict = ocg_dict(utf16_string("EJES", true));
+        assert_eq!(doc.read_oc_name(dict.as_dict().unwrap(), 8).as_deref(), Some("EJES"));
+    }
+
+    #[test]
+    fn test_oc_name_ocmd_single_ocg() {
+        // OCMD has no /Name — resolution follows /OCGs (single OCG) to its name.
+        let doc = oc_test_doc();
+        let ocmd = ocmd_dict(ocg_dict(Object::String(b"M-DUCT".to_vec())));
+        assert_eq!(doc.read_oc_name(ocmd.as_dict().unwrap(), 8).as_deref(), Some("M-DUCT"));
+    }
+
+    #[test]
+    fn test_oc_name_ocmd_ocgs_array_first_wins() {
+        // /OCGs may be an array of OCGs; the first resolvable member wins.
+        let doc = oc_test_doc();
+        let arr = Object::Array(vec![
+            ocg_dict(Object::String(b"S-COLS".to_vec())),
+            ocg_dict(Object::String(b"S-BEAM".to_vec())),
+        ]);
+        let ocmd = ocmd_dict(arr);
+        assert_eq!(doc.read_oc_name(ocmd.as_dict().unwrap(), 8).as_deref(), Some("S-COLS"));
+    }
+
+    #[test]
+    fn test_oc_name_ocmd_depth_guard() {
+        // A pathological OCMD chain (each /OCGs points to another OCMD) must
+        // terminate via the depth guard rather than recursing without bound.
+        let doc = oc_test_doc();
+        let mut nested = ocmd_dict(Object::Array(vec![]));
+        for _ in 0..20 {
+            nested = ocmd_dict(nested);
+        }
+        assert_eq!(doc.read_oc_name(nested.as_dict().unwrap(), 8), None);
+    }
+
+    #[test]
+    fn test_resolve_oc_name_via_resources_properties() {
+        // Case 2 (name reference) resolves against the *passed-in* resources.
+        // This is the crux of the Form-XObject fix: the resolver reads
+        // /Properties /<name> from whatever resource scope the caller hands
+        // it — page /Resources at page level, the XObject's own /Resources
+        // when extracting inside a Form XObject.
+        let doc = oc_test_doc();
+        let mut props = std::collections::HashMap::new();
+        props.insert("MC0".to_string(), ocg_dict(Object::String(b"A-WALL-DIM".to_vec())));
+        let mut resources = std::collections::HashMap::new();
+        resources.insert("Properties".to_string(), Object::Dictionary(props));
+        let resources = Object::Dictionary(resources);
+
+        let name_ref = Object::Name("MC0".to_string());
+        assert_eq!(
+            doc.resolve_oc_layer_name(Some(&resources), &name_ref)
+                .as_deref(),
+            Some("A-WALL-DIM")
+        );
+    }
+
+    #[test]
+    fn test_resolve_oc_name_inline_dict() {
+        let doc = oc_test_doc();
+        let inline = ocg_dict(Object::String(b"CORTES".to_vec()));
+        assert_eq!(doc.resolve_oc_layer_name(None, &inline).as_deref(), Some("CORTES"));
+    }
+
+    #[test]
+    fn test_resolve_oc_name_unresolvable_is_none() {
+        // A name reference with no resources in scope yields None (the path
+        // is left unlabelled) rather than an error.
+        let doc = oc_test_doc();
+        let name_ref = Object::Name("MC9".to_string());
+        assert_eq!(doc.resolve_oc_layer_name(None, &name_ref), None);
+    }
+
+    #[test]
+    fn test_extract_paths_layer_none_for_plain_stroke() {
+        // End-to-end through the real page pipeline: a stroked line on a page
+        // with no optional content yields a path whose `layer` is None. Guards
+        // the page-level marked-content refactor against perturbing plain
+        // extraction (and mirrors the Python shape test's synthetic PDF).
+        let doc = PdfDocument::from_bytes(build_minimal_pdf(b"100 100 m 200 200 l S")).unwrap();
+        let paths = doc.extract_paths(0).unwrap();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].layer, None);
     }
 }

--- a/src/elements/path.rs
+++ b/src/elements/path.rs
@@ -48,6 +48,19 @@ pub struct PathContent {
     /// separator lines (footnote rules, header/footer rules).
     #[serde(skip)]
     pub artifact_type: Option<ArtifactType>,
+    /// Optional Content Group (PDF "layer") name resolved from the
+    /// surrounding `BDC /OC … EMC` markers in the content stream. Set
+    /// during path extraction by `PathExtractor` when an OCG is active;
+    /// `None` for paths emitted outside any `/OC`-tagged marked-content
+    /// region or in PDFs that do not declare optional content.
+    ///
+    /// The string is the human-readable `/Name` entry of the referenced
+    /// `OptionalContentGroup`, e.g. `"A-GRID"`, `"S-COLS"`, `"A-WALL-DIM"`
+    /// for PDFs exported from Revit/AutoCAD with layer metadata intact.
+    /// Reference: ISO 32000-1:2008 §8.11 (Optional Content) + §14.6
+    /// (Marked Content).
+    #[serde(default)]
+    pub layer: Option<String>,
 }
 
 impl PathContent {
@@ -65,6 +78,7 @@ impl PathContent {
             matrix: None,
             reading_order: None,
             artifact_type: None,
+            layer: None,
         }
     }
 
@@ -83,6 +97,7 @@ impl PathContent {
             matrix: None,
             reading_order: None,
             artifact_type: None,
+            layer: None,
         }
     }
 
@@ -107,6 +122,14 @@ impl PathContent {
     /// Set reading order.
     pub fn with_reading_order(mut self, order: usize) -> Self {
         self.reading_order = Some(order);
+        self
+    }
+
+    /// Set the Optional Content Group (PDF "layer") name. Used by
+    /// `PathExtractor` while walking the content stream to attach the
+    /// active OCG name to each extracted path.
+    pub fn with_layer(mut self, layer: impl Into<String>) -> Self {
+        self.layer = Some(layer.into());
         self
     }
 
@@ -397,6 +420,7 @@ impl Default for PathContent {
             matrix: None,
             reading_order: None,
             artifact_type: None,
+            layer: None,
         }
     }
 }

--- a/src/extractors/paths.rs
+++ b/src/extractors/paths.rs
@@ -157,6 +157,15 @@ pub struct PathExtractor {
     max_xobject_depth: usize,
     /// Cached XObject name → ObjectRef mapping, built on first lookup.
     cached_xobject_dict: Option<std::collections::HashMap<String, crate::object::ObjectRef>>,
+    /// Stack of active Optional Content Group (PDF "layer") names. Each
+    /// `BDC` operator (any tag) pushes an entry — `Some(layer_name)` when
+    /// the tag is `/OC` and the property dict resolves to a named OCG,
+    /// `None` for non-`/OC` marked content or unresolvable OCG names.
+    /// Every `EMC` pops one entry. Always-balanced so the depth tracks
+    /// the active marked-content nesting precisely; the *top* `Some(_)`
+    /// in the stack is the layer name attached to paths finalized while
+    /// inside this region (ISO 32000-1:2008 §8.11, §14.6).
+    oc_layer_stack: Vec<Option<String>>,
 }
 
 impl PathExtractor {
@@ -178,7 +187,33 @@ impl PathExtractor {
             processed_xobjects: std::collections::HashSet::new(),
             max_xobject_depth: 100,
             cached_xobject_dict: None,
+            oc_layer_stack: Vec::new(),
         }
+    }
+
+    /// Push an entry onto the marked-content layer stack.
+    ///
+    /// Pass `Some(name)` for `BDC /OC <<...>>` (or `BDC /OC /MC0`) where
+    /// the property dict resolves to a named Optional Content Group. Pass
+    /// `None` for any other `BDC`/`BMC` (e.g. `BDC /Span <<...>>`,
+    /// `BDC /Artifact`) so the stack stays balanced and outer OCG context
+    /// continues to apply to nested non-OC content.
+    pub fn push_oc_layer(&mut self, layer: Option<String>) {
+        self.oc_layer_stack.push(layer);
+    }
+
+    /// Pop the most recently pushed marked-content entry (called on `EMC`).
+    /// No-op if the stack is empty — keeps extraction robust against PDFs
+    /// with unbalanced markers.
+    pub fn pop_oc_layer(&mut self) {
+        self.oc_layer_stack.pop();
+    }
+
+    /// Return the innermost `Some(layer)` on the marked-content stack, or
+    /// `None` if no `/OC` region is currently active. Non-OC `BDC` entries
+    /// (`None` slots) are transparent: they do not shadow an outer OCG.
+    fn current_layer(&self) -> Option<String> {
+        self.oc_layer_stack.iter().rev().find_map(|e| e.clone())
     }
 
     /// Set the page resources for XObject resolution (Issue #40).
@@ -577,6 +612,10 @@ impl PathExtractor {
         } else {
             path.fill_color = None;
         }
+
+        // Attach the active Optional Content Group (PDF "layer") name, if
+        // the path was emitted inside a `BDC /OC … EMC` region.
+        path.layer = self.current_layer();
 
         self.paths.push(path);
 

--- a/src/extractors/paths.rs
+++ b/src/extractors/paths.rs
@@ -158,13 +158,14 @@ pub struct PathExtractor {
     /// Cached XObject name → ObjectRef mapping, built on first lookup.
     cached_xobject_dict: Option<std::collections::HashMap<String, crate::object::ObjectRef>>,
     /// Stack of active Optional Content Group (PDF "layer") names. Each
-    /// `BDC` operator (any tag) pushes an entry — `Some(layer_name)` when
-    /// the tag is `/OC` and the property dict resolves to a named OCG,
-    /// `None` for non-`/OC` marked content or unresolvable OCG names.
-    /// Every `EMC` pops one entry. Always-balanced so the depth tracks
-    /// the active marked-content nesting precisely; the *top* `Some(_)`
-    /// in the stack is the layer name attached to paths finalized while
-    /// inside this region (ISO 32000-1:2008 §8.11, §14.6).
+    /// `BDC`/`BMC` operator (any tag) pushes one entry and each `EMC` pops
+    /// one, so the depth tracks the marked-content nesting precisely
+    /// (ISO 32000-1:2008 §8.11, §14.6). Entries are stored *pre-resolved*
+    /// to the effective layer at that level: an `/OC` tag whose property
+    /// dict resolves to a named OCG stores that name, while non-`/OC`
+    /// marked content (and `/OC` regions whose name did not resolve)
+    /// inherits the layer already in effect. The top entry is therefore
+    /// always the active layer, making `current_layer` O(1).
     oc_layer_stack: Vec<Option<String>>,
 }
 
@@ -199,7 +200,13 @@ impl PathExtractor {
     /// `BDC /Artifact`) so the stack stays balanced and outer OCG context
     /// continues to apply to nested non-OC content.
     pub fn push_oc_layer(&mut self, layer: Option<String>) {
-        self.oc_layer_stack.push(layer);
+        // Store the *effective* layer for this nesting level: an `/OC` tag
+        // with a resolved OCG name takes effect; every other entry (non-OC
+        // `BDC`/`BMC`, or an `/OC` whose name did not resolve) inherits the
+        // layer already in effect. Pre-resolving here keeps `current_layer`
+        // O(1) instead of an O(depth) scan on every finalized path.
+        let effective = layer.or_else(|| self.oc_layer_stack.last().cloned().flatten());
+        self.oc_layer_stack.push(effective);
     }
 
     /// Pop the most recently pushed marked-content entry (called on `EMC`).
@@ -209,16 +216,39 @@ impl PathExtractor {
         self.oc_layer_stack.pop();
     }
 
-    /// Return the innermost `Some(layer)` on the marked-content stack, or
-    /// `None` if no `/OC` region is currently active. Non-OC `BDC` entries
-    /// (`None` slots) are transparent: they do not shadow an outer OCG.
+    /// Current marked-content nesting depth. Paired with [`truncate_oc_layers`]
+    /// to isolate a Form XObject's marked-content scope from its caller.
+    pub(crate) fn oc_layer_depth(&self) -> usize {
+        self.oc_layer_stack.len()
+    }
+
+    /// Drop any marked-content entries pushed above `depth`. Called when a
+    /// Form XObject content stream returns so an unbalanced `BDC` left open
+    /// inside the XObject cannot leak its layer onto the caller's subsequent
+    /// paths. The spec requires per-stream balance (§14.6), but real-world
+    /// PDFs occasionally violate it.
+    pub(crate) fn truncate_oc_layers(&mut self, depth: usize) {
+        self.oc_layer_stack.truncate(depth);
+    }
+
+    /// Return the active Optional Content Group ("layer") name, or `None`
+    /// if no `/OC` region is currently in effect. O(1): each stack entry is
+    /// pre-resolved to its effective layer by [`push_oc_layer`].
     fn current_layer(&self) -> Option<String> {
-        self.oc_layer_stack.iter().rev().find_map(|e| e.clone())
+        self.oc_layer_stack.last().cloned().flatten()
     }
 
     /// Set the page resources for XObject resolution (Issue #40).
     pub fn set_resources(&mut self, resources: crate::object::Object) {
         self.resources = Some(resources);
+    }
+
+    /// The resource dictionary currently in scope — the page resources, or
+    /// the active Form XObject's own `/Resources` after a [`swap_resources`].
+    /// Used to resolve `BDC /OC /Name` property references against the
+    /// current `/Properties` subdictionary (ISO 32000-1:2008 §14.6.2).
+    pub(crate) fn current_resources(&self) -> Option<&crate::object::Object> {
+        self.resources.as_ref()
     }
 
     /// Swap in a new resource scope for `Do` name lookups and return the
@@ -972,5 +1002,50 @@ mod tests {
         ext.push_xobject(r);
         ext.pop_xobject_failed(); // failure path
         assert!(ext.can_process_xobject(r), "Failed XObject should be retryable");
+    }
+
+    #[test]
+    fn test_oc_layer_truncate_isolates_unbalanced_xobject() {
+        // A page-level `/OC` region is active; we then descend into a Form
+        // XObject that opens a `/OC` marker but (malformed) never closes it.
+        // `truncate_oc_layers` back to the entry depth must drop the leaked
+        // entry so the caller's next path keeps the page-level layer rather
+        // than inheriting the XObject's.
+        let mut ext = PathExtractor::new();
+        ext.set_stroke_color(Color::black());
+
+        ext.push_oc_layer(Some("A-GRID".to_string())); // page-level BDC /OC
+        let base = ext.oc_layer_depth();
+
+        // Inside the XObject: opens its own region but leaves it dangling.
+        ext.push_oc_layer(Some("S-COLS".to_string()));
+        ext.move_to(0.0, 0.0);
+        ext.line_to(10.0, 0.0);
+        ext.stroke(); // belongs to the XObject's S-COLS
+                      // (no matching EMC — simulates a malformed XObject stream)
+        ext.truncate_oc_layers(base); // XObject returns
+
+        ext.move_to(0.0, 20.0);
+        ext.line_to(10.0, 20.0);
+        ext.stroke(); // back at page scope → A-GRID, not S-COLS
+
+        let paths = ext.finish();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].layer.as_deref(), Some("S-COLS"));
+        assert_eq!(paths[1].layer.as_deref(), Some("A-GRID"));
+    }
+
+    #[test]
+    fn test_oc_layer_effective_is_o1_top_of_stack() {
+        // push_oc_layer pre-resolves the effective layer, so a non-OC `BMC`
+        // nested inside an `/OC` region inherits the OCG name and the top of
+        // the stack is always the active layer.
+        let mut ext = PathExtractor::new();
+        ext.push_oc_layer(Some("A-WALL".to_string())); // BDC /OC
+        ext.push_oc_layer(None); // BMC /Span (non-OC) inherits A-WALL
+        assert_eq!(ext.current_layer().as_deref(), Some("A-WALL"));
+        ext.pop_oc_layer();
+        ext.pop_oc_layer();
+        assert_eq!(ext.current_layer(), None);
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -3832,6 +3832,16 @@ fn path_to_py_dict(py: Python<'_>, path: &crate::elements::PathContent) -> PyRes
     }
     d.set_item("operations_count", path.operations.len())?;
 
+    // Optional Content Group (PDF "layer") name resolved from the
+    // enclosing `BDC /OC … EMC` markers in the source content stream.
+    // `None` when the path was emitted outside any /OC region or when
+    // the PDF has no optional-content metadata. See PDF spec
+    // ISO 32000-1:2008 §8.11 (Optional Content) and §14.6 (Marked Content).
+    match path.layer {
+        Some(ref name) => d.set_item("layer", name.as_str())?,
+        None => d.set_item("layer", py.None())?,
+    }
+
     // Expose path operations as list of dicts for vector extraction use cases
     let ops_list = pyo3::types::PyList::empty(py);
     for op in &path.operations {

--- a/src/writer/content_stream.rs
+++ b/src/writer/content_stream.rs
@@ -3008,6 +3008,7 @@ mod tests {
             matrix: None,
             reading_order: None,
             artifact_type: None,
+            layer: None,
         };
 
         let mut builder = ContentStreamBuilder::new();
@@ -3037,6 +3038,7 @@ mod tests {
             matrix: None,
             reading_order: None,
             artifact_type: None,
+            layer: None,
         };
 
         let mut builder = ContentStreamBuilder::new();
@@ -3067,6 +3069,7 @@ mod tests {
             matrix: None,
             reading_order: None,
             artifact_type: None,
+            layer: None,
         };
 
         let mut builder = ContentStreamBuilder::new();
@@ -3096,6 +3099,7 @@ mod tests {
             matrix: None,
             reading_order: None,
             artifact_type: None,
+            layer: None,
         };
 
         let mut builder = ContentStreamBuilder::new();

--- a/src/writer/document_builder.rs
+++ b/src/writer/document_builder.rs
@@ -980,6 +980,7 @@ impl<'a> FluentPageBuilder<'a> {
                 matrix: None,
                 reading_order: None,
                 artifact_type: None,
+                layer: None,
             }));
         self.cursor_y -= self.text_config.size;
         self
@@ -3447,6 +3448,7 @@ impl DocumentBuilder {
                     matrix: None,
                     reading_order: None,
                     artifact_type: Some(ArtifactType::Layout),
+                    layer: None,
                 }));
 
                 // Footnote bodies, stacked from sep_y downward.

--- a/tests/test_path_extraction.rs
+++ b/tests/test_path_extraction.rs
@@ -199,6 +199,7 @@ mod svg_conversion_tests {
             matrix: None,
             artifact_type: None,
             reading_order: None,
+            layer: None,
         }
     }
 
@@ -264,6 +265,7 @@ mod svg_conversion_tests {
             matrix: None,
             artifact_type: None,
             reading_order: None,
+            layer: None,
         };
 
         // Generate curve path data
@@ -296,6 +298,7 @@ mod svg_conversion_tests {
             matrix: None,
             artifact_type: None,
             reading_order: None,
+            layer: None,
         };
 
         // Rectangle should be converted to M L L L Z
@@ -323,6 +326,7 @@ mod svg_conversion_tests {
             matrix: None,
             artifact_type: None,
             reading_order: None,
+            layer: None,
         };
 
         assert_eq!(round_cap.line_cap, LineCap::Round);
@@ -346,6 +350,7 @@ mod svg_conversion_tests {
             matrix: None,
             artifact_type: None,
             reading_order: None,
+            layer: None,
         };
 
         assert_eq!(bevel_join.line_join, LineJoin::Bevel);

--- a/tests/test_path_extraction.rs
+++ b/tests/test_path_extraction.rs
@@ -172,6 +172,132 @@ mod path_extractor_tests {
         let paths = extractor.finish();
         assert!(paths.is_empty());
     }
+
+    // ─── Optional Content Group (PDF "layer") tagging ─────────────────
+    //
+    // Covers the BDC/BMC/EMC marked-content stack added to expose the
+    // OCG name on each finalized path (ISO 32000-1:2008 §8.11, §14.6).
+
+    #[test]
+    fn test_layer_attached_when_oc_active() {
+        let mut extractor = PathExtractor::new();
+        extractor.set_stroke_color(Color::black());
+
+        // Simulate `BDC /OC <</Name (A-GRID)>>` — dispatcher resolves the
+        // OCG /Name and pushes Some("A-GRID") onto the layer stack.
+        extractor.push_oc_layer(Some("A-GRID".to_string()));
+        extractor.move_to(0.0, 0.0);
+        extractor.line_to(100.0, 0.0);
+        extractor.stroke();
+        extractor.pop_oc_layer();
+
+        let paths = extractor.finish();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].layer.as_deref(), Some("A-GRID"));
+    }
+
+    #[test]
+    fn test_layer_none_outside_oc() {
+        let mut extractor = PathExtractor::new();
+        extractor.set_stroke_color(Color::black());
+
+        // No BDC /OC seen — path is emitted in the default content scope.
+        extractor.move_to(0.0, 0.0);
+        extractor.line_to(50.0, 50.0);
+        extractor.stroke();
+
+        let paths = extractor.finish();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].layer, None);
+    }
+
+    #[test]
+    fn test_layer_cleared_after_pop() {
+        let mut extractor = PathExtractor::new();
+        extractor.set_stroke_color(Color::black());
+
+        extractor.push_oc_layer(Some("S-COLS".to_string()));
+        extractor.move_to(0.0, 0.0);
+        extractor.line_to(10.0, 0.0);
+        extractor.stroke(); // belongs to S-COLS
+        extractor.pop_oc_layer();
+
+        extractor.move_to(0.0, 20.0);
+        extractor.line_to(10.0, 20.0);
+        extractor.stroke(); // belongs to no layer
+
+        let paths = extractor.finish();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].layer.as_deref(), Some("S-COLS"));
+        assert_eq!(paths[1].layer, None);
+    }
+
+    #[test]
+    fn test_outer_oc_survives_nested_non_oc_bmc() {
+        // Real-world PDFs nest non-/OC marked content (e.g. /Span <<...>>
+        // for accessibility) inside an /OC region. The outer OCG must
+        // continue to apply to paths emitted in the inner region.
+        let mut extractor = PathExtractor::new();
+        extractor.set_stroke_color(Color::black());
+
+        extractor.push_oc_layer(Some("A-WALL".to_string())); // BDC /OC /Layer_1
+        extractor.push_oc_layer(None); // BMC /Span (non-OC marked content)
+
+        extractor.move_to(0.0, 0.0);
+        extractor.line_to(10.0, 0.0);
+        extractor.stroke();
+
+        extractor.pop_oc_layer(); // EMC (closes /Span)
+        extractor.pop_oc_layer(); // EMC (closes /OC)
+
+        let paths = extractor.finish();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].layer.as_deref(), Some("A-WALL"));
+    }
+
+    #[test]
+    fn test_nested_oc_inner_wins() {
+        // When two /OC regions nest, paths in the inner region belong to
+        // the inner OCG (the innermost Some(_) on the stack wins).
+        let mut extractor = PathExtractor::new();
+        extractor.set_stroke_color(Color::black());
+
+        extractor.push_oc_layer(Some("OUTER".to_string()));
+        extractor.push_oc_layer(Some("INNER".to_string()));
+
+        extractor.move_to(0.0, 0.0);
+        extractor.line_to(10.0, 0.0);
+        extractor.stroke();
+
+        extractor.pop_oc_layer();
+        extractor.move_to(0.0, 20.0);
+        extractor.line_to(10.0, 20.0);
+        extractor.stroke();
+
+        extractor.pop_oc_layer();
+
+        let paths = extractor.finish();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].layer.as_deref(), Some("INNER"));
+        assert_eq!(paths[1].layer.as_deref(), Some("OUTER"));
+    }
+
+    #[test]
+    fn test_underflow_pop_is_safe() {
+        // Malformed PDFs may emit EMC without a matching BDC. Pop on an
+        // empty stack must be a no-op — extraction should keep going.
+        let mut extractor = PathExtractor::new();
+        extractor.set_stroke_color(Color::black());
+
+        extractor.pop_oc_layer(); // stack empty — must not panic
+        extractor.move_to(0.0, 0.0);
+        extractor.line_to(10.0, 0.0);
+        extractor.stroke();
+
+        let paths = extractor.finish();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].layer, None);
+    }
 }
 
 // ============================================================================

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -814,31 +814,64 @@ def test_extract_paths_operations():
         pytest.skip("Test fixture '1.pdf' not available or invalid")
 
 
+def _minimal_pdf_with_path(content: bytes = b"100 100 m 200 200 l S") -> bytes:
+    """Build a minimal in-memory PDF whose single page draws one stroked
+    line, mirroring the Rust `build_minimal_pdf` test helper. The committed
+    fixtures carry no vector geometry, so this gives `extract_paths` a
+    deterministic, non-empty result to exercise the per-path assertions."""
+    pdf = bytearray(b"%PDF-1.4\n")
+
+    off1 = len(pdf)
+    pdf += b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+
+    off2 = len(pdf)
+    pdf += b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+
+    off3 = len(pdf)
+    pdf += (
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R /Resources << >> >>\nendobj\n"
+    )
+
+    off4 = len(pdf)
+    pdf += b"4 0 obj\n<< /Length %d >>\nstream\n" % len(content)
+    pdf += content
+    pdf += b"\nendstream\nendobj\n"
+
+    xref_off = len(pdf)
+    pdf += b"xref\n0 5\n"
+    pdf += b"0000000000 65535 f \n"
+    for off in (off1, off2, off3, off4):
+        pdf += b"%010d 00000 n \n" % off
+    pdf += b"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % xref_off
+    return bytes(pdf)
+
+
 def test_extract_paths_layer_field_shape():
     """Test that extract_paths surfaces the OCG (PDF layer) field.
 
     The `layer` key must be present on every path dict and be either a
-    non-empty `str` (when the path was emitted inside a `BDC /OC … EMC`
-    region whose property dict resolves to a named OCG) or `None`
-    (when the path was emitted outside any /OC region, or when the
-    PDF has no /OCProperties metadata).
+    `str` (when the path was emitted inside a `BDC /OC … EMC` region whose
+    property dict resolves to a named OCG) or `None` (when the path was
+    emitted outside any /OC region, or when the PDF has no /OCProperties
+    metadata).
 
-    `simple.pdf` is unlikely to carry OCG metadata, so the assertion
-    targets the field's *shape* (key present, type str-or-None) rather
-    than a specific value. A construction-PDF fixture with OCGs (e.g.
-    exported from Revit or AutoCAD with layers preserved) would let
-    us additionally assert recognizable layer names like "A-GRID".
+    The synthetic PDF below draws a single stroked line with no optional
+    content, so the assertion targets the field's *shape* (key present,
+    value str-or-None) on a guaranteed-non-empty path list. A construction
+    PDF with OCGs (exported from Revit/AutoCAD with layers preserved) would
+    let us additionally assert recognizable names like "A-GRID".
     """
-    try:
-        doc = PdfDocument("tests/fixtures/simple.pdf")
-        paths = doc.extract_paths(0)
-        assert isinstance(paths, list)
-        for path in paths:
-            assert isinstance(path, dict)
-            assert "layer" in path, "Path dict should contain 'layer' field"
-            assert path["layer"] is None or isinstance(path["layer"], str)
-    except (OSError, RuntimeError):
-        pytest.skip("Test fixture 'simple.pdf' not available or invalid")
+    doc = PdfDocument.from_bytes(_minimal_pdf_with_path())
+    paths = doc.extract_paths(0)
+    assert isinstance(paths, list)
+    # The synthetic page has exactly one stroked line; a vacuous (empty)
+    # list would skip the per-path checks below.
+    assert paths, "expected at least one extracted path from the synthetic PDF"
+    for path in paths:
+        assert isinstance(path, dict)
+        assert "layer" in path, "Path dict should contain 'layer' field"
+        assert path["layer"] is None or isinstance(path["layer"], str)
 
 
 def test_extract_images_invalid_page():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -814,6 +814,33 @@ def test_extract_paths_operations():
         pytest.skip("Test fixture '1.pdf' not available or invalid")
 
 
+def test_extract_paths_layer_field_shape():
+    """Test that extract_paths surfaces the OCG (PDF layer) field.
+
+    The `layer` key must be present on every path dict and be either a
+    non-empty `str` (when the path was emitted inside a `BDC /OC … EMC`
+    region whose property dict resolves to a named OCG) or `None`
+    (when the path was emitted outside any /OC region, or when the
+    PDF has no /OCProperties metadata).
+
+    `simple.pdf` is unlikely to carry OCG metadata, so the assertion
+    targets the field's *shape* (key present, type str-or-None) rather
+    than a specific value. A construction-PDF fixture with OCGs (e.g.
+    exported from Revit or AutoCAD with layers preserved) would let
+    us additionally assert recognizable layer names like "A-GRID".
+    """
+    try:
+        doc = PdfDocument("tests/fixtures/simple.pdf")
+        paths = doc.extract_paths(0)
+        assert isinstance(paths, list)
+        for path in paths:
+            assert isinstance(path, dict)
+            assert "layer" in path, "Path dict should contain 'layer' field"
+            assert path["layer"] is None or isinstance(path["layer"], str)
+    except (OSError, RuntimeError):
+        pytest.skip("Test fixture 'simple.pdf' not available or invalid")
+
+
 def test_extract_images_invalid_page():
     """Test extract_images with invalid page index."""
     try:


### PR DESCRIPTION
## Description

Adds a `layer: Option<String>` field to `PathContent` (and the dict returned by `extract_paths()` Python binding) that surfaces the **Optional Content Group** name — a.k.a. the PDF "layer name" — the path belongs to.

Today the marked-content operators `BDC` / `BMC` / `EMC` are silently dropped during path extraction (`document.rs::extract_paths` does not match them and they fall through `_ => {}`), so the layer membership written by the source CAD application is unrecoverable from the Python API even though the raw bytes are still in the content stream.

**Use case:** construction document processing — architectural and structural PDFs exported from AutoCAD / Revit preserve layer names like `A-GRID`, `S-COLS`, `A-WALL-DIM`, `M-DUCT`. Surfacing those names lets consumers classify gridlines / columns / dimensions / MEP geometry with the source-of-truth metadata instead of brittle stroke-width-and-dash heuristics. Same pattern as PR #261 (path operations exposure).

Closes #586.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Tests
- [ ] CI/CD changes

## Related Issues

Closes #586 (request + design + non-goals).

Continues the same construction-document-processing motivation as PR #261 — that PR exposed path operations, this one exposes the layer the path lives on.

## Changes Made

8 files, 651 insertions:

1. **`src/elements/path.rs`** — `PathContent` gains `layer: Option<String>` with `#[serde(default)]` for backward compat. New `with_layer()` builder.
2. **`src/extractors/paths.rs`** — `PathExtractor` maintains a `Vec<Option<String>>` stack via `push_oc_layer()` / `pop_oc_layer()`. The stack stays depth-balanced for non-`/OC` `BDC` / `BMC` (Span, Article, …) by pushing `None` for those tags, so an outer `/OC` region continues to apply to nested non-OC content. Each entry is stored *pre-resolved* to the effective layer so `current_layer` is O(1). `oc_layer_depth()` + `truncate_oc_layers()` isolate a Form XObject's marked-content scope from its caller (defends against a malformed unbalanced `BDC` leaking out). `current_resources()` exposes the active resource dict so the resolver can read `/Properties` against the right scope.
3. **`src/document.rs`** — `extract_paths` and `process_form_xobject_paths` both handle `BeginMarkedContent` / `BeginMarkedContentDict` / `EndMarkedContent`. `/OC` property operands are resolved through `resolve_oc_layer_name(resources, properties)`, which:
   - inline-dict branch hands straight to `read_oc_name`;
   - name-reference branch (`/MC0` etc.) resolves through whatever resource scope the caller passes — page `/Resources` at page level, the XObject's own `/Resources` when extracting inside a Form XObject (§14.6.2, §8.10.1).
   `read_oc_name` reads either an OCG `/Name` *or* follows an OCMD's `/OCGs` (dict-or-array per Table 99) to the first member OCG, with a recursion depth guard (8). `/Name` strings go through the existing `Self::decode_pdf_text_string(&bytes)`, so PDFDocEncoding (Annex D), UTF-16BE and UTF-16LE (with BOM) all round-trip identically to the rest of the library. A small `deref_object` helper centralises single-level reference loading inside the OC name path.
4. **`src/python.rs::path_to_py_dict`** — exposes `layer: str | None` on every dict emitted by `extract_paths`, `extract_lines`, `extract_rects`.
5. **`src/writer/content_stream.rs` + `src/writer/document_builder.rs`** — mechanical `layer: None` fixes at the 4 PathContent literal sites required by the new struct field.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass locally (`cargo test --lib` — 5257 passed, 2 ignored, 0 failed; `cargo test --test test_path_extraction` — 29 passed)
- [x] `cargo clippy --lib` passes (only the pre-existing `unknown lint: clippy::manual_checked_ops` from `clippy.toml`, unrelated to this PR)
- [x] `cargo fmt --check` passes

New test coverage:

**Rust integration** (`tests/test_path_extraction.rs`, 6 tests in `path_extractor_tests`): `test_layer_attached_when_oc_active`, `test_layer_none_outside_oc`, `test_layer_cleared_after_pop`, `test_outer_oc_survives_nested_non_oc_bmc`, `test_nested_oc_inner_wins`, `test_underflow_pop_is_safe`.

**Rust unit — extractor** (`src/extractors/paths.rs`, 2 new): `test_oc_layer_truncate_isolates_unbalanced_xobject` (Form XObject leak-isolation), `test_oc_layer_effective_is_o1_top_of_stack` (O(1) `current_layer` semantics).

**Rust unit — resolver** (`src/document.rs::tests`, 10 new):
- `test_oc_name_ocg_ascii`, `test_oc_name_ocg_utf16le_bom` (regression for the UTF-16LE branch the previous inline reader misread as latin-1), `test_oc_name_ocg_utf16be_bom`.
- OCMD: `test_oc_name_ocmd_single_ocg`, `test_oc_name_ocmd_ocgs_array_first_wins`, `test_oc_name_ocmd_depth_guard` (20-deep OCMD chain, depth guard at 8).
- Resolver entry: `test_resolve_oc_name_via_resources_properties` (proves Case 2 honours the *passed-in* resources — the crux of the XObject `/Resources/Properties` fix), `test_resolve_oc_name_inline_dict`, `test_resolve_oc_name_unresolvable_is_none`.
- End-to-end: `test_extract_paths_layer_none_for_plain_stroke` (full page pipeline through `from_bytes`).

**Python** (`tests/test_python.py`): `test_extract_paths_layer_field_shape` now builds a synthetic path-bearing PDF via `PdfDocument.from_bytes` so the per-path assertions actually iterate (the committed fixtures carry no vector geometry).

## Python Bindings (if applicable)

- [x] Python bindings have been updated
- [x] Python tests added

## Documentation

- [ ] README.md or documentation site has been updated
- [ ] Code examples have been updated
- [ ] CHANGELOG.md has been updated

> Note: I did not update CHANGELOG.md as I am not sure which version this would target. Happy to add an entry under the appropriate `## [Unreleased]` / next-version section if you point me to it.

## Checklist

- [x] My code follows the coding guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (resolver helpers, OCMD branch, stack invariants, encoding handling, XObject scope isolation)
- [x] My changes generate no new warnings
- [x] I have checked my code for spelling errors
- [x] PR title follows conventional commits format

## Additional Notes

- **Non-breaking, additive change** — `PathContent.layer` defaults to `None` for every PDF that does not declare `/OCProperties` and for every path emitted outside any `/OC` region. The new Python dict key is purely added.
- Name resolution falls back to `None` (not an error) for malformed PDFs, missing `/Resources /Properties` entries, OCG / OCMD objects without a resolvable name, or OCMD chains that exceed the recursion depth guard. Path extraction continues normally in those cases.
- **Out of scope** for this PR (issue #586 lists them under "Non-goals"): OCG visibility filtering (`/D` defaults, intents), nested OCG hierarchies (`/OCGs` groups, `/Order` arrays), XObject-level OCG inheritance (§8.11.3.3, the XObject *itself* carrying `/OC`). The PR delivers the `/Name` only — those higher-level concerns are easier to add incrementally on top.