### PR TITLE
feat: add rendered_advance to TextChar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to PDFOxide are documented here.
 
+## next-release
+
+### Added
+- `TextChar::rendered_advance` - provides character advance width
+  including character and word space.
+
+### ⚠️ Breaking Changes
+- external callers constructing TextChar { ... } literals will need
+  to add `rendered_advance: advance_width` for prior behavior
+
 ## [0.3.55] - 2026-05-25
 
 > Ruby + PHP language bindings + multi-line heading reading-order fix

--- a/src/converters/html.rs
+++ b/src/converters/html.rs
@@ -646,6 +646,7 @@ mod tests {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         }
     }

--- a/src/converters/markdown.rs
+++ b/src/converters/markdown.rs
@@ -1296,6 +1296,7 @@ mod tests {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         }
     }

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -4140,6 +4140,7 @@ impl<'doc> TextExtractor<'doc> {
                                             origin_y: pos.y,
                                             rotation_degrees,
                                             advance_width: tx.abs(),
+                                            rendered_advance: tx.abs(),
                                             matrix: Some([
                                                 final_matrix.a,
                                                 final_matrix.b,
@@ -6806,8 +6807,16 @@ impl<'doc> TextExtractor<'doc> {
             let hs_factor = horizontal_scaling / 100.0;
             let glyph_width_user_space = glyph_width_font_units * fs_factor * hs_factor;
 
+            // Advance position: Tx = (w0 * Tfs + Tc + Tw) * Th
+            let mut tx = glyph_width_user_space;
+            tx += char_space * hs_factor;
+            if char_code == 32 {
+                tx += word_space * hs_factor;
+            }
+
             // For TextChar, we use the device-space width
             let glyph_width_device_space = glyph_width_user_space * combined_char.a.abs();
+            let tx_device_space = tx * combined_char.a.abs();
             let height_device_space = effective_font_size;
 
             // Determine font weight and style
@@ -6851,6 +6860,11 @@ impl<'doc> TextExtractor<'doc> {
             } else {
                 glyph_width_user_space
             };
+            let rendered_advance_per_char = if char_count > 0 {
+                tx_device_space / char_count as f32
+            } else {
+                tx_device_space
+            };
 
             for (char_index, unicode_char) in unicode_string.chars().enumerate() {
                 let should_skip = unicode_char == '\0'
@@ -6885,6 +6899,7 @@ impl<'doc> TextExtractor<'doc> {
                         origin_y: char_origin_y,
                         rotation_degrees,
                         advance_width: char_width_device,
+                        rendered_advance: rendered_advance_per_char,
                         matrix: Some([
                             final_matrix.a,
                             final_matrix.b,
@@ -6897,13 +6912,6 @@ impl<'doc> TextExtractor<'doc> {
 
                     self.chars.push(text_char);
                 }
-            }
-
-            // Advance position: Tx = (w0 * Tfs + Tc + Tw) * Th
-            let mut tx = glyph_width_user_space;
-            tx += char_space * hs_factor;
-            if char_code == 32 {
-                tx += word_space * hs_factor;
             }
 
             // Update text matrix in current state per ISO 32000-1:2008 §9.4.4
@@ -8815,6 +8823,7 @@ mod tests {
                 origin_y: 700.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
             TextChar {
@@ -8831,6 +8840,7 @@ mod tests {
                 origin_y: 700.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
         ];
@@ -8859,6 +8869,7 @@ mod tests {
                 origin_y: 700.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
             TextChar {
@@ -8875,6 +8886,7 @@ mod tests {
                 origin_y: 680.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
         ];
@@ -8909,6 +8921,7 @@ mod tests {
             origin_y: 700.0,
             rotation_degrees: 0.0,
             advance_width: 6.0,
+            rendered_advance: 6.0,
             matrix: None,
         };
 
@@ -8949,6 +8962,7 @@ mod tests {
             origin_y: 700.0,
             rotation_degrees: 0.0,
             advance_width: 6.0,
+            rendered_advance: 6.0,
             matrix: None,
         };
 
@@ -8985,6 +8999,7 @@ mod tests {
             origin_y: 700.0,
             rotation_degrees: 0.0,
             advance_width: advance_em * font_size,
+            rendered_advance: advance_em * font_size,
             matrix: None,
         };
 
@@ -9036,6 +9051,7 @@ mod tests {
             origin_y: 700.0,
             rotation_degrees: 0.0,
             advance_width: 2.5, // 0.278 em × 9 pt
+            rendered_advance: 2.5,
             matrix: None,
         };
 
@@ -9281,6 +9297,7 @@ mod tests {
                 origin_y: 680.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
             TextChar {
@@ -9297,6 +9314,7 @@ mod tests {
                 origin_y: 700.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
         ];
@@ -9326,6 +9344,7 @@ mod tests {
                 origin_y: 700.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
             TextChar {
@@ -9342,6 +9361,7 @@ mod tests {
                 origin_y: 700.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
         ];
@@ -9370,6 +9390,7 @@ mod tests {
                 origin_y: 0.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
             TextChar {
@@ -9386,6 +9407,7 @@ mod tests {
                 origin_y: 700.0,
                 rotation_degrees: 0.0,
                 advance_width: 6.0,
+                rendered_advance: 6.0,
                 matrix: None,
             },
         ];

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -6860,6 +6860,10 @@ impl<'doc> TextExtractor<'doc> {
             } else {
                 glyph_width_user_space
             };
+            // Spread the total advance evenly across the ligature's output chars.
+            // Tc applies once per character *code*, not per output glyph, so this
+            // approximation slightly over-distributes Tc for multi-char ligatures —
+            // the same trade-off advance_width already makes for glyph_width_device.
             let rendered_advance_per_char = if char_count > 0 {
                 tx_device_space / char_count as f32
             } else {

--- a/src/hybrid/complexity_estimator.rs
+++ b/src/hybrid/complexity_estimator.rs
@@ -272,6 +272,7 @@ mod tests {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         };
 

--- a/src/hybrid/smart_analyzer.rs
+++ b/src/hybrid/smart_analyzer.rs
@@ -254,6 +254,7 @@ mod tests {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         };
 

--- a/src/layout/clustering.rs
+++ b/src/layout/clustering.rs
@@ -40,6 +40,12 @@ use crate::layout::text_block::{TextBlock, TextChar};
 ///         font_weight: FontWeight::Normal,
 ///         color: Color::black(),
 ///         mcid: None,
+///         origin_x: 0.0,
+///         origin_y: 0.0,
+///         rotation_degrees: 0.0,
+///         advance_width: 10.0,
+///         rendered_advance: 10.0,
+///         matrix: None,
 ///     },
 ///     TextChar {
 ///         char: 'i',
@@ -49,6 +55,12 @@ use crate::layout::text_block::{TextBlock, TextChar};
 ///         font_weight: FontWeight::Normal,
 ///         color: Color::black(),
 ///         mcid: None,
+///         origin_x: 11.0,
+///         origin_y: 0.0,
+///         rotation_degrees: 0.0,
+///         advance_width: 5.0,
+///         rendered_advance: 5.0,
+///         matrix: None,
 ///     },
 /// ];
 ///
@@ -157,8 +169,16 @@ pub fn cluster_chars_into_words(chars: &[TextChar], epsilon: f32) -> Vec<Vec<usi
 ///         font_name: "Times".to_string(),
 ///         font_size: 12.0,
 ///         font_weight: FontWeight::Normal,
+///         is_italic: false,
+///         is_monospace: false,
 ///         color: Color::black(),
 ///         mcid: None,
+///         origin_x: 0.0,
+///         origin_y: 0.0,
+///         rotation_degrees: 0.0,
+///         advance_width: 10.0,
+///         rendered_advance: 10.0,
+///         matrix: None,
 ///     },
 /// ];
 /// let word1 = TextBlock::from_chars(chars1);
@@ -170,8 +190,16 @@ pub fn cluster_chars_into_words(chars: &[TextChar], epsilon: f32) -> Vec<Vec<usi
 ///         font_name: "Times".to_string(),
 ///         font_size: 12.0,
 ///         font_weight: FontWeight::Normal,
+///         is_italic: false,
+///         is_monospace: false,
 ///         color: Color::black(),
 ///         mcid: None,
+///         origin_x: 50.0,
+///         origin_y: 1.0,
+///         rotation_degrees: 0.0,
+///         advance_width: 10.0,
+///         rendered_advance: 10.0,
+///         matrix: None,
 ///     },
 /// ];
 /// let word2 = TextBlock::from_chars(chars2);
@@ -410,6 +438,7 @@ mod tests {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         }
     }

--- a/src/layout/document_analyzer.rs
+++ b/src/layout/document_analyzer.rs
@@ -446,6 +446,7 @@ mod tests {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         }
     }

--- a/src/layout/reading_order.rs
+++ b/src/layout/reading_order.rs
@@ -87,6 +87,7 @@ mod tests {
                     origin_y: bbox.y,
                     rotation_degrees: 0.0,
                     advance_width: bbox.width,
+                    rendered_advance: bbox.width,
                     matrix: None,
                 }
             })

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -130,6 +130,7 @@ impl TextSpan {
                         origin_y: self.bbox.y,
                         rotation_degrees: 0.0,
                         advance_width: w,
+                        rendered_advance: w,
                         matrix: Some([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
                     }
                 })
@@ -158,6 +159,7 @@ impl TextSpan {
                     origin_y: self.bbox.y,
                     rotation_degrees: 0.0,
                     advance_width: char_width,
+                    rendered_advance: char_width,
                     matrix: Some([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
                 })
                 .collect()
@@ -232,10 +234,29 @@ pub struct TextChar {
 
     /// Horizontal advance width (distance to next character position).
     ///
-    /// This is the amount the text position advances after drawing this
-    /// character, accounting for character width and any spacing. Used
-    /// for precise text layout calculations.
+    /// Glyph advance width from font metrics (device space).
+    ///
+    /// This is the advance for the glyph shape only — it does **not** include
+    /// character spacing (Tc), word spacing (Tw), or TJ kerning offsets.
+    /// For word-boundary detection, prefer [`rendered_advance`] which includes
+    /// all spacing adjustments and is equivalent to Poppler's `dx` argument.
     pub advance_width: f32,
+
+    /// Actual rendered advance to the next character's origin (device space).
+    ///
+    /// This is the full advance used to move the text position after this
+    /// character, including the glyph advance plus character spacing (Tc),
+    /// word spacing (Tw for U+0020), and any TJ kerning adjustments.
+    ///
+    /// Equivalent to Poppler's `dx` argument in `drawChar`, and to the PDF
+    /// spec's Tx formula: `(w0 × Tfs / 1000 + Tc + Tw) × Th` converted to
+    /// device space.
+    ///
+    /// For the last character on a line this falls back to `advance_width`.
+    /// Use this field (not `advance_width`) to detect word boundaries:
+    /// a gap `next.origin_x − (this.origin_x + this.rendered_advance) > threshold`
+    /// reliably identifies inter-word spacing.
+    pub rendered_advance: f32,
 
     /// Full transformation matrix [a, b, c, d, e, f].
     ///
@@ -269,6 +290,7 @@ impl Default for TextChar {
             origin_y: 0.0,
             rotation_degrees: 0.0,
             advance_width: 0.0,
+            rendered_advance: 0.0,
             matrix: Some([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
         }
     }
@@ -344,6 +366,7 @@ impl TextChar {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         }
     }
@@ -608,6 +631,7 @@ mod tests {
             origin_y: bbox.y,
             rotation_degrees: 0.0,
             advance_width: bbox.width,
+            rendered_advance: bbox.width,
             matrix: None,
         }
     }
@@ -666,6 +690,7 @@ mod tests {
             origin_y: 0.0,
             rotation_degrees: 0.0,
             advance_width: 10.0,
+            rendered_advance: 10.0,
             matrix: None,
         };
         assert!(c.is_monospace);

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -237,20 +237,23 @@ pub struct TextChar {
     /// Glyph advance width from font metrics (device space).
     ///
     /// This is the advance for the glyph shape only — it does **not** include
-    /// character spacing (Tc), word spacing (Tw), or TJ kerning offsets.
-    /// For word-boundary detection, prefer [`rendered_advance`] which includes
-    /// all spacing adjustments and is equivalent to Poppler's `dx` argument.
+    /// character spacing (Tc), word spacing (Tw), or TJ array adjustments.
+    /// For word-boundary detection and the full cursor advance including all
+    /// spacing, use [`rendered_advance`].
     pub advance_width: f32,
 
     /// Actual rendered advance to the next character's origin (device space).
     ///
-    /// This is the full advance used to move the text position after this
-    /// character, including the glyph advance plus character spacing (Tc),
-    /// word spacing (Tw for U+0020), and any TJ kerning adjustments.
+    /// This is the per-glyph cursor advance including character spacing (Tc)
+    /// and word spacing (Tw for U+0020), per the PDF spec Tx formula:
+    /// `(w0 × Tfs / 1000 + Tc + Tw) × Th` converted to device space.
     ///
-    /// Equivalent to Poppler's `dx` argument in `drawChar`, and to the PDF
-    /// spec's Tx formula: `(w0 × Tfs / 1000 + Tc + Tw) × Th` converted to
-    /// device space.
+    /// TJ array adjustments between strings are **not** folded into this
+    /// field.  They are emitted as separate synthetic-space [`TextChar`]s
+    /// inserted between the glyphs they affect, so the overall cursor
+    /// displacement is correctly represented by walking the full char list.
+    ///
+    /// Equivalent to Poppler's `dx` argument in `drawChar`.
     ///
     /// For the last character on a line this falls back to `advance_width`.
     /// Use this field (not `advance_width`) to detect word boundaries:

--- a/tests/test_rendered_advance_spacing.rs
+++ b/tests/test_rendered_advance_spacing.rs
@@ -1,0 +1,181 @@
+//! Tests for rendered_advance including Tc/Tw character and word spacing.
+//!
+//! rendered_advance is the full cursor advance after a character (equiv. to
+//! Poppler's dx): glyph advance + Tc (+ Tw for U+0020). This differs from
+//! advance_width, which is only the glyph's own width.
+
+use pdf_oxide::PdfDocument;
+
+/// Build a minimal 1-page PDF where the content stream sets character spacing
+/// (Tc) to a known value before rendering a short string.
+fn pdf_with_char_spacing(tc: f32) -> Vec<u8> {
+    let content = format!(
+        "BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc (ABC) Tj ET\n"
+    );
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0];
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+         /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{content}\nendstream", content.len() + 1),
+    );
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+/// Build a minimal 1-page PDF with both character spacing (Tc) and word
+/// spacing (Tw) set, and a string that includes a space character.
+fn pdf_with_word_spacing(tc: f32, tw: f32) -> Vec<u8> {
+    let content = format!(
+        "BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc {tw} Tw (A B) Tj ET\n"
+    );
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0];
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+         /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{content}\nendstream", content.len() + 1),
+    );
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+/// `rendered_advance` for a non-space character must exceed `advance_width` by
+/// exactly Tc (character spacing) when Tc > 0.
+#[test]
+fn rendered_advance_includes_char_spacing() {
+    let tc = 2.0_f32;
+    let pdf = pdf_with_char_spacing(tc);
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &pdf).unwrap();
+
+    let doc = PdfDocument::open(tmp.path()).expect("open");
+    let chars = doc.extract_chars(0).expect("extract_chars");
+
+    // Filter to non-whitespace chars from the "ABC" string.
+    let letters: Vec<_> = chars.iter().filter(|c| !c.char.is_whitespace()).collect();
+    assert!(!letters.is_empty(), "expected to extract 'A', 'B', 'C'");
+
+    for ch in &letters {
+        let delta = ch.rendered_advance - ch.advance_width;
+        assert!(
+            (delta - tc).abs() < 0.5,
+            "char {:?}: rendered_advance - advance_width = {delta:.3}, expected Tc={tc}",
+            ch.char
+        );
+    }
+}
+
+/// `rendered_advance` for a space character must exceed `advance_width` by
+/// Tc + Tw when both character spacing and word spacing are set.
+#[test]
+fn rendered_advance_includes_word_spacing_for_space() {
+    let tc = 1.0_f32;
+    let tw = 3.0_f32;
+    let pdf = pdf_with_word_spacing(tc, tw);
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &pdf).unwrap();
+
+    let doc = PdfDocument::open(tmp.path()).expect("open");
+    let chars = doc.extract_chars(0).expect("extract_chars");
+
+    let spaces: Vec<_> = chars.iter().filter(|c| c.char == ' ').collect();
+    assert!(!spaces.is_empty(), "expected a space character in 'A B'");
+
+    for sp in &spaces {
+        let delta = sp.rendered_advance - sp.advance_width;
+        let expected = tc + tw;
+        assert!(
+            (delta - expected).abs() < 0.5,
+            "space: rendered_advance - advance_width = {delta:.3}, expected Tc+Tw={expected}"
+        );
+    }
+}
+
+/// With Tc = 0 and Tw = 0, rendered_advance must equal advance_width for every
+/// character (no extra spacing is added).
+#[test]
+fn rendered_advance_equals_advance_width_when_no_spacing() {
+    let pdf = pdf_with_char_spacing(0.0);
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &pdf).unwrap();
+
+    let doc = PdfDocument::open(tmp.path()).expect("open");
+    let chars = doc.extract_chars(0).expect("extract_chars");
+
+    let letters: Vec<_> = chars.iter().filter(|c| !c.char.is_whitespace()).collect();
+    assert!(!letters.is_empty(), "expected to extract 'A', 'B', 'C'");
+
+    for ch in &letters {
+        let delta = (ch.rendered_advance - ch.advance_width).abs();
+        assert!(
+            delta < 0.1,
+            "char {:?}: rendered_advance ({:.3}) should equal advance_width ({:.3}) when Tc=0",
+            ch.char,
+            ch.rendered_advance,
+            ch.advance_width
+        );
+    }
+}

--- a/tests/test_rendered_advance_spacing.rs
+++ b/tests/test_rendered_advance_spacing.rs
@@ -1,17 +1,16 @@
 //! Tests for rendered_advance including Tc/Tw character and word spacing.
 //!
-//! rendered_advance is the full cursor advance after a character (equiv. to
-//! Poppler's dx): glyph advance + Tc (+ Tw for U+0020). This differs from
-//! advance_width, which is only the glyph's own width.
+//! rendered_advance is the per-glyph cursor advance including Tc (+ Tw for
+//! U+0020).  TJ array adjustments are NOT folded in — they are emitted as
+//! separate synthetic-space TextChars.  This differs from advance_width,
+//! which is only the glyph's own width.
 
 use pdf_oxide::PdfDocument;
 
 /// Build a minimal 1-page PDF where the content stream sets character spacing
 /// (Tc) to a known value before rendering a short string.
 fn pdf_with_char_spacing(tc: f32) -> Vec<u8> {
-    let content = format!(
-        "BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc (ABC) Tj ET\n"
-    );
+    let content = format!("BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc (ABC) Tj ET\n");
 
     let mut out: Vec<u8> = Vec::new();
     let mut offsets: Vec<usize> = vec![0];
@@ -57,9 +56,7 @@ fn pdf_with_char_spacing(tc: f32) -> Vec<u8> {
 /// Build a minimal 1-page PDF with both character spacing (Tc) and word
 /// spacing (Tw) set, and a string that includes a space character.
 fn pdf_with_word_spacing(tc: f32, tw: f32) -> Vec<u8> {
-    let content = format!(
-        "BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc {tw} Tw (A B) Tj ET\n"
-    );
+    let content = format!("BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc {tw} Tw (A B) Tj ET\n");
 
     let mut out: Vec<u8> = Vec::new();
     let mut offsets: Vec<usize> = vec![0];
@@ -178,4 +175,215 @@ fn rendered_advance_equals_advance_width_when_no_spacing() {
             ch.advance_width
         );
     }
+}
+
+/// A glyph inside a TJ array must have rendered_advance ≈ glyph_advance + Tc,
+/// NOT including the neighboring TJ kern offset.  The kern is emitted as a
+/// separate synthetic-space TextChar between the two letter glyphs.
+#[test]
+fn tj_kern_offset_is_separate_synthetic_space_not_in_rendered_advance() {
+    // TJ array: render 'A', then advance by a large positive kern (-600 units =
+    // 7.2 pt at 12 pt), then render 'B'.  The kern exceeds the space-insertion
+    // threshold so a synthetic ' ' is inserted between the two glyphs.
+    let tc = 3.0_f32;
+    let content = format!("BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc [(A) -600 (B)] TJ ET\n");
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0];
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+         /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{content}\nendstream", content.len() + 1),
+    );
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &out).unwrap();
+    let doc = PdfDocument::open(tmp.path()).expect("open");
+    let chars = doc.extract_chars(0).expect("extract_chars");
+
+    // Expect: 'A', synthetic ' ' (from the -600 kern), 'B'
+    let letter_a = chars.iter().find(|c| c.char == 'A').expect("'A' not found");
+    let letter_b = chars.iter().find(|c| c.char == 'B').expect("'B' not found");
+
+    // The kern gap (600/1000 * 12 = 7.2 pt) must NOT be included in 'A's advance.
+    let kern_gap = 600.0_f32 / 1000.0 * 12.0; // 7.2 pt
+    let max_allowed = letter_a.advance_width + tc + kern_gap * 0.5;
+    assert!(
+        letter_a.rendered_advance < max_allowed,
+        "'A' rendered_advance ({:.3}) should not include the TJ kern gap ({kern_gap:.1} pt); \
+         advance_width={:.3} Tc={tc}",
+        letter_a.rendered_advance,
+        letter_a.advance_width,
+    );
+    // rendered_advance should be approximately advance_width + Tc
+    let expected = letter_a.advance_width + tc;
+    assert!(
+        (letter_a.rendered_advance - expected).abs() < 0.5,
+        "'A' rendered_advance ({:.3}) should ≈ advance_width + Tc = {expected:.3}",
+        letter_a.rendered_advance,
+    );
+    // 'B' should likewise have rendered_advance ≈ advance_width + Tc
+    let expected_b = letter_b.advance_width + tc;
+    assert!(
+        (letter_b.rendered_advance - expected_b).abs() < 0.5,
+        "'B' rendered_advance ({:.3}) should ≈ advance_width + Tc = {expected_b:.3}",
+        letter_b.rendered_advance,
+    );
+}
+
+/// Horizontal scaling (Tz) must multiply through both the glyph-width term
+/// and the Tc term.  With `Tz = 50` (Th = 0.5) and Tc = 4, the extra
+/// spacing over advance_width must be Tc × Th = 2.0, not Tc = 4.0.
+#[test]
+fn horizontal_scaling_multiplies_both_glyph_and_tc_terms() {
+    let tc = 4.0_f32;
+    let content = format!("BT /F0 12 Tf 1 0 0 1 100 700 Tm {tc} Tc 50 Tz (A) Tj ET\n");
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0];
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+         /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{content}\nendstream", content.len() + 1),
+    );
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &out).unwrap();
+    let doc = PdfDocument::open(tmp.path()).expect("open");
+    let chars = doc.extract_chars(0).expect("extract_chars");
+
+    let letter = chars.iter().find(|c| c.char == 'A').expect("'A' not found");
+
+    // With Th=0.5, the Tc contribution to rendered_advance is Tc * Th = 4 * 0.5 = 2.0.
+    // If Th were ignored for the Tc term, the delta would be 4.0 instead.
+    let th = 0.5_f32;
+    let expected_delta = tc * th; // 2.0
+    let actual_delta = letter.rendered_advance - letter.advance_width;
+    assert!(
+        (actual_delta - expected_delta).abs() < 0.3,
+        "rendered_advance - advance_width = {actual_delta:.3}; expected Tc×Th = {expected_delta:.3} \
+         (Tc={tc}, Th={th}); if Th were not applied to Tc the delta would be {tc:.1}",
+    );
+}
+
+/// With a flipped CTM (a = -1), rendered_advance must still be positive.
+/// The extractor uses `combined_char.a.abs()` to convert tx to device space,
+/// so a negative `a` component must not negate the advance.
+#[test]
+fn flipped_ctm_rendered_advance_is_positive() {
+    // Flip the x-axis: CTM = [-1 0 0 1 300 700].  Text advances leftward in
+    // page space, but the glyph cursor advance is still a positive distance.
+    let content = "BT /F0 12 Tf 0 0 Td (A) Tj ET\n";
+    let page_stream = format!("-1 0 0 1 300 700 cm\n{content}");
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = vec![0];
+    out.extend_from_slice(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3\n");
+    let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &str| {
+        offsets.push(out.len());
+        let id = offsets.len() - 1;
+        out.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    push(&mut out, &mut offsets, "<< /Type /Catalog /Pages 2 0 R >>");
+    push(&mut out, &mut offsets, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    push(
+        &mut out,
+        &mut offsets,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 900] \
+         /Resources << /Font << /F0 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    push(
+        &mut out,
+        &mut offsets,
+        &format!("<< /Length {} >>\nstream\n{page_stream}\nendstream", page_stream.len() + 1),
+    );
+    push(&mut out, &mut offsets, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    let xref_offset = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n",
+            offsets.len()
+        )
+        .as_bytes(),
+    );
+
+    let tmp = tempfile::NamedTempFile::new().expect("temp");
+    std::fs::write(tmp.path(), &out).unwrap();
+    let doc = PdfDocument::open(tmp.path()).expect("open");
+    let chars = doc.extract_chars(0).expect("extract_chars");
+
+    let letter = chars.iter().find(|c| c.char == 'A').expect("'A' not found");
+    assert!(
+        letter.rendered_advance > 0.0,
+        "rendered_advance ({:.3}) must be positive even with a flipped CTM (a=-1)",
+        letter.rendered_advance,
+    );
+    // With no Tc/Tw, rendered_advance should equal advance_width
+    assert!(
+        (letter.rendered_advance - letter.advance_width).abs() < 0.1,
+        "rendered_advance ({:.3}) should equal advance_width ({:.3}) when Tc=0 and CTM is flipped",
+        letter.rendered_advance,
+        letter.advance_width,
+    );
 }

--- a/tests/test_textchar_transformation.rs
+++ b/tests/test_textchar_transformation.rs
@@ -32,6 +32,7 @@ fn create_char_with_transform(
         origin_y: y,
         rotation_degrees: rotation,
         advance_width: 10.0,
+        rendered_advance: 10.0,
         matrix,
     }
 }
@@ -134,6 +135,7 @@ fn test_textchar_advance_width() {
         origin_y: 200.0,
         rotation_degrees: 0.0,
         advance_width: 15.5, // Wide character
+        rendered_advance: 15.5,
         matrix: None,
     };
 
@@ -182,6 +184,7 @@ fn test_textchar_with_matrix_builder() {
         origin_y: 200.0,
         rotation_degrees: 0.0,
         advance_width: 10.0,
+        rendered_advance: 10.0,
         matrix: None,
     };
 


### PR DESCRIPTION
## Description

Adds rendered_advance to TextChar: the distance the text position moves
after rendering this character, including glyph advance width, character
spacing (Tc) and word spacing (Tw for U+0020).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Related Issues

Fixes: https://github.com/yfedoseev/pdf_oxide/issues/594

Fixes #

## Changes Made

- Adds rendered_advance to TextChar

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

## Documentation

- [x] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [x] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)
