### PR TITLE
feat: ocg ink filtering 

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -8652,9 +8652,19 @@ impl PdfDocument {
 
     /// Extract text from a page, excluding content from specified layers and inks.
     ///
-    /// Uses a simplified text assembly pipeline (no structure-tree ordering or
-    /// table detection). For most layer/ink filtering use cases this is
-    /// sufficient since the caller is performing targeted extraction.
+    /// # Text assembly differences
+    ///
+    /// This method uses a simplified text assembly pipeline compared to
+    /// [`extract_text`](Self::extract_text): spans are sorted by row-aware reading order and joined
+    /// with line breaks based on Y-gap heuristics. The full pipeline's
+    /// structure-tree ordering, table detection, and column detection are
+    /// **not** applied. This means:
+    /// - Multi-column layouts may interleave columns
+    /// - Tables will not be reconstructed
+    /// - Reading order depends on coordinate sorting, not document structure
+    ///
+    /// For precise spatial control, use [`extract_chars_filtered`](Self::extract_chars_filtered) and assemble
+    /// text yourself, or apply region filtering on top.
     ///
     /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
     /// ANY ink in the DeviceN array matches an excluded ink name. Tint values

--- a/src/document.rs
+++ b/src/document.rs
@@ -4694,9 +4694,19 @@ impl PdfDocument {
         page_index: usize,
         options: &crate::converters::ConversionOptions,
     ) -> Result<String> {
+        let base_spans = self.extract_spans(page_index)?;
+        self.assemble_text_from_spans(page_index, base_spans, options)
+    }
+
+    fn assemble_text_from_spans(
+        &self,
+        page_index: usize,
+        base_spans: Vec<crate::layout::TextSpan>,
+        options: &crate::converters::ConversionOptions,
+    ) -> Result<String> {
         self.require_authenticated()?;
 
-        let mut base_spans = self.extract_spans(page_index)?;
+        let mut base_spans = base_spans;
 
         // Drop spans that fall inside any caller-specified exclusion region.
         // This runs before the structure-tree and table pipelines so that
@@ -7989,7 +7999,26 @@ impl PdfDocument {
     /// # }
     /// ```
     pub fn extract_spans(&self, page_index: usize) -> Result<Vec<crate::layout::TextSpan>> {
-        let mut spans = self.extract_spans_raw(page_index)?;
+        let spans = self.extract_spans_raw(page_index)?;
+        self.postprocess_spans(page_index, spans)
+    }
+
+    fn extract_spans_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        let spans = self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
+        self.postprocess_spans(page_index, spans)
+    }
+
+    fn postprocess_spans(
+        &self,
+        page_index: usize,
+        raw_spans: Vec<crate::layout::TextSpan>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        let mut spans = raw_spans;
 
         // Drop spans whose bbox lies entirely outside the page's MediaBox.
         // PDFs that reuse one big Form XObject across pages (ExpertPdf and
@@ -8652,19 +8681,9 @@ impl PdfDocument {
 
     /// Extract text from a page, excluding content from specified layers and inks.
     ///
-    /// # Text assembly differences
-    ///
-    /// This method uses a simplified text assembly pipeline compared to
-    /// [`extract_text`](Self::extract_text): spans are sorted by row-aware reading order and joined
-    /// with line breaks based on Y-gap heuristics. The full pipeline's
-    /// structure-tree ordering, table detection, and column detection are
-    /// **not** applied. This means:
-    /// - Multi-column layouts may interleave columns
-    /// - Tables will not be reconstructed
-    /// - Reading order depends on coordinate sorting, not document structure
-    ///
-    /// For precise spatial control, use [`extract_chars_filtered`](Self::extract_chars_filtered) and assemble
-    /// text yourself, or apply region filtering on top.
+    /// Uses the same full text assembly pipeline as [`extract_text`](Self::extract_text)
+    /// (structure-tree ordering, table detection, column detection), but with
+    /// layer/ink-excluded spans removed before assembly.
     ///
     /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
     /// ANY ink in the DeviceN array matches an excluded ink name. Tint values
@@ -8685,48 +8704,12 @@ impl PdfDocument {
             return self.extract_text(page_index);
         }
 
-        let mut spans =
-            self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
-
-        // Apply media-box clipping (same as extract_spans)
-        if let Ok((llx, lly, urx, ury)) = self.get_page_media_box(page_index) {
-            const EDGE_TOLERANCE_PT: f32 = 2.0;
-            let left = llx - EDGE_TOLERANCE_PT;
-            let bottom = lly - EDGE_TOLERANCE_PT;
-            let right = urx + EDGE_TOLERANCE_PT;
-            let top = ury + EDGE_TOLERANCE_PT;
-            spans.retain(|span| {
-                let sx1 = span.bbox.x;
-                let sx2 = span.bbox.x + span.bbox.width;
-                let sy1 = span.bbox.y;
-                let sy2 = span.bbox.y + span.bbox.height;
-                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
-            });
-        }
-
-        // Row-aware reading order sort
-        spans.sort_by(|a, b| {
-            crate::utils::row_aware_span_cmp(a.bbox.y, a.bbox.x, b.bbox.y, b.bbox.x)
-        });
-
-        // Build text from spans
-        let mut text = String::new();
-        let mut last_y: Option<f32> = None;
-        for span in &spans {
-            if let Some(prev_y) = last_y {
-                let y_gap = (prev_y - span.bbox.y).abs();
-                if y_gap > span.bbox.height.max(1.0) * 0.5 {
-                    text.push('\n');
-                }
-            }
-            if !text.is_empty() && !text.ends_with('\n') && !text.ends_with(' ') {
-                text.push(' ');
-            }
-            text.push_str(&span.text);
-            last_y = Some(span.bbox.y);
-        }
-
-        Ok(text)
+        let spans = self.extract_spans_filtered(page_index, excluded_layers, excluded_inks)?;
+        let options = crate::converters::ConversionOptions {
+            extract_tables: true,
+            ..Default::default()
+        };
+        self.assemble_text_from_spans(page_index, spans, &options)
     }
 
     /// Extract text spans from a page using a specified reading order strategy.

--- a/src/document.rs
+++ b/src/document.rs
@@ -8712,6 +8712,33 @@ impl PdfDocument {
         self.assemble_text_from_spans(page_index, spans, &options)
     }
 
+    /// Extract text from a region of a page with layer/ink filtering applied.
+    ///
+    /// Composes [`extract_text_filtered`] with [`extract_text_in_rect`]: spans
+    /// are filtered by layer/ink first, then by region, then assembled via
+    /// the full text pipeline (structure-tree ordering, table detection,
+    /// column detection, whitespace + line breaks).
+    pub fn extract_text_filtered_in_rect(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+        region: crate::geometry::Rect,
+        mode: crate::layout::RectFilterMode,
+    ) -> Result<String> {
+        let spans = if excluded_layers.is_empty() && excluded_inks.is_empty() {
+            self.extract_spans(page_index)?
+        } else {
+            self.extract_spans_filtered(page_index, excluded_layers, excluded_inks)?
+        };
+        let options = crate::converters::ConversionOptions {
+            extract_tables: true,
+            include_region: Some((region, mode)),
+            ..Default::default()
+        };
+        self.assemble_text_from_spans(page_index, spans, &options)
+    }
+
     /// Extract text spans from a page using a specified reading order strategy.
     ///
     /// This method extracts text spans identically to [`extract_spans`](Self::extract_spans),
@@ -9046,6 +9073,14 @@ impl PdfDocument {
     /// and `/DeviceN` color space definitions and returns their ink names.
     /// These names can be passed to `extract_text_filtered` /
     /// `extract_chars_filtered` via `excluded_inks`.
+    ///
+    /// **Note:** Only the page's own `/Resources` is walked. Spot inks
+    /// declared inside a Form XObject's local `/Resources /ColorSpace`
+    /// dictionary will not be enumerated — even though the renderer and
+    /// extractor will still honor them at use time. Callers populating a
+    /// UI picker from this list may miss XObject-local inks; if that
+    /// matters, walk the page's XObject resources separately or
+    /// enumerate inks from the content stream operators.
     pub fn get_page_inks(&self, page_index: usize) -> Result<Vec<String>> {
         let page = self.get_page(page_index)?;
         let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {

--- a/src/document.rs
+++ b/src/document.rs
@@ -8624,6 +8624,129 @@ impl PdfDocument {
         extractor.extract_text_spans(&content_data)
     }
 
+    /// Extract raw text spans with layer and ink exclusion filtering.
+    ///
+    /// Same as [`extract_spans_raw`] but configures the extractor to suppress
+    /// content from specified OCG layers and Separation/DeviceN ink color spaces.
+    fn extract_spans_raw_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        self.require_authenticated()?;
+        use crate::extractors::TextExtractor;
+
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        if self.page_cannot_have_text(page_dict) {
+            return Ok(Vec::new());
+        }
+
+        let content_data = match self.get_page_content_data(page_index) {
+            Ok(data) => data,
+            Err(e) => {
+                log::warn!(
+                    "Failed to decode content stream for page {}: {}, returning empty",
+                    page_index,
+                    e
+                );
+                return Ok(Vec::new());
+            },
+        };
+
+        if !Self::may_contain_text(&content_data) {
+            return Ok(Vec::new());
+        }
+
+        let mut extractor =
+            TextExtractor::with_config(crate::extractors::TextExtractionConfig::default());
+        extractor.set_excluded_layers(excluded_layers);
+        extractor.set_excluded_inks(excluded_inks);
+        if let Some(resources) = page_dict.get("Resources") {
+            extractor.set_resources(resources.clone());
+            extractor.set_document(self);
+            if let Err(e) = self.load_fonts(resources, &mut extractor) {
+                log::warn!(
+                    "Failed to load fonts for page {}: {}, continuing with defaults",
+                    page_index,
+                    e
+                );
+            }
+        }
+
+        extractor.extract_text_spans(&content_data)
+    }
+
+    /// Extract text from a page, excluding content from specified layers and inks.
+    ///
+    /// Uses a simplified text assembly pipeline (no structure-tree ordering or
+    /// table detection). For most layer/ink filtering use cases this is
+    /// sufficient since the caller is performing targeted extraction.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_index` - Zero-based page index
+    /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
+    /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
+    pub fn extract_text_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<String> {
+        if excluded_layers.is_empty() && excluded_inks.is_empty() {
+            return self.extract_text(page_index);
+        }
+
+        let mut spans =
+            self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
+
+        // Apply media-box clipping (same as extract_spans)
+        if let Ok((llx, lly, urx, ury)) = self.get_page_media_box(page_index) {
+            const EDGE_TOLERANCE_PT: f32 = 2.0;
+            let left = llx - EDGE_TOLERANCE_PT;
+            let bottom = lly - EDGE_TOLERANCE_PT;
+            let right = urx + EDGE_TOLERANCE_PT;
+            let top = ury + EDGE_TOLERANCE_PT;
+            spans.retain(|span| {
+                let sx1 = span.bbox.x;
+                let sx2 = span.bbox.x + span.bbox.width;
+                let sy1 = span.bbox.y;
+                let sy2 = span.bbox.y + span.bbox.height;
+                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
+            });
+        }
+
+        // Row-aware reading order sort
+        spans.sort_by(|a, b| {
+            crate::utils::row_aware_span_cmp(a.bbox.y, a.bbox.x, b.bbox.y, b.bbox.x)
+        });
+
+        // Build text from spans
+        let mut text = String::new();
+        let mut last_y: Option<f32> = None;
+        for span in &spans {
+            if let Some(prev_y) = last_y {
+                let y_gap = (prev_y - span.bbox.y).abs();
+                if y_gap > span.bbox.height.max(1.0) * 0.5 {
+                    text.push('\n');
+                }
+            }
+            if !text.is_empty() && !text.ends_with('\n') && !text.ends_with(' ') {
+                text.push(' ');
+            }
+            text.push_str(&span.text);
+            last_y = Some(span.bbox.y);
+        }
+
+        Ok(text)
+    }
+
     /// Extract text spans from a page using a specified reading order strategy.
     ///
     /// This method extracts text spans identically to [`extract_spans`](Self::extract_spans),
@@ -8884,6 +9007,162 @@ impl PdfDocument {
     /// # }
     /// ```
     ///
+    /// List all Optional Content Group (OCG) layer names in the document.
+    ///
+    /// Reads `/OCProperties` from the document catalog and returns the `/Name`
+    /// of each OCG dictionary listed in `/OCGs`. These names can be passed to
+    /// `extract_text_filtered` / `extract_chars_filtered` via `excluded_layers`.
+    ///
+    /// Returns an empty vec if the document has no optional content.
+    pub fn get_layers(&self) -> Result<Vec<String>> {
+        let catalog = self.catalog()?;
+        let catalog_dict = catalog
+            .as_dict()
+            .ok_or_else(|| Error::InvalidPdf("Catalog is not a dictionary".to_string()))?;
+
+        let oc_props = match catalog_dict.get("OCProperties") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let oc_dict = match oc_props.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let ocgs_obj = match oc_dict.get("OCGs") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let ocgs_arr = match ocgs_obj.as_array() {
+            Some(a) => a,
+            None => return Ok(Vec::new()),
+        };
+
+        let mut names = Vec::new();
+        for item in ocgs_arr {
+            let ocg_obj = if let Some(r) = item.as_reference() {
+                match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                item.clone()
+            };
+            if let Some(d) = ocg_obj.as_dict() {
+                if let Some(Object::Name(n)) = d.get("Name") {
+                    names.push(n.clone());
+                } else if let Some(Object::String(s)) = d.get("Name") {
+                    if let Ok(text) = String::from_utf8(s.clone()) {
+                        names.push(text);
+                    }
+                }
+            }
+        }
+        Ok(names)
+    }
+
+    /// List ink / separation names used on a specific page.
+    ///
+    /// Scans the page's `/Resources /ColorSpace` dictionary for `/Separation`
+    /// and `/DeviceN` color space definitions and returns their ink names.
+    /// These names can be passed to `extract_text_filtered` /
+    /// `extract_chars_filtered` via `excluded_inks`.
+    pub fn get_page_inks(&self, page_index: usize) -> Result<Vec<String>> {
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        let resources = match page_dict.get("Resources") {
+            Some(r) => {
+                if let Some(rr) = r.as_reference() {
+                    self.load_object(rr)?
+                } else {
+                    r.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let res_dict = match resources.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let cs_obj = match res_dict.get("ColorSpace") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let cs_dict = match cs_obj.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let mut ink_names = Vec::new();
+        for (_name, cs_def) in cs_dict.iter() {
+            let cs_arr_obj = if let Some(r) = cs_def.as_reference() {
+                match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                cs_def.clone()
+            };
+
+            if let Some(arr) = cs_arr_obj.as_array() {
+                if arr.len() >= 2 {
+                    if let Some(Object::Name(cs_type)) = arr.first() {
+                        match cs_type.as_str() {
+                            "Separation" => {
+                                // [/Separation /InkName /AlternateCS /TintTransform]
+                                if let Some(Object::Name(ink)) = arr.get(1) {
+                                    ink_names.push(ink.clone());
+                                }
+                            },
+                            "DeviceN" => {
+                                // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
+                                if let Some(Object::Array(inks)) = arr.get(1) {
+                                    for ink_obj in inks {
+                                        if let Object::Name(ink) = ink_obj {
+                                            ink_names.push(ink.clone());
+                                        }
+                                    }
+                                }
+                            },
+                            _ => {},
+                        }
+                    }
+                }
+            }
+        }
+
+        ink_names.sort();
+        ink_names.dedup();
+        Ok(ink_names)
+    }
+
     /// # Performance Note
     ///
     /// Character extraction is typically 30-50% faster than span extraction
@@ -8946,6 +9225,73 @@ impl PdfDocument {
                 return y_cmp;
             }
             // X-ascending (left-to-right)
+            crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
+        });
+
+        Ok(chars)
+    }
+
+    /// Extract characters from a page, excluding content from specified layers and inks.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_index` - Zero-based page index
+    /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
+    /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
+    pub fn extract_chars_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextChar>> {
+        use crate::extractors::TextExtractor;
+
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        let content_data = match self.get_page_content_data(page_index) {
+            Ok(data) => data,
+            Err(e) => {
+                log::warn!(
+                    "Failed to decode content stream for page {}: {}, returning empty",
+                    page_index,
+                    e
+                );
+                return Ok(Vec::new());
+            },
+        };
+
+        if !Self::may_contain_text(&content_data) {
+            return Ok(Vec::new());
+        }
+
+        let mut extractor = TextExtractor::new();
+        extractor.set_excluded_layers(excluded_layers);
+        extractor.set_excluded_inks(excluded_inks);
+
+        if let Some(resources) = page_dict.get("Resources") {
+            extractor.set_resources(resources.clone());
+            extractor.set_document(self);
+
+            if let Err(e) = self.load_fonts(resources, &mut extractor) {
+                log::warn!(
+                    "Failed to load fonts for page {}: {}, continuing with defaults",
+                    page_index,
+                    e
+                );
+            }
+        }
+
+        let mut chars = extractor.extract(&content_data)?;
+
+        chars.sort_by(|a, b| {
+            let y_cmp = crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y);
+            if y_cmp != std::cmp::Ordering::Equal {
+                return y_cmp;
+            }
             crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
         });
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -9006,7 +9006,7 @@ impl PdfDocument {
     /// # Ok(())
     /// # }
     /// ```
-    ///
+
     /// List all Optional Content Group (OCG) layer names in the document.
     ///
     /// Reads `/OCProperties` from the document catalog and returns the `/Name`

--- a/src/document.rs
+++ b/src/document.rs
@@ -8688,6 +8688,10 @@ impl PdfDocument {
     /// table detection). For most layer/ink filtering use cases this is
     /// sufficient since the caller is performing targeted extraction.
     ///
+    /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
+    /// ANY ink in the DeviceN array matches an excluded ink name. Tint values
+    /// are not evaluated — this is an all-or-nothing match.
+    ///
     /// # Arguments
     ///
     /// * `page_index` - Zero-based page index

--- a/src/document.rs
+++ b/src/document.rs
@@ -8575,62 +8575,27 @@ impl PdfDocument {
         page_index: usize,
         config: crate::extractors::TextExtractionConfig,
     ) -> Result<Vec<crate::layout::TextSpan>> {
-        self.require_authenticated()?;
-        use crate::extractors::TextExtractor;
-
-        // Get page object
-        let page = self.get_page(page_index)?;
-        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
-            offset: 0,
-            reason: "Page is not a dictionary".to_string(),
-        })?;
-
-        // Fast pre-check: skip pages that cannot produce text based on resources alone.
-        if self.page_cannot_have_text(page_dict) {
-            return Ok(Vec::new());
-        }
-
-        // Get content stream data — skip page on decode failure (Annex I)
-        let content_data = match self.get_page_content_data(page_index) {
-            Ok(data) => data,
-            Err(e) => {
-                log::warn!(
-                    "Failed to decode content stream for page {}: {}, returning empty",
-                    page_index,
-                    e
-                );
-                return Ok(Vec::new());
-            },
-        };
-
-        if !Self::may_contain_text(&content_data) {
-            return Ok(Vec::new());
-        }
-
-        // Single-pass extraction with the provided config
-        let mut extractor = TextExtractor::with_config(config);
-        if let Some(resources) = page_dict.get("Resources") {
-            extractor.set_resources(resources.clone());
-            extractor.set_document(self);
-            if let Err(e) = self.load_fonts(resources, &mut extractor) {
-                log::warn!(
-                    "Failed to load fonts for page {}: {}, continuing with defaults",
-                    page_index,
-                    e
-                );
-            }
-        }
-
-        extractor.extract_text_spans(&content_data)
+        self.extract_spans_impl(page_index, config, HashSet::new(), HashSet::new())
     }
 
-    /// Extract raw text spans with layer and ink exclusion filtering.
-    ///
-    /// Same as [`extract_spans_raw`] but configures the extractor to suppress
-    /// content from specified OCG layers and Separation/DeviceN ink color spaces.
     fn extract_spans_raw_filtered(
         &self,
         page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        self.extract_spans_impl(
+            page_index,
+            crate::extractors::TextExtractionConfig::default(),
+            excluded_layers,
+            excluded_inks,
+        )
+    }
+
+    fn extract_spans_impl(
+        &self,
+        page_index: usize,
+        config: crate::extractors::TextExtractionConfig,
         excluded_layers: HashSet<String>,
         excluded_inks: HashSet<String>,
     ) -> Result<Vec<crate::layout::TextSpan>> {
@@ -8663,10 +8628,13 @@ impl PdfDocument {
             return Ok(Vec::new());
         }
 
-        let mut extractor =
-            TextExtractor::with_config(crate::extractors::TextExtractionConfig::default());
-        extractor.set_excluded_layers(excluded_layers);
-        extractor.set_excluded_inks(excluded_inks);
+        let mut extractor = TextExtractor::with_config(config);
+        if !excluded_layers.is_empty() {
+            extractor.set_excluded_layers(excluded_layers);
+        }
+        if !excluded_inks.is_empty() {
+            extractor.set_excluded_inks(excluded_inks);
+        }
         if let Some(resources) = page_dict.get("Resources") {
             extractor.set_resources(resources.clone());
             extractor.set_document(self);
@@ -9172,67 +9140,7 @@ impl PdfDocument {
     /// Character extraction is typically 30-50% faster than span extraction
     /// because it skips the text grouping and merging logic.
     pub fn extract_chars(&self, page_index: usize) -> Result<Vec<crate::layout::TextChar>> {
-        use crate::extractors::TextExtractor;
-
-        // Get page object
-        let page = self.get_page(page_index)?;
-        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
-            offset: 0,
-            reason: "Page is not a dictionary".to_string(),
-        })?;
-
-        // Get content stream data — skip page on decode failure (Annex I)
-        let content_data = match self.get_page_content_data(page_index) {
-            Ok(data) => data,
-            Err(e) => {
-                log::warn!(
-                    "Failed to decode content stream for page {}: {}, returning empty",
-                    page_index,
-                    e
-                );
-                return Ok(Vec::new());
-            },
-        };
-
-        // Early-out for pages with no text content (§9.4.3)
-        if !Self::may_contain_text(&content_data) {
-            return Ok(Vec::new());
-        }
-
-        // Create text extractor for character-level extraction
-        let mut extractor = TextExtractor::new();
-
-        // Load fonts from page resources and set resources for XObject access
-        if let Some(resources) = page_dict.get("Resources") {
-            extractor.set_resources(resources.clone());
-            extractor.set_document(self);
-
-            // Load fonts
-            if let Err(e) = self.load_fonts(resources, &mut extractor) {
-                log::warn!(
-                    "Failed to load fonts for page {}: {}, continuing with defaults",
-                    page_index,
-                    e
-                );
-            }
-        }
-
-        // Extract characters directly (single-pass, no document classification)
-        let mut chars = extractor.extract(&content_data)?;
-
-        // Sort characters by reading order (Y-descending, then X-ascending)
-        // This ensures extract_words and extract_text_lines process them in logical order.
-        chars.sort_by(|a, b| {
-            // Y-descending (top-to-bottom)
-            let y_cmp = crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y);
-            if y_cmp != std::cmp::Ordering::Equal {
-                return y_cmp;
-            }
-            // X-ascending (left-to-right)
-            crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
-        });
-
-        Ok(chars)
+        self.extract_chars_impl(page_index, HashSet::new(), HashSet::new())
     }
 
     /// Extract characters from a page, excluding content from specified layers and inks.
@@ -9243,6 +9151,15 @@ impl PdfDocument {
     /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
     /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
     pub fn extract_chars_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextChar>> {
+        self.extract_chars_impl(page_index, excluded_layers, excluded_inks)
+    }
+
+    fn extract_chars_impl(
         &self,
         page_index: usize,
         excluded_layers: HashSet<String>,
@@ -9273,13 +9190,16 @@ impl PdfDocument {
         }
 
         let mut extractor = TextExtractor::new();
-        extractor.set_excluded_layers(excluded_layers);
-        extractor.set_excluded_inks(excluded_inks);
+        if !excluded_layers.is_empty() {
+            extractor.set_excluded_layers(excluded_layers);
+        }
+        if !excluded_inks.is_empty() {
+            extractor.set_excluded_inks(excluded_inks);
+        }
 
         if let Some(resources) = page_dict.get("Resources") {
             extractor.set_resources(resources.clone());
             extractor.set_document(self);
-
             if let Err(e) = self.load_fonts(resources, &mut extractor) {
                 log::warn!(
                     "Failed to load fonts for page {}: {}, continuing with defaults",

--- a/src/document.rs
+++ b/src/document.rs
@@ -8971,7 +8971,7 @@ impl PdfDocument {
     /// # Ok(())
     /// # }
     /// ```
-
+    ///
     /// List all Optional Content Group (OCG) layer names in the document.
     ///
     /// Reads `/OCProperties` from the document catalog and returns the `/Name`

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2673,6 +2673,73 @@ impl<'doc> TextExtractor<'doc> {
         false
     }
 
+    /// Check whether a BDC properties dict represents an excluded OCG or OCMD.
+    ///
+    /// Handles two cases per ISO 32000-1 Section 8.11.2:
+    /// - Direct OCG: dict has `/Name` -> check against excluded layers
+    /// - OCMD: dict has `/Type /OCMD` and `/OCGs` array -> resolve each
+    ///   referenced OCG and check its `/Name` against excluded layers
+    fn check_ocg_excluded(&self, props_dict: &std::collections::HashMap<String, Object>) -> bool {
+        if let Some(ocg_name) = props_dict.get("Name") {
+            return self.ocg_name_is_excluded(ocg_name);
+        }
+
+        if let Some(Object::Name(t)) = props_dict.get("Type") {
+            if t == "OCMD" {
+                if let Some(ocgs_obj) = props_dict.get("OCGs") {
+                    return self.ocmd_ocgs_excluded(ocgs_obj);
+                }
+            }
+        }
+
+        false
+    }
+
+    fn ocg_name_is_excluded(&self, name_obj: &Object) -> bool {
+        if let Some(name_str) = name_obj.as_name() {
+            return self.excluded_layers.contains(name_str);
+        }
+        if let Some(name_bytes) = name_obj.as_string() {
+            let name_str = Self::decode_pdf_text_string(name_bytes);
+            return self.excluded_layers.contains(&name_str);
+        }
+        false
+    }
+
+    /// Resolve OCMD /OCGs and check if any referenced OCG is excluded.
+    /// /OCGs can be a single reference or an array of references.
+    fn ocmd_ocgs_excluded(&self, ocgs_obj: &Object) -> bool {
+        let doc = match self.document {
+            Some(d) => d,
+            None => return false,
+        };
+
+        let refs: Vec<&Object> = if let Some(arr) = ocgs_obj.as_array() {
+            arr.iter().collect()
+        } else {
+            vec![ocgs_obj]
+        };
+
+        for obj in refs {
+            let resolved = if let Some(r) = obj.as_reference() {
+                match doc.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                obj.clone()
+            };
+            if let Some(d) = resolved.as_dict() {
+                if let Some(name_obj) = d.get("Name") {
+                    if self.ocg_name_is_excluded(name_obj) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
     ///
     /// Searches from the innermost marked content context outward, returning
@@ -5081,25 +5148,12 @@ impl<'doc> TextExtractor<'doc> {
                         artifact_type = Self::parse_artifact_type(&props_dict);
                     }
 
-                    // OCG (Optional Content Group / layer) filtering.
-                    // Per ISO 32000-1:2008 Section 8.11.2, content within a BDC
-                    // tagged "OC" references an OCG dictionary with /Type /OCG
-                    // and /Name <layer-name>.
+                    // OCG / OCMD (Optional Content) filtering.
+                    // Per ISO 32000-1:2008 Section 8.11.2:
+                    //  - Direct OCG: << /Type /OCG /Name /LayerName >>
+                    //  - OCMD:       << /Type /OCMD /OCGs [refs...] /P /policy >>
                     if tag == "OC" && !self.excluded_layers.is_empty() {
-                        if let Some(ocg_name) = props_dict.get("Name") {
-                            if let Some(name_str) = ocg_name.as_name() {
-                                if self.excluded_layers.contains(name_str) {
-                                    is_excluded_layer = true;
-                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
-                                }
-                            } else if let Some(name_bytes) = ocg_name.as_string() {
-                                let name_str = Self::decode_pdf_text_string(name_bytes);
-                                if self.excluded_layers.contains(&name_str) {
-                                    is_excluded_layer = true;
-                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
-                                }
-                            }
-                        }
+                        is_excluded_layer = self.check_ocg_excluded(&props_dict);
                     }
                 }
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -1999,6 +1999,10 @@ struct MarkedContentContext {
     /// The /E entry provides the expansion of an abbreviation or acronym.
     /// e.g., "PDF" might expand to "Portable Document Format"
     expansion: Option<String>,
+    /// Whether this marked content context is an excluded Optional Content Group (layer).
+    ///
+    /// Set when tag is "OC" and the OCG /Name matches one of the excluded layers.
+    is_excluded_layer: bool,
 }
 
 /// Text extractor that processes content streams.
@@ -2057,6 +2061,25 @@ pub struct TextExtractor<'doc> {
     /// Per PDF Spec Section 14.6, artifact content should be excluded from text extraction.
     /// This flag is true when any ancestor in the marked_content_stack has is_artifact=true.
     inside_artifact: bool,
+    /// Layer names (Optional Content Groups) to exclude from extraction.
+    ///
+    /// When a BDC operator with tag "OC" references an OCG whose /Name matches
+    /// one of these entries, all content within that marked content scope is suppressed.
+    excluded_layers: HashSet<String>,
+    /// Whether we're currently inside an excluded OCG layer.
+    ///
+    /// True when any ancestor in the marked_content_stack has is_excluded_layer=true.
+    inside_excluded_layer: bool,
+    /// Ink / separation names to exclude from extraction.
+    ///
+    /// When a `cs` operator sets a Separation or DeviceN color space whose ink name(s)
+    /// match one of these entries, subsequent text is suppressed until the color space changes.
+    excluded_inks: HashSet<String>,
+    /// Whether the current fill color space is an excluded ink.
+    ///
+    /// Set when SetFillColorSpace resolves to a Separation or DeviceN color space
+    /// whose ink name(s) intersect with `excluded_inks`.
+    inside_excluded_ink: bool,
     /// Extraction mode: true for spans, false for characters
     extract_spans: bool,
     /// Buffer for accumulating consecutive Tj operators into single spans
@@ -2167,6 +2190,10 @@ impl<'doc> TextExtractor<'doc> {
             span_sequence_counter: 0, // Initialize sequence counter
             marked_content_stack: Vec::new(), // Track marked content contexts
             inside_artifact: false,   // Track artifact state
+            excluded_layers: HashSet::new(),
+            inside_excluded_layer: false,
+            excluded_inks: HashSet::new(),
+            inside_excluded_ink: false,
             tj_offset_history: Vec::with_capacity(1000), // Track TJ offsets for statistical analysis
             tj_character_array: Vec::new(),              // Character tracking for word boundaries
             current_x_position: 0.0,                     // Start at origin
@@ -2208,6 +2235,23 @@ impl<'doc> TextExtractor<'doc> {
     /// Set the document reference for loading XObjects.
     pub fn set_document(&mut self, document: &'doc crate::document::PdfDocument) {
         self.document = Some(document);
+    }
+
+    /// Set layer names (Optional Content Groups) to exclude from extraction.
+    ///
+    /// Content within BDC/EMC scopes tagged "OC" whose OCG /Name matches one of
+    /// the provided names will be suppressed during text extraction.
+    pub fn set_excluded_layers(&mut self, layers: HashSet<String>) {
+        self.excluded_layers = layers;
+    }
+
+    /// Set ink / separation names to exclude from extraction.
+    ///
+    /// When the fill color space is a Separation or DeviceN whose ink name(s)
+    /// intersect with any of the provided names, subsequent text is suppressed
+    /// until the color space changes to a non-excluded one.
+    pub fn set_excluded_inks(&mut self, inks: HashSet<String>) {
+        self.excluded_inks = inks;
     }
 
     // ========================================================================
@@ -2402,6 +2446,30 @@ impl<'doc> TextExtractor<'doc> {
         self.inside_artifact = self.marked_content_stack.iter().any(|ctx| ctx.is_artifact);
     }
 
+    /// Update the excluded-layer state based on the marked content stack.
+    ///
+    /// True if any ancestor in the stack is an excluded OCG layer.
+    /// Called each time a marked content boundary is crossed (BMC/BDC/EMC).
+    fn update_layer_state(&mut self) {
+        self.inside_excluded_layer = self
+            .marked_content_stack
+            .iter()
+            .any(|ctx| ctx.is_excluded_layer);
+    }
+
+    /// Whether content emission should be suppressed.
+    ///
+    /// Returns true when the current graphics/marked-content state means
+    /// extracted text should be discarded. Currently checks:
+    /// - Inside an excluded OCG layer (`inside_excluded_layer`)
+    /// - Inside an excluded ink / separation color space (`inside_excluded_ink`)
+    ///
+    /// Note: artifact filtering is handled separately via span metadata and
+    /// downstream filtering, so `inside_artifact` is intentionally not checked here.
+    fn is_content_suppressed(&self) -> bool {
+        self.inside_excluded_layer || self.inside_excluded_ink
+    }
+
     /// Parse artifact type and subtype from artifact properties dictionary.
     ///
     /// Per PDF Spec Section 14.8.2.2, artifacts have optional /Type and /Subtype entries:
@@ -2528,6 +2596,80 @@ impl<'doc> TextExtractor<'doc> {
             prop_obj.clone()
         };
         resolved.as_dict().cloned()
+    }
+
+    /// Resolve a named color space from the /Resources /ColorSpace dictionary.
+    ///
+    /// PDF content streams reference color spaces by name (e.g. `cs /CS1`).
+    /// Device color spaces like "DeviceRGB" are built-in, but Separation and
+    /// DeviceN color spaces live in the page resources:
+    ///
+    /// ```text
+    /// /Resources << /ColorSpace << /CS1 [/Separation /PANTONE_Red /DeviceCMYK ...] >> >>
+    /// ```
+    ///
+    /// Returns the resolved color space array if the name refers to a resource entry.
+    fn resolve_color_space(&self, name: &str) -> Option<Vec<Object>> {
+        let resources = self.resources.as_ref()?;
+        let res_dict = if let Some(res_ref) = resources.as_reference() {
+            self.document?.load_object(res_ref).ok()?
+        } else {
+            resources.clone()
+        };
+        let res_dict = res_dict.as_dict()?;
+        let cs_dict_obj = res_dict.get("ColorSpace")?;
+        let cs_dict = if let Some(r) = cs_dict_obj.as_reference() {
+            self.document?.load_object(r).ok()?
+        } else {
+            cs_dict_obj.clone()
+        };
+        let cs_dict = cs_dict.as_dict()?;
+        let cs_obj = cs_dict.get(name)?;
+        let resolved = if let Some(r) = cs_obj.as_reference() {
+            self.document?.load_object(r).ok()?
+        } else {
+            cs_obj.clone()
+        };
+        resolved.as_array().cloned()
+    }
+
+    /// Check if a color space name refers to an excluded ink.
+    ///
+    /// Resolves the color space from resources and checks:
+    /// - `[/Separation /InkName /AlternateCS /TintTransform]` — single ink name
+    /// - `[/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]` — multiple ink names
+    ///
+    /// Returns true if any ink name in the color space matches `excluded_inks`.
+    fn is_excluded_ink_color_space(&self, name: &str) -> bool {
+        if self.excluded_inks.is_empty() {
+            return false;
+        }
+        if let Some(cs_array) = self.resolve_color_space(name) {
+            if cs_array.len() >= 2 {
+                if let Some(cs_type) = cs_array[0].as_name() {
+                    match cs_type {
+                        "Separation" => {
+                            // [/Separation /InkName /AlternateCS /TintTransform]
+                            if let Some(ink_name) = cs_array[1].as_name() {
+                                return self.excluded_inks.contains(ink_name);
+                            }
+                        },
+                        "DeviceN" => {
+                            // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
+                            if let Some(ink_names) = cs_array[1].as_array() {
+                                return ink_names.iter().any(|obj| {
+                                    obj.as_name()
+                                        .map(|n| self.excluded_inks.contains(n))
+                                        .unwrap_or(false)
+                                });
+                            }
+                        },
+                        _ => {},
+                    }
+                }
+            }
+        }
+        false
     }
 
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
@@ -4149,7 +4291,9 @@ impl<'doc> TextExtractor<'doc> {
                                                 final_matrix.f,
                                             ]),
                                         };
-                                        self.chars.push(space_char);
+                                        if !self.is_content_suppressed() {
+                                            self.chars.push(space_char);
+                                        }
                                     }
 
                                     let state_mut = self.state_stack.current_mut();
@@ -4257,6 +4401,11 @@ impl<'doc> TextExtractor<'doc> {
                     .as_ref()
                     .and_then(|name| self.fonts.get(name))
                     .cloned();
+                // Re-evaluate ink exclusion for the restored color space
+                if !self.excluded_inks.is_empty() {
+                    let cs = self.state_stack.current().fill_color_space.clone();
+                    self.inside_excluded_ink = self.is_excluded_ink_color_space(&cs);
+                }
             },
             Operator::Cm { a, b, c, d, e, f } => {
                 let state = self.state_stack.current_mut();
@@ -4267,26 +4416,30 @@ impl<'doc> TextExtractor<'doc> {
 
             // Color operators
             Operator::SetFillRgb { r, g, b } => {
+                // rg operator implicitly sets DeviceRGB — a process color.
+                self.inside_excluded_ink = false;
                 self.state_stack.current_mut().fill_color_rgb = (r, g, b);
             },
             Operator::SetStrokeRgb { r, g, b } => {
                 self.state_stack.current_mut().stroke_color_rgb = (r, g, b);
             },
             Operator::SetFillGray { gray } => {
+                // g operator implicitly sets DeviceGray — a process color,
+                // so clear any active ink exclusion.
+                self.inside_excluded_ink = false;
                 self.state_stack.current_mut().fill_color_rgb = (gray, gray, gray);
             },
             Operator::SetStrokeGray { gray } => {
                 self.state_stack.current_mut().stroke_color_rgb = (gray, gray, gray);
             },
             Operator::SetFillCmyk { c, m, y, k } => {
-                // Store CMYK and convert to RGB for rendering
-                // CMYK to RGB conversion: R = 1 - min(1, C*(1-K) + K)
+                // k operator implicitly sets DeviceCMYK — a process color.
+                self.inside_excluded_ink = false;
                 let state = self.state_stack.current_mut();
                 state.fill_color_cmyk = Some((c, m, y, k));
                 state.fill_color_rgb = cmyk_to_rgb(c, m, y, k);
             },
             Operator::SetStrokeCmyk { c, m, y, k } => {
-                // Store CMYK and convert to RGB for rendering
                 let state = self.state_stack.current_mut();
                 state.stroke_color_cmyk = Some((c, m, y, k));
                 state.stroke_color_rgb = cmyk_to_rgb(c, m, y, k);
@@ -4294,6 +4447,16 @@ impl<'doc> TextExtractor<'doc> {
 
             // Color space operators
             Operator::SetFillColorSpace { name } => {
+                // Check for excluded ink before mutating state (needs &self)
+                let ink_excluded = self.is_excluded_ink_color_space(&name);
+                self.inside_excluded_ink = ink_excluded;
+                if ink_excluded {
+                    log::debug!(
+                        "Fill color space {:?} matches excluded ink, suppressing text",
+                        name
+                    );
+                }
+
                 let state = self.state_stack.current_mut();
                 state.fill_color_space = name.clone();
                 // Reset color when changing color space
@@ -4867,6 +5030,7 @@ impl<'doc> TextExtractor<'doc> {
                     artifact_type: None, // No artifact classification; None for backward compatibility
                     actual_text: None,   // BMC doesn't have ActualText
                     expansion: None,     // BMC doesn't have expansion
+                    is_excluded_layer: false, // BMC cannot carry OCG properties
                 });
                 self.update_artifact_state();
 
@@ -4881,6 +5045,8 @@ impl<'doc> TextExtractor<'doc> {
                 let mut actual_text = None;
                 let mut artifact_type = None;
                 let mut expansion = None;
+
+                let mut is_excluded_layer = false;
 
                 if let Some(props_dict) = self.resolve_bdc_properties(&properties) {
                     if let Some(mcid_obj) = props_dict.get("MCID") {
@@ -4907,6 +5073,27 @@ impl<'doc> TextExtractor<'doc> {
                     if tag == "Artifact" {
                         artifact_type = Self::parse_artifact_type(&props_dict);
                     }
+
+                    // OCG (Optional Content Group / layer) filtering.
+                    // Per ISO 32000-1:2008 Section 8.11.2, content within a BDC
+                    // tagged "OC" references an OCG dictionary with /Type /OCG
+                    // and /Name <layer-name>.
+                    if tag == "OC" && !self.excluded_layers.is_empty() {
+                        if let Some(ocg_name) = props_dict.get("Name") {
+                            if let Some(name_str) = ocg_name.as_name() {
+                                if self.excluded_layers.contains(name_str) {
+                                    is_excluded_layer = true;
+                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
+                                }
+                            } else if let Some(name_bytes) = ocg_name.as_string() {
+                                let name_str = Self::decode_pdf_text_string(name_bytes);
+                                if self.excluded_layers.contains(&name_str) {
+                                    is_excluded_layer = true;
+                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Check if this is an artifact (per PDF Spec Section 14.6)
@@ -4917,8 +5104,10 @@ impl<'doc> TextExtractor<'doc> {
                     artifact_type: artifact_type.clone(),
                     actual_text,
                     expansion,
+                    is_excluded_layer,
                 });
                 self.update_artifact_state();
+                self.update_layer_state();
 
                 if is_artifact {
                     if let Some(ref atype) = artifact_type {
@@ -4936,10 +5125,11 @@ impl<'doc> TextExtractor<'doc> {
                 }
                 self.current_mcid = None;
 
-                // Pop from marked content stack and update artifact state
+                // Pop from marked content stack and update artifact/layer state
                 if !self.marked_content_stack.is_empty() {
                     self.marked_content_stack.pop();
                     self.update_artifact_state();
+                    self.update_layer_state();
                 }
             },
 
@@ -5484,7 +5674,9 @@ impl<'doc> TextExtractor<'doc> {
         };
         self.span_sequence_counter += 1;
 
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
         Ok(())
     }
 
@@ -5980,7 +6172,9 @@ impl<'doc> TextExtractor<'doc> {
 
         // Step 6: Increment sequence counter and add to spans
         self.span_sequence_counter += 1;
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
 
         Ok(())
     }
@@ -6582,7 +6776,9 @@ impl<'doc> TextExtractor<'doc> {
 
         log::trace!("PUSH space span with offset_semantic={}", span.offset_semantic);
 
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
 
         // Advance position per ISO 32000-1:2008 §9.4.4
         let state = self.state_stack.current_mut();
@@ -6741,7 +6937,9 @@ impl<'doc> TextExtractor<'doc> {
                     span.offset_semantic
                 );
 
-                self.spans.push(span);
+                if !self.is_content_suppressed() {
+                    self.spans.push(span);
+                }
             }
         }
         Ok(())
@@ -6895,7 +7093,9 @@ impl<'doc> TextExtractor<'doc> {
                         ]),
                     };
 
-                    self.chars.push(text_char);
+                    if !self.is_content_suppressed() {
+                        self.chars.push(text_char);
+                    }
                 }
             }
 
@@ -8451,6 +8651,7 @@ mod tests {
             is_artifact: true,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.update_artifact_state();
         assert!(extractor.inside_artifact);
@@ -8465,6 +8666,7 @@ mod tests {
             is_artifact: true,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.marked_content_stack.push(MarkedContentContext {
             artifact_type: None,
@@ -8472,6 +8674,7 @@ mod tests {
             is_artifact: false,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.update_artifact_state();
         // Should still be inside artifact because parent is artifact
@@ -12594,6 +12797,7 @@ mod tests {
             is_artifact: false,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
 
         extractor
@@ -13125,6 +13329,7 @@ fn test_marked_content_context_with_actual_text() {
         is_artifact: false,
         actual_text: Some("fi".to_string()), // Ligature expansion
         expansion: None,
+        is_excluded_layer: false,
     };
 
     assert_eq!(ctx.actual_text, Some("fi".to_string()));
@@ -13140,6 +13345,7 @@ fn test_marked_content_context_with_expansion() {
         is_artifact: false,
         actual_text: None,
         expansion: Some("Portable Document Format".to_string()),
+        is_excluded_layer: false,
     };
 
     assert_eq!(ctx.expansion, Some("Portable Document Format".to_string()));
@@ -13154,6 +13360,7 @@ fn test_marked_content_context_artifact_with_actual_text() {
         artifact_type: Some(ArtifactType::Pagination(PaginationSubtype::Header)),
         actual_text: Some("Header text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     };
 
     assert!(ctx.is_artifact);
@@ -13172,6 +13379,7 @@ fn test_get_current_actual_text_finds_first() {
         is_artifact: false,
         actual_text: Some("outer text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     extractor.marked_content_stack.push(MarkedContentContext {
@@ -13180,6 +13388,7 @@ fn test_get_current_actual_text_finds_first() {
         is_artifact: false,
         actual_text: Some("inner text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Should return innermost (most recent) ActualText
@@ -13199,6 +13408,7 @@ fn test_get_current_actual_text_skips_none() {
         is_artifact: false,
         actual_text: Some("replacement text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Push context without ActualText
@@ -13208,6 +13418,7 @@ fn test_get_current_actual_text_skips_none() {
         is_artifact: false,
         actual_text: None,
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Should find the ActualText from outer context

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -10,6 +10,7 @@ use crate::config::ExtractionProfile;
 use crate::content::graphics_state::{GraphicsStateStack, Matrix};
 use crate::content::operators::{Operator, TextElement};
 use crate::content::parse_and_execute_text_only;
+use crate::content::parse_content_stream;
 use crate::content::parse_content_stream_text_only;
 use crate::error::Result;
 use crate::extract_log_debug;
@@ -2907,12 +2908,17 @@ impl<'doc> TextExtractor<'doc> {
         self.spans.clear();
         self.span_sequence_counter = 0; // Reset sequence counter for this page
 
-        // Streaming parse+execute: operators are processed immediately without
-        // building an intermediate Vec<Operator>. This eliminates allocation of
-        // potentially huge vectors (196K+ operators for graphics-heavy pages)
-        // and improves cache locality.
         extract_log_debug!("Parsing content stream for text extraction");
-        parse_and_execute_text_only(content_stream, |op| self.execute_operator(op))?;
+        if self.excluded_inks.is_empty() {
+            parse_and_execute_text_only(content_stream, |op| self.execute_operator(op))?;
+        } else {
+            // Ink filtering requires color operators (cs, rg, g, k) which the
+            // text-only parser skips. Fall back to the full parser.
+            let operators = parse_content_stream(content_stream)?;
+            for op in operators {
+                self.execute_operator(op)?;
+            }
+        }
 
         // Flush any remaining Tj buffer at end of content stream
         self.flush_tj_span_buffer()?;
@@ -2955,10 +2961,11 @@ impl<'doc> TextExtractor<'doc> {
         self.chars.clear();
         self.spans.clear(); // Ensure spans are clear so they don't poison xobject_spans_cache
 
-        // Parse content stream into operators
-        let operators = parse_content_stream_text_only(content_stream)?;
-
-        // Execute each operator
+        let operators = if self.excluded_inks.is_empty() {
+            parse_content_stream_text_only(content_stream)?
+        } else {
+            parse_content_stream(content_stream)?
+        };
         for op in operators {
             self.execute_operator(op)?;
         }
@@ -5301,7 +5308,8 @@ impl<'doc> TextExtractor<'doc> {
         //
         // `ctm_key` was already computed above for the `processed_xobjects` guard.
         let spans_cache_key = (xobject_ref, ctm_key);
-        if self.extract_spans {
+        let has_filters = !self.excluded_layers.is_empty() || !self.excluded_inks.is_empty();
+        if self.extract_spans && !has_filters {
             let cached_spans = {
                 doc.xobject_spans_cache
                     .lock()
@@ -5506,10 +5514,21 @@ impl<'doc> TextExtractor<'doc> {
                 let state = self.state_stack.current_mut();
                 state.ctm = form_matrix.multiply(&state.ctm);
 
-                // Streaming parse+execute: avoids allocating Vec<Operator>
                 self.xobject_depth += 1;
-                let parse_result =
-                    parse_and_execute_text_only(&stream_data, |op| self.execute_operator(op));
+                let parse_result = if self.excluded_inks.is_empty() {
+                    parse_and_execute_text_only(&stream_data, |op| self.execute_operator(op))
+                } else {
+                    let ops = parse_content_stream(&stream_data);
+                    match ops {
+                        Ok(ops) => {
+                            for op in ops {
+                                self.execute_operator(op)?;
+                            }
+                            Ok(())
+                        },
+                        Err(e) => Err(e),
+                    }
+                };
                 self.xobject_depth -= 1;
                 if let Err(e) = parse_result {
                     log::debug!(
@@ -5530,7 +5549,7 @@ impl<'doc> TextExtractor<'doc> {
                 // We still require `has_own_resources` so that font lookups are
                 // self-contained; XObjects that inherit page-level fonts would
                 // produce spans whose glyph mappings depend on caller context.
-                if has_own_resources && self.extract_spans {
+                if has_own_resources && self.extract_spans && !has_filters {
                     let new_spans = if self.spans.len() > spans_before {
                         Some(self.spans[spans_before..].to_vec())
                     } else {
@@ -5562,6 +5581,13 @@ impl<'doc> TextExtractor<'doc> {
                 }
                 if let Some(cache) = saved_xobj_cache {
                     self.cached_xobject_refs = cache;
+                }
+                // Re-evaluate ink exclusion against the restored color space
+                // and resources. The XObject may have set an excluded ink that
+                // must not persist into the caller's scope.
+                if !self.excluded_inks.is_empty() {
+                    let cs = self.state_stack.current().fill_color_space.clone();
+                    self.inside_excluded_ink = self.is_excluded_ink_color_space(&cs);
                 }
 
                 // Keep xobject_ref in processed_xobjects permanently.

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2251,6 +2251,11 @@ impl<'doc> TextExtractor<'doc> {
     /// When the fill color space is a Separation or DeviceN whose ink name(s)
     /// intersect with any of the provided names, subsequent text is suppressed
     /// until the color space changes to a non-excluded one.
+    ///
+    /// **DeviceN behavior:** For DeviceN color spaces (e.g.
+    /// `[/DeviceN [/Cyan /SpotGold] ...]`), text is suppressed if ANY ink in
+    /// the array matches — even process colors sharing the DeviceN definition.
+    /// This is because tint values are not evaluated during extraction.
     pub fn set_excluded_inks(&mut self, inks: HashSet<String>) {
         self.excluded_inks = inks;
     }
@@ -2641,6 +2646,9 @@ impl<'doc> TextExtractor<'doc> {
     /// - `[/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]` — multiple ink names
     ///
     /// Returns true if any ink name in the color space matches `excluded_inks`.
+    ///
+    /// **Note:** For DeviceN, this is all-or-nothing — if any ink matches, the
+    /// entire color space is treated as excluded. Tint values are not evaluated.
     fn is_excluded_ink_color_space(&self, name: &str) -> bool {
         if self.excluded_inks.is_empty() {
             return false;

--- a/src/python.rs
+++ b/src/python.rs
@@ -232,11 +232,10 @@ impl PyPdfDocument {
     ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
     ///
     /// Note:
-    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, a simplified
-    ///     text assembly pipeline is used (no structure-tree ordering, table
-    ///     detection, or column detection). For precise results with complex
-    ///     layouts, use ``extract_chars()`` with the same filter parameters
-    ///     and assemble text from the positioned characters.
+    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, the same
+    ///     full text assembly pipeline is used (structure-tree ordering, table
+    ///     detection, column detection) — excluded content is simply removed
+    ///     before assembly.
     #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,

--- a/src/python.rs
+++ b/src/python.rs
@@ -230,6 +230,13 @@ impl PyPdfDocument {
     ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
     ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
     ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    ///
+    /// Note:
+    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, a simplified
+    ///     text assembly pipeline is used (no structure-tree ordering, table
+    ///     detection, or column detection). For precise results with complex
+    ///     layouts, use ``extract_chars()`` with the same filter parameters
+    ///     and assemble text from the positioned characters.
     #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,

--- a/src/python.rs
+++ b/src/python.rs
@@ -261,7 +261,11 @@ impl PyPdfDocument {
                     &crate::geometry::Rect::new(x, y, w, h),
                     crate::layout::RectFilterMode::Intersects,
                 );
-                Ok(filtered.iter().map(|c| c.char.to_string()).collect::<Vec<_>>().join(""))
+                Ok(filtered
+                    .iter()
+                    .map(|c| c.char.to_string())
+                    .collect::<Vec<_>>()
+                    .join(""))
             } else {
                 self.inner
                     .extract_text_in_rect(

--- a/src/python.rs
+++ b/src/python.rs
@@ -3,6 +3,7 @@
 //! This module provides Python bindings for the PDF library, exposing the core functionality
 //! through a Python-friendly API with proper error handling and type hints.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use pyo3::exceptions::{PyIOError, PyNotImplementedError, PyRuntimeError, PyValueError};
@@ -154,6 +155,39 @@ impl PyPdfDocument {
         }
     }
 
+    /// List all Optional Content Group (OCG) layer names in the document.
+    ///
+    /// Returns:
+    ///     list[str]: Layer names from /OCProperties. Empty if no layers.
+    ///
+    /// Example:
+    ///     layers = doc.get_layers()
+    ///     # ['Dieline', 'Varnish', 'Text', 'Barcode']
+    ///     text = doc.extract_text(0, exclude_layers=['Dieline', 'Varnish'])
+    fn get_layers(&mut self) -> PyResult<Vec<String>> {
+        self.inner
+            .get_layers()
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get layers: {}", e)))
+    }
+
+    /// List ink / separation names used on a specific page.
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///
+    /// Returns:
+    ///     list[str]: Ink names from Separation/DeviceN color spaces.
+    ///
+    /// Example:
+    ///     inks = doc.get_page_inks(0)
+    ///     # ['PANTONE 186 C', 'Spot Varnish', 'Die Cut']
+    ///     text = doc.extract_text(0, exclude_inks=['Spot Varnish', 'Die Cut'])
+    fn get_page_inks(&mut self, page: usize) -> PyResult<Vec<String>> {
+        self.inner
+            .get_page_inks(page)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page inks: {}", e)))
+    }
+
     /// Enumerate existing PDF signatures. Returns a list of
     /// `Signature` objects — empty list when the document has no
     /// AcroForm or no signed signature fields.
@@ -190,21 +224,55 @@ impl PyPdfDocument {
     }
 
     /// Extract text from a page.
-    #[pyo3(signature = (page, region=None))]
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
+    ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
+    ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,
         page: usize,
         region: Option<(f32, f32, f32, f32)>,
+        exclude_layers: Option<Vec<String>>,
+        exclude_inks: Option<Vec<String>>,
     ) -> PyResult<String> {
+        let has_filters = exclude_layers.is_some() || exclude_inks.is_some();
+        let layers: HashSet<String> = exclude_layers.unwrap_or_default().into_iter().collect();
+        let inks: HashSet<String> = exclude_inks.unwrap_or_default().into_iter().collect();
+
         if let Some((x, y, w, h)) = region {
+            if has_filters {
+                // Filtered extraction with region: extract filtered text, then
+                // filter chars by rect from the result. For region + filter combos
+                // we do filtered span extraction and then apply the region filter.
+                let text = self
+                    .inner
+                    .extract_text_filtered(page, layers, inks)
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
+                    })?;
+                // When both region and filters are specified, the region filter
+                // is best-effort since extract_text_filtered returns a string.
+                // For precise region + filter, use extract_chars with both params.
+                Ok(text)
+            } else {
+                self.inner
+                    .extract_text_in_rect(
+                        page,
+                        crate::geometry::Rect::new(x, y, w, h),
+                        crate::layout::RectFilterMode::Intersects,
+                    )
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to extract text in region: {}", e))
+                    })
+            }
+        } else if has_filters {
             self.inner
-                .extract_text_in_rect(
-                    page,
-                    crate::geometry::Rect::new(x, y, w, h),
-                    crate::layout::RectFilterMode::Intersects,
-                )
+                .extract_text_filtered(page, layers, inks)
                 .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to extract text in region: {}", e))
+                    PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
                 })
         } else {
             self.inner
@@ -531,13 +599,42 @@ impl PyPdfDocument {
     }
 
     /// Extract low-level characters.
-    #[pyo3(signature = (page, region=None))]
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
+    ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
+    ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_chars(
         &mut self,
         page: usize,
         region: Option<(f32, f32, f32, f32)>,
+        exclude_layers: Option<Vec<String>>,
+        exclude_inks: Option<Vec<String>>,
     ) -> PyResult<Vec<PyTextChar>> {
-        let chars_result = if let Some((x, y, w, h)) = region {
+        let has_filters = exclude_layers.is_some() || exclude_inks.is_some();
+        let layers: HashSet<String> = exclude_layers.unwrap_or_default().into_iter().collect();
+        let inks: HashSet<String> = exclude_inks.unwrap_or_default().into_iter().collect();
+
+        let chars_result = if has_filters {
+            let chars = self
+                .inner
+                .extract_chars_filtered(page, layers, inks)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to extract characters: {}", e))
+                })?;
+            // Apply region filter on top if specified
+            if let Some((x, y, w, h)) = region {
+                use crate::layout::SpatialCollectionFiltering;
+                Ok(chars.filter_by_rect(
+                    &crate::geometry::Rect::new(x, y, w, h),
+                    crate::layout::RectFilterMode::Intersects,
+                ))
+            } else {
+                Ok(chars)
+            }
+        } else if let Some((x, y, w, h)) = region {
             self.inner.extract_chars_in_rect(
                 page,
                 crate::geometry::Rect::new(x, y, w, h),
@@ -2658,12 +2755,16 @@ impl PyDocPage {
 
     #[getter]
     fn text(&self, py: Python<'_>) -> PyResult<String> {
-        self.doc.borrow_mut(py).extract_text(self.page_index, None)
+        self.doc
+            .borrow_mut(py)
+            .extract_text(self.page_index, None, None, None)
     }
 
     #[getter]
     fn chars(&self, py: Python<'_>) -> PyResult<Vec<PyTextChar>> {
-        self.doc.borrow_mut(py).extract_chars(self.page_index, None)
+        self.doc
+            .borrow_mut(py)
+            .extract_chars(self.page_index, None, None, None)
     }
 
     #[getter]
@@ -3266,7 +3367,7 @@ impl PyPdfPageRegion {
     }
     fn extract_text(&self, py: Python<'_>) -> PyResult<String> {
         let mut d = self.doc.bind(py).borrow_mut();
-        d.extract_text(self.page_index, Some(self.bbox()))
+        d.extract_text(self.page_index, Some(self.bbox()), None, None)
     }
     fn extract_words(&self, py: Python<'_>) -> PyResult<Vec<PyWord>> {
         let mut d = self.doc.bind(py).borrow_mut();

--- a/src/python.rs
+++ b/src/python.rs
@@ -250,22 +250,17 @@ impl PyPdfDocument {
 
         if let Some((x, y, w, h)) = region {
             if has_filters {
-                let chars = self
-                    .inner
-                    .extract_chars_filtered(page, layers, inks)
+                self.inner
+                    .extract_text_filtered_in_rect(
+                        page,
+                        layers,
+                        inks,
+                        crate::geometry::Rect::new(x, y, w, h),
+                        crate::layout::RectFilterMode::Intersects,
+                    )
                     .map_err(|e| {
                         PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
-                    })?;
-                use crate::layout::SpatialCollectionFiltering;
-                let filtered = chars.filter_by_rect(
-                    &crate::geometry::Rect::new(x, y, w, h),
-                    crate::layout::RectFilterMode::Intersects,
-                );
-                Ok(filtered
-                    .iter()
-                    .map(|c| c.char.to_string())
-                    .collect::<Vec<_>>()
-                    .join(""))
+                    })
             } else {
                 self.inner
                     .extract_text_in_rect(

--- a/src/python.rs
+++ b/src/python.rs
@@ -244,19 +244,18 @@ impl PyPdfDocument {
 
         if let Some((x, y, w, h)) = region {
             if has_filters {
-                // Filtered extraction with region: extract filtered text, then
-                // filter chars by rect from the result. For region + filter combos
-                // we do filtered span extraction and then apply the region filter.
-                let text = self
+                let chars = self
                     .inner
-                    .extract_text_filtered(page, layers, inks)
+                    .extract_chars_filtered(page, layers, inks)
                     .map_err(|e| {
                         PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
                     })?;
-                // When both region and filters are specified, the region filter
-                // is best-effort since extract_text_filtered returns a string.
-                // For precise region + filter, use extract_chars with both params.
-                Ok(text)
+                use crate::layout::SpatialCollectionFiltering;
+                let filtered = chars.filter_by_rect(
+                    &crate::geometry::Rect::new(x, y, w, h),
+                    crate::layout::RectFilterMode::Intersects,
+                );
+                Ok(filtered.iter().map(|c| c.char.to_string()).collect::<Vec<_>>().join(""))
             } else {
                 self.inner
                     .extract_text_in_rect(

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -642,3 +642,94 @@ fn test_empty_filters_fall_through_to_normal_extraction() {
         "Empty filters should produce identical output to unfiltered extraction"
     );
 }
+
+// ============================================================================
+// Task 2: OCMD (Optional Content Membership Dictionary) support
+// ============================================================================
+
+fn build_pdf_with_ocmd() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [7 0 R] /D << /ON [7 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+    let content = b"BT /F1 12 Tf 50 700 Td (ALWAYS) Tj ET /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (MEMBER) Tj ET EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    // Obj 6: OCMD referencing OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n",
+    );
+    // Obj 7: OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /MemberLayer >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ocmd_layer_filtering() {
+    let pdf_bytes = build_pdf_with_ocmd();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let layers = doc.get_layers().expect("get_layers");
+    assert!(
+        layers.contains(&"MemberLayer".to_string()),
+        "got: {:?}",
+        layers
+    );
+
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
+    assert!(text_all.contains("MEMBER"), "got: {:?}", text_all);
+
+    let excluded = HashSet::from(["MemberLayer".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered");
+    assert!(
+        text_filtered.contains("ALWAYS"),
+        "got: {:?}",
+        text_filtered
+    );
+    assert!(
+        !text_filtered.contains("MEMBER"),
+        "MEMBER should be excluded via OCMD resolution, got: {:?}",
+        text_filtered
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -500,6 +500,109 @@ fn test_extract_text_filtered_respects_region() {
     );
 }
 
+fn build_pdf_for_full_pipeline_region_test() -> Vec<u8> {
+    // Page has 3 visible-after-filter runs arranged so that pipeline
+    // assembly (sort + whitespace + line breaks) is observable:
+    //   y=720 x=50:  "Hello"   (line 1, left)
+    //   y=720 x=200: "World"   (line 1, right) -> space between expected
+    //   y=700 x=50:  "Second"  (line 2)         -> newline before expected
+    //   y=650 (excluded OCG layer): "HIDDEN"
+    //   y=100 (outside region): "Footer"
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"BT /F1 12 Tf 50 720 Td (Hello) Tj ET \
+                    BT /F1 12 Tf 200 720 Td (World) Tj ET \
+                    BT /F1 12 Tf 50 700 Td (Second) Tj ET \
+                    /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (HIDDEN) Tj ET EMC \
+                    BT /F1 12 Tf 50 100 Td (Footer) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Overlay >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n0000000000 65535 f \n", n_obj);
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_extract_text_filtered_in_rect_uses_full_pipeline() {
+    // extract_text_filtered_in_rect must go through the full text-assembly
+    // pipeline: reading-order sort, whitespace between adjacent runs,
+    // line breaks between rows. Composing layer/ink filters with a region
+    // must NOT regress to char-stream concatenation.
+    let pdf_bytes = build_pdf_for_full_pipeline_region_test();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded = HashSet::from(["Overlay".to_string()]);
+    let region = pdf_oxide::geometry::Rect::new(0.0, 600.0, 612.0, 200.0);
+    let text = doc
+        .extract_text_filtered_in_rect(
+            0,
+            excluded,
+            HashSet::new(),
+            region,
+            pdf_oxide::layout::RectFilterMode::Intersects,
+        )
+        .expect("filtered text in rect");
+
+    assert!(text.contains("Hello"), "Hello missing: {:?}", text);
+    assert!(text.contains("World"), "World missing: {:?}", text);
+    assert!(text.contains("Second"), "Second missing: {:?}", text);
+    assert!(!text.contains("HIDDEN"), "HIDDEN should be layer-excluded: {:?}", text);
+    assert!(!text.contains("Footer"), "Footer should be region-excluded: {:?}", text);
+
+    // Whitespace between "Hello" and "World" on the same row.
+    let h = text.find("Hello").unwrap();
+    let w = text.find("World").unwrap();
+    let between = &text[h + "Hello".len()..w];
+    assert!(
+        between.chars().any(|c| c.is_whitespace()),
+        "Expected whitespace between Hello and World; got {:?}",
+        text
+    );
+
+    // Newline or other separator between line 1 and "Second" (line 2).
+    let s = text.find("Second").unwrap();
+    let line_break = &text[w + "World".len()..s];
+    assert!(line_break.contains('\n'), "Expected line break before 'Second'; got {:?}", text);
+}
+
 // ============================================================================
 // Basic OCG filtering (no XObject cache involvement)
 // ============================================================================
@@ -620,6 +723,75 @@ fn test_get_page_inks_returns_separation_names() {
         "SpotRed is in XObject resources, not page, got: {:?}",
         inks
     );
+}
+
+/// Build a minimal PDF whose page-level /Resources/ColorSpace declares
+/// both a /Separation and a /DeviceN entry. Verifies the happy path of
+/// get_page_inks — the previous test only covered the negative case
+/// (XObject-local color space).
+fn build_pdf_with_page_level_inks() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100]\n\
+           /Contents 4 0 R\n\
+           /Resources << /ColorSpace << /CS1 5 0 R /CS2 6 0 R >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"4 0 obj\n<< /Length 0 >>\nstream\n\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n[/Separation /PANTONE#20185#20C /DeviceCMYK 7 0 R]\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n[/DeviceN [/Cyan /Magenta /SpotGold] /DeviceCMYK 7 0 R]\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"7 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 4 /C0 [0 0 0 0] /C1 [1 0 0 0] >>\nendobj\n\n",
+    );
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n0000000000 65535 f \n", n_obj);
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_get_page_inks_happy_path() {
+    let pdf_bytes = build_pdf_with_page_level_inks();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+    let inks = doc.get_page_inks(0).expect("get_page_inks");
+
+    // Both Separation and DeviceN ink names should be returned.
+    assert!(
+        inks.iter()
+            .any(|i| i == "PANTONE 185 C" || i == "PANTONE#20185#20C"),
+        "Separation ink missing: {:?}",
+        inks
+    );
+    assert!(inks.contains(&"SpotGold".to_string()), "DeviceN ink missing: {:?}", inks);
+    // Cyan/Magenta are process colorant names declared as DeviceN components
+    // — they're enumerated as plate-able inks at this layer.
+    assert!(inks.contains(&"Cyan".to_string()), "DeviceN component missing: {:?}", inks);
 }
 
 #[test]

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -733,3 +733,96 @@ fn test_ocmd_layer_filtering() {
         text_filtered
     );
 }
+
+// ============================================================================
+// Task 3: DeviceN all-or-nothing semantics
+// ============================================================================
+
+fn build_pdf_with_devicen() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >>\n\
+           /ColorSpace << /CS1 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"BT /F1 12 Tf 50 700 Td (PLAIN) Tj ET \
+                    /CS1 cs 1 0 scn BT /F1 12 Tf 50 650 Td (MIXED_INK) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n",
+    );
+
+    let tint_fn = b"{ 0 exch }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "7 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0 0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
+    // Documents the all-or-nothing DeviceN behavior:
+    // Excluding "SpotGold" suppresses ALL text in the DeviceN space,
+    // even though Cyan (a process color) is also part of the space.
+    let pdf_bytes = build_pdf_with_devicen();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded_inks = HashSet::from(["SpotGold".to_string()]);
+    let text = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered");
+
+    assert!(
+        text.contains("PLAIN"),
+        "PLAIN (DeviceGray) should survive, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("MIXED_INK"),
+        "MIXED_INK should be suppressed (DeviceN contains excluded SpotGold), got: {:?}",
+        text
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -84,9 +84,7 @@ fn build_pdf_with_ocg_in_xobject() -> Vec<u8> {
 
     // Obj 8: OCG dictionary
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n");
 
     // Xref
     let xref_offset = pdf.len();
@@ -140,7 +138,8 @@ fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
     );
 
     // Obj 4: Page content — text before XObject, invoke XObject, text after
-    let page_content = b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
+    let page_content =
+        b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
     offsets.push(pdf.len());
     let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
     pdf.extend_from_slice(hdr.as_bytes());
@@ -170,9 +169,7 @@ fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
 
     // Obj 7: Separation color space [/Separation /SpotRed /DeviceRGB <tint fn>]
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n");
 
     // Obj 8: Tint transform function (Type 4 PostScript calculator)
     let tint_fn = b"{ 0 0 }";
@@ -337,9 +334,7 @@ fn build_pdf_with_inline_separation() -> Vec<u8> {
 
     // Obj 6: Separation color space array
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n");
 
     // Obj 7: Tint transform function
     let tint_fn = b"{ 0 0 }";
@@ -679,9 +674,7 @@ fn build_pdf_with_ocmd() -> Vec<u8> {
     );
     // Obj 6: OCMD referencing OCG
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n");
     // Obj 7: OCG
     offsets.push(pdf.len());
     pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /MemberLayer >>\nendobj\n\n");
@@ -708,11 +701,7 @@ fn test_ocmd_layer_filtering() {
     let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
 
     let layers = doc.get_layers().expect("get_layers");
-    assert!(
-        layers.contains(&"MemberLayer".to_string()),
-        "got: {:?}",
-        layers
-    );
+    assert!(layers.contains(&"MemberLayer".to_string()), "got: {:?}", layers);
 
     let text_all = doc.extract_text(0).expect("unfiltered");
     assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
@@ -722,11 +711,7 @@ fn test_ocmd_layer_filtering() {
     let text_filtered = doc
         .extract_text_filtered(0, excluded, HashSet::new())
         .expect("filtered");
-    assert!(
-        text_filtered.contains("ALWAYS"),
-        "got: {:?}",
-        text_filtered
-    );
+    assert!(text_filtered.contains("ALWAYS"), "got: {:?}", text_filtered);
     assert!(
         !text_filtered.contains("MEMBER"),
         "MEMBER should be excluded via OCMD resolution, got: {:?}",
@@ -771,9 +756,7 @@ fn build_pdf_with_devicen() -> Vec<u8> {
     );
 
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n");
 
     let tint_fn = b"{ 0 exch }";
     offsets.push(pdf.len());
@@ -815,11 +798,7 @@ fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
         .extract_text_filtered(0, HashSet::new(), excluded_inks)
         .expect("filtered");
 
-    assert!(
-        text.contains("PLAIN"),
-        "PLAIN (DeviceGray) should survive, got: {:?}",
-        text
-    );
+    assert!(text.contains("PLAIN"), "PLAIN (DeviceGray) should survive, got: {:?}", text);
     assert!(
         !text.contains("MIXED_INK"),
         "MIXED_INK should be suppressed (DeviceN contains excluded SpotGold), got: {:?}",
@@ -896,11 +875,7 @@ fn test_filtering_unrelated_layer_produces_identical_output() {
 
     let text_normal = doc.extract_text(0).expect("unfiltered");
     let text_filtered = doc
-        .extract_text_filtered(
-            0,
-            HashSet::from(["Dieline".to_string()]),
-            HashSet::new(),
-        )
+        .extract_text_filtered(0, HashSet::from(["Dieline".to_string()]), HashSet::new())
         .expect("filtered with non-matching layer");
 
     assert_eq!(

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -826,3 +826,88 @@ fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
         text
     );
 }
+
+// ============================================================================
+// Pipeline parity: filtering non-matching layers must not alter output
+// ============================================================================
+
+/// Build a PDF with a table-like layout and an OCG layer that doesn't
+/// overlap with any content. Filtering this layer should produce output
+/// identical to unfiltered extraction.
+fn build_pdf_with_table_and_unrelated_layer() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Content: multiple text lines (simulating rows), plus an empty OCG layer
+    let content = b"BT /F1 12 Tf 50 700 Td (Name) Tj 200 0 Td (Age) Tj ET \
+                    BT /F1 12 Tf 50 680 Td (Alice) Tj 200 0 Td (30) Tj ET \
+                    BT /F1 12 Tf 50 660 Td (Bob) Tj 200 0 Td (25) Tj ET \
+                    /OC /MC0 BDC EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Dieline >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_filtering_unrelated_layer_produces_identical_output() {
+    let pdf_bytes = build_pdf_with_table_and_unrelated_layer();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let text_normal = doc.extract_text(0).expect("unfiltered");
+    let text_filtered = doc
+        .extract_text_filtered(
+            0,
+            HashSet::from(["Dieline".to_string()]),
+            HashSet::new(),
+        )
+        .expect("filtered with non-matching layer");
+
+    assert_eq!(
+        text_normal, text_filtered,
+        "Excluding a layer with no content must produce identical output.\n\
+         Unfiltered: {:?}\n\
+         Filtered:   {:?}",
+        text_normal, text_filtered
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -416,6 +416,98 @@ fn test_ink_filtering_blocked_by_text_only_parser() {
 // ============================================================================
 // Basic OCG filtering (no XObject cache involvement)
 // ============================================================================
+// Task 1: region + filter combo
+// ============================================================================
+
+fn build_pdf_for_region_and_filter() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"BT /F1 12 Tf 50 700 Td (TOP_VISIBLE) Tj ET \
+                    /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (TOP_HIDDEN) Tj ET EMC \
+                    BT /F1 12 Tf 50 100 Td (BOT_VISIBLE) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Overlay >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_extract_text_filtered_respects_region() {
+    let pdf_bytes = build_pdf_for_region_and_filter();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded = HashSet::from(["Overlay".to_string()]);
+    let chars = doc
+        .extract_chars_filtered(0, excluded, HashSet::new())
+        .expect("filtered chars");
+
+    use pdf_oxide::geometry::Rect;
+    use pdf_oxide::layout::{RectFilterMode, SpatialCollectionFiltering};
+    let region = Rect::new(0.0, 600.0, 612.0, 200.0);
+    let filtered: Vec<_> = chars.filter_by_rect(&region, RectFilterMode::Intersects);
+    let text: String = filtered.iter().map(|c| c.char).collect();
+
+    assert!(
+        text.contains("TOP_VISIBLE"),
+        "TOP_VISIBLE should survive both filters, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("TOP_HIDDEN"),
+        "TOP_HIDDEN should be excluded by layer filter, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("BOT_VISIBLE"),
+        "BOT_VISIBLE should be excluded by region filter, got: {:?}",
+        text
+    );
+}
+
+// ============================================================================
+// Basic OCG filtering (no XObject cache involvement)
+// ============================================================================
 
 /// Build a minimal PDF with inline OCG-tagged text (no XObjects).
 fn build_pdf_with_inline_ocg() -> Vec<u8> {

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -1,0 +1,552 @@
+//! Tests for OCG layer and Separation ink filtering in text extraction.
+//!
+//! Bug 1: XObject cached spans bypass suppression — filtered extraction
+//!         replays unfiltered cached spans, leaking excluded content.
+//! Bug 2: `inside_excluded_ink` not re-evaluated after Form XObject restore —
+//!         ink exclusion state lost after XObject processing.
+//! Bug 3: `get_layers` doc comment bleeds into `extract_chars` — verified
+//!         separately via `cargo doc`.
+
+use std::collections::HashSet;
+
+use pdf_oxide::document::PdfDocument;
+
+// ============================================================================
+// Helper: build a PDF with an OCG layer wrapping text inside a Form XObject
+// ============================================================================
+
+/// Build a PDF where a Form XObject contains OCG-tagged text.
+///
+/// Page content:  /Fm0 Do
+/// Form XObject:  BDC /OC /MC0  →  BT (LAYERED) Tj ET  →  EMC
+///                                  BT (VISIBLE) Tj ET
+///
+/// The OCG "HiddenLayer" is defined in OCProperties and referenced via
+/// the Form XObject's /Resources /Properties.
+fn build_pdf_with_ocg_in_xobject() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog with OCProperties
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [8 0 R] /D << /ON [8 0 R] >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Page content — just invoke the Form XObject
+    let page_content = b"/Fm0 Do";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject with OCG-tagged text + untagged text
+    // BDC syntax: /Tag /PropertiesName BDC ... EMC
+    let form_stream =
+        b"/OC /MC0 BDC BT /F1 12 Tf 50 700 Td (LAYERED) Tj ET EMC BT /F1 12 Tf 50 650 Td (VISIBLE) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >> /Properties << /MC0 8 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: (unused, keep numbering simple)
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\nnull\nendobj\n\n");
+
+    // Obj 8: OCG dictionary
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n",
+    );
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+// ============================================================================
+// Helper: build a PDF with Separation ink color space in a Form XObject
+// ============================================================================
+
+/// Build a PDF where a Form XObject switches to a Separation ink, renders text,
+/// then returns. After the XObject, the page renders more text in DeviceGray.
+///
+/// Page content:  BT (BEFORE) Tj ET  /Fm0 Do  BT (AFTER) Tj ET
+/// Form XObject:  /CS1 cs  BT (SPOT_INK) Tj ET
+///
+/// /CS1 is [/Separation /SpotRed /DeviceRGB ...].
+fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Page content — text before XObject, invoke XObject, text after
+    let page_content = b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject — sets Separation color space, then renders text
+    let form_stream = b"/CS1 cs 1 scn BT /F1 12 Tf 50 650 Td (SPOT_INK) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >>\n\
+            /ColorSpace << /CS1 7 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: Separation color space [/Separation /SpotRed /DeviceRGB <tint fn>]
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n",
+    );
+
+    // Obj 8: Tint transform function (Type 4 PostScript calculator)
+    let tint_fn = b"{ 0 0 }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "8 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+// ============================================================================
+// Bug 1: XObject cached spans bypass suppression
+// ============================================================================
+
+#[test]
+fn test_xobject_cache_does_not_leak_filtered_content() {
+    let pdf_bytes = build_pdf_with_ocg_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // First: unfiltered extraction — caches XObject spans
+    let text_all = doc.extract_text(0).expect("unfiltered extract");
+    assert!(
+        text_all.contains("LAYERED"),
+        "Unfiltered should contain LAYERED, got: {:?}",
+        text_all
+    );
+    assert!(
+        text_all.contains("VISIBLE"),
+        "Unfiltered should contain VISIBLE, got: {:?}",
+        text_all
+    );
+
+    // Second: filtered extraction excluding "HiddenLayer"
+    // BUG: cached XObject spans from first call are replayed verbatim,
+    // so LAYERED text leaks through despite being in excluded layer.
+    let excluded = HashSet::from(["HiddenLayer".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered extract");
+
+    assert!(
+        text_filtered.contains("VISIBLE"),
+        "Filtered should still contain VISIBLE, got: {:?}",
+        text_filtered
+    );
+    assert!(
+        !text_filtered.contains("LAYERED"),
+        "Filtered must NOT contain LAYERED (XObject cache leak), got: {:?}",
+        text_filtered
+    );
+}
+
+// ============================================================================
+// Bug 2: inside_excluded_ink not re-evaluated after XObject restore
+// ============================================================================
+
+#[test]
+fn test_ink_exclusion_restored_after_xobject() {
+    let pdf_bytes = build_pdf_with_ink_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Extract with "SpotRed" excluded
+    let excluded_inks = HashSet::from(["SpotRed".to_string()]);
+    let text = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered extract");
+
+    // SPOT_INK should be suppressed (it's in SpotRed color space)
+    assert!(
+        !text.contains("SPOT_INK"),
+        "SPOT_INK should be suppressed by ink filter, got: {:?}",
+        text
+    );
+
+    // BEFORE and AFTER are in DeviceGray — should NOT be suppressed.
+    // BUG: the Form XObject sets inside_excluded_ink=true for SpotRed,
+    // but after XObject restore, inside_excluded_ink is not re-evaluated
+    // back to false. So AFTER text is incorrectly suppressed.
+    assert!(
+        text.contains("BEFORE"),
+        "BEFORE should be visible (DeviceGray), got: {:?}",
+        text
+    );
+    assert!(
+        text.contains("AFTER"),
+        "AFTER should be visible (DeviceGray, post-XObject restore), got: {:?}",
+        text
+    );
+}
+
+// ============================================================================
+// Bug 3: text-only parser skips color operators — ink filtering is inert
+// ============================================================================
+
+/// Build a PDF with Separation ink color space directly in the page stream.
+/// No XObjects — isolates the parser from caching.
+///
+/// Page content:
+///   BT (PROCESS) Tj ET          ← default (DeviceGray) fill
+///   /CS1 cs 1 scn               ← switch to Separation /SpotRed
+///   BT (SPOT) Tj ET             ← text in SpotRed ink
+///   0 g                         ← switch back to DeviceGray
+///   BT (RESTORED) Tj ET         ← text in DeviceGray again
+fn build_pdf_with_inline_separation() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page with ColorSpace in resources
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >>\n\
+           /ColorSpace << /CS1 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Content stream
+    let content = b"BT /F1 12 Tf 50 700 Td (PROCESS) Tj ET /CS1 cs 1 scn BT /F1 12 Tf 50 650 Td (SPOT) Tj ET 0 g BT /F1 12 Tf 50 600 Td (RESTORED) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: Separation color space array
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n",
+    );
+
+    // Obj 7: Tint transform function
+    let tint_fn = b"{ 0 0 }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "7 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ink_filtering_blocked_by_text_only_parser() {
+    // The text-only parser (parse_and_execute_text_only) skips color operators
+    // (cs, rg, g, k) for performance. This means the SetFillColorSpace handler
+    // never fires, and ink filtering is completely inert.
+    //
+    // This test proves the bug: excluding "SpotRed" has no effect because the
+    // `cs` operator is never delivered to the extractor.
+    let pdf_bytes = build_pdf_with_inline_separation();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Unfiltered: all three texts present
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("PROCESS"), "got: {:?}", text_all);
+    assert!(text_all.contains("SPOT"), "got: {:?}", text_all);
+    assert!(text_all.contains("RESTORED"), "got: {:?}", text_all);
+
+    // Filtered: exclude SpotRed ink
+    let excluded_inks = HashSet::from(["SpotRed".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered");
+
+    // PROCESS and RESTORED are in DeviceGray — must survive
+    assert!(
+        text_filtered.contains("PROCESS"),
+        "PROCESS (DeviceGray) should survive ink filter, got: {:?}",
+        text_filtered
+    );
+    assert!(
+        text_filtered.contains("RESTORED"),
+        "RESTORED (DeviceGray after `0 g`) should survive ink filter, got: {:?}",
+        text_filtered
+    );
+
+    // SPOT is in SpotRed Separation — must be suppressed
+    assert!(
+        !text_filtered.contains("SPOT"),
+        "SPOT (SpotRed ink) must be suppressed by ink filter, got: {:?}",
+        text_filtered
+    );
+}
+
+// ============================================================================
+// Basic OCG filtering (no XObject cache involvement)
+// ============================================================================
+
+/// Build a minimal PDF with inline OCG-tagged text (no XObjects).
+fn build_pdf_with_inline_ocg() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog with OCProperties
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Content stream with OCG-tagged and untagged text
+    // BDC syntax: /Tag /PropertiesName BDC ... EMC
+    let content =
+        b"BT /F1 12 Tf 50 700 Td (ALWAYS) Tj ET /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (HIDDEN) Tj ET EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Overlay >>\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ocg_layer_filtering_inline() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Unfiltered: both texts present
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
+    assert!(text_all.contains("HIDDEN"), "got: {:?}", text_all);
+
+    // Filtered: exclude "Overlay" layer
+    let excluded = HashSet::from(["Overlay".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered");
+    assert!(text_filtered.contains("ALWAYS"), "got: {:?}", text_filtered);
+    assert!(
+        !text_filtered.contains("HIDDEN"),
+        "HIDDEN should be excluded, got: {:?}",
+        text_filtered
+    );
+}
+
+#[test]
+fn test_get_layers_returns_ocg_names() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let layers = doc.get_layers().expect("get_layers");
+    assert!(
+        layers.contains(&"Overlay".to_string()),
+        "Should find 'Overlay' layer, got: {:?}",
+        layers
+    );
+}
+
+#[test]
+fn test_get_page_inks_returns_separation_names() {
+    let pdf_bytes = build_pdf_with_ink_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // The Separation color space is in the Form XObject's resources, not the
+    // page's direct resources. get_page_inks only checks page resources, so
+    // it won't find SpotRed here. This is a known limitation — the test
+    // documents expected behavior.
+    let inks = doc.get_page_inks(0).expect("get_page_inks");
+    // SpotRed is in XObject resources, not page resources — empty is correct
+    assert!(
+        !inks.contains(&"SpotRed".to_string()),
+        "SpotRed is in XObject resources, not page, got: {:?}",
+        inks
+    );
+}
+
+#[test]
+fn test_empty_filters_fall_through_to_normal_extraction() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let text_normal = doc.extract_text(0).expect("normal");
+    let text_filtered = doc
+        .extract_text_filtered(0, HashSet::new(), HashSet::new())
+        .expect("empty filters");
+
+    assert_eq!(
+        text_normal, text_filtered,
+        "Empty filters should produce identical output to unfiltered extraction"
+    );
+}


### PR DESCRIPTION

## Description

Add OCG (Optional Content Group) layer filtering and Separation/DeviceN ink filtering to text extraction. Allows callers to exclude text rendered in specific layers or spot-color inks — the primary use case is stripping prepress overlays (dielines, varnish marks, approval stamps) from production PDFs.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests


## Changes Made

### New public API
- `get_layers()` — list OCG layer names from the document catalog
- `get_page_inks(page)` — list Separation/DeviceN ink names on a page
- `extract_text_filtered(page, excluded_layers, excluded_inks)` — text extraction with layer/ink suppression, using the same full assembly pipeline as `extract_text` (structure-tree ordering, table detection, column detection)
- `extract_chars_filtered(page, excluded_layers, excluded_inks)` — character extraction with layer/ink suppression
- Python: `extract_text()` and `extract_chars()` gain `exclude_layers` and `exclude_inks` keyword arguments; region filtering composes correctly with both

### Layer filtering (`src/extractors/text.rs`)
- Tracks OCG scope via BDC/EMC marked content stack — content within an excluded layer's scope is suppressed at all span and character emission points
- Resolves both direct OCG dictionaries and OCMD (Optional Content Membership Dictionaries) per ISO 32000-1 §8.11.2

### Ink filtering (`src/extractors/text.rs`)
- Tracks fill color space changes (`cs`, `rg`, `g`, `k` operators) and checks Separation/DeviceN definitions against the exclusion set
- Falls back to full content stream parser when ink exclusions are active, since the text-only fast-path parser skips color operators
- Correctly restores ink exclusion state across graphics state save/restore (`q`/`Q`) and Form XObject boundaries
- Bypasses XObject span cache when any filter is active to prevent cross-call interference

### Refactoring
- Deduplicated extraction boilerplate into shared `extract_spans_impl` / `extract_chars_impl` helpers
- Extracted `postprocess_spans` and `assemble_text_from_spans` so filtered and unfiltered paths share the same pipeline

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

11 integration tests in `tests/test_ocg_ink_filtering.rs`, all using synthetic PDF construction:
- Inline OCG layer filtering (BDC/EMC)
- OCMD membership dictionary resolution
- Separation ink filtering via color space tracking
- DeviceN all-or-nothing suppression (documents intentional semantics)
- Form XObject: span cache isolation under filters
- Form XObject: ink state restoration after implicit Q
- Parser fallback: ink filtering with full content stream parser
- Region + filter composition
- Empty filters produce identical output to unfiltered
- Non-matching layer exclusion produces identical output (pipeline parity)
- `get_layers()` / `get_page_inks()` correctness


## Python Bindings (if applicable)

- [x] Python bindings updated (if needed)
- [x] Python tests pass
- [x] Python code formatted with `ruff format`
- [x] Python code linted with `ruff check`

New methods: `get_layers()`, `get_page_inks(page)`. Existing `extract_text()` and `extract_chars()` extended with `exclude_layers` and `exclude_inks` keyword arguments.

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

Doc comments on all new public and key internal methods. DeviceN semantics and pipeline parity documented inline.

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Additional Notes

**DeviceN is all-or-nothing:** For `[/DeviceN [/Cyan /SpotGold] ...]`, excluding "SpotGold" suppresses all text in that color space. Tint values are not evaluated — this is the correct default for prepress workflows where any content touching a spot ink should be fully removed.

**OCMD visibility policies** (`/P /AllOn`, `/AnyOn`, etc.) are not evaluated — any excluded OCG in the membership triggers suppression. Full policy evaluation would require tracking OCG on/off state from the document's default configuration, which is out of scope.

**Performance:** Zero impact on unfiltered extraction. Ink-filtered extraction uses the full content stream parser instead of the text-only fast path. Layer-only filtering has no parser overhead.