### PR TITLE
fix: cache poisoning when fonts collide on basename with different To…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [Unreleased]
+
+### Fixed
+- **#595** — Cross-document font cache poisoning when subset fonts
+  (e.g. `AAAAAA+Arial`) from different PDFs collide on BaseFont name.
+  The global cache now skips subset fonts entirely, and fonts without
+  a `BaseFont` entry default to `is_subset = true` as a fail-safe.
+
 ## [0.3.55] - 2026-05-25
 
 > Ruby + PHP language bindings + multi-line heading reading-order fix

--- a/src/document.rs
+++ b/src/document.rs
@@ -10689,15 +10689,30 @@ impl PdfDocument {
     /// uniquely identify fonts within a document. For reference-only fields (ToUnicode,
     /// FontDescriptor, DescendantFonts), hashes their presence to avoid false positives
     /// between fonts with vs without these features.
-    fn font_identity_hash_cheap(font_obj: &Object) -> u64 {
+    /// Returns `(hash, is_subset)`.
+    ///
+    /// Subset fonts (e.g. `AAAAAA+ArialUnicodeMS`) have document-specific
+    /// glyph subsets and ToUnicode mappings that are NOT safe to share across
+    /// documents even when the BaseFont name matches. The caller must skip
+    /// the global cross-document cache for subset fonts.
+    fn font_identity_hash_cheap(font_obj: &Object) -> (u64, bool) {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let mut is_subset = false;
 
         if let Some(d) = font_obj.as_dict() {
             // BaseFont: primary identity — unique per font within a document
             if let Some(Object::Name(n)) = d.get("BaseFont") {
                 1u8.hash(&mut hasher);
                 n.hash(&mut hasher);
+                // Detect subset prefix: 6 uppercase ASCII letters followed by '+'
+                let name_bytes = n.as_bytes();
+                if name_bytes.len() > 7
+                    && name_bytes[6] == b'+'
+                    && name_bytes[..6].iter().all(|b| b.is_ascii_uppercase())
+                {
+                    is_subset = true;
+                }
             }
             // Subtype: Type1, TrueType, Type0, CIDFontType0, CIDFontType2
             if let Some(Object::Name(n)) = d.get("Subtype") {
@@ -10709,12 +10724,16 @@ impl PdfDocument {
                 3u8.hash(&mut hasher);
                 match enc {
                     Object::Name(n) => n.hash(&mut hasher),
-                    Object::Reference(_) => b"enc_ref".hash(&mut hasher),
+                    Object::Reference(r) => {
+                        b"enc_ref".hash(&mut hasher);
+                        r.id.hash(&mut hasher);
+                        r.gen.hash(&mut hasher);
+                    },
                     Object::Dictionary(_) => b"enc_dict".hash(&mut hasher),
                     _ => {},
                 }
             }
-            // ToUnicode: hash content via reference or inline presence
+            // ToUnicode: hash reference ID (unique within a document)
             if let Some(to_unicode) = d.get("ToUnicode") {
                 4u8.hash(&mut hasher);
                 if let Some(r) = to_unicode.as_reference() {
@@ -10737,7 +10756,7 @@ impl PdfDocument {
                 }
             }
         }
-        hasher.finish()
+        (hasher.finish(), is_subset)
     }
 
     /// Load fonts from a Resources dictionary into the extractor.
@@ -10913,10 +10932,11 @@ impl PdfDocument {
                         let font = self.load_object(font_ref)?;
 
                         // Compute identity hash (cheap: 3-6 dict lookups, ~200ns)
-                        let id_hash = Self::font_identity_hash_cheap(&font);
+                        let (id_hash, is_subset) = Self::font_identity_hash_cheap(&font);
 
                         // Layer 5: Per-font identity cache — skip from_dict when a
-                        // structurally identical font was already parsed elsewhere.
+                        // structurally identical font was already parsed elsewhere
+                        // in the SAME document.
                         let cached_identity_opt = self
                             .font_identity_cache
                             .lock_or_recover()
@@ -10932,27 +10952,34 @@ impl PdfDocument {
 
                         // Layer 6: Global cross-document font cache — reuse fonts
                         // parsed by previous PdfDocument instances in this process.
-                        if let Some(cached) =
-                            crate::fonts::global_cache::global_font_cache_get(id_hash)
-                        {
-                            self.font_identity_cache
-                                .lock_or_recover()
-                                .insert(id_hash, Arc::clone(&cached));
-                            self.font_cache
-                                .lock_or_recover()
-                                .insert(font_ref, Arc::clone(&cached));
-                            extractor.add_font_shared((*name).clone(), cached);
-                            continue;
+                        // Skip for subset fonts: their ToUnicode mappings are
+                        // document-specific and unsafe to share across documents.
+                        if !is_subset {
+                            if let Some(cached) =
+                                crate::fonts::global_cache::global_font_cache_get(id_hash)
+                            {
+                                self.font_identity_cache
+                                    .lock_or_recover()
+                                    .insert(id_hash, Arc::clone(&cached));
+                                self.font_cache
+                                    .lock_or_recover()
+                                    .insert(font_ref, Arc::clone(&cached));
+                                extractor.add_font_shared((*name).clone(), cached);
+                                continue;
+                            }
                         }
 
                         match FontInfo::from_dict(&font, self) {
                             Ok(font_info) => {
                                 let arc = Arc::new(font_info);
-                                // Populate both document-level and global caches
-                                crate::fonts::global_cache::global_font_cache_insert(
-                                    id_hash,
-                                    Arc::clone(&arc),
-                                );
+                                // Global cache: only for non-subset fonts
+                                if !is_subset {
+                                    crate::fonts::global_cache::global_font_cache_insert(
+                                        id_hash,
+                                        Arc::clone(&arc),
+                                    );
+                                }
+                                // Document-level caches: always populate
                                 self.font_identity_cache
                                     .lock_or_recover()
                                     .insert(id_hash, Arc::clone(&arc));
@@ -17103,7 +17130,10 @@ mod tests {
         let mut enc = std::collections::HashMap::new();
         enc.insert("Type".to_string(), Object::Name("Encoding".to_string()));
         font_dict.insert("Encoding".to_string(), Object::Dictionary(enc));
-        assert_ne!(PdfDocument::font_identity_hash_cheap(&Object::Dictionary(font_dict)), 0);
+        let (hash, is_subset) =
+            PdfDocument::font_identity_hash_cheap(&Object::Dictionary(font_dict));
+        assert_ne!(hash, 0);
+        assert!(!is_subset);
     }
 
     #[test]
@@ -17111,7 +17141,10 @@ mod tests {
         let mut font_dict = std::collections::HashMap::new();
         font_dict.insert("BaseFont".to_string(), Object::Name("Helvetica".to_string()));
         font_dict.insert("Encoding".to_string(), Object::Reference(ObjectRef::new(99, 0)));
-        assert_ne!(PdfDocument::font_identity_hash_cheap(&Object::Dictionary(font_dict)), 0);
+        let (hash, is_subset) =
+            PdfDocument::font_identity_hash_cheap(&Object::Dictionary(font_dict));
+        assert_ne!(hash, 0);
+        assert!(!is_subset);
     }
 
     #[test]
@@ -17119,11 +17152,11 @@ mod tests {
         let mut d1 = std::collections::HashMap::new();
         d1.insert("BaseFont".to_string(), Object::Name("Arial".to_string()));
         d1.insert("ToUnicode".to_string(), Object::Reference(ObjectRef::new(50, 0)));
-        let h1 = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d1));
+        let (h1, _) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d1));
 
         let mut d2 = std::collections::HashMap::new();
         d2.insert("BaseFont".to_string(), Object::Name("Arial".to_string()));
-        let h2 = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d2));
+        let (h2, _) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d2));
         assert_ne!(h1, h2);
     }
 
@@ -17136,7 +17169,23 @@ mod tests {
             "DescendantFonts".to_string(),
             Object::Array(vec![Object::Reference(ObjectRef::new(20, 0))]),
         );
-        assert_ne!(PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d)), 0);
+        let (hash, is_subset) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d));
+        assert_ne!(hash, 0);
+        assert!(!is_subset);
+    }
+
+    #[test]
+    fn test_font_identity_hash_detects_subset_prefix() {
+        let mut d = std::collections::HashMap::new();
+        d.insert("BaseFont".to_string(), Object::Name("AAAAAA+ArialUnicodeMS".to_string()));
+        d.insert("Subtype".to_string(), Object::Name("Type0".to_string()));
+        let (_, is_subset) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d));
+        assert!(is_subset, "Should detect AAAAAA+ as subset prefix");
+
+        let mut d2 = std::collections::HashMap::new();
+        d2.insert("BaseFont".to_string(), Object::Name("ArialUnicodeMS".to_string()));
+        let (_, is_subset2) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d2));
+        assert!(!is_subset2, "No prefix should not be detected as subset");
     }
 
     // ========================================================================

--- a/src/document.rs
+++ b/src/document.rs
@@ -10687,8 +10687,9 @@ impl PdfDocument {
     /// Uses only inline fields (no reference resolution / load_object calls) to keep
     /// the cost at ~200ns. Relies on BaseFont + Subtype + Encoding (when inline) to
     /// uniquely identify fonts within a document. For reference-only fields (ToUnicode,
-    /// FontDescriptor, DescendantFonts), hashes their presence to avoid false positives
-    /// between fonts with vs without these features.
+    /// FontDescriptor, DescendantFonts), hashes their values to avoid false positives
+    /// between fonts with vs without these features. Indirect references (Encoding,
+    /// ToUnicode, DescendantFonts) are hashed by object ID, not just presence.
     /// Returns `(hash, is_subset)`.
     ///
     /// Subset fonts (e.g. `AAAAAA+ArialUnicodeMS`) have document-specific
@@ -10698,7 +10699,7 @@ impl PdfDocument {
     fn font_identity_hash_cheap(font_obj: &Object) -> (u64, bool) {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        let mut is_subset = false;
+        let mut is_subset = true;
 
         if let Some(d) = font_obj.as_dict() {
             // BaseFont: primary identity — unique per font within a document
@@ -10707,12 +10708,9 @@ impl PdfDocument {
                 n.hash(&mut hasher);
                 // Detect subset prefix: 6 uppercase ASCII letters followed by '+'
                 let name_bytes = n.as_bytes();
-                if name_bytes.len() > 7
+                is_subset = name_bytes.len() > 7
                     && name_bytes[6] == b'+'
-                    && name_bytes[..6].iter().all(|b| b.is_ascii_uppercase())
-                {
-                    is_subset = true;
-                }
+                    && name_bytes[..6].iter().all(|b| b.is_ascii_uppercase());
             }
             // Subtype: Type1, TrueType, Type0, CIDFontType0, CIDFontType2
             if let Some(Object::Name(n)) = d.get("Subtype") {
@@ -10891,7 +10889,8 @@ impl PdfDocument {
                             if let Some(font_ref) = font_obj.as_reference() {
                                 if let Ok(font) = self.load_object(font_ref) {
                                     name.as_str().hash(&mut h);
-                                    Self::font_identity_hash_cheap(&font).hash(&mut h);
+                                    let (id_hash, _) = Self::font_identity_hash_cheap(&font);
+                                    id_hash.hash(&mut h);
                                 }
                             }
                         }
@@ -11051,7 +11050,8 @@ impl PdfDocument {
                             if let Some(font_ref) = font_obj.as_reference() {
                                 if let Ok(font) = self.load_object(font_ref) {
                                     name.as_str().hash(&mut h);
-                                    Self::font_identity_hash_cheap(&font).hash(&mut h);
+                                    let (id_hash, _) = Self::font_identity_hash_cheap(&font);
+                                    id_hash.hash(&mut h);
                                 }
                             }
                         }
@@ -15845,8 +15845,8 @@ mod tests {
         dict2.insert("BaseFont".to_string(), Object::Name("Helvetica".to_string()));
         dict2.insert("Subtype".to_string(), Object::Name("Type1".to_string()));
 
-        let hash1 = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict1));
-        let hash2 = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict2));
+        let (hash1, _) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict1));
+        let (hash2, _) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict2));
         assert_eq!(hash1, hash2);
     }
 
@@ -15858,16 +15858,16 @@ mod tests {
         let mut dict2 = std::collections::HashMap::new();
         dict2.insert("BaseFont".to_string(), Object::Name("Times-Roman".to_string()));
 
-        let hash1 = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict1));
-        let hash2 = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict2));
+        let (hash1, _) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict1));
+        let (hash2, _) = PdfDocument::font_identity_hash_cheap(&Object::Dictionary(dict2));
         assert_ne!(hash1, hash2);
     }
 
     #[test]
     fn test_font_identity_hash_null_object() {
-        let hash = PdfDocument::font_identity_hash_cheap(&Object::Null);
-        // Should not panic, returns some hash
-        let _ = hash;
+        let (_, is_subset) = PdfDocument::font_identity_hash_cheap(&Object::Null);
+        // No BaseFont key → is_subset defaults to true (fail-safe)
+        assert!(is_subset);
     }
 
     // ========================================================================

--- a/src/fonts/global_cache.rs
+++ b/src/fonts/global_cache.rs
@@ -358,6 +358,7 @@ mod tests {
 
     #[test]
     fn test_global_api_insert_get_clear_stats() {
+        // Relies on process-global state — may interact with parallel tests
         // Use very high unique keys to avoid collisions with other tests
         let key_base = 9_000_000u64;
 

--- a/tests/test_subset_font_cache.rs
+++ b/tests/test_subset_font_cache.rs
@@ -1,0 +1,134 @@
+//! Regression test: global font cache must not share subset fonts across documents.
+//!
+//! Subset fonts (e.g. AAAAAA+Arial) have document-specific ToUnicode CMaps.
+//! Before the fix, two PDFs with the same subset-prefixed BaseFont name would
+//! share a cached FontInfo, causing the second document to use the first
+//! document's ToUnicode mapping — producing wrong characters.
+
+use pdf_oxide::document::PdfDocument;
+
+/// Build a minimal PDF with a Type0 (CID) subset font and a ToUnicode CMap
+/// that maps CID 1 to a specific Unicode character.
+fn build_pdf_with_subset_font(unicode_char: char) -> Vec<u8> {
+    let hex = format!("{:04X}", unicode_char as u32);
+    let cmap = format!(
+        "/CIDInit /ProcSet findresource begin\n\
+         12 dict begin\n\
+         begincmap\n\
+         /CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n\
+         /CMapName /Adobe-Identity-UCS def\n\
+         /CMapType 2 def\n\
+         1 begincodespacerange\n\
+         <0000> <FFFF>\n\
+         endcodespacerange\n\
+         1 beginbfchar\n\
+         <0001> <{hex}>\n\
+         endbfchar\n\
+         endcmap\n\
+         CMapName currentdict /CMap defineresource pop\n\
+         end\n\
+         end"
+    );
+    let cmap_bytes = cmap.as_bytes();
+
+    // Minimal CID font content stream: show CID 1
+    let content = b"BT /F1 12 Tf <0001> Tj ET";
+
+    // Build raw PDF
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    let o1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n");
+
+    // Obj 2: Pages
+    let o2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n");
+
+    // Obj 3: Page
+    let o3 = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+          /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n",
+    );
+
+    // Obj 4: Content stream
+    let o4 = pdf.len();
+    let c4 = format!("4 0 obj << /Length {} >> stream\n", content.len());
+    pdf.extend_from_slice(c4.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream endobj\n");
+
+    // Obj 5: Type0 font with subset prefix
+    let o5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj << /Type /Font /Subtype /Type0 \
+          /BaseFont /AAAAAA+TestFont \
+          /Encoding /Identity-H \
+          /ToUnicode 7 0 R \
+          /DescendantFonts [6 0 R] >> endobj\n",
+    );
+
+    // Obj 6: CIDFont descendant
+    let o6 = pdf.len();
+    pdf.extend_from_slice(
+        b"6 0 obj << /Type /Font /Subtype /CIDFontType2 \
+          /BaseFont /AAAAAA+TestFont \
+          /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+          /W [1 [600]] /DW 1000 >> endobj\n",
+    );
+
+    // Obj 7: ToUnicode CMap stream
+    let o7 = pdf.len();
+    let c7 = format!("7 0 obj << /Length {} >> stream\n", cmap_bytes.len());
+    pdf.extend_from_slice(c7.as_bytes());
+    pdf.extend_from_slice(cmap_bytes);
+    pdf.extend_from_slice(b"\nendstream endobj\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 8\n");
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in [o1, o2, o3, o4, o5, o6, o7] {
+        let entry = format!("{:010} 00000 n \n", offset);
+        pdf.extend_from_slice(entry.as_bytes());
+    }
+
+    pdf.extend_from_slice(b"trailer << /Size 8 /Root 1 0 R >>\nstartxref\n");
+    let xref_str = format!("{}\n%%EOF\n", xref_offset);
+    pdf.extend_from_slice(xref_str.as_bytes());
+
+    pdf
+}
+
+#[test]
+fn test_subset_font_cache_isolation() {
+    // Clear any leftover state from other tests
+    pdf_oxide::fonts::global_cache::clear_global_font_cache();
+    pdf_oxide::fonts::cmap::clear_cmap_cache();
+
+    // PDF 1: subset font maps CID 1 → 'A' (U+0041)
+    let pdf1_bytes = build_pdf_with_subset_font('A');
+    let doc1 = PdfDocument::from_bytes(pdf1_bytes).expect("load pdf1");
+    let text1 = doc1.extract_text(0).expect("extract pdf1");
+    assert!(text1.contains('A'), "PDF 1 should contain 'A', got: {:?}", text1);
+
+    // PDF 2: same BaseFont name (AAAAAA+TestFont) but maps CID 1 → 'Z' (U+005A)
+    let pdf2_bytes = build_pdf_with_subset_font('Z');
+    let doc2 = PdfDocument::from_bytes(pdf2_bytes).expect("load pdf2");
+    let text2 = doc2.extract_text(0).expect("extract pdf2");
+
+    // Before the fix, text2 would contain 'A' (from cached PDF 1 font).
+    // After the fix, text2 should contain 'Z'.
+    assert!(
+        text2.contains('Z'),
+        "PDF 2 should contain 'Z' (not 'A' from cached font), got: {:?}",
+        text2
+    );
+    assert!(
+        !text2.contains('A'),
+        "PDF 2 must NOT contain 'A' from cross-document cache pollution, got: {:?}",
+        text2
+    );
+}


### PR DESCRIPTION
## Description

resolves issue #595 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Related Issues

<!-- Link to related issues, e.g., "Fixes #123" or "Relates to #456" -->

Fixes #595

## Changes Made

1. font_identity_hash_cheap — Return type changed from u64 to (u64, bool). The bool indicates whether the font has a subset prefix (AAAAAA+). Subset fonts have document-specific ToUnicode mappings that are unsafe to share across documents.

2. load_fonts — The global cross-document font cache (Layer 6) is now skipped for subset fonts, both for lookup and insertion. The per-document cache (Layer 5) still works for subset fonts.

3. Tests — Updated 4 existing tests to destructure the new return type. Added 1 new test test_font_identity_hash_detects_subset_prefix that verifies AAAAAA+ArialUnicodeMS is detected as subset and ArialUnicodeMS is not.

Root cause: Two different PDFs with the same subset-prefixed font name (e.g., AAAAAA+ArialUnicodeMS) but different glyph subsets would share a cached FontInfo across documents. The first document's ToUnicode CMap would be used for the second document, mapping characters to wrong codepoints (e.g., ° → 日).

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [ ] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Follow-ups (not in this PR) 

Issues #597 and #598 