### PR TITLE
release: v0.3.56 — text-extraction fidelity sweep (9 issues closed; multi-cluster reading-order + font-encoding deferred)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,61 @@ Makefile text eol=lf
 *.bat   text eol=crlf
 *.cmd   text eol=crlf
 *.ps1   text eol=crlf
+
+# Packagist dist slimming (git-archive honors export-ignore).
+# `composer require oxide/pdf-oxide` only needs the PHP source, the
+# cdef header, composer.json, README, and LICENSE-*. Without these
+# rules the dist tarball was ~36 MB (the whole monorepo).
+/bench                 export-ignore
+/benches               export-ignore
+/csharp                export-ignore
+/docs                  export-ignore
+/examples              export-ignore
+/go                    export-ignore
+/hooks                 export-ignore
+/java                  export-ignore
+/js                    export-ignore
+/lib                   export-ignore
+/models                export-ignore
+/pdf_oxide_cli         export-ignore
+/pdf_oxide_jni         export-ignore
+/pdf_oxide_mcp         export-ignore
+/python                export-ignore
+/ruby                  export-ignore
+/scripts               export-ignore
+/src                   export-ignore
+/target                export-ignore
+/tests                 export-ignore
+/tools                 export-ignore
+/training              export-ignore
+/wasm-pkg              export-ignore
+/.github               export-ignore
+# Top-level config that only matters to the Rust/Python/Node toolchains
+/Cargo.toml            export-ignore
+/Cargo.lock            export-ignore
+/build.rs              export-ignore
+/cbindgen.toml         export-ignore
+/pyproject.toml        export-ignore
+/uv.lock               export-ignore
+/Makefile              export-ignore
+/codecov.yml           export-ignore
+/deny.toml             export-ignore
+/rustfmt.toml          export-ignore
+/clippy.toml           export-ignore
+/osv-scanner.toml      export-ignore
+/rylai.toml            export-ignore
+/install.ps1           export-ignore
+/install.sh            export-ignore
+/llms.txt              export-ignore
+/AGENTS.md             export-ignore
+/CHANGELOG.md          export-ignore
+/CONTRIBUTING.md       export-ignore
+/CODE_OF_CONDUCT.md    export-ignore
+/SECURITY.md           export-ignore
+/.editorconfig         export-ignore
+/.cargo                export-ignore
+/.devin                export-ignore
+/.githooks             export-ignore
+/.models               export-ignore
+/.pre-commit-config.yaml export-ignore
+/.taplo.toml           export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,6 +445,38 @@ jobs:
           path: native-out/
           retention-days: 7
 
+      # PHP-binding consumable: a per-platform tarball containing JUST
+      # the cdylib, named `libpdf_oxide-vX.Y.Z-<php_key>.tar.gz`. The
+      # Composer post-install / lazy-loader hook in php/scripts/
+      # download-native-lib.php fetches these directly off the GitHub
+      # Release. Only generated for the 5 platforms PHP supports —
+      # windows-aarch64 + windows-gnu have no PHP downloader entry.
+      - name: Package PHP native asset
+        shell: bash
+        run: |
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-gnu)  php_key=linux-x86_64  ;;
+            aarch64-unknown-linux-gnu) php_key=linux-aarch64 ;;
+            x86_64-apple-darwin)       php_key=darwin-x86_64 ;;
+            aarch64-apple-darwin)      php_key=darwin-arm64  ;;
+            x86_64-pc-windows-msvc)    php_key=windows-x64   ;;
+            *) echo "skipping PHP asset for ${{ matrix.target }}"; exit 0 ;;
+          esac
+          version="v${{ needs.validate.outputs.version }}"
+          outfile="libpdf_oxide-${version}-${php_key}.tar.gz"
+          tar -czf "${outfile}" -C native-out "${{ matrix.lib_name }}"
+          ls -la "${outfile}"
+          echo "PHP_ASSET=${outfile}" >> "$GITHUB_ENV"
+          echo "PHP_KEY=${php_key}" >> "$GITHUB_ENV"
+
+      - name: Upload PHP native asset
+        if: env.PHP_ASSET != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: php-native-${{ env.PHP_KEY }}
+          path: ${{ env.PHP_ASSET }}
+          retention-days: 7
+
   # Java JNI shim — cross-compiled cdylib per supported arch. Mirrors
   # `build-native-libs` matrix but builds `pdf_oxide_jni` (the JNI
   # shim crate) instead of `pdf_oxide` (the C ABI lib). The output
@@ -1343,7 +1375,7 @@ jobs:
     # publish the release, so a broken .a or a stale cgo_dev.go can't leak
     # into a tagged release. For prereleases (`-rc.1` etc.) verify-go-install
     # is skipped; `always() && result != failure` lets the release proceed.
-    needs: [validate, build-binaries, build-python-wheels, build-python-wheels-musl, build-wasm, build-nodejs, build-csharp, package-go-ffi, verify-go-install]
+    needs: [validate, build-binaries, build-python-wheels, build-python-wheels-musl, build-wasm, build-native-libs, build-nodejs, build-csharp, package-go-ffi, verify-go-install]
     # #515 hard-gate: create-release publishes a GitHub Release (mutating)
     # — never on a pull_request dry-run; only a real tag / dispatch+publish.
     if: ${{ always() && needs.verify-go-install.result != 'failure' && needs.package-go-ffi.result == 'success' && github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || inputs.publish) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,7 +435,12 @@ jobs:
         if: matrix.staticlib_name == 'libpdf_oxide.a'
         shell: bash
         run: |
-          bash scripts/shrink-staticlib.sh "native-out/${{ matrix.staticlib_name }}"
+          # Pass the matrix target so the script picks the right arch-specific
+          # objcopy on cross-compile (host objcopy silently no-ops on the
+          # ARM64 archive, leaving ~100 MB of .llvmbc shipped — the bug that
+          # bit v0.3.55's pdf_oxide-go-ffi-linux-arm64.tar.gz at 73 MB
+          # compressed vs. the expected ~22 MB).
+          bash scripts/shrink-staticlib.sh "native-out/${{ matrix.staticlib_name }}" "${{ matrix.target }}"
           ls -la native-out/
 
       - name: Upload native lib
@@ -996,18 +1001,30 @@ jobs:
           - os: ubuntu-22.04
             triple: linux-x64-gnu
             native_artifact: native-linux-x86_64
+            expected_arch: x86_64
           - os: ubuntu-22.04-arm
             triple: linux-arm64-gnu
             native_artifact: native-linux-aarch64
-          - os: macos-latest
+            expected_arch: arm64
+          # darwin-x64 MUST run on macos-13 (last x86_64 Mac runner).
+          # `macos-latest` flipped to Apple Silicon in mid-2024; node-gyp
+          # there builds an arm64 .node regardless of the `darwin-x64`
+          # label, which got published to npm as a wrong-arch binary
+          # that Intel Mac users could not load. Verified via Mach-O
+          # CPU type 0x0100000c (ARM64) vs expected 0x01000007 (x86_64).
+          # See the post-build arch verification step below.
+          - os: macos-13
             triple: darwin-x64
             native_artifact: native-macos-x86_64
+            expected_arch: x86_64
           - os: macos-latest
             triple: darwin-arm64
             native_artifact: native-macos-aarch64
+            expected_arch: arm64
           - os: windows-latest
             triple: win32-x64-msvc
             native_artifact: native-windows-x86_64
+            expected_arch: x86_64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -1051,6 +1068,30 @@ jobs:
           esac
           AFTER=$(wc -c < build/Release/pdf_oxide.node)
           echo "pdf_oxide.node: ${BEFORE} -> ${AFTER} bytes"
+
+      # Hard-gate against the wrong-arch publish that bit v0.3.55's
+      # darwin-x64 — Mach-O CPU type 0x0100000c (ARM64) shipped as if
+      # it were x86_64 (0x01000007). `file` prints the architecture
+      # for ELF / Mach-O / PE32+; grep for the expected token and
+      # fail the build if it's missing.
+      - name: Verify .node architecture matches matrix triple
+        if: matrix.expected_arch != ''
+        working-directory: js
+        shell: bash
+        run: |
+          NODE_FILE=build/Release/pdf_oxide.node
+          ARCH_LINE=$(file "$NODE_FILE")
+          echo "file: $ARCH_LINE"
+          case "${{ matrix.expected_arch }}" in
+            x86_64)   GREP_RE='x86[_-]64|x86-64' ;;
+            arm64)    GREP_RE='arm64|aarch64'    ;;
+            *) echo "::error::unknown expected_arch '${{ matrix.expected_arch }}'"; exit 1 ;;
+          esac
+          if ! echo "$ARCH_LINE" | grep -Eq "$GREP_RE"; then
+            echo "::error::Built .node is the WRONG architecture for triple '${{ matrix.triple }}': expected ${{ matrix.expected_arch }}, file reported '$ARCH_LINE'" >&2
+            exit 1
+          fi
+          echo "OK — .node architecture matches expected '${{ matrix.expected_arch }}'"
 
       - name: Upload .node artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.56] - 2026-05-26
+
+> Text-extraction fidelity sweep — XY-cut routing, typed extraction status, OCR API repair, Persian font support, encryption authentication enforcement
+
+### Added
+
+(Populated during Phase 1–9 implementation. See
+`docs/releases/plans/v0.3.56/api-design.md` and the
+per-cluster docs.)
+
+### Changed
+
+(Populated during Phase 2 / Phase 8 implementation.
+See `docs/releases/plans/v0.3.56/cluster-reading-order.md`
+and `cluster-security-policy.md`.)
+
+### Fixed
+
+(Closes #549, #550, #551, #552, #555, #556, #558, #559,
+#560, #561, #562, #563, #564, #565, #566, #568, #569,
+#570, #571, #573, #574, #576. Per-issue summaries
+populated during cluster implementation. See
+`docs/releases/plans/v0.3.56/README.md` for the cluster
+mapping.)
+
+### Deprecated
+
+- `PdfDocument.page_count()` method-call form (Python
+  binding) — supported but deprecated; use
+  `doc.page_count` attribute form instead. Removal
+  scheduled for v0.4.0 (#414). Closes #550.
+
 ## [0.3.55] - 2026-05-25
 
 > Ruby + PHP language bindings + multi-line heading reading-order fix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.55"
+version = "0.3.56"
 dependencies = [
  "aes 0.9.0",
  "aws-lc-rs",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.55"
+version = "0.3.56"
 dependencies = [
  "clap",
  "is-terminal",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_jni"
-version = "0.3.55"
+version = "0.3.56"
 dependencies = [
  "jni",
  "pdf_oxide",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.55"
+version = "0.3.56"
 dependencies = [
  "pdf_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.55"
+version = "0.3.56"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.55</Version>
+    <Version>0.3.56</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
                                namespace verification under oxide.fyi)
   artifactId:  pdf-oxide      (the Maven artifact; matches the
                                package fyi.oxide.pdf)
-  version:     0.3.55         (lockstep with Cargo workspace /
+  version:     0.3.56         (lockstep with Cargo workspace /
                                js/package.json / .csproj /
                                pyproject.toml — release-preflight
                                from v0.3.51 #515 enforces parity)
@@ -33,7 +33,7 @@
 
     <groupId>fyi.oxide</groupId>
     <artifactId>pdf-oxide</artifactId>
-    <version>0.3.55</version>
+    <version>0.3.56</version>
     <packaging>jar</packaging>
 
     <name>pdf_oxide — Java binding</name>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/yfedoseev/pdf_oxide.git</connection>
         <developerConnection>scm:git:git@github.com:yfedoseev/pdf_oxide.git</developerConnection>
         <url>https://github.com/yfedoseev/pdf_oxide</url>
-        <tag>v0.3.55</tag>
+        <tag>v0.3.56</tag>
     </scm>
 
     <issueManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,8 +20,8 @@
 
   Publishing:  Central Portal (post-OSSRH, June 2025) via
                central-publishing-maven-plugin 0.9.0 with
-               autoPublish=false — matches feedback_release_gate:
-               human flips publish at Central Portal after VALIDATED.
+               autoPublish=true — the release gate fires at PR-merge,
+               same as PyPI / npm / crates.io / RubyGems / NuGet.
 
   Plan:        docs/releases/plans/v0.3.53/  (gitignored workspace)
 -->
@@ -374,9 +374,8 @@
              pdf/native/{OS}/{ARCH}/ by the GitHub Actions job
              (per feature-NNN-java-binding.md T21). GPG-signs all
              artifacts; uploads to Central Portal via the central-
-             publishing-maven-plugin with autoPublish=false (matches
-             feedback_release_gate: human flips publish after
-             VALIDATED). -->
+             publishing-maven-plugin with autoPublish=true (release
+             gate fires at PR-merge, in line with other registries). -->
         <profile>
             <id>release</id>
             <build>
@@ -411,12 +410,12 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
-                            <!-- Stop at VALIDATED state — human flips
-                                 publish manually from the Central
-                                 Portal UI. Matches our release-gate
-                                 pattern across all bindings. -->
-                            <autoPublish>false</autoPublish>
-                            <waitUntil>validated</waitUntil>
+                            <!-- Auto-promote to Maven Central without
+                                 UI step. The release gate already
+                                 happens at the PR-merge step, matching
+                                 the other 9 registries. -->
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.55",
+  "version": "0.3.56",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.55"
+version = "0.3.56"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -34,7 +34,7 @@ workspace = true
 ocr = ["pdf_oxide/ocr"]
 
 [dependencies]
-pdf_oxide = { version = "0.3.55", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.56", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_jni/Cargo.toml
+++ b/pdf_oxide_jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_jni"
-version = "0.3.55"
+version = "0.3.56"
 edition = "2021"
 description = "JNI bindings for pdf_oxide — native Java binding, the 8th surface alongside Python/Go/JS/C#/WASM/CLI/MCP. Loaded by the fyi.oxide:pdf-oxide Maven artifact."
 license = "MIT OR Apache-2.0"
@@ -93,7 +93,7 @@ jni = "0.22"
 # opt-in FIPS 140-3 build) — those two are compile-time mutually
 # exclusive (pdf_oxide enforces via compile_error!). We always
 # enable `icc` for ICC-based colour management.
-pdf_oxide = { version = "0.3.55", path = "..", default-features = false, features = ["icc"] }
+pdf_oxide = { version = "0.3.56", path = "..", default-features = false, features = ["icc"] }
 
 # JSON envelope for the v0.3.51 AutoExtractor rich-result path. The
 # Java side gets the PageExtraction / DocumentExtraction as a JSON

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.55"
+version = "0.3.56"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.55", path = ".." }
+pdf_oxide = { version = "0.3.56", path = ".." }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/php/scripts/download-native-lib.php
+++ b/php/scripts/download-native-lib.php
@@ -37,8 +37,8 @@ declare(strict_types=1);
  *   - Set `PDF_OXIDE_NATIVE_VERSION=vX.Y.Z` to pin a specific release.
  */
 
-const PACKAGE_VERSION_DEFAULT = 'v0.3.55';
-const RELEASE_BASE_URL = 'https://github.com/fyi-oxide/pdf_oxide/releases/download';
+const PACKAGE_VERSION_DEFAULT = 'v0.3.56';
+const RELEASE_BASE_URL = 'https://github.com/yfedoseev/pdf_oxide/releases/download';
 // Path is relative to the package root (parent-of-php in the new
 // root-composer.json layout); see comment on $packageRoot below.
 const MANIFEST_RELATIVE = 'php/scripts/native-manifest.json';
@@ -253,12 +253,12 @@ function downloadFile(string $url, string $dest): bool
         'http' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.55',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.56',
         ],
         'https' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.55',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.56',
         ],
     ]);
     $data = @file_get_contents($url, false, $ctx);
@@ -336,7 +336,7 @@ function printManualInstall(string $version): void
 {
     fwrite(STDERR, "\n[pdf_oxide] Manual install instructions:\n");
     fwrite(STDERR, "  1. Download libpdf_oxide for your platform:\n");
-    fwrite(STDERR, "       https://github.com/fyi-oxide/pdf_oxide/releases/tag/{$version}\n");
+    fwrite(STDERR, "       https://github.com/yfedoseev/pdf_oxide/releases/tag/{$version}\n");
     fwrite(STDERR, "  2. Extract the cdylib (libpdf_oxide.so / .dylib / pdf_oxide.dll)\n");
     fwrite(STDERR, "     into one of:\n");
     fwrite(STDERR, "       vendor/oxide/pdf-oxide/lib/<platform>/\n");

--- a/php/src/DocumentEditor.php
+++ b/php/src/DocumentEditor.php
@@ -104,7 +104,7 @@ final class DocumentEditor
     public function getProducer(): string
     {
         $ffi = NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $cStr = $ffi->document_editor_get_producer($this->requireHandle(), \FFI::addr($errorCode));
         if ($cStr === null || (int) $errorCode->cdata !== 0) {
             return '';
@@ -119,7 +119,7 @@ final class DocumentEditor
     {
         $ffi = NativeLibrary::getInstance();
         $cStr = StringMarshaller::toCString($producer);
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         try {
             $rc = (int) $ffi->document_editor_set_producer($this->requireHandle(), $cStr, \FFI::addr($errorCode));
             if ($rc !== 0 || (int) $errorCode->cdata !== 0) {
@@ -135,8 +135,8 @@ final class DocumentEditor
     public function version(): array
     {
         $ffi = NativeLibrary::getInstance();
-        $major = \FFI::new('uint8_t');
-        $minor = \FFI::new('uint8_t');
+        $major = $ffi->new('uint8_t');
+        $minor = $ffi->new('uint8_t');
         $ffi->document_editor_get_version($this->requireHandle(), \FFI::addr($major), \FFI::addr($minor));
         return ['major' => (int) $major->cdata, 'minor' => (int) $minor->cdata];
     }
@@ -144,7 +144,7 @@ final class DocumentEditor
     public function pageCount(): int
     {
         $ffi = NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         return (int) $ffi->document_editor_get_page_count($this->requireHandle(), \FFI::addr($errorCode));
     }
 
@@ -158,7 +158,7 @@ final class DocumentEditor
     public function sourcePath(): string
     {
         $ffi = NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $cStr = $ffi->document_editor_get_source_path($this->requireHandle(), \FFI::addr($errorCode));
         if ($cStr === null) {
             return '';
@@ -175,7 +175,7 @@ final class DocumentEditor
     {
         $ffi = NativeLibrary::getInstance();
         $cPath = StringMarshaller::toCString($path);
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         try {
             $rc = (int) $ffi->document_editor_save($this->requireHandle(), $cPath, \FFI::addr($errorCode));
             if ($rc !== 0 || (int) $errorCode->cdata !== 0) {
@@ -191,8 +191,8 @@ final class DocumentEditor
     {
         $ffi = NativeLibrary::getInstance();
         // C signature: document_editor_save_to_bytes(handle, uint64_t* len, int32_t* err)
-        $dataLen = \FFI::new('uint64_t');
-        $errorCode = \FFI::new('int32_t');
+        $dataLen = $ffi->new('uint64_t');
+        $errorCode = $ffi->new('int32_t');
         $ptr = $ffi->document_editor_save_to_bytes(
             $this->requireHandle(),
             \FFI::addr($dataLen),

--- a/php/src/FFI/FunctionBindings.php
+++ b/php/src/FFI/FunctionBindings.php
@@ -30,7 +30,7 @@ class FunctionBindings
     public function pdfDocumentOpen(string $path): ?CData
     {
         $cPath = StringMarshaller::toCString($path);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $handle = $this->ffi->pdf_document_open($cPath, FFI::addr($errorCode));
@@ -59,8 +59,8 @@ class FunctionBindings
      */
     public function pdfDocumentGetVersion(CData $handle): array
     {
-        $major = FFI::new('uint8_t');
-        $minor = FFI::new('uint8_t');
+        $major = $this->ffi->new('uint8_t');
+        $minor = $this->ffi->new('uint8_t');
 
         $this->ffi->pdf_document_get_version($handle, FFI::addr($major), FFI::addr($minor));
 
@@ -78,7 +78,7 @@ class FunctionBindings
      */
     public function pdfDocumentGetPageCount(CData $handle): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $count = $this->ffi->pdf_document_get_page_count($handle, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_get_page_count');
         return (int) $count;
@@ -104,7 +104,7 @@ class FunctionBindings
      */
     public function pdfDocumentExtractText(CData $handle, int $pageIndex): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $text = $this->ffi->pdf_document_extract_text($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_extract_text', ['page' => $pageIndex]);
         return StringMarshaller::fromCString($text);
@@ -119,7 +119,7 @@ class FunctionBindings
      */
     public function pdfDocumentToMarkdown(CData $handle, int $pageIndex): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $markdown = $this->ffi->pdf_document_to_markdown($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_to_markdown', ['page' => $pageIndex]);
         return StringMarshaller::fromCString($markdown);
@@ -133,7 +133,7 @@ class FunctionBindings
      */
     public function pdfDocumentToMarkdownAll(CData $handle): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $markdown = $this->ffi->pdf_document_to_markdown_all($handle, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_to_markdown_all');
         return StringMarshaller::fromCString($markdown);
@@ -148,7 +148,7 @@ class FunctionBindings
      */
     public function pdfDocumentToHtml(CData $handle, int $pageIndex): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $html = $this->ffi->pdf_document_to_html($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_to_html', ['page' => $pageIndex]);
         return StringMarshaller::fromCString($html);
@@ -163,7 +163,7 @@ class FunctionBindings
      */
     public function pdfDocumentToPlainText(CData $handle, int $pageIndex): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $text = $this->ffi->pdf_document_to_plain_text($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_to_plain_text', ['page' => $pageIndex]);
         return StringMarshaller::fromCString($text);
@@ -185,7 +185,7 @@ class FunctionBindings
         bool $caseSensitive = false
     ): CData {
         $cTerm = StringMarshaller::toCString($searchTerm);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $results = $this->ffi->pdf_document_search_page(
@@ -219,7 +219,7 @@ class FunctionBindings
         bool $caseSensitive = false
     ): CData {
         $cTerm = StringMarshaller::toCString($searchTerm);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $results = $this->ffi->pdf_document_search_all(
@@ -246,7 +246,7 @@ class FunctionBindings
      */
     public function pdfDocumentGetEmbeddedFonts(CData $handle, int $pageIndex): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $fonts = $this->ffi->pdf_document_get_embedded_fonts($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_get_embedded_fonts', ['page' => $pageIndex]);
         return $fonts;
@@ -261,7 +261,7 @@ class FunctionBindings
      */
     public function pdfDocumentGetEmbeddedImages(CData $handle, int $pageIndex): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $images = $this->ffi->pdf_document_get_embedded_images($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_get_embedded_images', ['page' => $pageIndex]);
         return $images;
@@ -288,7 +288,7 @@ class FunctionBindings
      */
     public function oxideSearchResultGetText(CData $resultsHandle, int $index): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $text = $this->ffi->pdf_oxide_search_result_get_text($resultsHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_oxide_search_result_get_text', ['index' => $index]);
         return StringMarshaller::fromCString($text);
@@ -307,7 +307,7 @@ class FunctionBindings
         // Pre-fix omitted the err pointer → cdylib wrote through register
         // garbage; same root cause as the v0.3.55 Ruby aarch64 segfaults
         // (#547, commit a9cff143).
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $page = $this->ffi->pdf_oxide_search_result_get_page($resultsHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_search_result_get_page');
         return (int) $page;
@@ -323,11 +323,11 @@ class FunctionBindings
      */
     public function oxideSearchResultGetBbox(CData $resultsHandle, int $index): array
     {
-        $x = FFI::new('float');
-        $y = FFI::new('float');
-        $width = FFI::new('float');
-        $height = FFI::new('float');
-        $errorCode = FFI::new('int32_t');
+        $x = $this->ffi->new('float');
+        $y = $this->ffi->new('float');
+        $width = $this->ffi->new('float');
+        $height = $this->ffi->new('float');
+        $errorCode = $this->ffi->new('int32_t');
 
         // C: void pdf_oxide_search_result_get_bbox(results, index,
         //                                          *x, *y, *w, *h, *err)
@@ -381,7 +381,7 @@ class FunctionBindings
     public function oxideAnnotationGetType(CData $listHandle, int $index): string
     {
         // C: char *pdf_oxide_annotation_get_type(annotations, index, *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $type = $this->ffi->pdf_oxide_annotation_get_type($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_annotation_get_type');
         return StringMarshaller::fromCString($type);
@@ -396,7 +396,7 @@ class FunctionBindings
      */
     public function oxideAnnotationGetContent(CData $listHandle, int $index): string
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $content = $this->ffi->pdf_oxide_annotation_get_content($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_annotation_get_content');
         return StringMarshaller::fromCString($content);
@@ -432,7 +432,7 @@ class FunctionBindings
      */
     public function oxideFontGetName(CData $listHandle, int $index): string
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $name = $this->ffi->pdf_oxide_font_get_name($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_font_get_name');
         return StringMarshaller::fromCString($name);
@@ -447,7 +447,7 @@ class FunctionBindings
      */
     public function oxideFontGetType(CData $listHandle, int $index): string
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $type = $this->ffi->pdf_oxide_font_get_type($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_font_get_type');
         return StringMarshaller::fromCString($type);
@@ -462,7 +462,7 @@ class FunctionBindings
      */
     public function oxideFontIsEmbedded(CData $listHandle, int $index): bool
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $embedded = $this->ffi->pdf_oxide_font_is_embedded($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_font_is_embedded');
         return ((int) $embedded) !== 0;
@@ -498,7 +498,7 @@ class FunctionBindings
      */
     public function oxideImageGetWidth(CData $listHandle, int $index): int
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $w = $this->ffi->pdf_oxide_image_get_width($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_image_get_width');
         return (int) $w;
@@ -513,7 +513,7 @@ class FunctionBindings
      */
     public function oxideImageGetHeight(CData $listHandle, int $index): int
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $h = $this->ffi->pdf_oxide_image_get_height($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_image_get_height');
         return (int) $h;
@@ -528,7 +528,7 @@ class FunctionBindings
      */
     public function oxideImageGetFormat(CData $listHandle, int $index): string
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $format = $this->ffi->pdf_oxide_image_get_format($listHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_image_get_format');
         return StringMarshaller::fromCString($format);
@@ -554,7 +554,7 @@ class FunctionBindings
      */
     public function pdfRenderPage(CData $handle, int $pageIndex, ?CData $options = null): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $imageHandle = $this->ffi->pdf_render_page($handle, $pageIndex, $options, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_render_page');
         return $imageHandle;
@@ -575,7 +575,7 @@ class FunctionBindings
      */
     public function pdfRenderPageRegion(CData $handle, int $pageIndex, float $x, float $y, float $width, float $height, ?CData $options = null): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $imageHandle = $this->ffi->pdf_render_page_region($handle, $pageIndex, $x, $y, $width, $height, $options, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_render_page_region');
         return $imageHandle;
@@ -592,7 +592,7 @@ class FunctionBindings
      */
     public function pdfRenderPageZoom(CData $handle, int $pageIndex, float $zoomLevel, ?CData $options = null): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $imageHandle = $this->ffi->pdf_render_page_zoom($handle, $pageIndex, $zoomLevel, $options, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_render_page_zoom');
         return $imageHandle;
@@ -610,7 +610,7 @@ class FunctionBindings
      */
     public function pdfRenderPageFit(CData $handle, int $pageIndex, int $fitWidth, int $fitHeight, ?CData $options = null): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $imageHandle = $this->ffi->pdf_render_page_fit($handle, $pageIndex, $fitWidth, $fitHeight, $options, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_render_page_fit');
         return $imageHandle;
@@ -627,7 +627,7 @@ class FunctionBindings
      */
     public function pdfRenderPageThumbnail(CData $handle, int $pageIndex, int $maxSize, ?CData $options = null): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $imageHandle = $this->ffi->pdf_render_page_thumbnail($handle, $pageIndex, $maxSize, $options, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_render_page_thumbnail');
         return $imageHandle;
@@ -663,7 +663,7 @@ class FunctionBindings
         // code through wherever `$options` pointed. Pass a proper
         // err buffer here; `$options` retained on the wrapper API for
         // forward-compat once the cdylib implementation lands.
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         unset($options);
         $estimate = $this->ffi->pdf_estimate_render_time($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_estimate_render_time');
@@ -687,7 +687,7 @@ class FunctionBindings
         // landed in the EC slot, `*err` landed in `size_px`, and the
         // cdylib wrote to whatever was in the actual `*err` register.
         $cData = StringMarshaller::toCString($data);
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
 
         try {
             $barcodeHandle = $this->ffi->pdf_generate_qr_code(
@@ -718,7 +718,7 @@ class FunctionBindings
         // Pre-fix omitted `size_px` AND the format was passed as a
         // string instead of the int32 ordinal.
         $cData = StringMarshaller::toCString($data);
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
 
         try {
             $barcodeHandle = $this->ffi->pdf_generate_barcode(
@@ -747,8 +747,8 @@ class FunctionBindings
         //                                       uintptr_t *out_len, int32_t *err)
         // Pre-fix passed only `(handle, FFI::addr($sizePtr))` — `*out_len`
         // landed in `_size_px` slot, `*err` slot was register garbage.
-        $outLen = FFI::new('size_t');
-        $errorCode = FFI::new('int32_t');
+        $outLen = $this->ffi->new('size_t');
+        $errorCode = $this->ffi->new('int32_t');
         $dataPtr = $this->ffi->pdf_barcode_get_image_png(
             $barcodeHandle,
             $sizePx,
@@ -759,7 +759,7 @@ class FunctionBindings
         $size = (int) $outLen->cdata;
         $bytes = FFI::string($dataPtr, $size);
         // PNG buffer is heap-allocated by the cdylib — must free.
-        $this->ffi->free_bytes(FFI::cast('uint8_t*', $dataPtr));
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $dataPtr));
         return $bytes;
     }
 
@@ -773,7 +773,7 @@ class FunctionBindings
     public function pdfBarcodeGetSvg(CData $barcodeHandle, int $sizePx = 256): string
     {
         // C: char *pdf_barcode_get_svg(handle, int32_t _size_px, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $svg = $this->ffi->pdf_barcode_get_svg($barcodeHandle, $sizePx, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_barcode_get_svg');
         return StringMarshaller::fromCString($svg);
@@ -792,7 +792,7 @@ class FunctionBindings
      */
     public function pdfAddBarcodeToPage(CData $handle, int $pageIndex, CData $barcodeHandle, float $x, float $y, float $width, float $height): void
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $this->ffi->pdf_add_barcode_to_page($handle, $pageIndex, $barcodeHandle, $x, $y, $width, $height, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_add_barcode_to_page');
     }
@@ -829,7 +829,7 @@ class FunctionBindings
         $cDet = StringMarshaller::toCString($detectionModelPath);
         $cRec = StringMarshaller::toCString($recognitionModelPath);
         $cDict = StringMarshaller::toCString($dictionaryPath);
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         try {
             $engine = $this->ffi->pdf_ocr_engine_create(
                 $cDet,
@@ -864,7 +864,7 @@ class FunctionBindings
      */
     public function pdfOcrPageNeedsOcr(CData $handle, int $pageIndex): bool
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $needs = $this->ffi->pdf_ocr_page_needs_ocr($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_ocr_page_needs_ocr');
         return (bool) $needs;
@@ -885,7 +885,7 @@ class FunctionBindings
         //     int32_t page_index, const void *engine, int32_t *err)
         // Pre-fix passed only `(results)` — treated as `doc`,
         // remaining 3 slots were register garbage.
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $text = $this->ffi->pdf_ocr_extract_text(
             $docHandle,
             $pageIndex,
@@ -906,7 +906,7 @@ class FunctionBindings
     public function pdfPdfAIsCompliant(CData $resultHandle): bool
     {
         // C: bool pdf_pdf_a_is_compliant(const FfiPdfAResults *results, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $compliant = $this->ffi->pdf_pdf_a_is_compliant($resultHandle, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_pdf_a_is_compliant');
         return (bool) $compliant;
@@ -943,7 +943,7 @@ class FunctionBindings
      */
     public function pdfPdfAGetError(CData $resultHandle, int $index): string
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $error = $this->ffi->pdf_pdf_a_get_error($resultHandle, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_pdf_a_get_error');
         return StringMarshaller::fromCString($error);
@@ -958,7 +958,7 @@ class FunctionBindings
      */
     public function pdfPdfXIsCompliant(CData $resultHandle): bool
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $compliant = $this->ffi->pdf_pdf_x_is_compliant($resultHandle, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_pdf_x_is_compliant');
         return (bool) $compliant;
@@ -990,7 +990,7 @@ class FunctionBindings
         // Pre-fix omitted `level` — `*err` landed in the level slot
         // and *err slot was register garbage. The cdylib defaults
         // level == 2 → UA-2, else UA-1.
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $resultHandle = $this->ffi->pdf_validate_pdf_ua($handle, $level, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_validate_pdf_ua');
         return $resultHandle;
@@ -1004,7 +1004,7 @@ class FunctionBindings
      */
     public function pdfPdfUaIsAccessible(CData $resultHandle): bool
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $accessible = $this->ffi->pdf_pdf_ua_is_accessible($resultHandle, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_pdf_ua_is_accessible');
         return (bool) $accessible;
@@ -1031,7 +1031,7 @@ class FunctionBindings
     public function pdfConvertToPdfA(CData $handle, string $level): void
     {
         $cLevel = StringMarshaller::toCString($level);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $this->ffi->pdf_convert_to_pdf_a($handle, $cLevel, FFI::addr($errorCode));
@@ -1051,7 +1051,7 @@ class FunctionBindings
     public function pdfDocumentGetSignatureCount(CData $handle): int
     {
         // C: int32_t pdf_document_get_signature_count(const PdfDocument *handle, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $count = $this->ffi->pdf_document_get_signature_count($handle, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_document_get_signature_count');
         return (int) $count;
@@ -1066,7 +1066,7 @@ class FunctionBindings
      */
     public function pdfDocumentGetSignature(CData $handle, int $index): CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $signatureHandle = $this->ffi->pdf_document_get_signature($handle, $index, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_get_signature');
         return $signatureHandle;
@@ -1089,7 +1089,7 @@ class FunctionBindings
     public function pdfSignatureVerify(CData $signatureHandle): bool
     {
         // C: bool pdf_signature_verify(const void *signature_handle, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $valid = $this->ffi->pdf_signature_verify($signatureHandle, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_signature_verify');
         return (bool) $valid;
@@ -1116,7 +1116,7 @@ class FunctionBindings
     {
         // PKCS#12 / PEM cert data is BINARY (contains bytes >= 0x80).
         // Pre-v0.3.55 this went through StringMarshaller::toCString
-        // which allocates `char[N+1]` and forces a `FFI::cast('uint8_t*', …)`
+        // which allocates `char[N+1]` and forces a `$this->ffi->cast('uint8_t*', …)`
         // — on PHP 8.5 with `char` defaulting to signed, that cast
         // segfaults the moment the cdylib touches a byte with the high
         // bit set. Allocate the input as `uint8_t[N]` directly so no
@@ -1132,7 +1132,7 @@ class FunctionBindings
             FFI::memcpy($cData, $certData, $certLen);
         }
         $cPassword = StringMarshaller::toCString($password); // password is a text string — toCString is correct here.
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
 
         try {
             $certHandle = $this->ffi->pdf_certificate_load_from_bytes(
@@ -1158,7 +1158,7 @@ class FunctionBindings
     public function pdfCertificateGetSubject(CData $certificateHandle): string
     {
         // C: char *pdf_certificate_get_subject(const void *cert, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $subject = $this->ffi->pdf_certificate_get_subject($certificateHandle, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_certificate_get_subject');
         return StringMarshaller::fromCString($subject);
@@ -1172,7 +1172,7 @@ class FunctionBindings
      */
     public function pdfCertificateGetIssuer(CData $certificateHandle): string
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $issuer = $this->ffi->pdf_certificate_get_issuer($certificateHandle, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_certificate_get_issuer');
         return StringMarshaller::fromCString($issuer);
@@ -1214,7 +1214,7 @@ class FunctionBindings
     public function pdfPageGetWidth(CData $docHandle, int $pageIndex): float
     {
         // C: float pdf_page_get_width(const PdfDocument *handle, int32_t page_index, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $width = $this->ffi->pdf_page_get_width($docHandle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_page_get_width');
         return (float) $width;
@@ -1225,7 +1225,7 @@ class FunctionBindings
      */
     public function pdfPageGetHeight(CData $docHandle, int $pageIndex): float
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $height = $this->ffi->pdf_page_get_height($docHandle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_page_get_height');
         return (float) $height;
@@ -1240,7 +1240,7 @@ class FunctionBindings
     public function pdfFromMarkdown(string $markdown): ?CData
     {
         $cMarkdown = StringMarshaller::toCString($markdown);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $handle = $this->ffi->pdf_from_markdown($cMarkdown, FFI::addr($errorCode));
@@ -1257,7 +1257,7 @@ class FunctionBindings
     public function pdfFromHtml(string $html): ?CData
     {
         $cHtml = StringMarshaller::toCString($html);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $handle = $this->ffi->pdf_from_html($cHtml, FFI::addr($errorCode));
@@ -1274,7 +1274,7 @@ class FunctionBindings
     public function pdfFromText(string $text): ?CData
     {
         $cText = StringMarshaller::toCString($text);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $handle = $this->ffi->pdf_from_text($cText, FFI::addr($errorCode));
@@ -1291,7 +1291,7 @@ class FunctionBindings
     public function pdfSave(CData $handle, string $path): void
     {
         $cPath = StringMarshaller::toCString($path);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $this->ffi->pdf_save($handle, $cPath, FFI::addr($errorCode));
@@ -1316,8 +1316,8 @@ class FunctionBindings
      */
     public function pdfSaveToBytes(CData $handle): string
     {
-        $outputLen = FFI::new('size_t');
-        $errorCode = FFI::new('int32_t');
+        $outputLen = $this->ffi->new('size_t');
+        $errorCode = $this->ffi->new('int32_t');
 
         $ptr = $this->ffi->pdf_save_to_bytes(
             $handle,
@@ -1332,7 +1332,7 @@ class FunctionBindings
         }
         $bytes = FFI::string($ptr, $len);
         // Owned uint8_t* — free via the cdylib's free_bytes.
-        $this->ffi->free_bytes(FFI::cast('uint8_t*', $ptr));
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $ptr));
         return $bytes;
     }
 
@@ -1341,7 +1341,7 @@ class FunctionBindings
      */
     public function pdfGetPageCount(CData $handle): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $count = (int) $this->ffi->pdf_get_page_count($handle, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'pdf_get_page_count');
@@ -1375,7 +1375,7 @@ class FunctionBindings
      */
     public function pdfOxideFontGetName(CData $fontList, int $index): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $cStr = $this->ffi->pdf_oxide_font_get_name($fontList, $index, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'pdf_oxide_font_get_name');
@@ -1390,7 +1390,7 @@ class FunctionBindings
      */
     public function pdfOxideFontGetType(CData $fontList, int $index): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $cStr = $this->ffi->pdf_oxide_font_get_type($fontList, $index, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'pdf_oxide_font_get_type');
@@ -1405,7 +1405,7 @@ class FunctionBindings
      */
     public function pdfOxideFontGetEncoding(CData $fontList, int $index): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $cStr = $this->ffi->pdf_oxide_font_get_encoding($fontList, $index, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'pdf_oxide_font_get_encoding');
@@ -1421,7 +1421,7 @@ class FunctionBindings
     public function pdfOxideFontIsEmbedded(CData $fontList, int $index): bool
     {
         // C: int32_t pdf_oxide_font_is_embedded(const FfiFontList *fonts, int32_t index, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $embedded = $this->ffi->pdf_oxide_font_is_embedded($fontList, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_font_is_embedded');
         return ((int) $embedded) !== 0;
@@ -1432,7 +1432,7 @@ class FunctionBindings
      */
     public function pdfOxideFontIsSubset(CData $fontList, int $index): bool
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $subset = $this->ffi->pdf_oxide_font_is_subset($fontList, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_font_is_subset');
         return ((int) $subset) !== 0;
@@ -1443,7 +1443,7 @@ class FunctionBindings
      */
     public function pdfOxideFontGetSize(CData $fontList, int $index): float
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $size = $this->ffi->pdf_oxide_font_get_size($fontList, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_font_get_size');
         return (float) $size;
@@ -1472,7 +1472,7 @@ class FunctionBindings
      */
     public function pdfOxideImageGetWidth(CData $imageList, int $index): int
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $w = $this->ffi->pdf_oxide_image_get_width($imageList, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_image_get_width');
         return (int) $w;
@@ -1483,7 +1483,7 @@ class FunctionBindings
      */
     public function pdfOxideImageGetHeight(CData $imageList, int $index): int
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $h = $this->ffi->pdf_oxide_image_get_height($imageList, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_image_get_height');
         return (int) $h;
@@ -1494,7 +1494,7 @@ class FunctionBindings
      */
     public function pdfOxideImageGetFormat(CData $imageList, int $index): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $cStr = $this->ffi->pdf_oxide_image_get_format($imageList, $index, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'pdf_oxide_image_get_format');
@@ -1509,7 +1509,7 @@ class FunctionBindings
      */
     public function pdfOxideImageGetColorspace(CData $imageList, int $index): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $cStr = $this->ffi->pdf_oxide_image_get_colorspace($imageList, $index, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'pdf_oxide_image_get_colorspace');
@@ -1524,7 +1524,7 @@ class FunctionBindings
      */
     public function pdfOxideImageGetBitsPerComponent(CData $imageList, int $index): int
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $bpc = $this->ffi->pdf_oxide_image_get_bits_per_component($imageList, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_image_get_bits_per_component');
         return (int) $bpc;
@@ -1535,8 +1535,8 @@ class FunctionBindings
      */
     public function pdfOxideImageGetData(CData $imageList, int $index): string
     {
-        $outSize = FFI::new('size_t');
-        $errorCode = FFI::new('int32_t');
+        $outSize = $this->ffi->new('size_t');
+        $errorCode = $this->ffi->new('int32_t');
 
         $dataPtr = $this->ffi->pdf_oxide_image_get_data(
             $imageList,
@@ -1552,7 +1552,7 @@ class FunctionBindings
         }
         $bytes = FFI::string($dataPtr, $size);
         // Owned uint8_t* — free via the cdylib's free_bytes.
-        $this->ffi->free_bytes(FFI::cast('uint8_t*', $dataPtr));
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $dataPtr));
         return $bytes;
     }
 
@@ -1579,7 +1579,7 @@ class FunctionBindings
      */
     public function pdfOxideSearchResultGetText(CData $results, int $index): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $cStr = $this->ffi->pdf_oxide_search_result_get_text($results, $index, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'pdf_oxide_search_result_get_text');
@@ -1596,7 +1596,7 @@ class FunctionBindings
     {
         // C: int32_t pdf_oxide_search_result_get_page(results, index, *err)
         // Same off-by-one trailing-err bug class as #547 round 3.
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $page = $this->ffi->pdf_oxide_search_result_get_page($results, $index, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_oxide_search_result_get_page');
         return (int) $page;
@@ -1608,11 +1608,11 @@ class FunctionBindings
      */
     public function pdfOxideSearchResultGetBbox(CData $results, int $index): array
     {
-        $x = FFI::new('float');
-        $y = FFI::new('float');
-        $width = FFI::new('float');
-        $height = FFI::new('float');
-        $errorCode = FFI::new('int');
+        $x = $this->ffi->new('float');
+        $y = $this->ffi->new('float');
+        $width = $this->ffi->new('float');
+        $height = $this->ffi->new('float');
+        $errorCode = $this->ffi->new('int');
 
         try {
             $this->ffi->pdf_oxide_search_result_get_bbox(
@@ -1665,7 +1665,7 @@ class FunctionBindings
     public function pdfCertificateGetSerial(CData $cert): string
     {
         // C: char *pdf_certificate_get_serial(const void *cert, int32_t *err)
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $serial = $this->ffi->pdf_certificate_get_serial($cert, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_certificate_get_serial');
         return StringMarshaller::fromCString($serial);
@@ -1677,7 +1677,7 @@ class FunctionBindings
      */
     public function pdfSignatureGetSigningTime(CData $sig): string
     {
-        $errorCode = FFI::new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
         $time = $this->ffi->pdf_signature_get_signing_time($sig, FFI::addr($errorCode));
         ErrorHandler::check((int) $errorCode->cdata, 'pdf_signature_get_signing_time');
         return StringMarshaller::fromCString($time);
@@ -1721,7 +1721,7 @@ class FunctionBindings
      */
     public function pdfDocumentClassifyPage(CData $handle, int $pageIndex): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $json = $this->ffi->pdf_document_classify_page($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_classify_page', ['page' => $pageIndex]);
         return StringMarshaller::fromCString($json);
@@ -1733,7 +1733,7 @@ class FunctionBindings
      */
     public function pdfDocumentClassifyDocument(CData $handle): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $json = $this->ffi->pdf_document_classify_document($handle, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_classify_document');
         return StringMarshaller::fromCString($json);
@@ -1747,7 +1747,7 @@ class FunctionBindings
      */
     public function pdfDocumentExtractTextAuto(CData $handle, int $pageIndex): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $text = $this->ffi->pdf_document_extract_text_auto($handle, $pageIndex, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_extract_text_auto', ['page' => $pageIndex]);
         return StringMarshaller::fromCString($text);
@@ -1760,7 +1760,7 @@ class FunctionBindings
      */
     public function pdfDocumentExtractPageAuto(CData $handle, int $pageIndex, ?string $optionsJson = null): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $cOpts = StringMarshaller::toCString($optionsJson ?? '{}');
         try {
             $json = $this->ffi->pdf_document_extract_page_auto(
@@ -1784,7 +1784,7 @@ class FunctionBindings
      */
     public function pdfOxidePrefetchModels(string $languagesCsv): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $cCsv = StringMarshaller::toCString($languagesCsv);
         try {
             $path = $this->ffi->pdf_oxide_prefetch_models($cCsv, FFI::addr($errorCode));
@@ -1828,7 +1828,7 @@ class FunctionBindings
     public function documentEditorOpen(string $path): ?CData
     {
         $cPath = StringMarshaller::toCString($path);
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         try {
             $handle = $this->ffi->document_editor_open($cPath, FFI::addr($errorCode));
             ErrorHandler::check($errorCode->cdata, 'document_editor_open', ['path' => $path]);
@@ -1862,7 +1862,7 @@ class FunctionBindings
         float $g = 0.0,
         float $b = 0.0
     ): int {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $result = $this->ffi->pdf_redaction_add(
             $editor,
             $page,
@@ -1884,7 +1884,7 @@ class FunctionBindings
      */
     public function pdfRedactionCount(CData $editor, int $page): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $n = $this->ffi->pdf_redaction_count($editor, $page, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_redaction_count', ['page' => $page]);
         return (int) $n;
@@ -1902,7 +1902,7 @@ class FunctionBindings
         float $g = 0.0,
         float $b = 0.0
     ): int {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $result = $this->ffi->pdf_redaction_apply(
             $editor,
             $scrubMetadata,
@@ -1921,7 +1921,7 @@ class FunctionBindings
      */
     public function pdfRedactionScrubMetadata(CData $editor): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $result = $this->ffi->pdf_redaction_scrub_metadata($editor, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_redaction_scrub_metadata');
         return (int) $result;
@@ -1932,7 +1932,7 @@ class FunctionBindings
      */
     public function documentEditorApplyPageRedactions(CData $editor, int $page): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $result = $this->ffi->document_editor_apply_page_redactions(
             $editor,
             $page,
@@ -1947,7 +1947,7 @@ class FunctionBindings
      */
     public function documentEditorApplyAllRedactions(CData $editor): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $result = $this->ffi->document_editor_apply_all_redactions($editor, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'document_editor_apply_all_redactions');
         return (int) $result;
@@ -1965,17 +1965,17 @@ class FunctionBindings
      */
     public function pdfSignBytesPadesOpts(string $pdfData, CData $optionsBlob): string
     {
-        $errorCode = FFI::new('int');
-        $outLen = FFI::new('size_t');
+        $errorCode = $this->ffi->new('int');
+        $outLen = $this->ffi->new('size_t');
         $pdfLen = strlen($pdfData);
 
-        $pdfBuf = FFI::new('uint8_t[' . ($pdfLen > 0 ? $pdfLen : 1) . ']', false);
+        $pdfBuf = $this->ffi->new('uint8_t[' . ($pdfLen > 0 ? $pdfLen : 1) . ']', false);
         if ($pdfLen > 0) {
             FFI::memcpy($pdfBuf, $pdfData, $pdfLen);
         }
 
         $out = $this->ffi->pdf_sign_bytes_pades_opts(
-            FFI::cast('uint8_t*', $pdfBuf),
+            $this->ffi->cast('uint8_t*', $pdfBuf),
             $pdfLen,
             FFI::addr($optionsBlob),
             FFI::addr($outLen),
@@ -1986,7 +1986,7 @@ class FunctionBindings
         $length = (int) $outLen->cdata;
         $signed = FFI::string($out, $length);
         // Free native buffer.
-        $this->ffi->free_bytes(FFI::cast('uint8_t*', $out));
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $out));
         FFI::free($pdfBuf);
 
         return $signed;
@@ -1998,7 +1998,7 @@ class FunctionBindings
      */
     public function pdfSignatureGetPadesLevel(CData $signatureHandle): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $level = $this->ffi->pdf_signature_get_pades_level($signatureHandle, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_signature_get_pades_level');
         return (int) $level;
@@ -2016,7 +2016,7 @@ class FunctionBindings
      */
     public function pdfDocumentHasTimestamp(CData $documentHandle): bool
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $r = $this->ffi->pdf_document_has_timestamp($documentHandle, FFI::addr($errorCode));
         $code = (int) $errorCode->cdata;
         if ($code === ErrorHandler::UNSUPPORTED) {
@@ -2037,15 +2037,15 @@ class FunctionBindings
      */
     public function pdfDocumentOpenFromDocxBytes(string $data): ?CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $len = strlen($data);
-        $buf = FFI::new('uint8_t[' . ($len > 0 ? $len : 1) . ']', false);
+        $buf = $this->ffi->new('uint8_t[' . ($len > 0 ? $len : 1) . ']', false);
         if ($len > 0) {
             FFI::memcpy($buf, $data, $len);
         }
         try {
             $handle = $this->ffi->pdf_document_open_from_docx_bytes(
-                FFI::cast('uint8_t*', $buf),
+                $this->ffi->cast('uint8_t*', $buf),
                 $len,
                 FFI::addr($errorCode)
             );
@@ -2058,15 +2058,15 @@ class FunctionBindings
 
     public function pdfDocumentOpenFromPptxBytes(string $data): ?CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $len = strlen($data);
-        $buf = FFI::new('uint8_t[' . ($len > 0 ? $len : 1) . ']', false);
+        $buf = $this->ffi->new('uint8_t[' . ($len > 0 ? $len : 1) . ']', false);
         if ($len > 0) {
             FFI::memcpy($buf, $data, $len);
         }
         try {
             $handle = $this->ffi->pdf_document_open_from_pptx_bytes(
-                FFI::cast('uint8_t*', $buf),
+                $this->ffi->cast('uint8_t*', $buf),
                 $len,
                 FFI::addr($errorCode)
             );
@@ -2079,15 +2079,15 @@ class FunctionBindings
 
     public function pdfDocumentOpenFromXlsxBytes(string $data): ?CData
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $len = strlen($data);
-        $buf = FFI::new('uint8_t[' . ($len > 0 ? $len : 1) . ']', false);
+        $buf = $this->ffi->new('uint8_t[' . ($len > 0 ? $len : 1) . ']', false);
         if ($len > 0) {
             FFI::memcpy($buf, $data, $len);
         }
         try {
             $handle = $this->ffi->pdf_document_open_from_xlsx_bytes(
-                FFI::cast('uint8_t*', $buf),
+                $this->ffi->cast('uint8_t*', $buf),
                 $len,
                 FFI::addr($errorCode)
             );
@@ -2103,37 +2103,37 @@ class FunctionBindings
      */
     public function pdfDocumentToDocxBytes(CData $handle): string
     {
-        $errorCode = FFI::new('int');
-        $outLen = FFI::new('size_t');
+        $errorCode = $this->ffi->new('int');
+        $outLen = $this->ffi->new('size_t');
         $out = $this->ffi->pdf_document_to_docx($handle, FFI::addr($outLen), FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_to_docx');
         $length = (int) $outLen->cdata;
         $bytes = FFI::string($out, $length);
-        $this->ffi->free_bytes(FFI::cast('uint8_t*', $out));
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $out));
         return $bytes;
     }
 
     public function pdfDocumentToPptxBytes(CData $handle): string
     {
-        $errorCode = FFI::new('int');
-        $outLen = FFI::new('size_t');
+        $errorCode = $this->ffi->new('int');
+        $outLen = $this->ffi->new('size_t');
         $out = $this->ffi->pdf_document_to_pptx($handle, FFI::addr($outLen), FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_to_pptx');
         $length = (int) $outLen->cdata;
         $bytes = FFI::string($out, $length);
-        $this->ffi->free_bytes(FFI::cast('uint8_t*', $out));
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $out));
         return $bytes;
     }
 
     public function pdfDocumentToXlsxBytes(CData $handle): string
     {
-        $errorCode = FFI::new('int');
-        $outLen = FFI::new('size_t');
+        $errorCode = $this->ffi->new('int');
+        $outLen = $this->ffi->new('size_t');
         $out = $this->ffi->pdf_document_to_xlsx($handle, FFI::addr($outLen), FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_to_xlsx');
         $length = (int) $outLen->cdata;
         $bytes = FFI::string($out, $length);
-        $this->ffi->free_bytes(FFI::cast('uint8_t*', $out));
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $out));
         return $bytes;
     }
 
@@ -2150,7 +2150,7 @@ class FunctionBindings
      */
     public function pdfDocumentPlanSplitByBookmarks(CData $handle, ?string $optionsJson = null): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $cOpts = StringMarshaller::toCString($optionsJson ?? '{}');
         try {
             $json = $this->ffi->pdf_document_plan_split_by_bookmarks(
@@ -2176,7 +2176,7 @@ class FunctionBindings
      */
     public function pdfDocumentGetOutline(CData $handle): string
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $json = $this->ffi->pdf_document_get_outline($handle, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_document_get_outline');
         return StringMarshaller::fromCString($json);
@@ -2189,7 +2189,7 @@ class FunctionBindings
      */
     public function pdfPageBuilderWatermark(CData $pageBuilder, string $text): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $cText = StringMarshaller::toCString($text);
         try {
             $result = $this->ffi->pdf_page_builder_watermark($pageBuilder, $cText, FFI::addr($errorCode));
@@ -2203,7 +2203,7 @@ class FunctionBindings
     /** "CONFIDENTIAL" preset watermark. */
     public function pdfPageBuilderWatermarkConfidential(CData $pageBuilder): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $result = $this->ffi->pdf_page_builder_watermark_confidential($pageBuilder, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_page_builder_watermark_confidential');
         return (int) $result;
@@ -2212,7 +2212,7 @@ class FunctionBindings
     /** "DRAFT" preset watermark. */
     public function pdfPageBuilderWatermarkDraft(CData $pageBuilder): int
     {
-        $errorCode = FFI::new('int');
+        $errorCode = $this->ffi->new('int');
         $result = $this->ffi->pdf_page_builder_watermark_draft($pageBuilder, FFI::addr($errorCode));
         ErrorHandler::check($errorCode->cdata, 'pdf_page_builder_watermark_draft');
         return (int) $result;

--- a/php/src/FFI/NativeLibrary.php
+++ b/php/src/FFI/NativeLibrary.php
@@ -144,13 +144,53 @@ class NativeLibrary
             return realpath($compiledPath);
         }
 
+        // Lazy fallback: Composer does NOT fire dependency-level
+        // post-install-cmd hooks, so end users of
+        // `composer require oxide/pdf-oxide` never trigger
+        // scripts/download-native-lib.php automatically. Detect the
+        // miss on first use and invoke the downloader once. Opt out
+        // with PDF_OXIDE_AUTO_DOWNLOAD=0 (e.g. air-gapped envs).
+        if (getenv('PDF_OXIDE_AUTO_DOWNLOAD') !== '0' && self::attemptLazyDownload()) {
+            $platformKey = self::detectPlatformKey($platform);
+            $stagedPath = dirname(__DIR__, 3) . '/lib/' . $platformKey . '/' . $libName;
+            if (file_exists($stagedPath) && is_readable($stagedPath)) {
+                return realpath($stagedPath);
+            }
+        }
+
         throw new RuntimeException(
             sprintf(
-                'PDF Oxide library not found for %s. Searched paths: %s',
+                'PDF Oxide library not found for %s. Searched paths: %s. '
+                . 'Run `php vendor/oxide/pdf-oxide/php/scripts/download-native-lib.php` '
+                . 'to fetch the prebuilt cdylib for your platform.',
                 $platform,
                 implode(', ', $searchPaths)
             )
         );
+    }
+
+    /**
+     * Run the bundled downloader script in-process. Returns true if
+     * the script exited 0 (download succeeded), false otherwise.
+     * Output is suppressed unless PDF_OXIDE_DEBUG=1 is set.
+     */
+    private static function attemptLazyDownload(): bool
+    {
+        $script = dirname(__DIR__, 2) . '/scripts/download-native-lib.php';
+        if (!is_file($script)) {
+            return false;
+        }
+        $verbose = getenv('PDF_OXIDE_DEBUG') === '1';
+        if (!$verbose) {
+            fwrite(STDERR, "[pdf_oxide] Fetching native library on first use (set PDF_OXIDE_AUTO_DOWNLOAD=0 to disable)...\n");
+        }
+        $cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($script);
+        if (!$verbose) {
+            $cmd .= ' >/dev/null 2>&1';
+        }
+        $rc = 0;
+        passthru($cmd, $rc);
+        return $rc === 0;
     }
 
     /**

--- a/php/src/FFI/StringMarshaller.php
+++ b/php/src/FFI/StringMarshaller.php
@@ -26,7 +26,7 @@ class StringMarshaller
         $bytes = strlen($str) + 1;
 
         // Allocate C string
-        $cStr = FFI::new('char[' . $bytes . ']');
+        $cStr = $ffi->new('char[' . $bytes . ']');
 
         // Copy bytes
         FFI::memcpy($cStr, $str, strlen($str));
@@ -49,12 +49,13 @@ class StringMarshaller
             return '';
         }
 
+        $ffi = NativeLibrary::getInstance();
         // Use FFI::string() to copy the NUL-terminated C string in
         // O(n) rather than concatenating char-by-char in O(n²) — for
         // large extracted-text / markdown buffers the quadratic form
         // dominated wall time. The no-length overload reads until NUL
         // automatically; ext-ffi handles the strlen in C.
-        $str = FFI::string(FFI::cast('char*', $cStr));
+        $str = FFI::string($ffi->cast('char*', $cStr));
 
         if (!self::isValidUtf8($str)) {
             throw new \RuntimeException('Invalid UTF-8 string from FFI');
@@ -81,7 +82,7 @@ class StringMarshaller
 
         try {
             $ffi = NativeLibrary::getInstance();
-            $ffi->free_string(FFI::cast('char*', $cStr));
+            $ffi->free_string($ffi->cast('char*', $cStr));
         } catch (\Exception $e) {
             // Log but don't throw - we're in cleanup
             trigger_error('Failed to free C string: ' . $e->getMessage(), E_USER_WARNING);

--- a/php/src/Pdf.php
+++ b/php/src/Pdf.php
@@ -102,8 +102,8 @@ final class Pdf
         // (the FunctionBindings wrapper targets a different signature
         // and isn't usable for the Pdf* handle path).
         $ffi = NativeLibrary::getInstance();
-        $dataLen = \FFI::new('int32_t');
-        $errorCode = \FFI::new('int32_t');
+        $dataLen = $ffi->new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $ptr = $ffi->pdf_save_to_bytes($this->requireHandle(), \FFI::addr($dataLen), \FFI::addr($errorCode));
         if ((int) $errorCode->cdata !== 0 || $ptr === null) {
             throw new \PdfOxide\Exceptions\PdfException(

--- a/php/src/PdfDocument.php
+++ b/php/src/PdfDocument.php
@@ -173,7 +173,7 @@ final class PdfDocument
     public function hasFormFields(): bool
     {
         $ffi = \PdfOxide\FFI\NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $list = $ffi->pdf_document_get_form_fields($this->requireHandle(), \FFI::addr($errorCode));
         if ($list === null) {
             return false;
@@ -189,7 +189,7 @@ final class PdfDocument
     public function hasSignatures(): bool
     {
         $ffi = \PdfOxide\FFI\NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $count = (int) $ffi->pdf_document_get_signature_count($this->requireHandle(), \FFI::addr($errorCode));
         return $count > 0;
     }

--- a/php/src/PdfSigner.php
+++ b/php/src/PdfSigner.php
@@ -152,7 +152,7 @@ final class PdfSigner
         // known-NULL/0 before we set what we care about.
         FFI::memset(FFI::addr($opts), 0, FFI::sizeof($opts));
 
-        $opts->certificate_handle = FFI::cast('const void *', $this->credentials);
+        $opts->certificate_handle = $ffi->cast('const void *', $this->credentials);
 
         // Anchor C strings so PHP doesn't free them mid-call.
         $tsaBuf = self::cString($tsaUrl);
@@ -160,13 +160,13 @@ final class PdfSigner
         $locationBuf = self::cString($location);
 
         if ($tsaBuf !== null) {
-            $opts->tsa_url = FFI::cast('const char *', $tsaBuf);
+            $opts->tsa_url = $ffi->cast('const char *', $tsaBuf);
         }
         if ($reasonBuf !== null) {
-            $opts->reason = FFI::cast('const char *', $reasonBuf);
+            $opts->reason = $ffi->cast('const char *', $reasonBuf);
         }
         if ($locationBuf !== null) {
-            $opts->location = FFI::cast('const char *', $locationBuf);
+            $opts->location = $ffi->cast('const char *', $locationBuf);
         }
         $opts->level = $levelCode;
 
@@ -258,9 +258,10 @@ final class PdfSigner
             return null;
         }
         $len = strlen($s);
+        $ffi = NativeLibrary::getInstance();
         // +1 for NUL terminator. `false` = unowned — we rely on PHP's
         // refcount-driven free, NOT FFI's tracked allocator.
-        $buf = FFI::new("char[" . ($len + 1) . "]", false);
+        $buf = $ffi->new("char[" . ($len + 1) . "]", false);
         if ($len > 0) {
             FFI::memcpy($buf, $s, $len);
         }

--- a/php/src/PdfValidator.php
+++ b/php/src/PdfValidator.php
@@ -65,7 +65,7 @@ final class PdfValidator
     public static function isPdfA(PdfDocument $doc, int $level = self::PDFA_1B): bool
     {
         $ffi = NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $results = $ffi->pdf_validate_pdf_a_level($doc->getHandle(), $level, \FFI::addr($errorCode));
         if ((int) $errorCode->cdata !== 0 || $results === null) {
             return false;
@@ -82,7 +82,7 @@ final class PdfValidator
     public static function isPdfUa(PdfDocument $doc, int $level = self::PDFUA_1): bool
     {
         $ffi = NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $results = $ffi->pdf_validate_pdf_ua($doc->getHandle(), $level, \FFI::addr($errorCode));
         if ((int) $errorCode->cdata !== 0 || $results === null) {
             return false;
@@ -113,7 +113,7 @@ final class PdfValidator
     public static function validatePdfA(PdfDocument $doc, int $level = self::PDFA_1B): array
     {
         $ffi = NativeLibrary::getInstance();
-        $errorCode = \FFI::new('int32_t');
+        $errorCode = $ffi->new('int32_t');
         $results = $ffi->pdf_validate_pdf_a_level($doc->getHandle(), $level, \FFI::addr($errorCode));
         if ((int) $errorCode->cdata !== 0 || $results === null) {
             return ['compliant' => false, 'errorCount' => 0, 'warningCount' => 0];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.55"
+version = "0.3.56"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/python/pdf_oxide/__init__.py
+++ b/python/pdf_oxide/__init__.py
@@ -94,6 +94,49 @@ def _setup_ort_dylib_path() -> None:
 _setup_ort_dylib_path()
 
 
+def _setup_default_log_levels() -> None:
+    """Quiet stderr-spam from internal pdf_oxide warnings under default
+    Python logging config (#558).
+
+    pdf_oxide routes every internal ``log::warn!`` through the ``pyo3_log``
+    bridge, which forwards records to Python's ``logging`` module. Python's
+    default root-logger config emits ``WARNING``-level records to stderr,
+    so every quirky-but-recoverable PDF produces noise like
+    ``SPEC VIOLATION: No newline after stream keyword``,
+    ``Type0 font 'X' has no ToUnicode entry!``, etc. — observed at ~150
+    lines per PDF in `pdfa_001.pdf`.
+
+    v0.3.56 raises the effective level on the four highest-frequency
+    internal targets to ``ERROR`` so the default Python config no longer
+    captures them. Callers who want the warnings back can:
+
+    - Use ``pdf_oxide.setup_logging(level="WARNING")`` to globally restore.
+    - Use ``logging.getLogger("pdf_oxide.parser").setLevel(logging.WARNING)``
+      to target a single category.
+    - Use ``doc.flatten_warnings()`` (v0.3.56) to receive the warnings
+      as structured data instead of stderr text.
+
+    The downgrade is idempotent: repeated calls are harmless. Genuine
+    ERROR-level events bubble through the ``Result`` chain into Python
+    exceptions, not through ``log::warn!``, so this does not hide real
+    errors.
+
+    See ``docs/releases/plans/v0.3.56/cluster-diagnostics-noise.md``.
+    """
+    import logging as _logging
+    _QUIET_TARGETS = (
+        "pdf_oxide.parser",
+        "pdf_oxide.content",
+        "pdf_oxide.fonts",
+        "pdf_oxide.document",
+    )
+    for _target in _QUIET_TARGETS:
+        _logging.getLogger(_target).setLevel(_logging.ERROR)
+
+
+_setup_default_log_levels()
+
+
 class RenderedPixmap(NamedTuple):
     """Raw premultiplied RGBA8888 pixel buffer from :meth:`PdfDocument.render_pixmap`.
 

--- a/ruby/lib/pdf_oxide/version.rb
+++ b/ruby/lib/pdf_oxide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PdfOxide
-  VERSION = '0.3.55'
+  VERSION = '0.3.56'
 end

--- a/scripts/shrink-staticlib.sh
+++ b/scripts/shrink-staticlib.sh
@@ -8,16 +8,26 @@
 #   - node-gyp / gyp-ng (Node.js addon staticlib consumer)
 #   - MSVC's LINK.EXE in default mode (C# NuGet path uses cdylib anyway)
 #
-# Empirically on this repo: 35 MB `.llvmbc` + 4 MB DWARF per Linux x64 .a out
-# of 71 MB total. Removing both halves the committed Go lib payload.
+# Empirically on this repo (v0.3.55):
+#   - linux-x86_64: 35 MB .llvmbc + 4 MB DWARF (correctly shrunk)
+#   - linux-aarch64: 109 MB .llvmbc UNSTRIPPED before the cross-arch fix
+#     because the host's x86_64 `objcopy` silently no-op'd on ARM64
+#     objects (exited 0 but produced byte-identical output)
+#   - macOS x86_64/arm64: ~80-100 MB Mach-O `__LLVM,__bitcode` UNSTRIPPED
+#     before the llvm-objcopy fix (the prior `strip -S` only touched DWARF)
 #
-# Usage: shrink-staticlib.sh <path-to-staticlib>
-# Platform detection is automatic; on macOS we use `strip -S` (DWARF-only) and
-# skip bitcode since Mach-O uses `__LLVM,__bitcode` which `strip` ignores.
+# Usage: shrink-staticlib.sh <path-to-staticlib> [<target-triple>]
+#
+# The second argument is the Rust target triple (e.g. `aarch64-unknown-linux-gnu`,
+# `x86_64-apple-darwin`). It is consulted on Linux to pick the right
+# arch-specific `objcopy` for cross-compiled archives — when omitted the
+# script falls back to the host's `objcopy`, which is correct for native
+# builds but a silent no-op for cross-compiled ones.
 
 set -euo pipefail
 
 LIB="${1:?path to .a / .lib required}"
+TARGET="${2:-}"
 
 if [[ ! -f "$LIB" ]]; then
   echo "shrink-staticlib: file not found: $LIB" >&2
@@ -26,44 +36,101 @@ fi
 
 before=$(wc -c < "$LIB")
 
+# Pick the right `objcopy` for the archive's target. Generic Ubuntu `objcopy`
+# is built with BFD support for many targets but in practice silently no-ops
+# on objects whose ELF machine type the host binutils wasn't compiled to
+# touch — exit 0 + zero bytes saved. Using the cross-compile toolchain's
+# arch-specific objcopy (already installed for the cross-compile build
+# itself) avoids the silent-failure path entirely.
+pick_objcopy_linux() {
+  case "$TARGET" in
+    aarch64-unknown-linux-*)
+      if command -v aarch64-linux-gnu-objcopy >/dev/null 2>&1; then
+        echo "aarch64-linux-gnu-objcopy"
+        return
+      fi
+      ;;
+    x86_64-pc-windows-gnu)
+      if command -v x86_64-w64-mingw32-objcopy >/dev/null 2>&1; then
+        echo "x86_64-w64-mingw32-objcopy"
+        return
+      fi
+      ;;
+  esac
+  # Native target (or unknown — defer to host objcopy).
+  echo "objcopy"
+}
+
+# Pick a Mach-O-capable objcopy for Darwin. macOS's `strip` doesn't touch
+# `__LLVM,__bitcode`; LLVM's objcopy does. `xcrun -f llvm-objcopy` resolves
+# the one bundled with Xcode; fall back to PATH (Homebrew llvm) if Xcode
+# doesn't ship it on a given runner image.
+pick_objcopy_darwin() {
+  if command -v xcrun >/dev/null 2>&1; then
+    local path
+    path=$(xcrun -f llvm-objcopy 2>/dev/null || true)
+    if [[ -n "$path" && -x "$path" ]]; then
+      echo "$path"
+      return
+    fi
+  fi
+  if command -v llvm-objcopy >/dev/null 2>&1; then
+    echo "llvm-objcopy"
+    return
+  fi
+  echo ""
+}
+
 case "$(uname -s)" in
   Linux|MINGW*|MSYS*|CYGWIN*)
-    # GNU binutils path. objcopy handles archives: it iterates members and
-    # applies the operation to each, then rewrites the archive in place.
-    if command -v objcopy >/dev/null 2>&1; then
-      # Split-debug `.dwo` archive members (emitted by the mingw cross-compile
-      # toolchain on x86_64-pc-windows-gnu) contain *only* DWARF sections.
-      # `objcopy --strip-debug` removes their only sections and then aborts
-      # the whole archive with "has no sections". Drop these members first so
-      # objcopy has nothing debug-only left to process.
-      if command -v ar >/dev/null 2>&1; then
-        mapfile -t dwo_members < <(ar t "$LIB" 2>/dev/null | grep -E '\.dwo$' || true)
-        if [[ ${#dwo_members[@]} -gt 0 ]]; then
-          for m in "${dwo_members[@]}"; do
-            ar d "$LIB" "$m" || true
-          done
-        fi
+    OBJCOPY=$(pick_objcopy_linux)
+    if ! command -v "$OBJCOPY" >/dev/null 2>&1; then
+      echo "shrink-staticlib: $OBJCOPY not available; skipping $LIB" >&2
+      exit 0
+    fi
+    echo "shrink-staticlib: using $OBJCOPY (target=${TARGET:-host})"
+    # Split-debug `.dwo` archive members (emitted by the mingw cross-compile
+    # toolchain on x86_64-pc-windows-gnu) contain *only* DWARF sections.
+    # `objcopy --strip-debug` removes their only sections and then aborts
+    # the whole archive with "has no sections". Drop these members first so
+    # objcopy has nothing debug-only left to process.
+    if command -v ar >/dev/null 2>&1; then
+      mapfile -t dwo_members < <(ar t "$LIB" 2>/dev/null | grep -E '\.dwo$' || true)
+      if [[ ${#dwo_members[@]} -gt 0 ]]; then
+        for m in "${dwo_members[@]}"; do
+          ar d "$LIB" "$m" || true
+        done
       fi
-      # llvm-objcopy rejects "same input and output" on some distros; write to
-      # a sibling tmp file and move it into place atomically.
+    fi
+    # llvm-objcopy rejects "same input and output" on some distros; write to
+    # a sibling tmp file and move it into place atomically.
+    tmp="${LIB}.shrink.tmp"
+    "$OBJCOPY" \
+      --remove-section=.llvmbc \
+      --remove-section=.llvmcmd \
+      --strip-debug \
+      "$LIB" "$tmp"
+    mv "$tmp" "$LIB"
+    ;;
+  Darwin)
+    # macOS staticlibs from Rust w/ `lto = true` carry per-object
+    # `__LLVM,__bitcode` segments — multi-MB each, unused by CGo, node-gyp,
+    # or NuGet. `strip -S` removes DWARF only; `llvm-objcopy` removes the
+    # bitcode segment. Run both.
+    OBJCOPY=$(pick_objcopy_darwin)
+    if [[ -n "$OBJCOPY" ]]; then
+      echo "shrink-staticlib: using $OBJCOPY (Mach-O bitcode strip)"
       tmp="${LIB}.shrink.tmp"
-      objcopy \
-        --remove-section=.llvmbc \
-        --remove-section=.llvmcmd \
+      "$OBJCOPY" \
+        --remove-section=__LLVM,__bitcode \
+        --remove-section=__LLVM,__cmdline \
         --strip-debug \
         "$LIB" "$tmp"
       mv "$tmp" "$LIB"
     else
-      echo "shrink-staticlib: objcopy not available; skipping $LIB" >&2
+      echo "shrink-staticlib: llvm-objcopy not available, falling back to strip -S (DWARF-only)" >&2
+      strip -S "$LIB"
     fi
-    ;;
-  Darwin)
-    # macOS `strip -S` removes DWARF only. Bitcode in Mach-O lives in the
-    # `__LLVM,__bitcode` segment; on non-bitcode-framework archives `strip`
-    # leaves it alone, but modern Rust builds (1.74+) don't emit Mach-O
-    # bitcode segments by default for staticlib outputs, so the debug-only
-    # strip is the expected full win here.
-    strip -S "$LIB"
     ;;
   *)
     echo "shrink-staticlib: unknown OS $(uname -s); skipping" >&2
@@ -74,3 +141,14 @@ after=$(wc -c < "$LIB")
 saved=$((before - after))
 pct=$(awk -v b="$before" -v a="$after" 'BEGIN{ if(b>0) printf "%.1f", (b-a)*100/b; else print "0.0" }')
 echo "shrink-staticlib: $LIB  ${before} -> ${after} bytes  (saved ${saved}, ${pct}%)"
+
+# Defensive: refuse to ship a "shrunk" archive that's still gigantic.
+# A correctly-stripped pdf_oxide staticlib (default-features + ocr) lands at
+# ~50-90 MB depending on target. Anything >= 130 MB almost certainly means
+# bitcode survived — fail loudly so CI catches it instead of silently
+# uploading another bloated artifact.
+MAX_BYTES=$((130 * 1024 * 1024))
+if [[ "$after" -gt "$MAX_BYTES" ]]; then
+  echo "::error::shrink-staticlib: $LIB is $after bytes after stripping (> 130 MB cap). Bitcode / debug sections likely survived. Target=${TARGET:-host}" >&2
+  exit 1
+fi

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -24,11 +24,58 @@ use nom::Parser;
 use smallvec::SmallVec;
 use std::collections::HashMap;
 
-/// Maximum number of operators to parse from a single content stream.
+/// Default maximum number of operators to parse from a single content
+/// stream. Prevents pathological inputs (e.g., Isartor 6.1.12) from
+/// consuming unbounded time and memory.
 ///
-/// Prevents pathological inputs (e.g., Isartor 6.1.12) from consuming
-/// unbounded time and memory.
+/// v0.3.56 (#559): this is the default for the global override; callers
+/// can override via [`set_max_ops_per_stream`] to raise the cap (or set
+/// `usize::MAX` for effectively unbounded — use with caution on
+/// adversarial PDFs).
 const MAX_OPERATORS: usize = 1_000_000;
+
+/// Global cap override for content-stream operator count (#559). `0`
+/// means "use [`MAX_OPERATORS`] default"; any other value is the
+/// effective cap. Atomic so it's safe to set from one thread while
+/// extraction runs on another (e.g. parallel-page extraction).
+static MAX_OPERATORS_OVERRIDE: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Set the global content-stream operator cap (#559). `None` keeps the
+/// default ([`MAX_OPERATORS`] = 1,000,000). `Some(n)` overrides to `n`
+/// — pass `Some(usize::MAX)` for effectively unbounded.
+///
+/// Returns the previous override (or `None` if the default was active).
+/// The override is process-global; setting it on one thread affects all
+/// concurrent extractions.
+///
+/// **Use case**: large technical PDFs (textbooks, ISO standards) that
+/// have legitimate content streams exceeding 1,000,000 operators. The
+/// default cap exists to bound the cost of adversarial inputs; raise
+/// it when you know the inputs are trusted.
+///
+/// See `docs/releases/plans/v0.3.56/cluster-silent-data-loss.md`.
+pub fn set_max_ops_per_stream(limit: Option<usize>) -> Option<usize> {
+    let new = limit.unwrap_or(0);
+    let prev = MAX_OPERATORS_OVERRIDE.swap(new, std::sync::atomic::Ordering::SeqCst);
+    if prev == 0 {
+        None
+    } else {
+        Some(prev)
+    }
+}
+
+/// Current effective operator cap. Reads the override if set; otherwise
+/// returns [`MAX_OPERATORS`]. Internal hot-path helper.
+#[inline]
+fn effective_max_operators() -> usize {
+    let override_val = MAX_OPERATORS_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed);
+    if override_val == 0 {
+        MAX_OPERATORS
+    } else {
+        override_val
+    }
+}
 
 /// Maximum consecutive parse errors (byte skips) before bailing out.
 ///
@@ -68,7 +115,7 @@ pub fn parse_content_stream(data: &[u8]) -> Result<Vec<Operator>> {
                 input = rest;
                 consecutive_errors = 0;
 
-                if operators.len() >= MAX_OPERATORS {
+                if operators.len() >= effective_max_operators() {
                     log::warn!("Content stream exceeded {} operators, truncating", MAX_OPERATORS);
                     break;
                 }
@@ -128,7 +175,7 @@ pub fn parse_content_stream_paths_only(data: &[u8]) -> Result<Vec<Operator>> {
         if i >= len {
             break;
         }
-        if operators.len() >= MAX_OPERATORS {
+        if operators.len() >= effective_max_operators() {
             log::warn!("Content stream exceeded {} operators, truncating", MAX_OPERATORS);
             break;
         }
@@ -428,7 +475,7 @@ pub fn parse_content_stream_text_only(data: &[u8]) -> Result<Vec<Operator>> {
             break;
         }
 
-        if operators.len() >= MAX_OPERATORS {
+        if operators.len() >= effective_max_operators() {
             log::warn!("Content stream exceeded {} operators, truncating", MAX_OPERATORS);
             break;
         }
@@ -1223,7 +1270,7 @@ where
             break;
         }
 
-        if op_count >= MAX_OPERATORS {
+        if op_count >= effective_max_operators() {
             log::warn!("Content stream exceeded {} operators, truncating", MAX_OPERATORS);
             break;
         }
@@ -1355,7 +1402,7 @@ where
             break;
         }
 
-        if op_count >= MAX_OPERATORS {
+        if op_count >= effective_max_operators() {
             break;
         }
 
@@ -1472,7 +1519,7 @@ pub fn parse_content_stream_images_only(data: &[u8]) -> Result<Vec<Operator>> {
             break;
         }
 
-        if operators.len() >= MAX_OPERATORS {
+        if operators.len() >= effective_max_operators() {
             break;
         }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -5601,6 +5601,43 @@ impl PdfDocument {
         crate::ocr::extract_text_with_ocr(self, page_index, ocr_engine, ocr_options)
     }
 
+    /// Always rasterise the page and run the supplied OCR engine,
+    /// regardless of the embedded text layer. v0.3.56 additive companion
+    /// for #574 — the existing [`extract_text_with_ocr`] is
+    /// text-layer-first (OCR only when no native text), which the
+    /// reporter found misleading because the name implies OCR-always.
+    ///
+    /// `extract_text_ocr_only` makes the OCR-always contract explicit:
+    /// the engine is invoked unconditionally and its output is returned
+    /// even when an embedded text layer is present (useful for scanned-
+    /// then-machine-OCR'd PDFs where the embedded layer is poor quality
+    /// auto-OCR from the scanner).
+    ///
+    /// Returns `Err(Error::OcrUnavailable { reason: EngineNotProvided })`
+    /// if no engine is supplied — unlike [`extract_text_with_ocr`] which
+    /// silently degrades. This makes the OCR-required contract loud.
+    ///
+    /// See `docs/releases/plans/v0.3.56/cluster-ocr-api.md`.
+    #[cfg(feature = "ocr")]
+    pub fn extract_text_ocr_only(
+        &self,
+        page_index: usize,
+        ocr_engine: &crate::ocr::OcrEngine,
+        ocr_options: crate::ocr::OcrExtractOptions,
+    ) -> Result<String> {
+        // Run OCR unconditionally via the existing `ocr_page` helper.
+        // If ORT's init has previously panicked (missing libonnxruntime),
+        // the catch_unwind in `OrtBackend::from_bytes` (v0.3.56 #569 fix)
+        // ensures we get an OcrError instead of a panic.
+        crate::ocr::ocr_page(self, page_index, ocr_engine, &ocr_options).map_err(|e| {
+            Error::OcrUnavailable {
+                reason: crate::extractors::status::OcrUnavailableReason::ModelLoadFailed {
+                    detail: e.to_string(),
+                },
+            }
+        })
+    }
+
     /// Extract TextSpans with automatic OCR fallback for scanned pages.
     ///
     /// This method extracts text spans using native PDF text extraction, but falls back
@@ -7600,6 +7637,63 @@ impl PdfDocument {
 
         // No fonts and no Form XObjects → page is image-only
         true
+    }
+
+    /// Returns `true` if the page has any text-bearing content (fonts in
+    /// resources + at least one `BT`/`Do` operator in the content stream),
+    /// `false` if the page is image-only or genuinely empty.
+    ///
+    /// v0.3.56 additive accessor for #563. Callers route image-only pages
+    /// to OCR (`extract_text_ocr_only(page, engine)`) instead of receiving
+    /// an empty string with no signal.
+    ///
+    /// Conservative: returns `true` when the page resources can't be
+    /// inspected (load error, encrypted-not-authenticated, etc.) so the
+    /// caller still attempts extraction.
+    ///
+    /// # PDF spec basis
+    ///
+    /// §8.8 (Image XObjects): image-only pages have `/Resources` whose
+    /// only `/XObject` entries are `/Subtype /Image` with no `/Font`
+    /// resources. See `docs/releases/plans/v0.3.56/cluster-silent-data-loss.md`.
+    pub fn has_text_layer(&self, page_index: usize) -> Result<bool> {
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+        if self.page_cannot_have_text(page_dict) {
+            return Ok(false);
+        }
+        // Probe content stream for text-showing operators. If we can't
+        // read the content stream, be conservative and say yes (let
+        // extraction try).
+        match self.get_page_content_data(page_index) {
+            Ok(content_data) => Ok(Self::may_contain_text(&content_data)),
+            Err(_) => Ok(true),
+        }
+    }
+
+    /// Returns the document's `/P` permission flags as a `PdfPermissions`
+    /// struct if the document is encrypted; `None` otherwise.
+    ///
+    /// v0.3.56 additive accessor for #562. Per PDF spec §7.6.3.2 the `/P`
+    /// flag is advisory — pdf_oxide does not enforce restrictions — but
+    /// callers who want to enforce them (e.g., refuse copy-protected PDF
+    /// extraction) can do so themselves by checking the returned
+    /// permissions.
+    ///
+    /// # PDF spec basis
+    ///
+    /// §7.6.3.2 Table 22 (`/P` Standard Encryption Dictionary entry).
+    /// Decoding is implemented in `encryption::permissions::PdfPermissions::from_p_flag`.
+    pub fn permissions(&self) -> Option<crate::encryption::PdfPermissions> {
+        // ensure_encryption_initialized may fail on malformed Encrypt
+        // dicts — that's fine, no permissions surface for those.
+        let _ = self.ensure_encryption_initialized();
+        let handler = self.encryption_handler.lock_or_recover();
+        let handler = handler.as_ref()?;
+        Some(crate::encryption::PdfPermissions::from_p_flag(handler.raw_permissions()))
     }
 
     /// Extract text using structure tree for Tagged PDFs.

--- a/src/encryption/handler.rs
+++ b/src/encryption/handler.rs
@@ -174,6 +174,15 @@ impl EncryptionHandler {
         Permissions::from_bits(self.dict.permissions)
     }
 
+    /// Get the raw `/P` permission flag integer per PDF spec §7.6.3.2
+    /// Table 22. Used by [`PdfDocument::permissions`] to construct the
+    /// v0.3.56 [`PdfPermissions`] struct.
+    ///
+    /// PDF spec uses two's-complement int32 with bits 13-32 reserved.
+    pub fn raw_permissions(&self) -> i32 {
+        self.dict.permissions
+    }
+
     /// Get the encryption algorithm.
     pub fn algorithm(&self) -> Algorithm {
         self.algorithm

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -36,6 +36,7 @@ mod aes;
 mod algorithms;
 mod certificate;
 mod handler;
+pub mod permissions;
 // `pub(crate)` so the `crypto::RustCryptoProvider::SymmetricCipher`
 // impl in `src/crypto/rust_provider.rs` can call
 // `rc4::rc4_crypt_impl` (the cipher-only entry point that does NOT
@@ -53,6 +54,7 @@ pub use certificate::{
     KeyTransportAlgorithm, RecipientInfo, RecipientPermissions,
 };
 pub use handler::EncryptionHandler;
+pub use permissions::PdfPermissions;
 pub use write_handler::EncryptionWriteHandler;
 
 /// A fresh MD5 hasher for the ISO 32000-1 §7.6.3 Standard-Security-

--- a/src/encryption/permissions.rs
+++ b/src/encryption/permissions.rs
@@ -1,0 +1,171 @@
+//! PDF §7.6.3.2 `/P` permission flag set — v0.3.56 additive accessor
+//! for #562.
+//!
+//! `PdfDocument::permissions()` returns this struct when the document
+//! is encrypted. Per PDF spec §7.6.3.2 Table 22:
+//!
+//! | Bit | Meaning |
+//! |---|---|
+//! | 3 | print (low resolution) |
+//! | 4 | modify (other than annotation / form fill) |
+//! | 5 | copy text and graphics |
+//! | 6 | annotate and form-fill |
+//! | 9 | fill forms (rev ≥ 3) |
+//! | 10 | accessibility extract (rev ≥ 3) |
+//! | 11 | assemble (rev ≥ 3) |
+//! | 12 | print high resolution (rev ≥ 3) |
+//!
+//! Per PDF spec language, `/P` permissions are **advisory** — readers
+//! shall not enforce them. pdf_oxide surfaces them so callers who want
+//! to enforce can do so themselves.
+//!
+//! See `docs/releases/plans/v0.3.56/cluster-security-policy.md` §4.4
+//! and `docs/releases/plans/v0.3.56/api-design.md` §3.
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+
+/// Decoded `/P` permission flags from a PDF's standard encryption
+/// dictionary (§7.6.3.2 Table 22).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PdfPermissions {
+    /// Bit 3: print (low resolution).
+    pub print_low_res: bool,
+    /// Bit 4: modify (other than annotation / form fill).
+    pub modify: bool,
+    /// Bit 5: copy text and graphics.
+    pub copy: bool,
+    /// Bit 6: annotate and form-fill.
+    pub annotate: bool,
+    /// Bit 9 (rev ≥ 3): fill interactive form fields.
+    pub fill_forms: bool,
+    /// Bit 10 (rev ≥ 3): extract for accessibility.
+    pub accessibility: bool,
+    /// Bit 11 (rev ≥ 3): assemble (insert/rotate/delete pages).
+    pub assemble: bool,
+    /// Bit 12 (rev ≥ 3): print high resolution.
+    pub print_high_res: bool,
+    /// Raw `/P` integer for callers that need the pre-decoded value.
+    /// PDF uses two's-complement int32 with bits 13–32 reserved.
+    pub raw_p: i32,
+}
+
+impl PdfPermissions {
+    /// Decode a `/P` flag integer per spec §7.6.3.2 Table 22.
+    ///
+    /// Note: bit positions in the spec are 1-indexed; this code uses
+    /// 0-indexed shifts. So "bit 3" in spec = shift `1 << 2` here.
+    pub fn from_p_flag(p: i32) -> Self {
+        Self {
+            print_low_res: (p & (1 << 2)) != 0,
+            modify: (p & (1 << 3)) != 0,
+            copy: (p & (1 << 4)) != 0,
+            annotate: (p & (1 << 5)) != 0,
+            fill_forms: (p & (1 << 8)) != 0,
+            accessibility: (p & (1 << 9)) != 0,
+            assemble: (p & (1 << 10)) != 0,
+            print_high_res: (p & (1 << 11)) != 0,
+            raw_p: p,
+        }
+    }
+
+    /// "All allowed" — convenience for the no-restrictions case where
+    /// `/P = -1` (every bit set; common for unencrypted-but-tagged
+    /// documents).
+    pub fn all_allowed() -> Self {
+        Self::from_p_flag(-1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_p_flag_all_bits_set() {
+        // /P = -1 means every bit set
+        let p = PdfPermissions::from_p_flag(-1);
+        assert!(p.print_low_res);
+        assert!(p.modify);
+        assert!(p.copy);
+        assert!(p.annotate);
+        assert!(p.fill_forms);
+        assert!(p.accessibility);
+        assert!(p.assemble);
+        assert!(p.print_high_res);
+        assert_eq!(p.raw_p, -1);
+    }
+
+    #[test]
+    fn from_p_flag_typical_restrictive() {
+        // /P = -3904 (-1 minus bits 3, 5, 6, 9, 10, 11 set to 0) — common
+        // "no print, no copy, no annotate, no forms, no accessibility,
+        // no assemble" pattern.
+        // Compute the expected /P: start from -1 (all set), clear the
+        // forbidden bits.
+        let mut p: i32 = -1;
+        p &= !(1 << 2); // clear print_low_res (bit 3)
+        p &= !(1 << 4); // clear copy (bit 5)
+        p &= !(1 << 5); // clear annotate (bit 6)
+
+        let perms = PdfPermissions::from_p_flag(p);
+        assert!(!perms.print_low_res);
+        assert!(!perms.copy);
+        assert!(!perms.annotate);
+        assert!(perms.modify); // still set
+        assert_eq!(perms.raw_p, p);
+    }
+
+    #[test]
+    fn from_p_flag_kreuzberg_password_protected_shape() {
+        // kreuzberg's password_protected.pdf reports
+        // `print:no copy:no change:no addNotes:no` per pdfinfo
+        // — that's bits 3, 4, 5, 6 all cleared.
+        let mut p: i32 = -1;
+        p &= !(1 << 2); // clear print
+        p &= !(1 << 3); // clear modify (change)
+        p &= !(1 << 4); // clear copy
+        p &= !(1 << 5); // clear annotate (addNotes)
+
+        let perms = PdfPermissions::from_p_flag(p);
+        assert!(!perms.print_low_res);
+        assert!(!perms.modify);
+        assert!(!perms.copy);
+        assert!(!perms.annotate);
+        // rev-3+ bits left untouched
+        assert!(perms.fill_forms);
+        assert!(perms.accessibility);
+        assert!(perms.assemble);
+        assert!(perms.print_high_res);
+    }
+
+    #[test]
+    fn from_p_flag_zero_is_all_denied() {
+        let perms = PdfPermissions::from_p_flag(0);
+        assert!(!perms.print_low_res);
+        assert!(!perms.modify);
+        assert!(!perms.copy);
+        assert!(!perms.annotate);
+        assert!(!perms.fill_forms);
+        assert!(!perms.accessibility);
+        assert!(!perms.assemble);
+        assert!(!perms.print_high_res);
+        assert_eq!(perms.raw_p, 0);
+    }
+
+    #[test]
+    fn all_allowed_matches_minus_one() {
+        let allowed = PdfPermissions::all_allowed();
+        let from_minus_one = PdfPermissions::from_p_flag(-1);
+        assert_eq!(allowed, from_minus_one);
+    }
+
+    #[test]
+    fn serializes_to_json() {
+        let p = PdfPermissions::all_allowed();
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains("\"print_low_res\":true"));
+        assert!(json.contains("\"raw_p\":-1"));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,6 +134,17 @@ pub enum Error {
     /// `PdfDocument::open_with_password()` before extracting content.
     #[error("PDF is encrypted and requires a password. Call authenticate(password) before extracting content.")]
     EncryptedPdf,
+
+    /// OCR backend is unavailable. v0.3.56 additive variant for the
+    /// OCR API cluster (#569 / #573 / #574). Typed reason lets the
+    /// binding map to the right language-native exception
+    /// (`OcrUnavailable` in Python / Java / Ruby / PHP / Go / C# /
+    /// Node / WASM per `research-typed-signals-cross-lang.md` §13).
+    #[error("OCR unavailable: {reason:?}")]
+    OcrUnavailable {
+        /// Why OCR couldn't be initialised or invoked.
+        reason: crate::extractors::status::OcrUnavailableReason,
+    },
 }
 
 #[cfg(test)]

--- a/src/extractors/forms.rs
+++ b/src/extractors/forms.rs
@@ -362,16 +362,26 @@ impl FormExtractor {
             format!("{}.{}", parent_name, partial_name)
         };
 
-        // Check if this field has children
-        if let Some(kids_ref) = field_dict.get("Kids") {
-            // This is a non-terminal field - process children
+        // Check if this field has children. v0.3.56 (#570): we now
+        // recurse into Kids AND also emit a row for parent fields that
+        // carry a /T name, matching pypdf's traversal. Previously we
+        // recursed into Kids and dropped any parent without an explicit
+        // /FT, which under-counted IRS AcroForms by 15-30% (parent
+        // dictionaries for grouped fields like multi-digit SSN boxes
+        // have /T but no /FT — pypdf surfaces them, we did not).
+        let has_kids = if let Some(kids_ref) = field_dict.get("Kids") {
             let kids = Self::resolve_object(doc, kids_ref)?;
             if let Some(kids_array) = kids.as_array() {
                 for kid_ref in kids_array {
                     Self::extract_field_recursive(doc, kid_ref, &full_name, result)?;
                 }
+                true
+            } else {
+                false
             }
-        }
+        } else {
+            false
+        };
 
         // Extract field type
         let field_type = field_dict
@@ -381,8 +391,19 @@ impl FormExtractor {
             .map(|name| Self::parse_field_type(&name))
             .unwrap_or(FieldType::Unknown("".to_string()));
 
-        // Skip if no field type (non-terminal field with only Kids)
-        if matches!(field_type, FieldType::Unknown(ref s) if s.is_empty()) {
+        // v0.3.56 (#570): only skip the parent when it has NEITHER /FT
+        // NOR /T. A parent with /T but no /FT (logical grouping like
+        // `topmostSubform[0].Page1[0].FilingStatus[0]`) IS surfaced in
+        // results, matching pypdf's behaviour. The terminal kids that
+        // already got their own row carry the actual /V (checkbox
+        // /Off/Yes state).
+        let no_ft = matches!(field_type, FieldType::Unknown(ref s) if s.is_empty());
+        if no_ft && (has_kids && partial_name.is_empty()) {
+            // Truly anonymous parent with no /T — nothing to surface.
+            return Ok(());
+        }
+        if no_ft && !has_kids && partial_name.is_empty() {
+            // Leaf without /FT or /T — skip.
             return Ok(());
         }
 

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -12,9 +12,11 @@ pub mod images;
 pub mod page_labels;
 pub mod paths;
 pub mod pattern_detector;
+pub mod status;
 pub mod structured;
 pub mod synthetic_structure;
 pub mod text;
+pub mod warnings;
 pub mod xmp;
 
 #[cfg(feature = "debug-span-merging")]
@@ -40,10 +42,12 @@ pub use images::{
 pub use page_labels::{PageLabelExtractor, PageLabelRange, PageLabelStyle};
 pub use paths::{FillRule, PathExtractor};
 pub use pattern_detector::{PatternDetector, PatternPreservationConfig};
+pub use status::{ExtractionSignal, OcrUnavailableReason};
 pub use structured::{
     BoundingBox, DocumentElement, DocumentMetadata, ExtractorConfig, ListItem, StructuredDocument,
     StructuredExtractor, TextAlignment, TextStyle,
 };
 pub use synthetic_structure::{SyntheticStructureConfig, SyntheticStructureGenerator};
 pub use text::{SpanMergingConfig, TextExtractionConfig, TextExtractor};
+pub use warnings::{Warning, WarningCategory, WarningSink};
 pub use xmp::{XmpExtractor, XmpMetadata};

--- a/src/extractors/status.rs
+++ b/src/extractors/status.rs
@@ -1,0 +1,254 @@
+//! Per-call extraction signal — what fired during a single text-extraction
+//! invocation. v0.3.56 additive surface for #559, #563, #571, #574, #562.
+//!
+//! Returned alongside the existing return values by the new `*_status`
+//! companion accessors (`extract_text_status`, `to_plain_text_status`,
+//! `extract_words_status`, etc.). The existing accessors keep their
+//! original return shapes — this type is purely additive.
+//!
+//! **Naming note (v0.3.56)**: the v0.3.56 plan called this type
+//! `ExtractionStatus`, but v0.3.51 already exposes an
+//! `extractors::auto::ExtractionStatus` (page-level Complete /
+//! PartialSuccess / NoTextRecovered for the AutoExtractor surface from
+//! #517). Renaming this to `ExtractionSignal` keeps both types public and
+//! preserves additive back-compat.
+//!
+//! See `docs/releases/plans/v0.3.56/api-design.md` §1 for the design.
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+
+/// Per-call extraction signal returned by the `*_status` companion
+/// accessors. `Ok` means the operation completed without any caveat;
+/// every other variant carries enough structured detail for a caller
+/// to either route to OCR, raise a typed exception, or warn the user.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ExtractionSignal {
+    /// Operation completed cleanly; the returned text is authoritative.
+    #[default]
+    Ok,
+
+    /// The content-stream parser hit `MAX_OPERATORS` (default 1,000,000)
+    /// and stopped emitting glyphs. The returned text is everything up to
+    /// that point. `at_op` is the operator-index at which truncation fired.
+    /// Fix: `ParserOptions { max_ops_per_stream: None }`. Closes #559.
+    Truncated {
+        /// Operator index at which truncation fired.
+        at_op: usize,
+    },
+
+    /// The page has no text layer (no `/Font` resources used, no `Tj` /
+    /// `TJ` / `'` / `"` operators observed). The returned text is empty.
+    /// Route to OCR via `extract_text_ocr(page, engine)`. Closes #563.
+    NoTextLayer,
+
+    /// `count` glyphs on the page mapped to `U+FFFD` (REPLACEMENT
+    /// CHARACTER) because the font has neither ToUnicode nor a usable
+    /// AGL fallback. The returned text includes those U+FFFD chars
+    /// (v0.3.56 stops filtering them silently). Caller can decide whether
+    /// to keep, drop, or OCR. Closes #571.
+    UnmappedGlyphs {
+        /// Number of `U+FFFD` chars in the returned text.
+        count: usize,
+    },
+
+    /// OCR was requested but the backend is unavailable.
+    /// Closes #569, #573, #574.
+    OcrUnavailable {
+        /// The reason OCR is unavailable.
+        reason: OcrUnavailableReason,
+    },
+
+    /// Document was encrypted and the caller has not yet authenticated.
+    /// Body operations on the document return this signal (with empty
+    /// text) until `doc.authenticate(password)` succeeds. Closes #562.
+    PasswordRequired,
+
+    /// A composite signal: multiple non-Ok signals fired on the same
+    /// call. The vector preserves order of occurrence. Used when, for
+    /// example, a page is both truncated AND has unmapped glyphs.
+    Multiple(Vec<ExtractionSignal>),
+}
+
+/// Reason that OCR is unavailable on the current call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OcrUnavailableReason {
+    /// `libonnxruntime.so` / `.dylib` / `.dll` failed to load via
+    /// `dlopen` / `LoadLibrary`.
+    DylibMissing,
+    /// OCR feature is compile-time disabled in this build.
+    FeatureDisabled,
+    /// No `OcrEngine` was supplied and the caller invoked
+    /// `extract_text_ocr_only` (which requires an explicit engine).
+    /// `extract_text_auto` does NOT raise this — it silently degrades.
+    EngineNotProvided,
+    /// `ort::Session::run` or `Session::builder().commit()` returned
+    /// an error.
+    ModelLoadFailed {
+        /// Underlying error string from the ORT crate.
+        detail: String,
+    },
+    /// ORT init panicked (e.g. corrupted Mutex from a prior failed init).
+    /// Captured by `std::panic::catch_unwind`.
+    InitPanicked {
+        /// Panic payload as a string.
+        detail: String,
+    },
+}
+
+impl ExtractionSignal {
+    /// True when no caveat fired. Convenience for `== Self::Ok`.
+    pub fn is_ok(&self) -> bool {
+        matches!(self, Self::Ok)
+    }
+
+    /// True when the signal indicates the page has no recoverable text
+    /// from the embedded text layer (and so OCR is the recourse). Covers
+    /// `NoTextLayer` only — `UnmappedGlyphs` is NOT a should-OCR case
+    /// because OCR is unlikely to do better than the existing glyph
+    /// names.
+    pub fn should_ocr(&self) -> bool {
+        match self {
+            Self::NoTextLayer => true,
+            Self::Multiple(children) => children.iter().any(|c| c.should_ocr()),
+            _ => false,
+        }
+    }
+
+    /// Push another signal into a `Multiple` or upgrade a scalar to a
+    /// `Multiple`. Internal helper used when more than one signal fires
+    /// on the same call.
+    pub fn push(&mut self, other: ExtractionSignal) {
+        if matches!(other, Self::Ok) {
+            return;
+        }
+        match self {
+            Self::Ok => *self = other,
+            Self::Multiple(v) => v.push(other),
+            _ => {
+                let first = std::mem::replace(self, Self::Ok);
+                *self = Self::Multiple(vec![first, other]);
+            },
+        }
+    }
+}
+
+impl OcrUnavailableReason {
+    /// Stable string identifier (matches the Python-binding string form).
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            Self::DylibMissing => "dylib_missing",
+            Self::FeatureDisabled => "feature_disabled",
+            Self::EngineNotProvided => "engine_not_provided",
+            Self::ModelLoadFailed { .. } => "model_load_failed",
+            Self::InitPanicked { .. } => "init_panicked",
+        }
+    }
+
+    /// Detail string (empty for variants without detail).
+    pub fn detail(&self) -> String {
+        match self {
+            Self::ModelLoadFailed { detail } | Self::InitPanicked { detail } => detail.clone(),
+            _ => String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ok_is_ok() {
+        assert!(ExtractionSignal::Ok.is_ok());
+        assert!(!ExtractionSignal::NoTextLayer.is_ok());
+    }
+
+    #[test]
+    fn no_text_layer_should_ocr() {
+        assert!(ExtractionSignal::NoTextLayer.should_ocr());
+        assert!(!ExtractionSignal::Ok.should_ocr());
+        assert!(!ExtractionSignal::Truncated { at_op: 1000 }.should_ocr());
+        assert!(!ExtractionSignal::UnmappedGlyphs { count: 3 }.should_ocr());
+    }
+
+    #[test]
+    fn push_upgrades_ok_to_other() {
+        let mut s = ExtractionSignal::Ok;
+        s.push(ExtractionSignal::Truncated { at_op: 1000 });
+        assert_eq!(s, ExtractionSignal::Truncated { at_op: 1000 });
+    }
+
+    #[test]
+    fn push_skips_ok() {
+        let mut s = ExtractionSignal::Truncated { at_op: 1000 };
+        s.push(ExtractionSignal::Ok);
+        assert_eq!(s, ExtractionSignal::Truncated { at_op: 1000 });
+    }
+
+    #[test]
+    fn push_two_scalars_creates_multiple() {
+        let mut s = ExtractionSignal::Truncated { at_op: 1000 };
+        s.push(ExtractionSignal::UnmappedGlyphs { count: 3 });
+        match s {
+            ExtractionSignal::Multiple(v) => {
+                assert_eq!(v.len(), 2);
+                assert_eq!(v[0], ExtractionSignal::Truncated { at_op: 1000 });
+                assert_eq!(v[1], ExtractionSignal::UnmappedGlyphs { count: 3 });
+            },
+            _ => panic!("expected Multiple"),
+        }
+    }
+
+    #[test]
+    fn push_into_multiple_appends() {
+        let mut s = ExtractionSignal::Multiple(vec![ExtractionSignal::NoTextLayer]);
+        s.push(ExtractionSignal::Truncated { at_op: 500 });
+        match s {
+            ExtractionSignal::Multiple(v) => {
+                assert_eq!(v.len(), 2);
+                assert_eq!(v[1], ExtractionSignal::Truncated { at_op: 500 });
+            },
+            _ => panic!("expected Multiple"),
+        }
+    }
+
+    #[test]
+    fn multiple_with_no_text_layer_should_ocr() {
+        let s = ExtractionSignal::Multiple(vec![
+            ExtractionSignal::NoTextLayer,
+            ExtractionSignal::UnmappedGlyphs { count: 3 },
+        ]);
+        assert!(s.should_ocr());
+    }
+
+    #[test]
+    fn ocr_unavailable_kind_str_stable() {
+        assert_eq!(OcrUnavailableReason::DylibMissing.kind_str(), "dylib_missing");
+        assert_eq!(OcrUnavailableReason::EngineNotProvided.kind_str(), "engine_not_provided");
+        assert_eq!(
+            OcrUnavailableReason::ModelLoadFailed { detail: "x".into() }.kind_str(),
+            "model_load_failed"
+        );
+    }
+
+    #[test]
+    fn ocr_unavailable_detail_passthrough() {
+        let r = OcrUnavailableReason::ModelLoadFailed {
+            detail: "missing.onnx".into(),
+        };
+        assert_eq!(r.detail(), "missing.onnx");
+        assert_eq!(OcrUnavailableReason::DylibMissing.detail(), "");
+    }
+
+    #[test]
+    fn signal_serializes_to_snake_case_json() {
+        let s = ExtractionSignal::Truncated { at_op: 1_000_000 };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("\"kind\":\"truncated\""));
+        assert!(json.contains("\"at_op\":1000000"));
+    }
+}

--- a/src/extractors/warnings.rs
+++ b/src/extractors/warnings.rs
@@ -1,0 +1,220 @@
+//! Structured warning surface — v0.3.56 additive accessor for #558.
+//!
+//! `PdfDocument::flatten_warnings()` returns the warnings raised since
+//! the document was opened, as a list of structured `Warning` records.
+//! Callers who want diagnostics as data (rather than stderr text from
+//! `log::warn!`) opt in to this surface. The existing `log::warn!`
+//! calls continue to fire so the v0.3.54 `setup_logging(level="WARNING")`
+//! shape keeps working.
+//!
+//! See `docs/releases/plans/v0.3.56/cluster-diagnostics-noise.md` and
+//! `docs/releases/plans/v0.3.56/api-design.md` §3.
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+
+/// A single structured warning raised during PDF processing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Warning {
+    /// The category — used by callers to filter.
+    pub category: WarningCategory,
+    /// The page index the warning was raised on, if any. `None` means
+    /// the warning is document-scoped (xref recovery, trailer parse,
+    /// etc.).
+    pub page: Option<usize>,
+    /// Free-form message. Matches the v0.3.54 `log::warn!` strings to
+    /// preserve grep-ability for users transitioning off the stderr
+    /// noise.
+    pub message: String,
+    /// PDF spec section the warning references, when applicable.
+    /// E.g. "7.3.8.1" for the stream-keyword newline violation.
+    pub spec_section: Option<&'static str>,
+}
+
+/// Coarse-grained category for filtering. Each maps to a target in
+/// `log::warn!` calls — `pdf_oxide::parser`, `pdf_oxide::fonts`,
+/// `pdf_oxide::content`, etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WarningCategory {
+    /// PDF spec violations during xref / stream / content-stream parsing.
+    /// E.g. "SPEC VIOLATION: No newline after stream keyword".
+    SpecViolation,
+    /// Font has no `ToUnicode` entry; falling back to AGL / CID-as-
+    /// Unicode chain.
+    ToUnicodeMissing,
+    /// Xref table corrupt; reconstructing from `obj`/`endobj` scan.
+    XrefRecovery,
+    /// Content stream exceeded `MAX_OPERATORS` cap; truncating.
+    /// Closes #559's diagnostic half.
+    OperatorCapExceeded,
+    /// Type 3 font detected — may require special glyph name mapping.
+    Type3Font,
+    /// Unexpected EOF while reading an object header / body.
+    EofPremature,
+    /// Encryption / decryption related warning.
+    Encryption,
+    /// Other font warnings (DescendantFonts inline-dict fallback, etc.).
+    Font,
+    /// Layout / reading-order warnings.
+    Layout,
+}
+
+impl WarningCategory {
+    /// Stable kebab-case string for cross-binding consumption.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SpecViolation => "spec_violation",
+            Self::ToUnicodeMissing => "to_unicode_missing",
+            Self::XrefRecovery => "xref_recovery",
+            Self::OperatorCapExceeded => "operator_cap_exceeded",
+            Self::Type3Font => "type3_font",
+            Self::EofPremature => "eof_premature",
+            Self::Encryption => "encryption",
+            Self::Font => "font",
+            Self::Layout => "layout",
+        }
+    }
+}
+
+/// Thread-safe sink for warnings raised during a single `PdfDocument`
+/// lifetime. Backed by a `Mutex<Vec<Warning>>` so multi-threaded usage
+/// (e.g. parallel-page extraction) doesn't lose warnings to a data race.
+///
+/// One sink per document. The document holds it in an `Arc` so worker
+/// threads can clone it.
+#[derive(Debug, Default)]
+pub struct WarningSink {
+    warnings: Mutex<Vec<Warning>>,
+}
+
+impl WarningSink {
+    /// Create an empty sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push a new warning. Inexpensive — no `log` macro fired here; the
+    /// existing `log::warn!` sites continue to fire on their own. Use
+    /// `push_with_log` from the migrated call sites to emit both.
+    pub fn push(&self, warning: Warning) {
+        if let Ok(mut v) = self.warnings.lock() {
+            v.push(warning);
+        }
+        // If the mutex was poisoned, silently drop — better than panic.
+    }
+
+    /// Snapshot of all warnings raised so far. Returns owned clones so
+    /// the caller can keep them past the document's lifetime.
+    pub fn snapshot(&self) -> Vec<Warning> {
+        self.warnings.lock().map(|v| v.clone()).unwrap_or_default()
+    }
+
+    /// Total warning count.
+    pub fn len(&self) -> usize {
+        self.warnings.lock().map(|v| v.len()).unwrap_or(0)
+    }
+
+    /// True if no warnings have been raised.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Clear all warnings. Used by `PdfDocument::reset_warnings()` for
+    /// callers who want to track per-operation warnings.
+    pub fn clear(&self) {
+        if let Ok(mut v) = self.warnings.lock() {
+            v.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sink_starts_empty() {
+        let sink = WarningSink::new();
+        assert!(sink.is_empty());
+        assert_eq!(sink.len(), 0);
+        assert_eq!(sink.snapshot().len(), 0);
+    }
+
+    #[test]
+    fn push_and_snapshot() {
+        let sink = WarningSink::new();
+        sink.push(Warning {
+            category: WarningCategory::ToUnicodeMissing,
+            page: Some(0),
+            message: "Type0 font 'X' has no ToUnicode entry!".into(),
+            spec_section: Some("9.10.2"),
+        });
+        assert_eq!(sink.len(), 1);
+        let snap = sink.snapshot();
+        assert_eq!(snap[0].category, WarningCategory::ToUnicodeMissing);
+        assert_eq!(snap[0].page, Some(0));
+        assert!(snap[0].message.contains("ToUnicode"));
+    }
+
+    #[test]
+    fn category_as_str_stable() {
+        assert_eq!(WarningCategory::SpecViolation.as_str(), "spec_violation");
+        assert_eq!(WarningCategory::ToUnicodeMissing.as_str(), "to_unicode_missing");
+        assert_eq!(WarningCategory::OperatorCapExceeded.as_str(), "operator_cap_exceeded");
+    }
+
+    #[test]
+    fn clear_resets() {
+        let sink = WarningSink::new();
+        sink.push(Warning {
+            category: WarningCategory::SpecViolation,
+            page: None,
+            message: "x".into(),
+            spec_section: None,
+        });
+        assert_eq!(sink.len(), 1);
+        sink.clear();
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn warning_serializes_to_json() {
+        let w = Warning {
+            category: WarningCategory::SpecViolation,
+            page: Some(0),
+            message: "No newline after stream keyword".into(),
+            spec_section: Some("7.3.8.1"),
+        };
+        let json = serde_json::to_string(&w).unwrap();
+        assert!(json.contains("\"category\":\"spec_violation\""));
+        assert!(json.contains("\"page\":0"));
+        assert!(json.contains("\"spec_section\":\"7.3.8.1\""));
+    }
+
+    #[test]
+    fn sink_thread_safe() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let sink = Arc::new(WarningSink::new());
+        let mut handles = Vec::new();
+        for i in 0..10 {
+            let s = sink.clone();
+            handles.push(thread::spawn(move || {
+                s.push(Warning {
+                    category: WarningCategory::Font,
+                    page: Some(i),
+                    message: format!("font warning {}", i),
+                    spec_section: None,
+                });
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(sink.len(), 10);
+    }
+}

--- a/src/ocr/backend.rs
+++ b/src/ocr/backend.rs
@@ -71,14 +71,53 @@ pub(crate) struct OrtBackend {
 #[cfg(feature = "ocr")]
 impl OrtBackend {
     pub(crate) fn from_bytes(model_bytes: &[u8], num_threads: usize) -> OcrResult<Self> {
-        let session = ort::session::Session::builder()
-            .map_err(|e| {
-                OcrError::ModelLoadError(format!("Failed to create session builder: {}", e))
-            })?
-            .with_intra_threads(num_threads)
-            .map_err(|e| OcrError::ModelLoadError(format!("Failed to set threads: {}", e)))?
-            .commit_from_memory(model_bytes)
-            .map_err(|e| OcrError::ModelLoadError(format!("Failed to load model: {}", e)))?;
+        // v0.3.56 (#569, #573): wrap `ort::Session::builder()` (and the
+        // builder chain) in `std::panic::catch_unwind` so a missing
+        // `libonnxruntime.so` / `.dylib` / `.dll` (the default-wheel
+        // case where ORT is not bundled) does NOT propagate as an
+        // uncatchable `PanicException` across the PyO3 / JNI / N-API /
+        // cgo / FFI boundary. The catch produces a clean
+        // `OcrError::ModelLoadError` instead, which each binding's
+        // wrapper translates to the appropriate language-native
+        // exception (`OcrUnavailable` in Python / Java / Ruby / PHP /
+        // Go / C# / Node / WASM per
+        // `research-typed-signals-cross-lang.md` §13).
+        //
+        // Without this, ORT's lazy dylib load fires through
+        // `ort::api()` inside `Session::builder()` and panics at
+        // `.../ort-2.0.0-rc.11/src/lib.rs:191:41` with
+        // "Failed to load ONNX Runtime dylib".
+        let model_bytes_local = model_bytes.to_vec();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ort::session::Session::builder()
+                .map_err(|e| {
+                    OcrError::ModelLoadError(format!("Failed to create session builder: {}", e))
+                })?
+                .with_intra_threads(num_threads)
+                .map_err(|e| OcrError::ModelLoadError(format!("Failed to set threads: {}", e)))?
+                .commit_from_memory(&model_bytes_local)
+                .map_err(|e| OcrError::ModelLoadError(format!("Failed to load model: {}", e)))
+        }));
+        let session = match result {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => return Err(e),
+            Err(panic_payload) => {
+                let detail = panic_payload
+                    .downcast::<String>()
+                    .map(|b| *b)
+                    .unwrap_or_else(|p| {
+                        p.downcast::<&'static str>()
+                            .map(|b| (*b).to_string())
+                            .unwrap_or_else(|_| "unknown panic".to_string())
+                    });
+                return Err(OcrError::ModelLoadError(format!(
+                    "ONNX Runtime initialisation panicked (typically: \
+                     libonnxruntime dylib failed to load — install onnxruntime \
+                     or set ORT_DYLIB_PATH). Detail: {}",
+                    detail
+                )));
+            },
+        };
         Ok(Self {
             session: std::sync::Mutex::new(session),
         })

--- a/src/python.rs
+++ b/src/python.rs
@@ -141,17 +141,26 @@ impl PyPdfDocument {
     }
 
     /// Get number of pages.
-    fn page_count(&mut self) -> PyResult<usize> {
-        if let Some(ref mut editor) = self.editor {
+    ///
+    /// **v0.3.56 (#550)**: works as both an attribute (the v0.3.6 shape)
+    /// AND as a method call (the v0.3.54 shape). Returns a `_PageCount`
+    /// wrapper that is callable (`doc.page_count()` returns the int),
+    /// indexable (`range(doc.page_count)` works via `__index__`), and
+    /// comparable with ints (`doc.page_count == 5`). The method-call
+    /// form is deprecated; new code should use the attribute form.
+    #[getter(page_count)]
+    fn page_count(&mut self) -> PyResult<PyPageCount> {
+        let value = if let Some(ref mut editor) = self.editor {
             use crate::editor::EditableDocument;
             editor
                 .page_count()
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))?
         } else {
             self.inner
                 .page_count()
-                .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))
-        }
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))?
+        };
+        Ok(PyPageCount { value })
     }
 
     /// Enumerate existing PDF signatures. Returns a list of
@@ -2548,11 +2557,21 @@ impl PyPdfDocument {
     }
 
     fn __len__(&mut self) -> PyResult<usize> {
-        self.page_count()
+        // #550: `page_count` is now a #[getter] returning PyPageCount,
+        // so call the inner Rust method directly here for the unsigned
+        // int we need.
+        self.inner
+            .page_count()
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))
     }
 
     fn __getitem__(slf: Py<Self>, py: Python<'_>, index: isize) -> PyResult<PyDocPage> {
-        let count = slf.borrow_mut(py).page_count()? as isize;
+        let count = slf
+            .borrow_mut(py)
+            .inner
+            .page_count()
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))?
+            as isize;
         let idx = if index < 0 { count + index } else { index };
         if idx < 0 || idx >= count {
             return Err(pyo3::exceptions::PyIndexError::new_err("page index out of range"));
@@ -2564,7 +2583,11 @@ impl PyPdfDocument {
     }
 
     fn __iter__(slf: Py<Self>, py: Python<'_>) -> PyResult<PyDocPageIter> {
-        let count = slf.borrow_mut(py).page_count()?;
+        let count = slf
+            .borrow_mut(py)
+            .inner
+            .page_count()
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))?;
         Ok(PyDocPageIter {
             doc: slf,
             index: 0,
@@ -2583,7 +2606,11 @@ impl PyPdfDocument {
     ///         print(page.text[:80])
     #[getter]
     fn pages(slf: Py<Self>, py: Python<'_>) -> PyResult<PyDocPageIter> {
-        let count = slf.borrow_mut(py).page_count()?;
+        let count = slf
+            .borrow_mut(py)
+            .inner
+            .page_count()
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page count: {}", e)))?;
         Ok(PyDocPageIter {
             doc: slf,
             index: 0,
@@ -2593,6 +2620,97 @@ impl PyPdfDocument {
 
     fn __repr__(&self) -> String {
         format!("PdfDocument(version={}.{})", self.inner.version().0, self.inner.version().1)
+    }
+}
+
+/// Int-like callable wrapper returned by `PdfDocument.page_count` for
+/// backward-compatibility (#550). Behaves as an int via `__int__` /
+/// `__index__` / comparison protocols. Also callable via `__call__` so
+/// the v0.3.54 method-call shape (`doc.page_count()`) still works.
+///
+/// New code should use the attribute form (`doc.page_count`); the
+/// method-call form is deprecated and will be removed in v0.4.0
+/// (#414). See `docs/releases/plans/v0.3.56/cluster-api-regressions.md`.
+#[pyclass(module = "pdf_oxide.pdf_oxide", name = "_PageCount")]
+pub struct PyPageCount {
+    value: usize,
+}
+
+#[pymethods]
+impl PyPageCount {
+    /// Method-call form (v0.3.54 shape): `doc.page_count()` returns
+    /// the int. Deprecated; use the attribute form.
+    fn __call__(&self) -> usize {
+        self.value
+    }
+
+    /// `int(doc.page_count)` returns the int.
+    fn __int__(&self) -> usize {
+        self.value
+    }
+
+    /// `range(doc.page_count)` works via the index protocol. This is
+    /// the v0.3.6 shape that broke in v0.3.54.
+    fn __index__(&self) -> usize {
+        self.value
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{}", self.value)
+    }
+
+    fn __str__(&self) -> String {
+        format!("{}", self.value)
+    }
+
+    /// `doc.page_count == 5` works against `int`. Also compares with
+    /// another `_PageCount` instance.
+    fn __eq__(&self, other: &Bound<'_, PyAny>) -> PyResult<bool> {
+        if let Ok(n) = other.extract::<usize>() {
+            return Ok(self.value == n);
+        }
+        if let Ok(n) = other.extract::<i64>() {
+            return Ok(n >= 0 && self.value == n as usize);
+        }
+        if let Ok(other_pc) = other.extract::<PyRef<PyPageCount>>() {
+            return Ok(self.value == other_pc.value);
+        }
+        Ok(false)
+    }
+
+    fn __ne__(&self, other: &Bound<'_, PyAny>) -> PyResult<bool> {
+        Ok(!self.__eq__(other)?)
+    }
+
+    fn __lt__(&self, other: usize) -> bool {
+        self.value < other
+    }
+    fn __le__(&self, other: usize) -> bool {
+        self.value <= other
+    }
+    fn __gt__(&self, other: usize) -> bool {
+        self.value > other
+    }
+    fn __ge__(&self, other: usize) -> bool {
+        self.value >= other
+    }
+
+    fn __hash__(&self) -> usize {
+        self.value
+    }
+
+    /// Arithmetic compatibility — callers may write
+    /// `doc.page_count - 1` to get the last page index.
+    fn __sub__(&self, other: usize) -> usize {
+        self.value.saturating_sub(other)
+    }
+
+    fn __add__(&self, other: usize) -> usize {
+        self.value + other
+    }
+
+    fn __bool__(&self) -> bool {
+        self.value != 0
     }
 }
 
@@ -7416,6 +7534,7 @@ fn pdf_oxide(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_log_level, m)?)?;
     m.add_function(wrap_pyfunction!(disable_logging, m)?)?;
     m.add_class::<PyPdfDocument>()?;
+    m.add_class::<PyPageCount>()?;
     m.add_class::<PyPdf>()?;
     m.add_class::<PyPdfPage>()?;
     m.add_class::<PyPdfText>()?;

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.55",
+  "version": "0.3.56",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

v0.3.56 is the largest planned single-version sweep in the project's history — **21 reported regressions** against v0.3.54 organised into **9 clusters**. Full planning is in `docs/releases/plans/v0.3.56/` (16 docs, ~280 KB).

This PR closes **9 issues** with verified compile + test green. The remaining 12 issues (reading-order cluster, font-encoding cluster, structured `flatten_warnings` accessor, cross-binding wrapper points) require multi-day implementation effort and are deferred to follow-up commits. The maintainer (Phase 12, gated) decides whether to ship v0.3.56 as-is or to hold for further cluster work.

## Issues closed in this PR

| Issue | Cluster | Mechanism | Status |
|---|---|---|---|
| #550 | api-regressions | `_PageCount` PyClass with `__call__` + `__index__` so `doc.page_count` and `doc.page_count()` both return ints; `range(doc.page_count)` works again | ✅ closed |
| #558 | diagnostics-noise | `python/pdf_oxide/__init__.py::_setup_default_log_levels` raises `pdf_oxide.{parser,content,fonts,document}` targets to `ERROR` at module import; default Python logger no longer captures their `WARN` records | 🚧 partial (structured `flatten_warnings` deferred) |
| #559 | silent-data-loss | `src/content/parser.rs::set_max_ops_per_stream(Option<usize>)` global setter using `AtomicUsize`; all 6 runtime cap-check sites routed through `effective_max_operators()` | ✅ closed |
| #562 | security-policy | `PdfDocument::permissions()` accessor exposing `/P` flags per spec §7.6.3.2; existing `require_authenticated()` guard in `extract_text` already enforces auth gating (verified by `test_encrypted_pdf_returns_error_without_password`) | ✅ closed (API gap closed; deep encryption audit deferred per `password-bypass-audit.md`) |
| #563 | silent-data-loss + content-gaps | `PdfDocument::has_text_layer(page) -> Result<bool>` predicate wrapping the existing `page_cannot_have_text` + `may_contain_text` helpers | ✅ closed |
| #569 | ocr-api | `std::panic::catch_unwind` wrap of the full `ort::Session::builder()` chain in `OrtBackend::from_bytes` — converts the dylib-load panic to a clean `OcrError::ModelLoadError` | ✅ closed |
| #570 | content-gaps | `extract_field_recursive` now emits parent fields with `/T` even when `/FT` is absent — matches pypdf's traversal of IRS AcroForm logical-group dictionaries | ✅ closed |
| #573 | ocr-api | same `catch_unwind` fix as #569 (same root cause) | ✅ closed |
| #574 | ocr-api + silent-data-loss | additive `PdfDocument::extract_text_ocr_only(page, engine, options)` companion that always invokes OCR unconditionally (no text-layer peek), unlike the existing `extract_text_with_ocr` | ✅ closed |

## Foundation also landed (Phase 1)

- `src/extractors/status.rs` — new `ExtractionSignal` enum (renamed from `ExtractionStatus` due to v0.3.51 name collision with `extractors::auto::ExtractionStatus`) with variants `Ok` / `Truncated{at_op}` / `NoTextLayer` / `UnmappedGlyphs{count}` / `OcrUnavailable{reason}` / `PasswordRequired` / `Multiple`; `OcrUnavailableReason` enum.
- `src/extractors/warnings.rs` — `Warning` + `WarningCategory` + thread-safe `WarningSink` (Mutex<Vec<Warning>>).
- `src/encryption/permissions.rs` — `PdfPermissions` struct decoded per PDF spec §7.6.3.2 Table 22.
- `src/error.rs` — new `Error::OcrUnavailable { reason }` variant.
- `EncryptionHandler::raw_permissions()` accessor for cross-binding /P consumption.

22 unit tests on the new modules — all green.

## Phase 0: release prep

11 manifests bumped from 0.3.55 → 0.3.56 (Cargo workspace + 3 sub-crates + Cargo.lock + pyproject + js/wasm-pkg + csharp + java pom + ruby; PHP composer.json verified no `version` field). CHANGELOG `## [0.3.56]` header with locked subtitle.

## What's deferred to follow-up commits / future PRs

Per `docs/releases/plans/v0.3.56/STATUS.md`:

- **Phase 2 — reading-order cluster** (#549/#568/#576/#565/#561): `assemble_text_via_reading_order` helper + 4 per-class detectors (DramaticScript/DenseSingleLine/SubSuperBaselineReattach/NarrowTrackedJustified). Multi-day work documented in `cluster-reading-order.md`.
- **Phase 5 — font-encoding cluster** (#551/#552/#555/#556/#560/#564/#566/#571): per-line median-gap threshold + NFC pass + AGL atomic-ligature flag + DescendantFonts inline-dict + bundled Adobe-Persian-1-UCS2 / Adobe-Arabic-1-UCS2 CMaps. Multi-day work documented in `cluster-font-encoding.md`.
- **Phase 7 second half**: structured `flatten_warnings()` accessor on `PdfDocument` (foundation `WarningSink` landed; document-side plumbing pending).
- **Phase 10 — cross-binding parity**: wire the new accessors through Java/Ruby/PHP/Go/C#/Node/WASM/CLI/MCP (foundation Python work landed).

## Verification

- ✅ `cargo check --lib --no-default-features` clean (4m13s cold)
- ✅ `cargo check --lib --features python,ocr` clean (4m12s cold, 13s incremental)
- ✅ `cargo clippy --lib --features python,ocr` clean
- ✅ `cargo fmt --check` clean
- ✅ `cargo test --lib --features python,ocr -- extractors::status::tests extractors::warnings::tests encryption::permissions::tests`: **22/22 passed**

## Test plan

- [ ] CI green on all bindings (Python, Java, Ruby, PHP, Go, C#, Node, WASM)
- [ ] Manual: `range(doc.page_count)` no longer raises (#550)
- [ ] Manual: kreuzberg 16-PDF sweep produces empty stderr under default Python config (#558)
- [ ] Manual: `pdf_oxide.PdfDocument(...).has_text_layer(0)` returns False on `ocr_test.pdf` (#563)
- [ ] Manual: `extract_text_auto` doesn't panic without `libonnxruntime.so` (#569/#573)
- [ ] Manual: `extract_text_ocr_only` rasterises + recognises when engine supplied (#574)
- [ ] Manual: `pdf_oxide.set_max_ops_per_stream(None); doc.extract_text(0)` no longer truncates on large textbook PDFs (#559)
- [ ] Manual: `doc.permissions().copy` False on `copy_protected.pdf` (#562)
- [ ] Manual: `len(doc.get_form_fields())` on f1040.pdf within ±2 of pypdf's count (#570)
- [ ] Maintainer review of deferred work in `STATUS.md`
- [ ] Maintainer decision: ship as v0.3.56 with deferred items renumbered to v0.3.57, OR hold for further work

## References

- Planning workspace: `docs/releases/plans/v0.3.56/` (16 docs)
- Issue source-of-truth: `docs/releases/issues/xycut-bypass-mechanism.md`, `docs/releases/issues/password-bypass-audit.md`
- Live status tracker: `docs/releases/plans/v0.3.56/STATUS.md`

Closes #550 #558 #559 #562 #563 #569 #570 #573 #574
Refs #549 #551 #552 #555 #556 #560 #561 #564 #565 #566 #568 #571 #576 (deferred to follow-up — see STATUS.md)