### PR TITLE
feat: render ocg filtering

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -8652,9 +8652,19 @@ impl PdfDocument {
 
     /// Extract text from a page, excluding content from specified layers and inks.
     ///
-    /// Uses a simplified text assembly pipeline (no structure-tree ordering or
-    /// table detection). For most layer/ink filtering use cases this is
-    /// sufficient since the caller is performing targeted extraction.
+    /// # Text assembly differences
+    ///
+    /// This method uses a simplified text assembly pipeline compared to
+    /// [`extract_text`](Self::extract_text): spans are sorted by row-aware reading order and joined
+    /// with line breaks based on Y-gap heuristics. The full pipeline's
+    /// structure-tree ordering, table detection, and column detection are
+    /// **not** applied. This means:
+    /// - Multi-column layouts may interleave columns
+    /// - Tables will not be reconstructed
+    /// - Reading order depends on coordinate sorting, not document structure
+    ///
+    /// For precise spatial control, use [`extract_chars_filtered`](Self::extract_chars_filtered) and assemble
+    /// text yourself, or apply region filtering on top.
     ///
     /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
     /// ANY ink in the DeviceN array matches an excluded ink name. Tint values

--- a/src/document.rs
+++ b/src/document.rs
@@ -4694,9 +4694,19 @@ impl PdfDocument {
         page_index: usize,
         options: &crate::converters::ConversionOptions,
     ) -> Result<String> {
+        let base_spans = self.extract_spans(page_index)?;
+        self.assemble_text_from_spans(page_index, base_spans, options)
+    }
+
+    fn assemble_text_from_spans(
+        &self,
+        page_index: usize,
+        base_spans: Vec<crate::layout::TextSpan>,
+        options: &crate::converters::ConversionOptions,
+    ) -> Result<String> {
         self.require_authenticated()?;
 
-        let mut base_spans = self.extract_spans(page_index)?;
+        let mut base_spans = base_spans;
 
         // Drop spans that fall inside any caller-specified exclusion region.
         // This runs before the structure-tree and table pipelines so that
@@ -7989,7 +7999,26 @@ impl PdfDocument {
     /// # }
     /// ```
     pub fn extract_spans(&self, page_index: usize) -> Result<Vec<crate::layout::TextSpan>> {
-        let mut spans = self.extract_spans_raw(page_index)?;
+        let spans = self.extract_spans_raw(page_index)?;
+        self.postprocess_spans(page_index, spans)
+    }
+
+    fn extract_spans_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        let spans = self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
+        self.postprocess_spans(page_index, spans)
+    }
+
+    fn postprocess_spans(
+        &self,
+        page_index: usize,
+        raw_spans: Vec<crate::layout::TextSpan>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        let mut spans = raw_spans;
 
         // Drop spans whose bbox lies entirely outside the page's MediaBox.
         // PDFs that reuse one big Form XObject across pages (ExpertPdf and
@@ -8652,19 +8681,9 @@ impl PdfDocument {
 
     /// Extract text from a page, excluding content from specified layers and inks.
     ///
-    /// # Text assembly differences
-    ///
-    /// This method uses a simplified text assembly pipeline compared to
-    /// [`extract_text`](Self::extract_text): spans are sorted by row-aware reading order and joined
-    /// with line breaks based on Y-gap heuristics. The full pipeline's
-    /// structure-tree ordering, table detection, and column detection are
-    /// **not** applied. This means:
-    /// - Multi-column layouts may interleave columns
-    /// - Tables will not be reconstructed
-    /// - Reading order depends on coordinate sorting, not document structure
-    ///
-    /// For precise spatial control, use [`extract_chars_filtered`](Self::extract_chars_filtered) and assemble
-    /// text yourself, or apply region filtering on top.
+    /// Uses the same full text assembly pipeline as [`extract_text`](Self::extract_text)
+    /// (structure-tree ordering, table detection, column detection), but with
+    /// layer/ink-excluded spans removed before assembly.
     ///
     /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
     /// ANY ink in the DeviceN array matches an excluded ink name. Tint values
@@ -8685,48 +8704,12 @@ impl PdfDocument {
             return self.extract_text(page_index);
         }
 
-        let mut spans =
-            self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
-
-        // Apply media-box clipping (same as extract_spans)
-        if let Ok((llx, lly, urx, ury)) = self.get_page_media_box(page_index) {
-            const EDGE_TOLERANCE_PT: f32 = 2.0;
-            let left = llx - EDGE_TOLERANCE_PT;
-            let bottom = lly - EDGE_TOLERANCE_PT;
-            let right = urx + EDGE_TOLERANCE_PT;
-            let top = ury + EDGE_TOLERANCE_PT;
-            spans.retain(|span| {
-                let sx1 = span.bbox.x;
-                let sx2 = span.bbox.x + span.bbox.width;
-                let sy1 = span.bbox.y;
-                let sy2 = span.bbox.y + span.bbox.height;
-                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
-            });
-        }
-
-        // Row-aware reading order sort
-        spans.sort_by(|a, b| {
-            crate::utils::row_aware_span_cmp(a.bbox.y, a.bbox.x, b.bbox.y, b.bbox.x)
-        });
-
-        // Build text from spans
-        let mut text = String::new();
-        let mut last_y: Option<f32> = None;
-        for span in &spans {
-            if let Some(prev_y) = last_y {
-                let y_gap = (prev_y - span.bbox.y).abs();
-                if y_gap > span.bbox.height.max(1.0) * 0.5 {
-                    text.push('\n');
-                }
-            }
-            if !text.is_empty() && !text.ends_with('\n') && !text.ends_with(' ') {
-                text.push(' ');
-            }
-            text.push_str(&span.text);
-            last_y = Some(span.bbox.y);
-        }
-
-        Ok(text)
+        let spans = self.extract_spans_filtered(page_index, excluded_layers, excluded_inks)?;
+        let options = crate::converters::ConversionOptions {
+            extract_tables: true,
+            ..Default::default()
+        };
+        self.assemble_text_from_spans(page_index, spans, &options)
     }
 
     /// Extract text spans from a page using a specified reading order strategy.

--- a/src/document.rs
+++ b/src/document.rs
@@ -8624,6 +8624,129 @@ impl PdfDocument {
         extractor.extract_text_spans(&content_data)
     }
 
+    /// Extract raw text spans with layer and ink exclusion filtering.
+    ///
+    /// Same as [`extract_spans_raw`] but configures the extractor to suppress
+    /// content from specified OCG layers and Separation/DeviceN ink color spaces.
+    fn extract_spans_raw_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        self.require_authenticated()?;
+        use crate::extractors::TextExtractor;
+
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        if self.page_cannot_have_text(page_dict) {
+            return Ok(Vec::new());
+        }
+
+        let content_data = match self.get_page_content_data(page_index) {
+            Ok(data) => data,
+            Err(e) => {
+                log::warn!(
+                    "Failed to decode content stream for page {}: {}, returning empty",
+                    page_index,
+                    e
+                );
+                return Ok(Vec::new());
+            },
+        };
+
+        if !Self::may_contain_text(&content_data) {
+            return Ok(Vec::new());
+        }
+
+        let mut extractor =
+            TextExtractor::with_config(crate::extractors::TextExtractionConfig::default());
+        extractor.set_excluded_layers(excluded_layers);
+        extractor.set_excluded_inks(excluded_inks);
+        if let Some(resources) = page_dict.get("Resources") {
+            extractor.set_resources(resources.clone());
+            extractor.set_document(self);
+            if let Err(e) = self.load_fonts(resources, &mut extractor) {
+                log::warn!(
+                    "Failed to load fonts for page {}: {}, continuing with defaults",
+                    page_index,
+                    e
+                );
+            }
+        }
+
+        extractor.extract_text_spans(&content_data)
+    }
+
+    /// Extract text from a page, excluding content from specified layers and inks.
+    ///
+    /// Uses a simplified text assembly pipeline (no structure-tree ordering or
+    /// table detection). For most layer/ink filtering use cases this is
+    /// sufficient since the caller is performing targeted extraction.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_index` - Zero-based page index
+    /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
+    /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
+    pub fn extract_text_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<String> {
+        if excluded_layers.is_empty() && excluded_inks.is_empty() {
+            return self.extract_text(page_index);
+        }
+
+        let mut spans =
+            self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
+
+        // Apply media-box clipping (same as extract_spans)
+        if let Ok((llx, lly, urx, ury)) = self.get_page_media_box(page_index) {
+            const EDGE_TOLERANCE_PT: f32 = 2.0;
+            let left = llx - EDGE_TOLERANCE_PT;
+            let bottom = lly - EDGE_TOLERANCE_PT;
+            let right = urx + EDGE_TOLERANCE_PT;
+            let top = ury + EDGE_TOLERANCE_PT;
+            spans.retain(|span| {
+                let sx1 = span.bbox.x;
+                let sx2 = span.bbox.x + span.bbox.width;
+                let sy1 = span.bbox.y;
+                let sy2 = span.bbox.y + span.bbox.height;
+                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
+            });
+        }
+
+        // Row-aware reading order sort
+        spans.sort_by(|a, b| {
+            crate::utils::row_aware_span_cmp(a.bbox.y, a.bbox.x, b.bbox.y, b.bbox.x)
+        });
+
+        // Build text from spans
+        let mut text = String::new();
+        let mut last_y: Option<f32> = None;
+        for span in &spans {
+            if let Some(prev_y) = last_y {
+                let y_gap = (prev_y - span.bbox.y).abs();
+                if y_gap > span.bbox.height.max(1.0) * 0.5 {
+                    text.push('\n');
+                }
+            }
+            if !text.is_empty() && !text.ends_with('\n') && !text.ends_with(' ') {
+                text.push(' ');
+            }
+            text.push_str(&span.text);
+            last_y = Some(span.bbox.y);
+        }
+
+        Ok(text)
+    }
+
     /// Extract text spans from a page using a specified reading order strategy.
     ///
     /// This method extracts text spans identically to [`extract_spans`](Self::extract_spans),
@@ -8884,6 +9007,162 @@ impl PdfDocument {
     /// # }
     /// ```
     ///
+    /// List all Optional Content Group (OCG) layer names in the document.
+    ///
+    /// Reads `/OCProperties` from the document catalog and returns the `/Name`
+    /// of each OCG dictionary listed in `/OCGs`. These names can be passed to
+    /// `extract_text_filtered` / `extract_chars_filtered` via `excluded_layers`.
+    ///
+    /// Returns an empty vec if the document has no optional content.
+    pub fn get_layers(&self) -> Result<Vec<String>> {
+        let catalog = self.catalog()?;
+        let catalog_dict = catalog
+            .as_dict()
+            .ok_or_else(|| Error::InvalidPdf("Catalog is not a dictionary".to_string()))?;
+
+        let oc_props = match catalog_dict.get("OCProperties") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let oc_dict = match oc_props.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let ocgs_obj = match oc_dict.get("OCGs") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let ocgs_arr = match ocgs_obj.as_array() {
+            Some(a) => a,
+            None => return Ok(Vec::new()),
+        };
+
+        let mut names = Vec::new();
+        for item in ocgs_arr {
+            let ocg_obj = if let Some(r) = item.as_reference() {
+                match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                item.clone()
+            };
+            if let Some(d) = ocg_obj.as_dict() {
+                if let Some(Object::Name(n)) = d.get("Name") {
+                    names.push(n.clone());
+                } else if let Some(Object::String(s)) = d.get("Name") {
+                    if let Ok(text) = String::from_utf8(s.clone()) {
+                        names.push(text);
+                    }
+                }
+            }
+        }
+        Ok(names)
+    }
+
+    /// List ink / separation names used on a specific page.
+    ///
+    /// Scans the page's `/Resources /ColorSpace` dictionary for `/Separation`
+    /// and `/DeviceN` color space definitions and returns their ink names.
+    /// These names can be passed to `extract_text_filtered` /
+    /// `extract_chars_filtered` via `excluded_inks`.
+    pub fn get_page_inks(&self, page_index: usize) -> Result<Vec<String>> {
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        let resources = match page_dict.get("Resources") {
+            Some(r) => {
+                if let Some(rr) = r.as_reference() {
+                    self.load_object(rr)?
+                } else {
+                    r.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let res_dict = match resources.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let cs_obj = match res_dict.get("ColorSpace") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let cs_dict = match cs_obj.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let mut ink_names = Vec::new();
+        for (_name, cs_def) in cs_dict.iter() {
+            let cs_arr_obj = if let Some(r) = cs_def.as_reference() {
+                match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                cs_def.clone()
+            };
+
+            if let Some(arr) = cs_arr_obj.as_array() {
+                if arr.len() >= 2 {
+                    if let Some(Object::Name(cs_type)) = arr.first() {
+                        match cs_type.as_str() {
+                            "Separation" => {
+                                // [/Separation /InkName /AlternateCS /TintTransform]
+                                if let Some(Object::Name(ink)) = arr.get(1) {
+                                    ink_names.push(ink.clone());
+                                }
+                            },
+                            "DeviceN" => {
+                                // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
+                                if let Some(Object::Array(inks)) = arr.get(1) {
+                                    for ink_obj in inks {
+                                        if let Object::Name(ink) = ink_obj {
+                                            ink_names.push(ink.clone());
+                                        }
+                                    }
+                                }
+                            },
+                            _ => {},
+                        }
+                    }
+                }
+            }
+        }
+
+        ink_names.sort();
+        ink_names.dedup();
+        Ok(ink_names)
+    }
+
     /// # Performance Note
     ///
     /// Character extraction is typically 30-50% faster than span extraction
@@ -8946,6 +9225,73 @@ impl PdfDocument {
                 return y_cmp;
             }
             // X-ascending (left-to-right)
+            crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
+        });
+
+        Ok(chars)
+    }
+
+    /// Extract characters from a page, excluding content from specified layers and inks.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_index` - Zero-based page index
+    /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
+    /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
+    pub fn extract_chars_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextChar>> {
+        use crate::extractors::TextExtractor;
+
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        let content_data = match self.get_page_content_data(page_index) {
+            Ok(data) => data,
+            Err(e) => {
+                log::warn!(
+                    "Failed to decode content stream for page {}: {}, returning empty",
+                    page_index,
+                    e
+                );
+                return Ok(Vec::new());
+            },
+        };
+
+        if !Self::may_contain_text(&content_data) {
+            return Ok(Vec::new());
+        }
+
+        let mut extractor = TextExtractor::new();
+        extractor.set_excluded_layers(excluded_layers);
+        extractor.set_excluded_inks(excluded_inks);
+
+        if let Some(resources) = page_dict.get("Resources") {
+            extractor.set_resources(resources.clone());
+            extractor.set_document(self);
+
+            if let Err(e) = self.load_fonts(resources, &mut extractor) {
+                log::warn!(
+                    "Failed to load fonts for page {}: {}, continuing with defaults",
+                    page_index,
+                    e
+                );
+            }
+        }
+
+        let mut chars = extractor.extract(&content_data)?;
+
+        chars.sort_by(|a, b| {
+            let y_cmp = crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y);
+            if y_cmp != std::cmp::Ordering::Equal {
+                return y_cmp;
+            }
             crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
         });
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -9006,7 +9006,7 @@ impl PdfDocument {
     /// # Ok(())
     /// # }
     /// ```
-    ///
+
     /// List all Optional Content Group (OCG) layer names in the document.
     ///
     /// Reads `/OCProperties` from the document catalog and returns the `/Name`

--- a/src/document.rs
+++ b/src/document.rs
@@ -8688,6 +8688,10 @@ impl PdfDocument {
     /// table detection). For most layer/ink filtering use cases this is
     /// sufficient since the caller is performing targeted extraction.
     ///
+    /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
+    /// ANY ink in the DeviceN array matches an excluded ink name. Tint values
+    /// are not evaluated — this is an all-or-nothing match.
+    ///
     /// # Arguments
     ///
     /// * `page_index` - Zero-based page index

--- a/src/document.rs
+++ b/src/document.rs
@@ -8575,62 +8575,27 @@ impl PdfDocument {
         page_index: usize,
         config: crate::extractors::TextExtractionConfig,
     ) -> Result<Vec<crate::layout::TextSpan>> {
-        self.require_authenticated()?;
-        use crate::extractors::TextExtractor;
-
-        // Get page object
-        let page = self.get_page(page_index)?;
-        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
-            offset: 0,
-            reason: "Page is not a dictionary".to_string(),
-        })?;
-
-        // Fast pre-check: skip pages that cannot produce text based on resources alone.
-        if self.page_cannot_have_text(page_dict) {
-            return Ok(Vec::new());
-        }
-
-        // Get content stream data — skip page on decode failure (Annex I)
-        let content_data = match self.get_page_content_data(page_index) {
-            Ok(data) => data,
-            Err(e) => {
-                log::warn!(
-                    "Failed to decode content stream for page {}: {}, returning empty",
-                    page_index,
-                    e
-                );
-                return Ok(Vec::new());
-            },
-        };
-
-        if !Self::may_contain_text(&content_data) {
-            return Ok(Vec::new());
-        }
-
-        // Single-pass extraction with the provided config
-        let mut extractor = TextExtractor::with_config(config);
-        if let Some(resources) = page_dict.get("Resources") {
-            extractor.set_resources(resources.clone());
-            extractor.set_document(self);
-            if let Err(e) = self.load_fonts(resources, &mut extractor) {
-                log::warn!(
-                    "Failed to load fonts for page {}: {}, continuing with defaults",
-                    page_index,
-                    e
-                );
-            }
-        }
-
-        extractor.extract_text_spans(&content_data)
+        self.extract_spans_impl(page_index, config, HashSet::new(), HashSet::new())
     }
 
-    /// Extract raw text spans with layer and ink exclusion filtering.
-    ///
-    /// Same as [`extract_spans_raw`] but configures the extractor to suppress
-    /// content from specified OCG layers and Separation/DeviceN ink color spaces.
     fn extract_spans_raw_filtered(
         &self,
         page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        self.extract_spans_impl(
+            page_index,
+            crate::extractors::TextExtractionConfig::default(),
+            excluded_layers,
+            excluded_inks,
+        )
+    }
+
+    fn extract_spans_impl(
+        &self,
+        page_index: usize,
+        config: crate::extractors::TextExtractionConfig,
         excluded_layers: HashSet<String>,
         excluded_inks: HashSet<String>,
     ) -> Result<Vec<crate::layout::TextSpan>> {
@@ -8663,10 +8628,13 @@ impl PdfDocument {
             return Ok(Vec::new());
         }
 
-        let mut extractor =
-            TextExtractor::with_config(crate::extractors::TextExtractionConfig::default());
-        extractor.set_excluded_layers(excluded_layers);
-        extractor.set_excluded_inks(excluded_inks);
+        let mut extractor = TextExtractor::with_config(config);
+        if !excluded_layers.is_empty() {
+            extractor.set_excluded_layers(excluded_layers);
+        }
+        if !excluded_inks.is_empty() {
+            extractor.set_excluded_inks(excluded_inks);
+        }
         if let Some(resources) = page_dict.get("Resources") {
             extractor.set_resources(resources.clone());
             extractor.set_document(self);
@@ -9172,67 +9140,7 @@ impl PdfDocument {
     /// Character extraction is typically 30-50% faster than span extraction
     /// because it skips the text grouping and merging logic.
     pub fn extract_chars(&self, page_index: usize) -> Result<Vec<crate::layout::TextChar>> {
-        use crate::extractors::TextExtractor;
-
-        // Get page object
-        let page = self.get_page(page_index)?;
-        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
-            offset: 0,
-            reason: "Page is not a dictionary".to_string(),
-        })?;
-
-        // Get content stream data — skip page on decode failure (Annex I)
-        let content_data = match self.get_page_content_data(page_index) {
-            Ok(data) => data,
-            Err(e) => {
-                log::warn!(
-                    "Failed to decode content stream for page {}: {}, returning empty",
-                    page_index,
-                    e
-                );
-                return Ok(Vec::new());
-            },
-        };
-
-        // Early-out for pages with no text content (§9.4.3)
-        if !Self::may_contain_text(&content_data) {
-            return Ok(Vec::new());
-        }
-
-        // Create text extractor for character-level extraction
-        let mut extractor = TextExtractor::new();
-
-        // Load fonts from page resources and set resources for XObject access
-        if let Some(resources) = page_dict.get("Resources") {
-            extractor.set_resources(resources.clone());
-            extractor.set_document(self);
-
-            // Load fonts
-            if let Err(e) = self.load_fonts(resources, &mut extractor) {
-                log::warn!(
-                    "Failed to load fonts for page {}: {}, continuing with defaults",
-                    page_index,
-                    e
-                );
-            }
-        }
-
-        // Extract characters directly (single-pass, no document classification)
-        let mut chars = extractor.extract(&content_data)?;
-
-        // Sort characters by reading order (Y-descending, then X-ascending)
-        // This ensures extract_words and extract_text_lines process them in logical order.
-        chars.sort_by(|a, b| {
-            // Y-descending (top-to-bottom)
-            let y_cmp = crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y);
-            if y_cmp != std::cmp::Ordering::Equal {
-                return y_cmp;
-            }
-            // X-ascending (left-to-right)
-            crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
-        });
-
-        Ok(chars)
+        self.extract_chars_impl(page_index, HashSet::new(), HashSet::new())
     }
 
     /// Extract characters from a page, excluding content from specified layers and inks.
@@ -9243,6 +9151,15 @@ impl PdfDocument {
     /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
     /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
     pub fn extract_chars_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextChar>> {
+        self.extract_chars_impl(page_index, excluded_layers, excluded_inks)
+    }
+
+    fn extract_chars_impl(
         &self,
         page_index: usize,
         excluded_layers: HashSet<String>,
@@ -9273,13 +9190,16 @@ impl PdfDocument {
         }
 
         let mut extractor = TextExtractor::new();
-        extractor.set_excluded_layers(excluded_layers);
-        extractor.set_excluded_inks(excluded_inks);
+        if !excluded_layers.is_empty() {
+            extractor.set_excluded_layers(excluded_layers);
+        }
+        if !excluded_inks.is_empty() {
+            extractor.set_excluded_inks(excluded_inks);
+        }
 
         if let Some(resources) = page_dict.get("Resources") {
             extractor.set_resources(resources.clone());
             extractor.set_document(self);
-
             if let Err(e) = self.load_fonts(resources, &mut extractor) {
                 log::warn!(
                     "Failed to load fonts for page {}: {}, continuing with defaults",

--- a/src/document.rs
+++ b/src/document.rs
@@ -8971,7 +8971,7 @@ impl PdfDocument {
     /// # Ok(())
     /// # }
     /// ```
-
+    ///
     /// List all Optional Content Group (OCG) layer names in the document.
     ///
     /// Reads `/OCProperties` from the document catalog and returns the `/Name`

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2673,6 +2673,73 @@ impl<'doc> TextExtractor<'doc> {
         false
     }
 
+    /// Check whether a BDC properties dict represents an excluded OCG or OCMD.
+    ///
+    /// Handles two cases per ISO 32000-1 Section 8.11.2:
+    /// - Direct OCG: dict has `/Name` -> check against excluded layers
+    /// - OCMD: dict has `/Type /OCMD` and `/OCGs` array -> resolve each
+    ///   referenced OCG and check its `/Name` against excluded layers
+    fn check_ocg_excluded(&self, props_dict: &std::collections::HashMap<String, Object>) -> bool {
+        if let Some(ocg_name) = props_dict.get("Name") {
+            return self.ocg_name_is_excluded(ocg_name);
+        }
+
+        if let Some(Object::Name(t)) = props_dict.get("Type") {
+            if t == "OCMD" {
+                if let Some(ocgs_obj) = props_dict.get("OCGs") {
+                    return self.ocmd_ocgs_excluded(ocgs_obj);
+                }
+            }
+        }
+
+        false
+    }
+
+    fn ocg_name_is_excluded(&self, name_obj: &Object) -> bool {
+        if let Some(name_str) = name_obj.as_name() {
+            return self.excluded_layers.contains(name_str);
+        }
+        if let Some(name_bytes) = name_obj.as_string() {
+            let name_str = Self::decode_pdf_text_string(name_bytes);
+            return self.excluded_layers.contains(&name_str);
+        }
+        false
+    }
+
+    /// Resolve OCMD /OCGs and check if any referenced OCG is excluded.
+    /// /OCGs can be a single reference or an array of references.
+    fn ocmd_ocgs_excluded(&self, ocgs_obj: &Object) -> bool {
+        let doc = match self.document {
+            Some(d) => d,
+            None => return false,
+        };
+
+        let refs: Vec<&Object> = if let Some(arr) = ocgs_obj.as_array() {
+            arr.iter().collect()
+        } else {
+            vec![ocgs_obj]
+        };
+
+        for obj in refs {
+            let resolved = if let Some(r) = obj.as_reference() {
+                match doc.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                obj.clone()
+            };
+            if let Some(d) = resolved.as_dict() {
+                if let Some(name_obj) = d.get("Name") {
+                    if self.ocg_name_is_excluded(name_obj) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
     ///
     /// Searches from the innermost marked content context outward, returning
@@ -5081,25 +5148,12 @@ impl<'doc> TextExtractor<'doc> {
                         artifact_type = Self::parse_artifact_type(&props_dict);
                     }
 
-                    // OCG (Optional Content Group / layer) filtering.
-                    // Per ISO 32000-1:2008 Section 8.11.2, content within a BDC
-                    // tagged "OC" references an OCG dictionary with /Type /OCG
-                    // and /Name <layer-name>.
+                    // OCG / OCMD (Optional Content) filtering.
+                    // Per ISO 32000-1:2008 Section 8.11.2:
+                    //  - Direct OCG: << /Type /OCG /Name /LayerName >>
+                    //  - OCMD:       << /Type /OCMD /OCGs [refs...] /P /policy >>
                     if tag == "OC" && !self.excluded_layers.is_empty() {
-                        if let Some(ocg_name) = props_dict.get("Name") {
-                            if let Some(name_str) = ocg_name.as_name() {
-                                if self.excluded_layers.contains(name_str) {
-                                    is_excluded_layer = true;
-                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
-                                }
-                            } else if let Some(name_bytes) = ocg_name.as_string() {
-                                let name_str = Self::decode_pdf_text_string(name_bytes);
-                                if self.excluded_layers.contains(&name_str) {
-                                    is_excluded_layer = true;
-                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
-                                }
-                            }
-                        }
+                        is_excluded_layer = self.check_ocg_excluded(&props_dict);
                     }
                 }
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -1999,6 +1999,10 @@ struct MarkedContentContext {
     /// The /E entry provides the expansion of an abbreviation or acronym.
     /// e.g., "PDF" might expand to "Portable Document Format"
     expansion: Option<String>,
+    /// Whether this marked content context is an excluded Optional Content Group (layer).
+    ///
+    /// Set when tag is "OC" and the OCG /Name matches one of the excluded layers.
+    is_excluded_layer: bool,
 }
 
 /// Text extractor that processes content streams.
@@ -2057,6 +2061,25 @@ pub struct TextExtractor<'doc> {
     /// Per PDF Spec Section 14.6, artifact content should be excluded from text extraction.
     /// This flag is true when any ancestor in the marked_content_stack has is_artifact=true.
     inside_artifact: bool,
+    /// Layer names (Optional Content Groups) to exclude from extraction.
+    ///
+    /// When a BDC operator with tag "OC" references an OCG whose /Name matches
+    /// one of these entries, all content within that marked content scope is suppressed.
+    excluded_layers: HashSet<String>,
+    /// Whether we're currently inside an excluded OCG layer.
+    ///
+    /// True when any ancestor in the marked_content_stack has is_excluded_layer=true.
+    inside_excluded_layer: bool,
+    /// Ink / separation names to exclude from extraction.
+    ///
+    /// When a `cs` operator sets a Separation or DeviceN color space whose ink name(s)
+    /// match one of these entries, subsequent text is suppressed until the color space changes.
+    excluded_inks: HashSet<String>,
+    /// Whether the current fill color space is an excluded ink.
+    ///
+    /// Set when SetFillColorSpace resolves to a Separation or DeviceN color space
+    /// whose ink name(s) intersect with `excluded_inks`.
+    inside_excluded_ink: bool,
     /// Extraction mode: true for spans, false for characters
     extract_spans: bool,
     /// Buffer for accumulating consecutive Tj operators into single spans
@@ -2167,6 +2190,10 @@ impl<'doc> TextExtractor<'doc> {
             span_sequence_counter: 0, // Initialize sequence counter
             marked_content_stack: Vec::new(), // Track marked content contexts
             inside_artifact: false,   // Track artifact state
+            excluded_layers: HashSet::new(),
+            inside_excluded_layer: false,
+            excluded_inks: HashSet::new(),
+            inside_excluded_ink: false,
             tj_offset_history: Vec::with_capacity(1000), // Track TJ offsets for statistical analysis
             tj_character_array: Vec::new(),              // Character tracking for word boundaries
             current_x_position: 0.0,                     // Start at origin
@@ -2208,6 +2235,23 @@ impl<'doc> TextExtractor<'doc> {
     /// Set the document reference for loading XObjects.
     pub fn set_document(&mut self, document: &'doc crate::document::PdfDocument) {
         self.document = Some(document);
+    }
+
+    /// Set layer names (Optional Content Groups) to exclude from extraction.
+    ///
+    /// Content within BDC/EMC scopes tagged "OC" whose OCG /Name matches one of
+    /// the provided names will be suppressed during text extraction.
+    pub fn set_excluded_layers(&mut self, layers: HashSet<String>) {
+        self.excluded_layers = layers;
+    }
+
+    /// Set ink / separation names to exclude from extraction.
+    ///
+    /// When the fill color space is a Separation or DeviceN whose ink name(s)
+    /// intersect with any of the provided names, subsequent text is suppressed
+    /// until the color space changes to a non-excluded one.
+    pub fn set_excluded_inks(&mut self, inks: HashSet<String>) {
+        self.excluded_inks = inks;
     }
 
     // ========================================================================
@@ -2402,6 +2446,30 @@ impl<'doc> TextExtractor<'doc> {
         self.inside_artifact = self.marked_content_stack.iter().any(|ctx| ctx.is_artifact);
     }
 
+    /// Update the excluded-layer state based on the marked content stack.
+    ///
+    /// True if any ancestor in the stack is an excluded OCG layer.
+    /// Called each time a marked content boundary is crossed (BMC/BDC/EMC).
+    fn update_layer_state(&mut self) {
+        self.inside_excluded_layer = self
+            .marked_content_stack
+            .iter()
+            .any(|ctx| ctx.is_excluded_layer);
+    }
+
+    /// Whether content emission should be suppressed.
+    ///
+    /// Returns true when the current graphics/marked-content state means
+    /// extracted text should be discarded. Currently checks:
+    /// - Inside an excluded OCG layer (`inside_excluded_layer`)
+    /// - Inside an excluded ink / separation color space (`inside_excluded_ink`)
+    ///
+    /// Note: artifact filtering is handled separately via span metadata and
+    /// downstream filtering, so `inside_artifact` is intentionally not checked here.
+    fn is_content_suppressed(&self) -> bool {
+        self.inside_excluded_layer || self.inside_excluded_ink
+    }
+
     /// Parse artifact type and subtype from artifact properties dictionary.
     ///
     /// Per PDF Spec Section 14.8.2.2, artifacts have optional /Type and /Subtype entries:
@@ -2528,6 +2596,80 @@ impl<'doc> TextExtractor<'doc> {
             prop_obj.clone()
         };
         resolved.as_dict().cloned()
+    }
+
+    /// Resolve a named color space from the /Resources /ColorSpace dictionary.
+    ///
+    /// PDF content streams reference color spaces by name (e.g. `cs /CS1`).
+    /// Device color spaces like "DeviceRGB" are built-in, but Separation and
+    /// DeviceN color spaces live in the page resources:
+    ///
+    /// ```text
+    /// /Resources << /ColorSpace << /CS1 [/Separation /PANTONE_Red /DeviceCMYK ...] >> >>
+    /// ```
+    ///
+    /// Returns the resolved color space array if the name refers to a resource entry.
+    fn resolve_color_space(&self, name: &str) -> Option<Vec<Object>> {
+        let resources = self.resources.as_ref()?;
+        let res_dict = if let Some(res_ref) = resources.as_reference() {
+            self.document?.load_object(res_ref).ok()?
+        } else {
+            resources.clone()
+        };
+        let res_dict = res_dict.as_dict()?;
+        let cs_dict_obj = res_dict.get("ColorSpace")?;
+        let cs_dict = if let Some(r) = cs_dict_obj.as_reference() {
+            self.document?.load_object(r).ok()?
+        } else {
+            cs_dict_obj.clone()
+        };
+        let cs_dict = cs_dict.as_dict()?;
+        let cs_obj = cs_dict.get(name)?;
+        let resolved = if let Some(r) = cs_obj.as_reference() {
+            self.document?.load_object(r).ok()?
+        } else {
+            cs_obj.clone()
+        };
+        resolved.as_array().cloned()
+    }
+
+    /// Check if a color space name refers to an excluded ink.
+    ///
+    /// Resolves the color space from resources and checks:
+    /// - `[/Separation /InkName /AlternateCS /TintTransform]` — single ink name
+    /// - `[/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]` — multiple ink names
+    ///
+    /// Returns true if any ink name in the color space matches `excluded_inks`.
+    fn is_excluded_ink_color_space(&self, name: &str) -> bool {
+        if self.excluded_inks.is_empty() {
+            return false;
+        }
+        if let Some(cs_array) = self.resolve_color_space(name) {
+            if cs_array.len() >= 2 {
+                if let Some(cs_type) = cs_array[0].as_name() {
+                    match cs_type {
+                        "Separation" => {
+                            // [/Separation /InkName /AlternateCS /TintTransform]
+                            if let Some(ink_name) = cs_array[1].as_name() {
+                                return self.excluded_inks.contains(ink_name);
+                            }
+                        },
+                        "DeviceN" => {
+                            // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
+                            if let Some(ink_names) = cs_array[1].as_array() {
+                                return ink_names.iter().any(|obj| {
+                                    obj.as_name()
+                                        .map(|n| self.excluded_inks.contains(n))
+                                        .unwrap_or(false)
+                                });
+                            }
+                        },
+                        _ => {},
+                    }
+                }
+            }
+        }
+        false
     }
 
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
@@ -4149,7 +4291,9 @@ impl<'doc> TextExtractor<'doc> {
                                                 final_matrix.f,
                                             ]),
                                         };
-                                        self.chars.push(space_char);
+                                        if !self.is_content_suppressed() {
+                                            self.chars.push(space_char);
+                                        }
                                     }
 
                                     let state_mut = self.state_stack.current_mut();
@@ -4257,6 +4401,11 @@ impl<'doc> TextExtractor<'doc> {
                     .as_ref()
                     .and_then(|name| self.fonts.get(name))
                     .cloned();
+                // Re-evaluate ink exclusion for the restored color space
+                if !self.excluded_inks.is_empty() {
+                    let cs = self.state_stack.current().fill_color_space.clone();
+                    self.inside_excluded_ink = self.is_excluded_ink_color_space(&cs);
+                }
             },
             Operator::Cm { a, b, c, d, e, f } => {
                 let state = self.state_stack.current_mut();
@@ -4267,26 +4416,30 @@ impl<'doc> TextExtractor<'doc> {
 
             // Color operators
             Operator::SetFillRgb { r, g, b } => {
+                // rg operator implicitly sets DeviceRGB — a process color.
+                self.inside_excluded_ink = false;
                 self.state_stack.current_mut().fill_color_rgb = (r, g, b);
             },
             Operator::SetStrokeRgb { r, g, b } => {
                 self.state_stack.current_mut().stroke_color_rgb = (r, g, b);
             },
             Operator::SetFillGray { gray } => {
+                // g operator implicitly sets DeviceGray — a process color,
+                // so clear any active ink exclusion.
+                self.inside_excluded_ink = false;
                 self.state_stack.current_mut().fill_color_rgb = (gray, gray, gray);
             },
             Operator::SetStrokeGray { gray } => {
                 self.state_stack.current_mut().stroke_color_rgb = (gray, gray, gray);
             },
             Operator::SetFillCmyk { c, m, y, k } => {
-                // Store CMYK and convert to RGB for rendering
-                // CMYK to RGB conversion: R = 1 - min(1, C*(1-K) + K)
+                // k operator implicitly sets DeviceCMYK — a process color.
+                self.inside_excluded_ink = false;
                 let state = self.state_stack.current_mut();
                 state.fill_color_cmyk = Some((c, m, y, k));
                 state.fill_color_rgb = cmyk_to_rgb(c, m, y, k);
             },
             Operator::SetStrokeCmyk { c, m, y, k } => {
-                // Store CMYK and convert to RGB for rendering
                 let state = self.state_stack.current_mut();
                 state.stroke_color_cmyk = Some((c, m, y, k));
                 state.stroke_color_rgb = cmyk_to_rgb(c, m, y, k);
@@ -4294,6 +4447,16 @@ impl<'doc> TextExtractor<'doc> {
 
             // Color space operators
             Operator::SetFillColorSpace { name } => {
+                // Check for excluded ink before mutating state (needs &self)
+                let ink_excluded = self.is_excluded_ink_color_space(&name);
+                self.inside_excluded_ink = ink_excluded;
+                if ink_excluded {
+                    log::debug!(
+                        "Fill color space {:?} matches excluded ink, suppressing text",
+                        name
+                    );
+                }
+
                 let state = self.state_stack.current_mut();
                 state.fill_color_space = name.clone();
                 // Reset color when changing color space
@@ -4867,6 +5030,7 @@ impl<'doc> TextExtractor<'doc> {
                     artifact_type: None, // No artifact classification; None for backward compatibility
                     actual_text: None,   // BMC doesn't have ActualText
                     expansion: None,     // BMC doesn't have expansion
+                    is_excluded_layer: false, // BMC cannot carry OCG properties
                 });
                 self.update_artifact_state();
 
@@ -4881,6 +5045,8 @@ impl<'doc> TextExtractor<'doc> {
                 let mut actual_text = None;
                 let mut artifact_type = None;
                 let mut expansion = None;
+
+                let mut is_excluded_layer = false;
 
                 if let Some(props_dict) = self.resolve_bdc_properties(&properties) {
                     if let Some(mcid_obj) = props_dict.get("MCID") {
@@ -4907,6 +5073,27 @@ impl<'doc> TextExtractor<'doc> {
                     if tag == "Artifact" {
                         artifact_type = Self::parse_artifact_type(&props_dict);
                     }
+
+                    // OCG (Optional Content Group / layer) filtering.
+                    // Per ISO 32000-1:2008 Section 8.11.2, content within a BDC
+                    // tagged "OC" references an OCG dictionary with /Type /OCG
+                    // and /Name <layer-name>.
+                    if tag == "OC" && !self.excluded_layers.is_empty() {
+                        if let Some(ocg_name) = props_dict.get("Name") {
+                            if let Some(name_str) = ocg_name.as_name() {
+                                if self.excluded_layers.contains(name_str) {
+                                    is_excluded_layer = true;
+                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
+                                }
+                            } else if let Some(name_bytes) = ocg_name.as_string() {
+                                let name_str = Self::decode_pdf_text_string(name_bytes);
+                                if self.excluded_layers.contains(&name_str) {
+                                    is_excluded_layer = true;
+                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Check if this is an artifact (per PDF Spec Section 14.6)
@@ -4917,8 +5104,10 @@ impl<'doc> TextExtractor<'doc> {
                     artifact_type: artifact_type.clone(),
                     actual_text,
                     expansion,
+                    is_excluded_layer,
                 });
                 self.update_artifact_state();
+                self.update_layer_state();
 
                 if is_artifact {
                     if let Some(ref atype) = artifact_type {
@@ -4936,10 +5125,11 @@ impl<'doc> TextExtractor<'doc> {
                 }
                 self.current_mcid = None;
 
-                // Pop from marked content stack and update artifact state
+                // Pop from marked content stack and update artifact/layer state
                 if !self.marked_content_stack.is_empty() {
                     self.marked_content_stack.pop();
                     self.update_artifact_state();
+                    self.update_layer_state();
                 }
             },
 
@@ -5484,7 +5674,9 @@ impl<'doc> TextExtractor<'doc> {
         };
         self.span_sequence_counter += 1;
 
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
         Ok(())
     }
 
@@ -5980,7 +6172,9 @@ impl<'doc> TextExtractor<'doc> {
 
         // Step 6: Increment sequence counter and add to spans
         self.span_sequence_counter += 1;
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
 
         Ok(())
     }
@@ -6582,7 +6776,9 @@ impl<'doc> TextExtractor<'doc> {
 
         log::trace!("PUSH space span with offset_semantic={}", span.offset_semantic);
 
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
 
         // Advance position per ISO 32000-1:2008 §9.4.4
         let state = self.state_stack.current_mut();
@@ -6741,7 +6937,9 @@ impl<'doc> TextExtractor<'doc> {
                     span.offset_semantic
                 );
 
-                self.spans.push(span);
+                if !self.is_content_suppressed() {
+                    self.spans.push(span);
+                }
             }
         }
         Ok(())
@@ -6895,7 +7093,9 @@ impl<'doc> TextExtractor<'doc> {
                         ]),
                     };
 
-                    self.chars.push(text_char);
+                    if !self.is_content_suppressed() {
+                        self.chars.push(text_char);
+                    }
                 }
             }
 
@@ -8451,6 +8651,7 @@ mod tests {
             is_artifact: true,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.update_artifact_state();
         assert!(extractor.inside_artifact);
@@ -8465,6 +8666,7 @@ mod tests {
             is_artifact: true,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.marked_content_stack.push(MarkedContentContext {
             artifact_type: None,
@@ -8472,6 +8674,7 @@ mod tests {
             is_artifact: false,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.update_artifact_state();
         // Should still be inside artifact because parent is artifact
@@ -12594,6 +12797,7 @@ mod tests {
             is_artifact: false,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
 
         extractor
@@ -13125,6 +13329,7 @@ fn test_marked_content_context_with_actual_text() {
         is_artifact: false,
         actual_text: Some("fi".to_string()), // Ligature expansion
         expansion: None,
+        is_excluded_layer: false,
     };
 
     assert_eq!(ctx.actual_text, Some("fi".to_string()));
@@ -13140,6 +13345,7 @@ fn test_marked_content_context_with_expansion() {
         is_artifact: false,
         actual_text: None,
         expansion: Some("Portable Document Format".to_string()),
+        is_excluded_layer: false,
     };
 
     assert_eq!(ctx.expansion, Some("Portable Document Format".to_string()));
@@ -13154,6 +13360,7 @@ fn test_marked_content_context_artifact_with_actual_text() {
         artifact_type: Some(ArtifactType::Pagination(PaginationSubtype::Header)),
         actual_text: Some("Header text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     };
 
     assert!(ctx.is_artifact);
@@ -13172,6 +13379,7 @@ fn test_get_current_actual_text_finds_first() {
         is_artifact: false,
         actual_text: Some("outer text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     extractor.marked_content_stack.push(MarkedContentContext {
@@ -13180,6 +13388,7 @@ fn test_get_current_actual_text_finds_first() {
         is_artifact: false,
         actual_text: Some("inner text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Should return innermost (most recent) ActualText
@@ -13199,6 +13408,7 @@ fn test_get_current_actual_text_skips_none() {
         is_artifact: false,
         actual_text: Some("replacement text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Push context without ActualText
@@ -13208,6 +13418,7 @@ fn test_get_current_actual_text_skips_none() {
         is_artifact: false,
         actual_text: None,
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Should find the ActualText from outer context

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -10,6 +10,7 @@ use crate::config::ExtractionProfile;
 use crate::content::graphics_state::{GraphicsStateStack, Matrix};
 use crate::content::operators::{Operator, TextElement};
 use crate::content::parse_and_execute_text_only;
+use crate::content::parse_content_stream;
 use crate::content::parse_content_stream_text_only;
 use crate::error::Result;
 use crate::extract_log_debug;
@@ -2907,12 +2908,17 @@ impl<'doc> TextExtractor<'doc> {
         self.spans.clear();
         self.span_sequence_counter = 0; // Reset sequence counter for this page
 
-        // Streaming parse+execute: operators are processed immediately without
-        // building an intermediate Vec<Operator>. This eliminates allocation of
-        // potentially huge vectors (196K+ operators for graphics-heavy pages)
-        // and improves cache locality.
         extract_log_debug!("Parsing content stream for text extraction");
-        parse_and_execute_text_only(content_stream, |op| self.execute_operator(op))?;
+        if self.excluded_inks.is_empty() {
+            parse_and_execute_text_only(content_stream, |op| self.execute_operator(op))?;
+        } else {
+            // Ink filtering requires color operators (cs, rg, g, k) which the
+            // text-only parser skips. Fall back to the full parser.
+            let operators = parse_content_stream(content_stream)?;
+            for op in operators {
+                self.execute_operator(op)?;
+            }
+        }
 
         // Flush any remaining Tj buffer at end of content stream
         self.flush_tj_span_buffer()?;
@@ -2955,10 +2961,11 @@ impl<'doc> TextExtractor<'doc> {
         self.chars.clear();
         self.spans.clear(); // Ensure spans are clear so they don't poison xobject_spans_cache
 
-        // Parse content stream into operators
-        let operators = parse_content_stream_text_only(content_stream)?;
-
-        // Execute each operator
+        let operators = if self.excluded_inks.is_empty() {
+            parse_content_stream_text_only(content_stream)?
+        } else {
+            parse_content_stream(content_stream)?
+        };
         for op in operators {
             self.execute_operator(op)?;
         }
@@ -5301,7 +5308,8 @@ impl<'doc> TextExtractor<'doc> {
         //
         // `ctm_key` was already computed above for the `processed_xobjects` guard.
         let spans_cache_key = (xobject_ref, ctm_key);
-        if self.extract_spans {
+        let has_filters = !self.excluded_layers.is_empty() || !self.excluded_inks.is_empty();
+        if self.extract_spans && !has_filters {
             let cached_spans = {
                 doc.xobject_spans_cache
                     .lock()
@@ -5506,10 +5514,21 @@ impl<'doc> TextExtractor<'doc> {
                 let state = self.state_stack.current_mut();
                 state.ctm = form_matrix.multiply(&state.ctm);
 
-                // Streaming parse+execute: avoids allocating Vec<Operator>
                 self.xobject_depth += 1;
-                let parse_result =
-                    parse_and_execute_text_only(&stream_data, |op| self.execute_operator(op));
+                let parse_result = if self.excluded_inks.is_empty() {
+                    parse_and_execute_text_only(&stream_data, |op| self.execute_operator(op))
+                } else {
+                    let ops = parse_content_stream(&stream_data);
+                    match ops {
+                        Ok(ops) => {
+                            for op in ops {
+                                self.execute_operator(op)?;
+                            }
+                            Ok(())
+                        },
+                        Err(e) => Err(e),
+                    }
+                };
                 self.xobject_depth -= 1;
                 if let Err(e) = parse_result {
                     log::debug!(
@@ -5530,7 +5549,7 @@ impl<'doc> TextExtractor<'doc> {
                 // We still require `has_own_resources` so that font lookups are
                 // self-contained; XObjects that inherit page-level fonts would
                 // produce spans whose glyph mappings depend on caller context.
-                if has_own_resources && self.extract_spans {
+                if has_own_resources && self.extract_spans && !has_filters {
                     let new_spans = if self.spans.len() > spans_before {
                         Some(self.spans[spans_before..].to_vec())
                     } else {
@@ -5562,6 +5581,13 @@ impl<'doc> TextExtractor<'doc> {
                 }
                 if let Some(cache) = saved_xobj_cache {
                     self.cached_xobject_refs = cache;
+                }
+                // Re-evaluate ink exclusion against the restored color space
+                // and resources. The XObject may have set an excluded ink that
+                // must not persist into the caller's scope.
+                if !self.excluded_inks.is_empty() {
+                    let cs = self.state_stack.current().fill_color_space.clone();
+                    self.inside_excluded_ink = self.is_excluded_ink_color_space(&cs);
                 }
 
                 // Keep xobject_ref in processed_xobjects permanently.

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2251,6 +2251,11 @@ impl<'doc> TextExtractor<'doc> {
     /// When the fill color space is a Separation or DeviceN whose ink name(s)
     /// intersect with any of the provided names, subsequent text is suppressed
     /// until the color space changes to a non-excluded one.
+    ///
+    /// **DeviceN behavior:** For DeviceN color spaces (e.g.
+    /// `[/DeviceN [/Cyan /SpotGold] ...]`), text is suppressed if ANY ink in
+    /// the array matches — even process colors sharing the DeviceN definition.
+    /// This is because tint values are not evaluated during extraction.
     pub fn set_excluded_inks(&mut self, inks: HashSet<String>) {
         self.excluded_inks = inks;
     }
@@ -2641,6 +2646,9 @@ impl<'doc> TextExtractor<'doc> {
     /// - `[/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]` — multiple ink names
     ///
     /// Returns true if any ink name in the color space matches `excluded_inks`.
+    ///
+    /// **Note:** For DeviceN, this is all-or-nothing — if any ink matches, the
+    /// entire color space is treated as excluded. Tint values are not evaluated.
     fn is_excluded_ink_color_space(&self, name: &str) -> bool {
         if self.excluded_inks.is_empty() {
             return false;

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2534,74 +2534,21 @@ impl<'doc> TextExtractor<'doc> {
 
     /// Decode a PDF text string (handles UTF-16BE/LE with BOM and PDFDocEncoding).
     ///
-    /// Per ISO 32000 §7.9.2, strings without a UTF-16 BOM are PDFDocEncoding.
-    /// We try UTF-8 first as a lenient path for non-spec-compliant PDFs that
-    /// embed raw UTF-8 without a BOM; if that fails we fall back to the correct
-    /// PDFDocEncoding lookup (which handles the 0x80–0x9E special-char zone and
-    /// maps 0xA0–0xFF as ISO Latin-1, unlike from_utf8_lossy which substitutes
-    /// U+FFFD for any byte that is not valid UTF-8).
+    /// Thin delegate to [`crate::optional_content::decode_pdf_text_string`] — that
+    /// module owns the canonical implementation shared with the rendering path.
     fn decode_pdf_text_string(bytes: &[u8]) -> String {
-        if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
-            // UTF-16BE with BOM
-            let utf16_pairs: Vec<u16> = bytes[2..]
-                .chunks_exact(2)
-                .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
-                .collect();
-            String::from_utf16(&utf16_pairs)
-                .unwrap_or_else(|_| String::from_utf8_lossy(bytes).to_string())
-        } else if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
-            // UTF-16LE with BOM
-            let utf16_pairs: Vec<u16> = bytes[2..]
-                .chunks_exact(2)
-                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-                .collect();
-            String::from_utf16(&utf16_pairs)
-                .unwrap_or_else(|_| String::from_utf8_lossy(bytes).to_string())
-        } else {
-            // Try UTF-8 first (lenient: some PDFs embed raw UTF-8 without a BOM).
-            // Fall back to PDFDocEncoding per ISO 32000 §7.9.2.
-            String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| {
-                bytes
-                    .iter()
-                    .filter_map(|&b| crate::fonts::font_dict::pdfdoc_encoding_lookup(b))
-                    .collect()
-            })
-        }
+        crate::optional_content::decode_pdf_text_string(bytes)
     }
 
     /// Resolve BDC properties: can be an inline dictionary or a name referencing /Properties resource.
+    ///
+    /// Thin delegate to [`crate::optional_content::resolve_bdc_properties`].
     fn resolve_bdc_properties(
         &self,
         properties: &Object,
     ) -> Option<std::collections::HashMap<String, Object>> {
-        // Inline dictionary
-        if let Some(dict) = properties.as_dict() {
-            return Some(dict.clone());
-        }
-
-        // Name reference — look up in /Properties sub-dictionary of resources
-        let prop_name = properties.as_name()?;
-        let resources = self.resources.as_ref()?;
-        let res_dict = if let Some(res_ref) = resources.as_reference() {
-            self.document?.load_object(res_ref).ok()?
-        } else {
-            resources.clone()
-        };
-        let res_dict = res_dict.as_dict()?;
-        let properties_dict_obj = res_dict.get("Properties")?;
-        let properties_dict = if let Some(r) = properties_dict_obj.as_reference() {
-            self.document?.load_object(r).ok()?
-        } else {
-            properties_dict_obj.clone()
-        };
-        let properties_dict = properties_dict.as_dict()?;
-        let prop_obj = properties_dict.get(prop_name)?;
-        let resolved = if let Some(r) = prop_obj.as_reference() {
-            self.document?.load_object(r).ok()?
-        } else {
-            prop_obj.clone()
-        };
-        resolved.as_dict().cloned()
+        let doc = self.document?;
+        crate::optional_content::resolve_bdc_properties(properties, self.resources.as_ref(), doc)
     }
 
     /// Resolve a named color space from the /Resources /ColorSpace dictionary.
@@ -2683,70 +2630,17 @@ impl<'doc> TextExtractor<'doc> {
 
     /// Check whether a BDC properties dict represents an excluded OCG or OCMD.
     ///
-    /// Handles two cases per ISO 32000-1 Section 8.11.2:
-    /// - Direct OCG: dict has `/Name` -> check against excluded layers
-    /// - OCMD: dict has `/Type /OCMD` and `/OCGs` array -> resolve each
-    ///   referenced OCG and check its `/Name` against excluded layers
+    /// Thin delegate to [`crate::optional_content::check_ocg_excluded`] — that
+    /// module is the single source of truth for OCG/OCMD evaluation, including
+    /// OCMD `/P` visibility-policy handling.
     fn check_ocg_excluded(&self, props_dict: &std::collections::HashMap<String, Object>) -> bool {
-        if let Some(ocg_name) = props_dict.get("Name") {
-            return self.ocg_name_is_excluded(ocg_name);
-        }
-
-        if let Some(Object::Name(t)) = props_dict.get("Type") {
-            if t == "OCMD" {
-                if let Some(ocgs_obj) = props_dict.get("OCGs") {
-                    return self.ocmd_ocgs_excluded(ocgs_obj);
-                }
-            }
-        }
-
-        false
-    }
-
-    fn ocg_name_is_excluded(&self, name_obj: &Object) -> bool {
-        if let Some(name_str) = name_obj.as_name() {
-            return self.excluded_layers.contains(name_str);
-        }
-        if let Some(name_bytes) = name_obj.as_string() {
-            let name_str = Self::decode_pdf_text_string(name_bytes);
-            return self.excluded_layers.contains(&name_str);
-        }
-        false
-    }
-
-    /// Resolve OCMD /OCGs and check if any referenced OCG is excluded.
-    /// /OCGs can be a single reference or an array of references.
-    fn ocmd_ocgs_excluded(&self, ocgs_obj: &Object) -> bool {
         let doc = match self.document {
             Some(d) => d,
             None => return false,
         };
-
-        let refs: Vec<&Object> = if let Some(arr) = ocgs_obj.as_array() {
-            arr.iter().collect()
-        } else {
-            vec![ocgs_obj]
-        };
-
-        for obj in refs {
-            let resolved = if let Some(r) = obj.as_reference() {
-                match doc.load_object(r) {
-                    Ok(o) => o,
-                    Err(_) => continue,
-                }
-            } else {
-                obj.clone()
-            };
-            if let Some(d) = resolved.as_dict() {
-                if let Some(name_obj) = d.get("Name") {
-                    if self.ocg_name_is_excluded(name_obj) {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        crate::optional_content::check_ocg_excluded(props_dict, doc, &self.excluded_layers)
     }
+
 
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
     ///

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2543,12 +2543,18 @@ impl<'doc> TextExtractor<'doc> {
     /// Resolve BDC properties: can be an inline dictionary or a name referencing /Properties resource.
     ///
     /// Thin delegate to [`crate::optional_content::resolve_bdc_properties`].
+    /// Passing `self.document` as `Option` lets the inline-dict fast path work
+    /// even on a freshly-constructed extractor with no document attached (used
+    /// by unit tests).
     fn resolve_bdc_properties(
         &self,
         properties: &Object,
     ) -> Option<std::collections::HashMap<String, Object>> {
-        let doc = self.document?;
-        crate::optional_content::resolve_bdc_properties(properties, self.resources.as_ref(), doc)
+        crate::optional_content::resolve_bdc_properties(
+            properties,
+            self.resources.as_ref(),
+            self.document,
+        )
     }
 
     /// Resolve a named color space from the /Resources /ColorSpace dictionary.
@@ -2640,7 +2646,6 @@ impl<'doc> TextExtractor<'doc> {
         };
         crate::optional_content::check_ocg_excluded(props_dict, doc, &self.excluded_layers)
     }
-
 
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
     ///

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4686,6 +4686,8 @@ pub extern "C" fn pdf_render_page_with_options(
         } else {
             Some([bg_r, bg_g, bg_b, bg_a])
         };
+        // OCG layer filtering is exposed on the variant
+        // `pdf_render_page_with_options_ex` below — keeping this ABI stable.
         let opts = RustRenderOptions {
             dpi: dpi as u32,
             format: fmt,
@@ -4720,6 +4722,112 @@ pub extern "C" fn pdf_render_page_with_options(
             transparent_background,
             render_annotations,
             jpeg_quality,
+        );
+        set_error(error_code, _ERR_UNSUPPORTED);
+        ptr::null_mut()
+    }
+}
+
+/// Render a page with the full RenderOptions surface plus OCG layer filtering.
+///
+/// `excluded_layers` is a pointer to an array of `excluded_layers_count` null-
+/// terminated UTF-8 C strings. Each string is the `/Name` of an Optional
+/// Content Group (OCG) to suppress. Pass a null pointer or zero count to
+/// disable filtering (matches `pdf_render_page_with_options` behaviour).
+///
+/// The renderer also honours OCMD references that resolve to any of the named
+/// OCGs, per ISO 32000-1 §8.11.2.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn pdf_render_page_with_options_ex(
+    doc: *mut PdfDocument,
+    page_index: i32,
+    dpi: i32,
+    format: i32,
+    bg_r: f32,
+    bg_g: f32,
+    bg_b: f32,
+    bg_a: f32,
+    transparent_background: i32,
+    render_annotations: i32,
+    jpeg_quality: i32,
+    excluded_layers: *const *const c_char,
+    excluded_layers_count: usize,
+    error_code: *mut i32,
+) -> *mut FfiRenderedImage {
+    #[cfg(feature = "rendering")]
+    {
+        if doc.is_null() {
+            set_error(error_code, ERR_INVALID_ARG);
+            return ptr::null_mut();
+        }
+        if dpi <= 0 || !(1..=100).contains(&jpeg_quality) {
+            set_error(error_code, ERR_INVALID_ARG);
+            return ptr::null_mut();
+        }
+        let d = handle_ref(doc as *const _);
+        let fmt = if format == 1 {
+            RenderImageFormat::Jpeg
+        } else {
+            RenderImageFormat::Png
+        };
+        let background = if transparent_background != 0 {
+            None
+        } else {
+            Some([bg_r, bg_g, bg_b, bg_a])
+        };
+
+        let mut layers: std::collections::HashSet<String> = std::collections::HashSet::new();
+        if !excluded_layers.is_null() && excluded_layers_count > 0 {
+            for i in 0..excluded_layers_count {
+                // Safety: caller-supplied pointer must point to an array of
+                // at least `excluded_layers_count` C strings or be null.
+                let entry: *const c_char = unsafe { *excluded_layers.add(i) };
+                if entry.is_null() {
+                    continue;
+                }
+                if let Some(s) = c_str_lossy(entry) {
+                    layers.insert(s);
+                }
+            }
+        }
+
+        let opts = RustRenderOptions {
+            dpi: dpi as u32,
+            format: fmt,
+            background,
+            render_annotations: render_annotations != 0,
+            jpeg_quality: jpeg_quality as u8,
+            excluded_layers: layers,
+            scale_override: None,
+        };
+        match rendering::render_page(d, page_index as usize, &opts) {
+            Ok(img) => {
+                set_error(error_code, ERR_SUCCESS);
+                Box::into_raw(Box::new(FfiRenderedImage { inner: img }))
+            },
+            Err(e) => {
+                set_error(error_code, classify_error(&e));
+                ptr::null_mut()
+            },
+        }
+    }
+    #[cfg(not(feature = "rendering"))]
+    {
+        let _ = (
+            doc,
+            page_index,
+            dpi,
+            format,
+            bg_r,
+            bg_g,
+            bg_b,
+            bg_a,
+            transparent_background,
+            render_annotations,
+            jpeg_quality,
+            excluded_layers,
+            excluded_layers_count,
         );
         set_error(error_code, _ERR_UNSUPPORTED);
         ptr::null_mut()

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4692,6 +4692,7 @@ pub extern "C" fn pdf_render_page_with_options(
             background,
             render_annotations: render_annotations != 0,
             jpeg_quality: jpeg_quality as u8,
+            excluded_layers: std::collections::HashSet::new(),
             scale_override: None,
         };
         match rendering::render_page(d, page_index as usize, &opts) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ pub mod layout;
 pub mod content;
 pub mod extractors;
 pub mod fonts;
+pub mod optional_content;
 pub mod text;
 
 // Document structure

--- a/src/optional_content.rs
+++ b/src/optional_content.rs
@@ -182,10 +182,11 @@ pub fn check_ocg_excluded(
 
     if let Some(Object::Name(t)) = props_dict.get("Type") {
         if t == "OCMD" {
-            // /VE — visibility expression. Not implemented; if present, fall
-            // through to /P / /OCGs evaluation. A future implementation would
-            // walk the operator tree and short-circuit return here.
-            //
+            // /VE takes precedence over /P per ISO 32000-1 §8.11.2.4.
+            if let Some(ve) = props_dict.get("VE") {
+                return !evaluate_visibility_expression(ve, doc, excluded);
+            }
+
             // /P — visibility policy. Defaults to /AnyOn.
             let policy = props_dict
                 .get("P")
@@ -203,6 +204,65 @@ pub fn check_ocg_excluded(
     }
 
     false
+}
+
+/// Evaluate an OCMD `/VE` visibility expression to a boolean visibility state.
+///
+/// Per ISO 32000-1 §8.11.2.4 a visibility expression is an array whose first
+/// element is the operator (`/And`, `/Or`, or `/Not`) and remaining elements
+/// are operands. Each operand is either:
+///  - An indirect reference to an OCG dict (evaluates to that OCG's on-state)
+///  - A nested visibility expression array (evaluates recursively)
+///
+/// Returns `true` if the expression resolves to "visible", `false` to "hidden".
+/// For our exclusion model an OCG is on iff its `/Name` is NOT in `excluded`.
+/// Bounded recursion depth prevents stack overflow on hostile/malformed input.
+fn evaluate_visibility_expression(
+    expr: &Object,
+    doc: &PdfDocument,
+    excluded: &HashSet<String>,
+) -> bool {
+    fn eval(expr: &Object, doc: &PdfDocument, excluded: &HashSet<String>, depth: u8) -> bool {
+        if depth > 16 {
+            return true; // permissive: don't suppress on malformed/circular input
+        }
+
+        // Resolve indirect references — operands may be direct OCG refs.
+        let resolved = match expr.as_reference() {
+            Some(r) => doc.load_object(r).unwrap_or_else(|_| expr.clone()),
+            None => expr.clone(),
+        };
+
+        // Leaf: an OCG dictionary. On iff its name is not excluded.
+        if let Some(d) = resolved.as_dict() {
+            if let Some(name) = d.get("Name") {
+                return !ocg_name_is_excluded(name, excluded);
+            }
+            return true;
+        }
+
+        // Expression: array starting with operator name.
+        let arr = match resolved.as_array() {
+            Some(a) => a,
+            None => return true,
+        };
+        let op = match arr.first().and_then(|o| o.as_name()) {
+            Some(n) => n,
+            None => return true,
+        };
+
+        match op {
+            "Not" => !arr
+                .get(1)
+                .map(|o| eval(o, doc, excluded, depth + 1))
+                .unwrap_or(true),
+            "And" => arr[1..].iter().all(|o| eval(o, doc, excluded, depth + 1)),
+            "Or" => arr[1..].iter().any(|o| eval(o, doc, excluded, depth + 1)),
+            _ => true,
+        }
+    }
+
+    eval(expr, doc, excluded, 0)
 }
 
 /// Resolve BDC properties and decide if the resulting scope is excluded.

--- a/src/optional_content.rs
+++ b/src/optional_content.rs
@@ -17,6 +17,111 @@ use std::collections::{HashMap, HashSet};
 use crate::document::PdfDocument;
 use crate::object::Object;
 
+/// Compute the document's default-off OCG names per ISO 32000-1 §8.11.4.
+///
+/// Reads `/OCProperties/D` (the default configuration) and returns the set of
+/// OCG `/Name` strings that are off in the default state. Logic:
+///
+///  - `/D/BaseState` = `/ON` (or absent): OCGs default to on. `/D/OFF` lists
+///     names that are explicitly turned off.
+///  - `/D/BaseState` = `/OFF`: OCGs default to off. All OCGs in `/OCProperties
+///    /OCGs` that are NOT in `/D/ON` are off.
+///  - `/D/BaseState` = `/Unchanged`: treat as `/ON` (libraries have no prior
+///    viewer state to preserve).
+///  - `/OCProperties` or `/D` absent: returns empty set (all OCGs on).
+///
+/// Callers typically combine this with caller-supplied `excluded_layers` via
+/// `default_off | excluded_layers` to get the effective "off" set for filtering.
+pub fn compute_default_off_ocgs(doc: &PdfDocument) -> HashSet<String> {
+    let mut off = HashSet::new();
+    let catalog = match doc.catalog() {
+        Ok(c) => c,
+        Err(_) => return off,
+    };
+    let catalog_dict = match catalog.as_dict() {
+        Some(d) => d,
+        None => return off,
+    };
+    let oc_props = match resolve_indirect(catalog_dict.get("OCProperties"), doc) {
+        Some(o) => o,
+        None => return off,
+    };
+    let oc_dict = match oc_props.as_dict() {
+        Some(d) => d,
+        None => return off,
+    };
+    let d_obj = match resolve_indirect(oc_dict.get("D"), doc) {
+        Some(o) => o,
+        None => return off,
+    };
+    let d_dict = match d_obj.as_dict() {
+        Some(d) => d,
+        None => return off,
+    };
+
+    let base_state = d_dict
+        .get("BaseState")
+        .and_then(|o| o.as_name())
+        .unwrap_or("ON");
+    let on_set = collect_ocg_name_set(d_dict.get("ON"), doc);
+    let off_set = collect_ocg_name_set(d_dict.get("OFF"), doc);
+
+    if base_state == "OFF" {
+        // All OCGs default off; explicit /ON entries are on.
+        // Walk /OCProperties/OCGs and mark anything not in on_set as off.
+        let all_ocgs = collect_ocg_name_set(oc_dict.get("OCGs"), doc);
+        for name in all_ocgs {
+            if !on_set.contains(&name) {
+                off.insert(name);
+            }
+        }
+    } else {
+        // BaseState is /ON or /Unchanged: only explicit /D/OFF entries are off.
+        off.extend(off_set);
+    }
+
+    off
+}
+
+fn resolve_indirect(obj: Option<&Object>, doc: &PdfDocument) -> Option<Object> {
+    let obj = obj?;
+    match obj.as_reference() {
+        Some(r) => doc.load_object(r).ok(),
+        None => Some(obj.clone()),
+    }
+}
+
+fn collect_ocg_name_set(arr_obj: Option<&Object>, doc: &PdfDocument) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let resolved = match resolve_indirect(arr_obj, doc) {
+        Some(o) => o,
+        None => return names,
+    };
+    let arr = match resolved.as_array() {
+        Some(a) => a,
+        None => return names,
+    };
+    for item in arr {
+        let resolved = match item.as_reference() {
+            Some(r) => match doc.load_object(r) {
+                Ok(o) => o,
+                Err(_) => continue,
+            },
+            None => item.clone(),
+        };
+        if let Some(d) = resolved.as_dict() {
+            if let Some(Object::Name(n)) = d.get("Name") {
+                names.insert(n.clone());
+            } else if let Some(name_obj) = d.get("Name") {
+                if let Some(b) = name_obj.as_string() {
+                    names.insert(decode_pdf_text_string(b));
+                }
+            }
+        }
+    }
+    names
+}
+
 /// OCMD visibility policy (`/P` entry). Per ISO 32000-1 §8.11.2.2 Table 102.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OcmdPolicy {

--- a/src/optional_content.rs
+++ b/src/optional_content.rs
@@ -167,10 +167,10 @@ fn collect_ocmd_ocg_names(ocgs_obj: &Object, doc: &PdfDocument) -> Vec<Object> {
 ///
 /// Semantics:
 ///  - **OCG** (dict has `/Name`): excluded iff the name is in `excluded`.
-///  - **OCMD** (dict has `/Type /OCMD` and `/OCGs`): excluded iff the OCMD
-///    visibility policy applied to the membership states (`on = !excluded`)
-///    evaluates to "hidden". `/P` defaults to `AnyOn` per spec. `/VE` is
-///    not yet supported — see [`OcmdPolicy`].
+///  - **OCMD** (dict has `/Type /OCMD`): if `/VE` is present, evaluate the
+///    visibility expression tree (`/And`, `/Or`, `/Not`); otherwise apply
+///    the `/P` policy (`AnyOn` default) over the `/OCGs` membership where
+///    `on = !excluded`. Content is excluded iff the result is "hidden".
 pub fn check_ocg_excluded(
     props_dict: &HashMap<String, Object>,
     doc: &PdfDocument,

--- a/src/optional_content.rs
+++ b/src/optional_content.rs
@@ -95,10 +95,12 @@ pub fn ocg_name_is_excluded(name_obj: &Object, excluded: &HashSet<String>) -> bo
 ///
 /// Handles indirect references at every level (the resources dict, the
 /// Properties sub-dict, and the property entry itself can all be `Reference`s).
+/// `doc` may be `None` — in that case only the inline-dict fast path resolves;
+/// the name-reference path requires indirect-object resolution.
 pub fn resolve_bdc_properties(
     properties: &Object,
     resources: Option<&Object>,
-    doc: &PdfDocument,
+    doc: Option<&PdfDocument>,
 ) -> Option<HashMap<String, Object>> {
     if let Some(dict) = properties.as_dict() {
         return Some(dict.clone());
@@ -106,6 +108,7 @@ pub fn resolve_bdc_properties(
 
     let prop_name = properties.as_name()?;
     let resources = resources?;
+    let doc = doc?;
     let res_dict = if let Some(res_ref) = resources.as_reference() {
         doc.load_object(res_ref).ok()?
     } else {
@@ -210,14 +213,27 @@ pub fn check_ocg_excluded(
 pub fn resolve_and_check_ocg_excluded(
     properties: &Object,
     resources: Option<&Object>,
-    doc: &PdfDocument,
+    doc: Option<&PdfDocument>,
     excluded: &HashSet<String>,
 ) -> bool {
     let props_dict = match resolve_bdc_properties(properties, resources, doc) {
         Some(d) => d,
         None => return false,
     };
-    check_ocg_excluded(&props_dict, doc, excluded)
+    // OCMD evaluation needs the document to resolve referenced OCG /Name fields,
+    // but the inline-OCG case (Name in the props dict) does not. If we have no
+    // doc, only the OCG-Name short-circuit inside check_ocg_excluded can fire.
+    match doc {
+        Some(d) => check_ocg_excluded(&props_dict, d, excluded),
+        None => {
+            // Without a doc, only direct OCG checks (Name in props dict) are
+            // possible — the OCMD path needs to resolve /OCGs refs.
+            if let Some(ocg_name) = props_dict.get("Name") {
+                return ocg_name_is_excluded(ocg_name, excluded);
+            }
+            false
+        },
+    }
 }
 
 /// Resolve an annotation `/OC` entry (an OCG or OCMD dict, possibly indirect)
@@ -260,11 +276,7 @@ pub fn annotation_is_excluded(
 ///  - `AllOn`  — visible iff all referenced OCGs are on → hide iff any is off.
 ///  - `AnyOff` — visible iff any referenced OCG is off → hide iff all are on.
 ///  - `AllOff` — visible iff all referenced OCGs are off → hide iff any is on.
-fn ocmd_is_hidden(
-    ocg_names: &[Object],
-    policy: OcmdPolicy,
-    excluded: &HashSet<String>,
-) -> bool {
+fn ocmd_is_hidden(ocg_names: &[Object], policy: OcmdPolicy, excluded: &HashSet<String>) -> bool {
     if ocg_names.is_empty() {
         return false;
     }
@@ -286,10 +298,10 @@ fn ocmd_is_hidden(
     }
 
     match policy {
-        OcmdPolicy::AnyOn => !any_on,    // hide when none are on
-        OcmdPolicy::AllOn => !all_on,    // hide when any is off
-        OcmdPolicy::AnyOff => !any_off,  // hide when none are off
-        OcmdPolicy::AllOff => !all_off,  // hide when any is on
+        OcmdPolicy::AnyOn => !any_on,   // hide when none are on
+        OcmdPolicy::AllOn => !all_on,   // hide when any is off
+        OcmdPolicy::AnyOff => !any_off, // hide when none are off
+        OcmdPolicy::AllOff => !all_off, // hide when any is on
     }
 }
 
@@ -326,14 +338,8 @@ mod tests {
     fn ocg_name_is_excluded_matches_name_token() {
         let mut excluded = HashSet::new();
         excluded.insert("Watermark".to_string());
-        assert!(ocg_name_is_excluded(
-            &Object::Name("Watermark".into()),
-            &excluded
-        ));
-        assert!(!ocg_name_is_excluded(
-            &Object::Name("Other".into()),
-            &excluded
-        ));
+        assert!(ocg_name_is_excluded(&Object::Name("Watermark".into()), &excluded));
+        assert!(!ocg_name_is_excluded(&Object::Name("Other".into()), &excluded));
     }
 
     #[test]

--- a/src/optional_content.rs
+++ b/src/optional_content.rs
@@ -1,0 +1,414 @@
+//! Shared Optional Content (OCG / OCMD) helpers.
+//!
+//! Both the text-extraction path (`extractors::text`) and the rendering
+//! pipeline (`rendering::page_renderer`) need to decide whether a BDC scope
+//! tagged `/OC` belongs to an excluded layer. This module owns the logic so
+//! the two callers cannot drift apart (a previous duplication caused a real
+//! correctness bug where the renderer failed to decode UTF-16LE / PDFDocEncoding
+//! layer names that the extractor handled correctly).
+//!
+//! References:
+//!  - ISO 32000-1:2008 §8.11.2 — Optional Content
+//!  - ISO 32000-1:2008 §8.11.2.2 — Optional Content Membership Dictionaries
+//!  - ISO 32000-1:2008 §7.9.2 — Text string encoding (UTF-16BE/LE/PDFDocEncoding)
+
+use std::collections::{HashMap, HashSet};
+
+use crate::document::PdfDocument;
+use crate::object::Object;
+
+/// OCMD visibility policy (`/P` entry). Per ISO 32000-1 §8.11.2.2 Table 102.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OcmdPolicy {
+    /// Visible if **any** referenced OCG is on. (Default per spec.)
+    AnyOn,
+    /// Visible only if **all** referenced OCGs are on.
+    AllOn,
+    /// Visible if **any** referenced OCG is off.
+    AnyOff,
+    /// Visible only if **all** referenced OCGs are off.
+    AllOff,
+}
+
+impl OcmdPolicy {
+    fn from_name(s: &str) -> Self {
+        match s {
+            "AllOn" => OcmdPolicy::AllOn,
+            "AnyOff" => OcmdPolicy::AnyOff,
+            "AllOff" => OcmdPolicy::AllOff,
+            // "AnyOn" or anything unknown -> spec default
+            _ => OcmdPolicy::AnyOn,
+        }
+    }
+}
+
+/// Decode a PDF text string per ISO 32000-1 §7.9.2.
+///
+/// Handles:
+///  - UTF-16BE with `FE FF` BOM
+///  - UTF-16LE with `FF FE` BOM
+///  - UTF-8 (lenient — non-spec PDFs sometimes embed raw UTF-8)
+///  - PDFDocEncoding fallback (the spec default for non-BOM strings)
+pub fn decode_pdf_text_string(bytes: &[u8]) -> String {
+    if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
+        let utf16_pairs: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .collect();
+        String::from_utf16(&utf16_pairs)
+            .unwrap_or_else(|_| String::from_utf8_lossy(bytes).to_string())
+    } else if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
+        let utf16_pairs: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect();
+        String::from_utf16(&utf16_pairs)
+            .unwrap_or_else(|_| String::from_utf8_lossy(bytes).to_string())
+    } else {
+        String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| {
+            bytes
+                .iter()
+                .filter_map(|&b| crate::fonts::font_dict::pdfdoc_encoding_lookup(b))
+                .collect()
+        })
+    }
+}
+
+/// Check if a `Name` value (which can be either a `/Name` token or a PDF string)
+/// matches any entry in `excluded`.
+pub fn ocg_name_is_excluded(name_obj: &Object, excluded: &HashSet<String>) -> bool {
+    if let Some(name_str) = name_obj.as_name() {
+        return excluded.contains(name_str);
+    }
+    if let Some(name_bytes) = name_obj.as_string() {
+        let name_str = decode_pdf_text_string(name_bytes);
+        return excluded.contains(&name_str);
+    }
+    false
+}
+
+/// Resolve a BDC `properties` operand into a property dictionary.
+///
+/// `properties` is either an inline dictionary (e.g. `BDC /OC << /Name /Foo >>`)
+/// or a name (e.g. `BDC /OC /MC0`) which references an entry in the page's
+/// `/Resources /Properties` dictionary.
+///
+/// Handles indirect references at every level (the resources dict, the
+/// Properties sub-dict, and the property entry itself can all be `Reference`s).
+pub fn resolve_bdc_properties(
+    properties: &Object,
+    resources: Option<&Object>,
+    doc: &PdfDocument,
+) -> Option<HashMap<String, Object>> {
+    if let Some(dict) = properties.as_dict() {
+        return Some(dict.clone());
+    }
+
+    let prop_name = properties.as_name()?;
+    let resources = resources?;
+    let res_dict = if let Some(res_ref) = resources.as_reference() {
+        doc.load_object(res_ref).ok()?
+    } else {
+        resources.clone()
+    };
+    let res_dict = res_dict.as_dict()?;
+    let properties_dict_obj = res_dict.get("Properties")?;
+    let properties_dict = if let Some(r) = properties_dict_obj.as_reference() {
+        doc.load_object(r).ok()?
+    } else {
+        properties_dict_obj.clone()
+    };
+    let properties_dict = properties_dict.as_dict()?;
+    let prop_obj = properties_dict.get(prop_name)?;
+    let resolved = if let Some(r) = prop_obj.as_reference() {
+        doc.load_object(r).ok()?
+    } else {
+        prop_obj.clone()
+    };
+    resolved.as_dict().cloned()
+}
+
+/// Collect the `/Name` strings of every OCG referenced by an OCMD `/OCGs` entry.
+///
+/// `/OCGs` may be either a single OCG dictionary (or reference) or an array of
+/// them. Each entry that resolves to a dictionary with a `/Name` contributes
+/// one name. References that fail to resolve are silently skipped.
+fn collect_ocmd_ocg_names(ocgs_obj: &Object, doc: &PdfDocument) -> Vec<Object> {
+    let refs: Vec<&Object> = if let Some(arr) = ocgs_obj.as_array() {
+        arr.iter().collect()
+    } else {
+        vec![ocgs_obj]
+    };
+
+    let mut names = Vec::with_capacity(refs.len());
+    for obj in refs {
+        let resolved = if let Some(r) = obj.as_reference() {
+            match doc.load_object(r) {
+                Ok(o) => o,
+                Err(_) => continue,
+            }
+        } else {
+            obj.clone()
+        };
+        if let Some(d) = resolved.as_dict() {
+            if let Some(name_obj) = d.get("Name") {
+                names.push(name_obj.clone());
+            }
+        }
+    }
+    names
+}
+
+/// Decide whether a resolved BDC properties dict represents an excluded
+/// optional-content scope (OCG or OCMD).
+///
+/// Semantics:
+///  - **OCG** (dict has `/Name`): excluded iff the name is in `excluded`.
+///  - **OCMD** (dict has `/Type /OCMD` and `/OCGs`): excluded iff the OCMD
+///    visibility policy applied to the membership states (`on = !excluded`)
+///    evaluates to "hidden". `/P` defaults to `AnyOn` per spec. `/VE` is
+///    not yet supported — see [`OcmdPolicy`].
+pub fn check_ocg_excluded(
+    props_dict: &HashMap<String, Object>,
+    doc: &PdfDocument,
+    excluded: &HashSet<String>,
+) -> bool {
+    if let Some(ocg_name) = props_dict.get("Name") {
+        return ocg_name_is_excluded(ocg_name, excluded);
+    }
+
+    if let Some(Object::Name(t)) = props_dict.get("Type") {
+        if t == "OCMD" {
+            // /VE — visibility expression. Not implemented; if present, fall
+            // through to /P / /OCGs evaluation. A future implementation would
+            // walk the operator tree and short-circuit return here.
+            //
+            // /P — visibility policy. Defaults to /AnyOn.
+            let policy = props_dict
+                .get("P")
+                .and_then(|o| o.as_name())
+                .map(OcmdPolicy::from_name)
+                .unwrap_or(OcmdPolicy::AnyOn);
+
+            let names = match props_dict.get("OCGs") {
+                Some(o) => collect_ocmd_ocg_names(o, doc),
+                None => return false,
+            };
+
+            return ocmd_is_hidden(&names, policy, excluded);
+        }
+    }
+
+    false
+}
+
+/// Resolve BDC properties and decide if the resulting scope is excluded.
+///
+/// Convenience wrapper combining [`resolve_bdc_properties`] and
+/// [`check_ocg_excluded`] — the typical call site (BDC operator handler) just
+/// needs the boolean.
+pub fn resolve_and_check_ocg_excluded(
+    properties: &Object,
+    resources: Option<&Object>,
+    doc: &PdfDocument,
+    excluded: &HashSet<String>,
+) -> bool {
+    let props_dict = match resolve_bdc_properties(properties, resources, doc) {
+        Some(d) => d,
+        None => return false,
+    };
+    check_ocg_excluded(&props_dict, doc, excluded)
+}
+
+/// Resolve an annotation `/OC` entry (an OCG or OCMD dict, possibly indirect)
+/// and decide whether the annotation belongs to an excluded layer.
+///
+/// Per ISO 32000-1 §12.5.2, annotation dictionaries can carry an `/OC` entry
+/// that references the OCG / OCMD the annotation belongs to. If that scope is
+/// excluded, the annotation should not be rendered.
+pub fn annotation_is_excluded(
+    oc_obj: &Object,
+    doc: &PdfDocument,
+    excluded: &HashSet<String>,
+) -> bool {
+    if excluded.is_empty() {
+        return false;
+    }
+    let resolved = if let Some(r) = oc_obj.as_reference() {
+        match doc.load_object(r) {
+            Ok(o) => o,
+            Err(_) => return false,
+        }
+    } else {
+        oc_obj.clone()
+    };
+    let dict = match resolved.as_dict() {
+        Some(d) => d,
+        None => return false,
+    };
+    check_ocg_excluded(dict, doc, excluded)
+}
+
+/// Apply an OCMD policy to a list of referenced OCG names.
+///
+/// Returns `true` if the content should be **hidden** (i.e. the scope evaluates
+/// to "not visible"). With no referenced OCGs the result is `false` (spec says
+/// such an OCMD is always visible, which mirrors the AnyOn-with-empty case).
+///
+/// Semantics (membership state: `on = !excluded`):
+///  - `AnyOn`  — visible iff any referenced OCG is on → hide iff all are off.
+///  - `AllOn`  — visible iff all referenced OCGs are on → hide iff any is off.
+///  - `AnyOff` — visible iff any referenced OCG is off → hide iff all are on.
+///  - `AllOff` — visible iff all referenced OCGs are off → hide iff any is on.
+fn ocmd_is_hidden(
+    ocg_names: &[Object],
+    policy: OcmdPolicy,
+    excluded: &HashSet<String>,
+) -> bool {
+    if ocg_names.is_empty() {
+        return false;
+    }
+
+    let mut any_on = false;
+    let mut any_off = false;
+    let mut all_on = true;
+    let mut all_off = true;
+
+    for name in ocg_names {
+        let is_off = ocg_name_is_excluded(name, excluded);
+        if is_off {
+            any_off = true;
+            all_on = false;
+        } else {
+            any_on = true;
+            all_off = false;
+        }
+    }
+
+    match policy {
+        OcmdPolicy::AnyOn => !any_on,    // hide when none are on
+        OcmdPolicy::AllOn => !all_on,    // hide when any is off
+        OcmdPolicy::AnyOff => !any_off,  // hide when none are off
+        OcmdPolicy::AllOff => !all_off,  // hide when any is on
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_utf16be_bom() {
+        // FE FF "Layer"
+        let bytes = b"\xFE\xFF\x00L\x00a\x00y\x00e\x00r";
+        assert_eq!(decode_pdf_text_string(bytes), "Layer");
+    }
+
+    #[test]
+    fn decode_utf16le_bom() {
+        // FF FE "Layer"
+        let bytes = b"\xFF\xFEL\x00a\x00y\x00e\x00r\x00";
+        assert_eq!(decode_pdf_text_string(bytes), "Layer");
+    }
+
+    #[test]
+    fn decode_utf8_ascii() {
+        assert_eq!(decode_pdf_text_string(b"Hello"), "Hello");
+    }
+
+    #[test]
+    fn decode_pdfdoc_fallback() {
+        // 0x85 in PDFDocEncoding = U+2013 (endash)
+        assert_eq!(decode_pdf_text_string(&[0x85]), "\u{2013}");
+    }
+
+    #[test]
+    fn ocg_name_is_excluded_matches_name_token() {
+        let mut excluded = HashSet::new();
+        excluded.insert("Watermark".to_string());
+        assert!(ocg_name_is_excluded(
+            &Object::Name("Watermark".into()),
+            &excluded
+        ));
+        assert!(!ocg_name_is_excluded(
+            &Object::Name("Other".into()),
+            &excluded
+        ));
+    }
+
+    #[test]
+    fn ocg_name_is_excluded_matches_utf16le_string() {
+        let mut excluded = HashSet::new();
+        excluded.insert("Layer".to_string());
+        let bytes: Vec<u8> = b"\xFF\xFEL\x00a\x00y\x00e\x00r\x00".to_vec();
+        assert!(ocg_name_is_excluded(&Object::String(bytes), &excluded));
+    }
+
+    #[test]
+    fn policy_default_is_any_on() {
+        assert_eq!(OcmdPolicy::from_name("nonsense"), OcmdPolicy::AnyOn);
+        assert_eq!(OcmdPolicy::from_name("AnyOn"), OcmdPolicy::AnyOn);
+        assert_eq!(OcmdPolicy::from_name("AllOn"), OcmdPolicy::AllOn);
+        assert_eq!(OcmdPolicy::from_name("AnyOff"), OcmdPolicy::AnyOff);
+        assert_eq!(OcmdPolicy::from_name("AllOff"), OcmdPolicy::AllOff);
+    }
+
+    fn names(slice: &[&str]) -> Vec<Object> {
+        slice.iter().map(|s| Object::Name((*s).into())).collect()
+    }
+
+    #[test]
+    fn policy_any_on_hides_when_all_excluded() {
+        let mut excluded = HashSet::new();
+        excluded.insert("A".to_string());
+        excluded.insert("B".to_string());
+
+        // both off -> hidden
+        assert!(ocmd_is_hidden(&names(&["A", "B"]), OcmdPolicy::AnyOn, &excluded));
+        // one on -> visible
+        assert!(!ocmd_is_hidden(&names(&["A", "C"]), OcmdPolicy::AnyOn, &excluded));
+    }
+
+    #[test]
+    fn policy_all_on_hides_when_any_excluded() {
+        let mut excluded = HashSet::new();
+        excluded.insert("A".to_string());
+
+        // any off -> hidden
+        assert!(ocmd_is_hidden(&names(&["A", "B"]), OcmdPolicy::AllOn, &excluded));
+        // all on -> visible
+        assert!(!ocmd_is_hidden(&names(&["C", "B"]), OcmdPolicy::AllOn, &excluded));
+    }
+
+    #[test]
+    fn policy_any_off_hides_when_all_on() {
+        let mut excluded = HashSet::new();
+        excluded.insert("A".to_string());
+
+        // some off -> visible
+        assert!(!ocmd_is_hidden(&names(&["A", "B"]), OcmdPolicy::AnyOff, &excluded));
+        // all on -> hidden
+        assert!(ocmd_is_hidden(&names(&["B", "C"]), OcmdPolicy::AnyOff, &excluded));
+    }
+
+    #[test]
+    fn policy_all_off_hides_when_any_on() {
+        let mut excluded = HashSet::new();
+        excluded.insert("A".to_string());
+        excluded.insert("B".to_string());
+
+        // any on -> hidden
+        assert!(ocmd_is_hidden(&names(&["A", "C"]), OcmdPolicy::AllOff, &excluded));
+        // all off -> visible
+        assert!(!ocmd_is_hidden(&names(&["A", "B"]), OcmdPolicy::AllOff, &excluded));
+    }
+
+    #[test]
+    fn empty_ocgs_is_not_hidden() {
+        let excluded = HashSet::new();
+        assert!(!ocmd_is_hidden(&[], OcmdPolicy::AnyOn, &excluded));
+        assert!(!ocmd_is_hidden(&[], OcmdPolicy::AllOn, &excluded));
+        assert!(!ocmd_is_hidden(&[], OcmdPolicy::AnyOff, &excluded));
+        assert!(!ocmd_is_hidden(&[], OcmdPolicy::AllOff, &excluded));
+    }
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -232,11 +232,10 @@ impl PyPdfDocument {
     ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
     ///
     /// Note:
-    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, a simplified
-    ///     text assembly pipeline is used (no structure-tree ordering, table
-    ///     detection, or column detection). For precise results with complex
-    ///     layouts, use ``extract_chars()`` with the same filter parameters
-    ///     and assemble text from the positioned characters.
+    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, the same
+    ///     full text assembly pipeline is used (structure-tree ordering, table
+    ///     detection, column detection) — excluded content is simply removed
+    ///     before assembly.
     #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,

--- a/src/python.rs
+++ b/src/python.rs
@@ -230,6 +230,13 @@ impl PyPdfDocument {
     ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
     ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
     ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    ///
+    /// Note:
+    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, a simplified
+    ///     text assembly pipeline is used (no structure-tree ordering, table
+    ///     detection, or column detection). For precise results with complex
+    ///     layouts, use ``extract_chars()`` with the same filter parameters
+    ///     and assemble text from the positioned characters.
     #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,

--- a/src/python.rs
+++ b/src/python.rs
@@ -261,7 +261,11 @@ impl PyPdfDocument {
                     &crate::geometry::Rect::new(x, y, w, h),
                     crate::layout::RectFilterMode::Intersects,
                 );
-                Ok(filtered.iter().map(|c| c.char.to_string()).collect::<Vec<_>>().join(""))
+                Ok(filtered
+                    .iter()
+                    .map(|c| c.char.to_string())
+                    .collect::<Vec<_>>()
+                    .join(""))
             } else {
                 self.inner
                     .extract_text_in_rect(

--- a/src/python.rs
+++ b/src/python.rs
@@ -3,6 +3,7 @@
 //! This module provides Python bindings for the PDF library, exposing the core functionality
 //! through a Python-friendly API with proper error handling and type hints.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use pyo3::exceptions::{PyIOError, PyNotImplementedError, PyRuntimeError, PyValueError};
@@ -154,6 +155,39 @@ impl PyPdfDocument {
         }
     }
 
+    /// List all Optional Content Group (OCG) layer names in the document.
+    ///
+    /// Returns:
+    ///     list[str]: Layer names from /OCProperties. Empty if no layers.
+    ///
+    /// Example:
+    ///     layers = doc.get_layers()
+    ///     # ['Dieline', 'Varnish', 'Text', 'Barcode']
+    ///     text = doc.extract_text(0, exclude_layers=['Dieline', 'Varnish'])
+    fn get_layers(&mut self) -> PyResult<Vec<String>> {
+        self.inner
+            .get_layers()
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get layers: {}", e)))
+    }
+
+    /// List ink / separation names used on a specific page.
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///
+    /// Returns:
+    ///     list[str]: Ink names from Separation/DeviceN color spaces.
+    ///
+    /// Example:
+    ///     inks = doc.get_page_inks(0)
+    ///     # ['PANTONE 186 C', 'Spot Varnish', 'Die Cut']
+    ///     text = doc.extract_text(0, exclude_inks=['Spot Varnish', 'Die Cut'])
+    fn get_page_inks(&mut self, page: usize) -> PyResult<Vec<String>> {
+        self.inner
+            .get_page_inks(page)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page inks: {}", e)))
+    }
+
     /// Enumerate existing PDF signatures. Returns a list of
     /// `Signature` objects — empty list when the document has no
     /// AcroForm or no signed signature fields.
@@ -190,21 +224,55 @@ impl PyPdfDocument {
     }
 
     /// Extract text from a page.
-    #[pyo3(signature = (page, region=None))]
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
+    ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
+    ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,
         page: usize,
         region: Option<(f32, f32, f32, f32)>,
+        exclude_layers: Option<Vec<String>>,
+        exclude_inks: Option<Vec<String>>,
     ) -> PyResult<String> {
+        let has_filters = exclude_layers.is_some() || exclude_inks.is_some();
+        let layers: HashSet<String> = exclude_layers.unwrap_or_default().into_iter().collect();
+        let inks: HashSet<String> = exclude_inks.unwrap_or_default().into_iter().collect();
+
         if let Some((x, y, w, h)) = region {
+            if has_filters {
+                // Filtered extraction with region: extract filtered text, then
+                // filter chars by rect from the result. For region + filter combos
+                // we do filtered span extraction and then apply the region filter.
+                let text = self
+                    .inner
+                    .extract_text_filtered(page, layers, inks)
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
+                    })?;
+                // When both region and filters are specified, the region filter
+                // is best-effort since extract_text_filtered returns a string.
+                // For precise region + filter, use extract_chars with both params.
+                Ok(text)
+            } else {
+                self.inner
+                    .extract_text_in_rect(
+                        page,
+                        crate::geometry::Rect::new(x, y, w, h),
+                        crate::layout::RectFilterMode::Intersects,
+                    )
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to extract text in region: {}", e))
+                    })
+            }
+        } else if has_filters {
             self.inner
-                .extract_text_in_rect(
-                    page,
-                    crate::geometry::Rect::new(x, y, w, h),
-                    crate::layout::RectFilterMode::Intersects,
-                )
+                .extract_text_filtered(page, layers, inks)
                 .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to extract text in region: {}", e))
+                    PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
                 })
         } else {
             self.inner
@@ -531,13 +599,42 @@ impl PyPdfDocument {
     }
 
     /// Extract low-level characters.
-    #[pyo3(signature = (page, region=None))]
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
+    ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
+    ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_chars(
         &mut self,
         page: usize,
         region: Option<(f32, f32, f32, f32)>,
+        exclude_layers: Option<Vec<String>>,
+        exclude_inks: Option<Vec<String>>,
     ) -> PyResult<Vec<PyTextChar>> {
-        let chars_result = if let Some((x, y, w, h)) = region {
+        let has_filters = exclude_layers.is_some() || exclude_inks.is_some();
+        let layers: HashSet<String> = exclude_layers.unwrap_or_default().into_iter().collect();
+        let inks: HashSet<String> = exclude_inks.unwrap_or_default().into_iter().collect();
+
+        let chars_result = if has_filters {
+            let chars = self
+                .inner
+                .extract_chars_filtered(page, layers, inks)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to extract characters: {}", e))
+                })?;
+            // Apply region filter on top if specified
+            if let Some((x, y, w, h)) = region {
+                use crate::layout::SpatialCollectionFiltering;
+                Ok(chars.filter_by_rect(
+                    &crate::geometry::Rect::new(x, y, w, h),
+                    crate::layout::RectFilterMode::Intersects,
+                ))
+            } else {
+                Ok(chars)
+            }
+        } else if let Some((x, y, w, h)) = region {
             self.inner.extract_chars_in_rect(
                 page,
                 crate::geometry::Rect::new(x, y, w, h),
@@ -2658,12 +2755,16 @@ impl PyDocPage {
 
     #[getter]
     fn text(&self, py: Python<'_>) -> PyResult<String> {
-        self.doc.borrow_mut(py).extract_text(self.page_index, None)
+        self.doc
+            .borrow_mut(py)
+            .extract_text(self.page_index, None, None, None)
     }
 
     #[getter]
     fn chars(&self, py: Python<'_>) -> PyResult<Vec<PyTextChar>> {
-        self.doc.borrow_mut(py).extract_chars(self.page_index, None)
+        self.doc
+            .borrow_mut(py)
+            .extract_chars(self.page_index, None, None, None)
     }
 
     #[getter]
@@ -3266,7 +3367,7 @@ impl PyPdfPageRegion {
     }
     fn extract_text(&self, py: Python<'_>) -> PyResult<String> {
         let mut d = self.doc.bind(py).borrow_mut();
-        d.extract_text(self.page_index, Some(self.bbox()))
+        d.extract_text(self.page_index, Some(self.bbox()), None, None)
     }
     fn extract_words(&self, py: Python<'_>) -> PyResult<Vec<PyWord>> {
         let mut d = self.doc.bind(py).borrow_mut();

--- a/src/python.rs
+++ b/src/python.rs
@@ -401,6 +401,7 @@ impl PyPdfDocument {
     ///   (wins over `background`).
     /// - `render_annotations`: toggle for annotation rendering.
     /// - `jpeg_quality`: 1..=100, only applied when `format="jpeg"`.
+    /// - `excluded_layers`: list of OCG layer names to hide during rendering.
     #[pyo3(signature = (
         page,
         dpi=None,
@@ -409,6 +410,7 @@ impl PyPdfDocument {
         transparent=false,
         render_annotations=None,
         jpeg_quality=None,
+        excluded_layers=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn render_page(
@@ -420,6 +422,7 @@ impl PyPdfDocument {
         transparent: bool,
         render_annotations: Option<bool>,
         jpeg_quality: Option<u8>,
+        excluded_layers: Option<Vec<String>>,
     ) -> PyResult<Vec<u8>> {
         #[cfg(feature = "rendering")]
         {
@@ -458,6 +461,9 @@ impl PyPdfDocument {
             if let Some(flag) = render_annotations {
                 options.render_annotations = flag;
             }
+            if let Some(layers) = excluded_layers {
+                options.excluded_layers = layers.into_iter().collect();
+            }
 
             crate::rendering::render_page(&self.inner, page, &options)
                 .map(|img| img.data)
@@ -465,7 +471,16 @@ impl PyPdfDocument {
         }
         #[cfg(not(feature = "rendering"))]
         {
-            let _ = (page, dpi, format, background, transparent, render_annotations, jpeg_quality);
+            let _ = (
+                page,
+                dpi,
+                format,
+                background,
+                transparent,
+                render_annotations,
+                jpeg_quality,
+                excluded_layers,
+            );
             Err(PyRuntimeError::new_err("Rendering feature not enabled."))
         }
     }
@@ -485,12 +500,14 @@ impl PyPdfDocument {
     ///     transparent (bool, optional): If True, no background fill.
     ///     render_annotations (bool, optional): default True.
     ///     jpeg_quality (int, optional): 1-100, default 85.
+    ///     excluded_layers (list[str], optional): OCG layer names to hide.
     ///
     /// Returns: bytes of the rendered image. Issue #441 / #448.
     #[pyo3(signature = (
         page, width, height, *,
         format=None, background=None, transparent=false,
         render_annotations=None, jpeg_quality=None,
+        excluded_layers=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn render_page_fit(
@@ -503,6 +520,7 @@ impl PyPdfDocument {
         transparent: bool,
         render_annotations: Option<bool>,
         jpeg_quality: Option<u8>,
+        excluded_layers: Option<Vec<String>>,
     ) -> PyResult<Vec<u8>> {
         #[cfg(feature = "rendering")]
         {
@@ -544,6 +562,9 @@ impl PyPdfDocument {
             if let Some(flag) = render_annotations {
                 options.render_annotations = flag;
             }
+            if let Some(layers) = excluded_layers {
+                options.excluded_layers = layers.into_iter().collect();
+            }
 
             crate::rendering::render_page_fit(&self.inner, page, width, height, &options)
                 .map(|img| img.data)
@@ -560,6 +581,7 @@ impl PyPdfDocument {
                 transparent,
                 render_annotations,
                 jpeg_quality,
+                excluded_layers,
             );
             Err(PyRuntimeError::new_err("Rendering feature not enabled."))
         }
@@ -2902,6 +2924,7 @@ impl PyDocPage {
         transparent=false,
         render_annotations=None,
         jpeg_quality=None,
+        excluded_layers=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn render(
@@ -2913,6 +2936,7 @@ impl PyDocPage {
         transparent: bool,
         render_annotations: Option<bool>,
         jpeg_quality: Option<u8>,
+        excluded_layers: Option<Vec<String>>,
     ) -> PyResult<Vec<u8>> {
         self.doc.borrow_mut(py).render_page(
             self.page_index,
@@ -2922,6 +2946,7 @@ impl PyDocPage {
             transparent,
             render_annotations,
             jpeg_quality,
+            excluded_layers,
         )
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -244,19 +244,18 @@ impl PyPdfDocument {
 
         if let Some((x, y, w, h)) = region {
             if has_filters {
-                // Filtered extraction with region: extract filtered text, then
-                // filter chars by rect from the result. For region + filter combos
-                // we do filtered span extraction and then apply the region filter.
-                let text = self
+                let chars = self
                     .inner
-                    .extract_text_filtered(page, layers, inks)
+                    .extract_chars_filtered(page, layers, inks)
                     .map_err(|e| {
                         PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
                     })?;
-                // When both region and filters are specified, the region filter
-                // is best-effort since extract_text_filtered returns a string.
-                // For precise region + filter, use extract_chars with both params.
-                Ok(text)
+                use crate::layout::SpatialCollectionFiltering;
+                let filtered = chars.filter_by_rect(
+                    &crate::geometry::Rect::new(x, y, w, h),
+                    crate::layout::RectFilterMode::Intersects,
+                );
+                Ok(filtered.iter().map(|c| c.char.to_string()).collect::<Vec<_>>().join(""))
             } else {
                 self.inner
                     .extract_text_in_rect(

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -1284,7 +1284,8 @@ impl PageRenderer {
                                 &self.fonts,
                             )?
                         } else {
-                            self.text_rasterizer.measure_tj_array(array, gs, &self.fonts)
+                            self.text_rasterizer
+                                .measure_tj_array(array, gs, &self.fonts)
                         };
 
                         let gs_mut = gs_stack.current_mut();
@@ -1474,7 +1475,7 @@ impl PageRenderer {
                         is_excluded = crate::optional_content::resolve_and_check_ocg_excluded(
                             properties,
                             Some(resources),
-                            doc,
+                            Some(doc),
                             excluded_layers,
                         );
                     }
@@ -2347,19 +2348,15 @@ impl PageRenderer {
     ) -> Result<()> {
         let annotations = doc.get_annotations(page_num)?;
         // Reuse the per-render snapshot so we don't deep-clone the HashSet here.
-        let excluded_snapshot: Option<Arc<HashSet<String>>> =
-            self.excluded_layers_snapshot.clone();
+        let excluded_snapshot: Option<Arc<HashSet<String>>> = self.excluded_layers_snapshot.clone();
         for annot in annotations {
             // Per ISO 32000-1 §12.5.2, an annotation dict may carry an /OC
             // entry referencing the OCG/OCMD the annotation belongs to. Skip
             // the annotation entirely if its layer is excluded.
             if let Some(ref excluded_layers) = excluded_snapshot {
                 if let Some(oc_obj) = annot.raw_dict.as_ref().and_then(|d| d.get("OC")) {
-                    if crate::optional_content::annotation_is_excluded(
-                        oc_obj,
-                        doc,
-                        excluded_layers,
-                    ) {
+                    if crate::optional_content::annotation_is_excluded(oc_obj, doc, excluded_layers)
+                    {
                         continue;
                     }
                 }

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -145,6 +145,12 @@ pub struct PageRenderer {
     fonts: HashMap<String, Arc<FontInfo>>,
     /// Color space cache (name -> Object) for current context
     color_spaces: HashMap<String, Object>,
+    /// Snapshot of `options.excluded_layers` wrapped in an `Arc` so that every
+    /// recursive `execute_operators` call holds a cheap reference instead of
+    /// deep-cloning the set per nested Form XObject. Recomputed on the first
+    /// access per `render_page` invocation. Stays `None` (no allocation) when
+    /// the set is empty — the common case.
+    excluded_layers_snapshot: Option<Arc<HashSet<String>>>,
 }
 
 impl PageRenderer {
@@ -156,6 +162,7 @@ impl PageRenderer {
             text_rasterizer: TextRasterizer::new(),
             fonts: HashMap::new(),
             color_spaces: HashMap::new(),
+            excluded_layers_snapshot: None,
         }
     }
 
@@ -173,6 +180,15 @@ impl PageRenderer {
         // Clear caches for new page
         self.fonts.clear();
         self.color_spaces.clear();
+
+        // Refresh the excluded-layers snapshot once per page so that every
+        // recursive `execute_operators` / Form-XObject pass below can hold a
+        // cheap `Arc` reference instead of re-cloning the HashSet.
+        self.excluded_layers_snapshot = if self.options.excluded_layers.is_empty() {
+            None
+        } else {
+            Some(Arc::new(self.options.excluded_layers.clone()))
+        };
 
         // Get page info
         let page_info = doc.get_page_info(page_num)?;
@@ -377,10 +393,16 @@ impl PageRenderer {
         page_num: usize,
         resources: &Object,
     ) -> Result<()> {
-        // Snapshot excluded layers once so the operator loop below can use a
-        // borrow without conflicting with the `&mut self` calls inside it.
-        let excluded_layers = self.options.excluded_layers.clone();
-        let excluded_layers = &excluded_layers;
+        // Per-render snapshot lives on `self.excluded_layers_snapshot` (filled
+        // by `render_page_with_options`). Recursive calls into this function
+        // reuse the same `Arc` without any allocation. We snapshot it as a
+        // local `Arc::clone` (cheap pointer copy) so the operator loop below
+        // can hold a `&HashSet` reference while still calling `&mut self`
+        // methods through the inner match arms.
+        let snapshot: Option<Arc<HashSet<String>>> = self.excluded_layers_snapshot.clone();
+        static EMPTY: std::sync::OnceLock<HashSet<String>> = std::sync::OnceLock::new();
+        let empty_ref: &HashSet<String> = EMPTY.get_or_init(HashSet::new);
+        let excluded_layers: &HashSet<String> = snapshot.as_deref().unwrap_or(empty_ref);
         let mut gs_stack = GraphicsStateStack::new();
 
         // PDF default: DeviceGray, black
@@ -1115,15 +1137,23 @@ impl PageRenderer {
                     current_path = PathBuilder::new();
                 },
 
-                // Clipping
+                // Clipping — suppressed inside an excluded OCG scope. Per PDF
+                // spec the clip is a graphics-state side-effect; without
+                // gating it, a `W n` issued inside an excluded BDC scope that
+                // is not bracketed by `q/Q` would silently restrict subsequent
+                // visible content.
                 Operator::ClipNonZero => {
-                    if let Some(path) = current_path.clone().finish() {
-                        pending_clip = Some((path, tiny_skia::FillRule::Winding));
+                    if excluded_layer_depth == 0 {
+                        if let Some(path) = current_path.clone().finish() {
+                            pending_clip = Some((path, tiny_skia::FillRule::Winding));
+                        }
                     }
                 },
                 Operator::ClipEvenOdd => {
-                    if let Some(path) = current_path.clone().finish() {
-                        pending_clip = Some((path, tiny_skia::FillRule::EvenOdd));
+                    if excluded_layer_depth == 0 {
+                        if let Some(path) = current_path.clone().finish() {
+                            pending_clip = Some((path, tiny_skia::FillRule::EvenOdd));
+                        }
                     }
                 },
 
@@ -1159,22 +1189,28 @@ impl PageRenderer {
                     gs_stack.current_mut().render_mode = *render;
                 },
 
-                // Text showing — suppressed when inside an excluded OCG layer
+                // Text showing — glyphs suppressed inside an excluded OCG layer,
+                // but the text matrix still advances so that subsequent visible
+                // text inside the same BT/ET paints at the correct X position.
                 Operator::Tj { text } => {
-                    if in_text_object && excluded_layer_depth == 0 {
-                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                    if in_text_object {
                         let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        let advance = self.text_rasterizer.render_text(
-                            pixmap,
-                            text,
-                            transform,
-                            gs,
-                            resources,
-                            doc,
-                            clip,
-                            &self.fonts,
-                        )?;
+                        let advance = if excluded_layer_depth == 0 {
+                            let clip = clip_stack.last().and_then(|c| c.as_ref());
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            self.text_rasterizer.render_text(
+                                pixmap,
+                                text,
+                                transform,
+                                gs,
+                                resources,
+                                doc,
+                                clip,
+                                &self.fonts,
+                            )?
+                        } else {
+                            self.text_rasterizer.measure_text(text, gs, &self.fonts)
+                        };
 
                         let gs_mut = gs_stack.current_mut();
                         let advance_matrix = Matrix::translation(advance, 0.0);
@@ -1190,9 +1226,9 @@ impl PageRenderer {
                         gs_mut.text_line_matrix = translation.multiply(&gs_mut.text_line_matrix);
                         gs_mut.text_matrix = gs_mut.text_line_matrix;
 
-                        if excluded_layer_depth == 0 {
+                        let gs = gs_stack.current();
+                        let advance = if excluded_layer_depth == 0 {
                             let clip = clip_stack.last().and_then(|c| c.as_ref());
-                            let gs = gs_stack.current();
                             let transform = combine_transforms(base_transform, &gs.ctm);
                             log::debug!(
                                 "' (Quote): rendering text at Tm=[{}, {}, {}, {}, {}, {}]",
@@ -1203,7 +1239,7 @@ impl PageRenderer {
                                 gs.text_matrix.e,
                                 gs.text_matrix.f
                             );
-                            let advance = self.text_rasterizer.render_text(
+                            self.text_rasterizer.render_text(
                                 pixmap,
                                 text,
                                 transform,
@@ -1212,38 +1248,44 @@ impl PageRenderer {
                                 doc,
                                 clip,
                                 &self.fonts,
-                            )?;
+                            )?
+                        } else {
+                            self.text_rasterizer.measure_text(text, gs, &self.fonts)
+                        };
 
-                            let gs_mut = gs_stack.current_mut();
-                            let advance_matrix = Matrix::translation(advance, 0.0);
-                            gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
-                        }
+                        let gs_mut = gs_stack.current_mut();
+                        let advance_matrix = Matrix::translation(advance, 0.0);
+                        gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
                     }
                 },
                 Operator::TJ { array } => {
-                    if in_text_object && excluded_layer_depth == 0 {
-                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                    if in_text_object {
                         let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        log::debug!(
-                            "TJ: rendering array at Tm=[{}, {}, {}, {}, {}, {}]",
-                            gs.text_matrix.a,
-                            gs.text_matrix.b,
-                            gs.text_matrix.c,
-                            gs.text_matrix.d,
-                            gs.text_matrix.e,
-                            gs.text_matrix.f
-                        );
-                        let advance = self.text_rasterizer.render_tj_array(
-                            pixmap,
-                            array,
-                            transform,
-                            gs,
-                            resources,
-                            doc,
-                            clip,
-                            &self.fonts,
-                        )?;
+                        let advance = if excluded_layer_depth == 0 {
+                            let clip = clip_stack.last().and_then(|c| c.as_ref());
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            log::debug!(
+                                "TJ: rendering array at Tm=[{}, {}, {}, {}, {}, {}]",
+                                gs.text_matrix.a,
+                                gs.text_matrix.b,
+                                gs.text_matrix.c,
+                                gs.text_matrix.d,
+                                gs.text_matrix.e,
+                                gs.text_matrix.f
+                            );
+                            self.text_rasterizer.render_tj_array(
+                                pixmap,
+                                array,
+                                transform,
+                                gs,
+                                resources,
+                                doc,
+                                clip,
+                                &self.fonts,
+                            )?
+                        } else {
+                            self.text_rasterizer.measure_tj_array(array, gs, &self.fonts)
+                        };
 
                         let gs_mut = gs_stack.current_mut();
                         let advance_matrix = Matrix::translation(advance, 0.0);
@@ -1266,9 +1308,9 @@ impl PageRenderer {
                         gs_mut.text_line_matrix = translation.multiply(&gs_mut.text_line_matrix);
                         gs_mut.text_matrix = gs_mut.text_line_matrix;
 
-                        if excluded_layer_depth == 0 {
+                        let gs = gs_stack.current();
+                        let advance = if excluded_layer_depth == 0 {
                             let clip = clip_stack.last().and_then(|c| c.as_ref());
-                            let gs = gs_stack.current();
                             let transform = combine_transforms(base_transform, &gs.ctm);
                             log::debug!(
                                 "\" (DoubleQuote): rendering text at Tm=[{}, {}, {}, {}, {}, {}]",
@@ -1279,7 +1321,7 @@ impl PageRenderer {
                                 gs.text_matrix.e,
                                 gs.text_matrix.f
                             );
-                            let advance = self.text_rasterizer.render_text(
+                            self.text_rasterizer.render_text(
                                 pixmap,
                                 text,
                                 transform,
@@ -1288,12 +1330,14 @@ impl PageRenderer {
                                 doc,
                                 clip,
                                 &self.fonts,
-                            )?;
+                            )?
+                        } else {
+                            self.text_rasterizer.measure_text(text, gs, &self.fonts)
+                        };
 
-                            let gs_mut = gs_stack.current_mut();
-                            let advance_matrix = Matrix::translation(advance, 0.0);
-                            gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
-                        }
+                        let gs_mut = gs_stack.current_mut();
+                        let advance_matrix = Matrix::translation(advance, 0.0);
+                        gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
                     }
                 },
 
@@ -1392,14 +1436,21 @@ impl PageRenderer {
                 // EndPath (n operator): discard current path without painting,
                 // but apply any pending clip. Per PDF spec, W n is the standard
                 // way to set a clipping path without filling or stroking.
+                // Suppress the clip application inside an excluded OCG scope so
+                // the clip doesn't leak past EMC into visible content.
                 Operator::EndPath => {
-                    apply_pending_clip(
-                        &mut pending_clip,
-                        &mut clip_stack,
-                        pixmap,
-                        base_transform,
-                        &gs_stack,
-                    );
+                    if excluded_layer_depth == 0 {
+                        apply_pending_clip(
+                            &mut pending_clip,
+                            &mut clip_stack,
+                            pixmap,
+                            base_transform,
+                            &gs_stack,
+                        );
+                    } else {
+                        // Drop any pending clip without applying it.
+                        let _ = pending_clip.take();
+                    }
                     current_path = PathBuilder::new();
                 },
 
@@ -2295,7 +2346,24 @@ impl PageRenderer {
         page_num: usize,
     ) -> Result<()> {
         let annotations = doc.get_annotations(page_num)?;
+        // Reuse the per-render snapshot so we don't deep-clone the HashSet here.
+        let excluded_snapshot: Option<Arc<HashSet<String>>> =
+            self.excluded_layers_snapshot.clone();
         for annot in annotations {
+            // Per ISO 32000-1 §12.5.2, an annotation dict may carry an /OC
+            // entry referencing the OCG/OCMD the annotation belongs to. Skip
+            // the annotation entirely if its layer is excluded.
+            if let Some(ref excluded_layers) = excluded_snapshot {
+                if let Some(oc_obj) = annot.raw_dict.as_ref().and_then(|d| d.get("OC")) {
+                    if crate::optional_content::annotation_is_excluded(
+                        oc_obj,
+                        doc,
+                        excluded_layers,
+                    ) {
+                        continue;
+                    }
+                }
+            }
             // Check if annotation has an appearance stream (/AP)
             if let Some(ap_obj) = annot.raw_dict.as_ref().and_then(|d| d.get("AP")) {
                 let ap_stream_obj = doc.resolve_object(ap_obj)?;

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -1420,9 +1420,9 @@ impl PageRenderer {
                 Operator::BeginMarkedContentDict { tag, properties } => {
                     let mut is_excluded = false;
                     if tag == "OC" && !excluded_layers.is_empty() {
-                        is_excluded = resolve_and_check_ocg_excluded(
+                        is_excluded = crate::optional_content::resolve_and_check_ocg_excluded(
                             properties,
-                            resources,
+                            Some(resources),
                             doc,
                             excluded_layers,
                         );
@@ -2532,127 +2532,6 @@ fn encode_png(pixmap: &Pixmap) -> Result<Vec<u8>> {
 /// Combine two transformations.
 fn combine_transforms(base: Transform, ctm: &Matrix) -> Transform {
     base.pre_concat(Transform::from_row(ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f))
-}
-
-/// Resolve BDC properties and check whether the referenced OCG/OCMD is excluded.
-///
-/// Mirrors the logic from `TextExtractor::check_ocg_excluded` but operates as
-/// a standalone function for the renderer (which doesn't hold a TextExtractor).
-fn resolve_and_check_ocg_excluded(
-    properties: &Object,
-    resources: &Object,
-    doc: &PdfDocument,
-    excluded_layers: &HashSet<String>,
-) -> bool {
-    let props_dict = match resolve_bdc_properties_for_render(properties, resources, doc) {
-        Some(d) => d,
-        None => return false,
-    };
-    check_ocg_excluded_render(&props_dict, doc, excluded_layers)
-}
-
-/// Resolve BDC properties: inline dict or name reference into /Properties resource.
-fn resolve_bdc_properties_for_render(
-    properties: &Object,
-    resources: &Object,
-    doc: &PdfDocument,
-) -> Option<HashMap<String, Object>> {
-    if let Some(dict) = properties.as_dict() {
-        return Some(dict.clone());
-    }
-
-    let prop_name = properties.as_name()?;
-    let res_dict = resources.as_dict()?;
-    let properties_dict_obj = res_dict.get("Properties")?;
-    let properties_dict = match properties_dict_obj.as_reference() {
-        Some(r) => doc.load_object(r).ok()?,
-        None => properties_dict_obj.clone(),
-    };
-    let properties_dict = properties_dict.as_dict()?;
-    let prop_obj = properties_dict.get(prop_name)?;
-    let resolved = match prop_obj.as_reference() {
-        Some(r) => doc.load_object(r).ok()?,
-        None => prop_obj.clone(),
-    };
-    resolved.as_dict().cloned()
-}
-
-/// Check whether a resolved BDC properties dict represents an excluded OCG or OCMD.
-fn check_ocg_excluded_render(
-    props_dict: &HashMap<String, Object>,
-    doc: &PdfDocument,
-    excluded_layers: &HashSet<String>,
-) -> bool {
-    if let Some(ocg_name) = props_dict.get("Name") {
-        return ocg_name_is_excluded_render(ocg_name, excluded_layers);
-    }
-
-    if let Some(Object::Name(t)) = props_dict.get("Type") {
-        if t == "OCMD" {
-            if let Some(ocgs_obj) = props_dict.get("OCGs") {
-                return ocmd_ocgs_excluded_render(ocgs_obj, doc, excluded_layers);
-            }
-        }
-    }
-
-    false
-}
-
-fn ocg_name_is_excluded_render(name_obj: &Object, excluded_layers: &HashSet<String>) -> bool {
-    if let Some(name_str) = name_obj.as_name() {
-        return excluded_layers.contains(name_str);
-    }
-    if let Some(name_bytes) = name_obj.as_string() {
-        let name_str = decode_pdf_text_string_simple(name_bytes);
-        return excluded_layers.contains(&name_str);
-    }
-    false
-}
-
-fn ocmd_ocgs_excluded_render(
-    ocgs_obj: &Object,
-    doc: &PdfDocument,
-    excluded_layers: &HashSet<String>,
-) -> bool {
-    let refs: Vec<&Object> = if let Some(arr) = ocgs_obj.as_array() {
-        arr.iter().collect()
-    } else {
-        vec![ocgs_obj]
-    };
-
-    for obj in refs {
-        let resolved = if let Some(r) = obj.as_reference() {
-            match doc.load_object(r) {
-                Ok(o) => o,
-                Err(_) => continue,
-            }
-        } else {
-            obj.clone()
-        };
-        if let Some(d) = resolved.as_dict() {
-            if let Some(name_obj) = d.get("Name") {
-                if ocg_name_is_excluded_render(name_obj, excluded_layers) {
-                    return true;
-                }
-            }
-        }
-    }
-    false
-}
-
-/// Minimal PDF text string decoder (UTF-16BE BOM or latin-1 fallback).
-fn decode_pdf_text_string_simple(bytes: &[u8]) -> String {
-    if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
-        let utf16_pairs: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
-            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
-            .collect();
-        String::from_utf16(&utf16_pairs)
-            .unwrap_or_else(|_| String::from_utf8_lossy(bytes).to_string())
-    } else {
-        String::from_utf8(bytes.to_vec())
-            .unwrap_or_else(|_| bytes.iter().map(|&b| b as char).collect())
-    }
 }
 
 /// Convert DeviceCMYK (0.0–1.0) to DeviceRGB (0.0–1.0) per ISO 32000-1:2008

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -1471,7 +1471,12 @@ impl PageRenderer {
                 },
                 Operator::BeginMarkedContentDict { tag, properties } => {
                     let mut is_excluded = false;
-                    if tag == "OC" && !excluded_layers.is_empty() {
+                    // Tag "OC" scopes can hide content even with empty excluded_layers
+                    // when the OCMD uses /VE /Not or /P /AllOff/AnyOff (the
+                    // expression evaluates with all OCGs on by default). We can
+                    // only short-circuit cheaply for simple OCG refs, which the
+                    // optional_content module handles internally.
+                    if tag == "OC" {
                         is_excluded = crate::optional_content::resolve_and_check_ocg_excluded(
                             properties,
                             Some(resources),

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -181,13 +181,20 @@ impl PageRenderer {
         self.fonts.clear();
         self.color_spaces.clear();
 
-        // Refresh the excluded-layers snapshot once per page so that every
-        // recursive `execute_operators` / Form-XObject pass below can hold a
-        // cheap `Arc` reference instead of re-cloning the HashSet.
-        self.excluded_layers_snapshot = if self.options.excluded_layers.is_empty() {
+        // Refresh the excluded-layers snapshot once per page. The effective
+        // set combines (a) the PDF's default-off OCGs per /OCProperties/D
+        // (BaseState, /ON, /OFF) — ISO 32000-1 §8.11.4 — with (b) the caller's
+        // explicit excluded_layers. This makes the renderer respect the PDF's
+        // default visibility configuration, matching a viewer's initial state.
+        let default_off = crate::optional_content::compute_default_off_ocgs(doc);
+        let effective: HashSet<String> = default_off
+            .into_iter()
+            .chain(self.options.excluded_layers.iter().cloned())
+            .collect();
+        self.excluded_layers_snapshot = if effective.is_empty() {
             None
         } else {
-            Some(Arc::new(self.options.excluded_layers.clone()))
+            Some(Arc::new(effective))
         };
 
         // Get page info

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -23,7 +23,7 @@ use crate::rendering::path_rasterizer::PathRasterizer;
 use crate::rendering::text_rasterizer::TextRasterizer;
 
 use crate::fonts::FontInfo;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tiny_skia::{Color, PathBuilder, Pixmap, PixmapPaint, Transform};
 
@@ -53,6 +53,12 @@ pub struct RenderOptions {
     pub render_annotations: bool,
     /// JPEG quality (1-100, default: 85)
     pub jpeg_quality: u8,
+    /// Optional Content Group (layer) names to exclude from rendering.
+    ///
+    /// When a BDC operator with tag "OC" references an OCG whose /Name matches
+    /// one of these entries, all graphical content within that marked content
+    /// scope is suppressed (not painted). Empty means render everything.
+    pub excluded_layers: HashSet<String>,
     /// Explicit float scale factor set by `render_page_fit`.
     /// When `Some`, bypasses integer-DPI quantization so fit dimensions are
     /// exact (issue #480). Not part of the public API; set via
@@ -68,6 +74,7 @@ impl Default for RenderOptions {
             background: Some([1.0, 1.0, 1.0, 1.0]), // White background
             render_annotations: true,
             jpeg_quality: 85,
+            excluded_layers: HashSet::new(),
             scale_override: None,
         }
     }
@@ -357,6 +364,10 @@ impl PageRenderer {
     }
 
     /// Execute PDF operators to render content.
+    ///
+    /// OCG layer exclusion is sourced from `self.options.excluded_layers`;
+    /// BDC/EMC operators referencing matching layers cause graphical operators
+    /// inside that scope to be silently dropped.
     fn execute_operators(
         &mut self,
         pixmap: &mut Pixmap,
@@ -366,6 +377,10 @@ impl PageRenderer {
         page_num: usize,
         resources: &Object,
     ) -> Result<()> {
+        // Snapshot excluded layers once so the operator loop below can use a
+        // borrow without conflicting with the `&mut self` calls inside it.
+        let excluded_layers = self.options.excluded_layers.clone();
+        let excluded_layers = &excluded_layers;
         let mut gs_stack = GraphicsStateStack::new();
 
         // PDF default: DeviceGray, black
@@ -381,6 +396,14 @@ impl PageRenderer {
         let mut current_path = PathBuilder::new();
         let mut pending_clip: Option<(tiny_skia::Path, tiny_skia::FillRule)> = None;
         let mut clip_stack: Vec<Option<tiny_skia::Mask>> = vec![None]; // Start with no clip at depth 0
+
+        // OCG layer exclusion tracking.
+        // `excluded_layer_depth` counts how many nested BDC/OC scopes we are
+        // inside that match an excluded layer. >0 means content is suppressed.
+        // `marked_content_depth` tracks total BDC/BMC nesting so EMC correctly
+        // decrements only when it pops an excluded-layer entry.
+        let mut excluded_layer_depth: u32 = 0;
+        let mut marked_content_is_excluded: Vec<bool> = Vec::new();
 
         // Per-`execute_operators` resolved ExtGState resource dictionary. PDF
         // content streams often invoke `gs<N>` thousands of times per page
@@ -981,99 +1004,113 @@ impl PageRenderer {
                     current_path.close();
                 },
 
-                // Path painting
+                // Path painting — suppressed when inside an excluded OCG layer
                 Operator::Stroke => {
-                    apply_pending_clip(
-                        &mut pending_clip,
-                        &mut clip_stack,
-                        pixmap,
-                        base_transform,
-                        &gs_stack,
-                    );
-                    let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    if let Some(path) = current_path.finish() {
-                        let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        self.path_rasterizer
-                            .stroke_path_clipped(pixmap, &path, transform, gs, clip);
+                    if excluded_layer_depth == 0 {
+                        apply_pending_clip(
+                            &mut pending_clip,
+                            &mut clip_stack,
+                            pixmap,
+                            base_transform,
+                            &gs_stack,
+                        );
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        if let Some(path) = current_path.finish() {
+                            let gs = gs_stack.current();
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            self.path_rasterizer
+                                .stroke_path_clipped(pixmap, &path, transform, gs, clip);
+                        }
+                    } else {
+                        let _ = current_path.finish();
                     }
                     current_path = PathBuilder::new();
                 },
                 Operator::Fill => {
-                    apply_pending_clip(
-                        &mut pending_clip,
-                        &mut clip_stack,
-                        pixmap,
-                        base_transform,
-                        &gs_stack,
-                    );
-                    let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    if let Some(path) = current_path.finish() {
-                        let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        self.path_rasterizer.fill_path_clipped(
+                    if excluded_layer_depth == 0 {
+                        apply_pending_clip(
+                            &mut pending_clip,
+                            &mut clip_stack,
                             pixmap,
-                            &path,
-                            transform,
-                            gs,
-                            tiny_skia::FillRule::Winding,
-                            clip,
+                            base_transform,
+                            &gs_stack,
                         );
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        if let Some(path) = current_path.finish() {
+                            let gs = gs_stack.current();
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            self.path_rasterizer.fill_path_clipped(
+                                pixmap,
+                                &path,
+                                transform,
+                                gs,
+                                tiny_skia::FillRule::Winding,
+                                clip,
+                            );
+                        }
+                    } else {
+                        let _ = current_path.finish();
                     }
                     current_path = PathBuilder::new();
                 },
                 Operator::FillStroke
                 | Operator::CloseFillStroke
                 | Operator::CloseFillStrokeEvenOdd => {
-                    apply_pending_clip(
-                        &mut pending_clip,
-                        &mut clip_stack,
-                        pixmap,
-                        base_transform,
-                        &gs_stack,
-                    );
-                    let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    if let Some(path) = current_path.finish() {
-                        let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        // Fill first, then stroke on top
-                        let fill_rule = if matches!(op, Operator::CloseFillStrokeEvenOdd) {
-                            tiny_skia::FillRule::EvenOdd
-                        } else {
-                            tiny_skia::FillRule::Winding
-                        };
-                        self.path_rasterizer
-                            .fill_path_clipped(pixmap, &path, transform, gs, fill_rule, clip);
-                        self.path_rasterizer
-                            .stroke_path_clipped(pixmap, &path, transform, gs, clip);
+                    if excluded_layer_depth == 0 {
+                        apply_pending_clip(
+                            &mut pending_clip,
+                            &mut clip_stack,
+                            pixmap,
+                            base_transform,
+                            &gs_stack,
+                        );
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        if let Some(path) = current_path.finish() {
+                            let gs = gs_stack.current();
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            let fill_rule = if matches!(op, Operator::CloseFillStrokeEvenOdd) {
+                                tiny_skia::FillRule::EvenOdd
+                            } else {
+                                tiny_skia::FillRule::Winding
+                            };
+                            self.path_rasterizer
+                                .fill_path_clipped(pixmap, &path, transform, gs, fill_rule, clip);
+                            self.path_rasterizer
+                                .stroke_path_clipped(pixmap, &path, transform, gs, clip);
+                        }
+                    } else {
+                        let _ = current_path.finish();
                     }
                     current_path = PathBuilder::new();
                 },
                 Operator::FillEvenOdd | Operator::FillStrokeEvenOdd => {
-                    apply_pending_clip(
-                        &mut pending_clip,
-                        &mut clip_stack,
-                        pixmap,
-                        base_transform,
-                        &gs_stack,
-                    );
-                    let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    if let Some(path) = current_path.finish() {
-                        let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        self.path_rasterizer.fill_path_clipped(
+                    if excluded_layer_depth == 0 {
+                        apply_pending_clip(
+                            &mut pending_clip,
+                            &mut clip_stack,
                             pixmap,
-                            &path,
-                            transform,
-                            gs,
-                            tiny_skia::FillRule::EvenOdd,
-                            clip,
+                            base_transform,
+                            &gs_stack,
                         );
-                        // Add stroke for B* operator
-                        if matches!(op, Operator::FillStrokeEvenOdd) {
-                            self.path_rasterizer
-                                .stroke_path_clipped(pixmap, &path, transform, gs, clip);
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        if let Some(path) = current_path.finish() {
+                            let gs = gs_stack.current();
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            self.path_rasterizer.fill_path_clipped(
+                                pixmap,
+                                &path,
+                                transform,
+                                gs,
+                                tiny_skia::FillRule::EvenOdd,
+                                clip,
+                            );
+                            if matches!(op, Operator::FillStrokeEvenOdd) {
+                                self.path_rasterizer
+                                    .stroke_path_clipped(pixmap, &path, transform, gs, clip);
+                            }
                         }
+                    } else {
+                        let _ = current_path.finish();
                     }
                     current_path = PathBuilder::new();
                 },
@@ -1122,9 +1159,9 @@ impl PageRenderer {
                     gs_stack.current_mut().render_mode = *render;
                 },
 
-                // Text showing
+                // Text showing — suppressed when inside an excluded OCG layer
                 Operator::Tj { text } => {
-                    if in_text_object {
+                    if in_text_object && excluded_layer_depth == 0 {
                         let clip = clip_stack.last().and_then(|c| c.as_ref());
                         let gs = gs_stack.current();
                         let transform = combine_transforms(base_transform, &gs.ctm);
@@ -1139,7 +1176,6 @@ impl PageRenderer {
                             &self.fonts,
                         )?;
 
-                        // Advance text position: Tm = T(advance, 0) * Tm
                         let gs_mut = gs_stack.current_mut();
                         let advance_matrix = Matrix::translation(advance, 0.0);
                         gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
@@ -1147,44 +1183,45 @@ impl PageRenderer {
                 },
                 Operator::Quote { text } => {
                     if in_text_object {
-                        // Quote (') is T* followed by Tj
+                        // Quote (') is T* followed by Tj — always advance line
                         let gs_mut = gs_stack.current_mut();
                         let leading = gs_mut.leading;
                         let translation = Matrix::translation(0.0, -leading);
                         gs_mut.text_line_matrix = translation.multiply(&gs_mut.text_line_matrix);
                         gs_mut.text_matrix = gs_mut.text_line_matrix;
 
-                        let clip = clip_stack.last().and_then(|c| c.as_ref());
-                        let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        log::debug!(
-                            "' (Quote): rendering text at Tm=[{}, {}, {}, {}, {}, {}]",
-                            gs.text_matrix.a,
-                            gs.text_matrix.b,
-                            gs.text_matrix.c,
-                            gs.text_matrix.d,
-                            gs.text_matrix.e,
-                            gs.text_matrix.f
-                        );
-                        let advance = self.text_rasterizer.render_text(
-                            pixmap,
-                            text,
-                            transform,
-                            gs,
-                            resources,
-                            doc,
-                            clip,
-                            &self.fonts,
-                        )?;
+                        if excluded_layer_depth == 0 {
+                            let clip = clip_stack.last().and_then(|c| c.as_ref());
+                            let gs = gs_stack.current();
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            log::debug!(
+                                "' (Quote): rendering text at Tm=[{}, {}, {}, {}, {}, {}]",
+                                gs.text_matrix.a,
+                                gs.text_matrix.b,
+                                gs.text_matrix.c,
+                                gs.text_matrix.d,
+                                gs.text_matrix.e,
+                                gs.text_matrix.f
+                            );
+                            let advance = self.text_rasterizer.render_text(
+                                pixmap,
+                                text,
+                                transform,
+                                gs,
+                                resources,
+                                doc,
+                                clip,
+                                &self.fonts,
+                            )?;
 
-                        // Advance text position
-                        let gs_mut = gs_stack.current_mut();
-                        let advance_matrix = Matrix::translation(advance, 0.0);
-                        gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                            let gs_mut = gs_stack.current_mut();
+                            let advance_matrix = Matrix::translation(advance, 0.0);
+                            gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                        }
                     }
                 },
                 Operator::TJ { array } => {
-                    if in_text_object {
+                    if in_text_object && excluded_layer_depth == 0 {
                         let clip = clip_stack.last().and_then(|c| c.as_ref());
                         let gs = gs_stack.current();
                         let transform = combine_transforms(base_transform, &gs.ctm);
@@ -1208,7 +1245,6 @@ impl PageRenderer {
                             &self.fonts,
                         )?;
 
-                        // Advance text position: Tm = T(advance, 0) * Tm
                         let gs_mut = gs_stack.current_mut();
                         let advance_matrix = Matrix::translation(advance, 0.0);
                         gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
@@ -1220,7 +1256,7 @@ impl PageRenderer {
                     text,
                 } => {
                     if in_text_object {
-                        // Double Quote (") is Tw, Tc followed by ' (which is T*, Tj)
+                        // Double Quote (") always updates state
                         let gs_mut = gs_stack.current_mut();
                         gs_mut.word_space = *word_space;
                         gs_mut.char_space = *char_space;
@@ -1230,45 +1266,48 @@ impl PageRenderer {
                         gs_mut.text_line_matrix = translation.multiply(&gs_mut.text_line_matrix);
                         gs_mut.text_matrix = gs_mut.text_line_matrix;
 
-                        let clip = clip_stack.last().and_then(|c| c.as_ref());
-                        let gs = gs_stack.current();
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        log::debug!(
-                            "\" (DoubleQuote): rendering text at Tm=[{}, {}, {}, {}, {}, {}]",
-                            gs.text_matrix.a,
-                            gs.text_matrix.b,
-                            gs.text_matrix.c,
-                            gs.text_matrix.d,
-                            gs.text_matrix.e,
-                            gs.text_matrix.f
-                        );
-                        let advance = self.text_rasterizer.render_text(
-                            pixmap,
-                            text,
-                            transform,
-                            gs,
-                            resources,
-                            doc,
-                            clip,
-                            &self.fonts,
-                        )?;
+                        if excluded_layer_depth == 0 {
+                            let clip = clip_stack.last().and_then(|c| c.as_ref());
+                            let gs = gs_stack.current();
+                            let transform = combine_transforms(base_transform, &gs.ctm);
+                            log::debug!(
+                                "\" (DoubleQuote): rendering text at Tm=[{}, {}, {}, {}, {}, {}]",
+                                gs.text_matrix.a,
+                                gs.text_matrix.b,
+                                gs.text_matrix.c,
+                                gs.text_matrix.d,
+                                gs.text_matrix.e,
+                                gs.text_matrix.f
+                            );
+                            let advance = self.text_rasterizer.render_text(
+                                pixmap,
+                                text,
+                                transform,
+                                gs,
+                                resources,
+                                doc,
+                                clip,
+                                &self.fonts,
+                            )?;
 
-                        // Advance text position
-                        let gs_mut = gs_stack.current_mut();
-                        let advance_matrix = Matrix::translation(advance, 0.0);
-                        gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                            let gs_mut = gs_stack.current_mut();
+                            let advance_matrix = Matrix::translation(advance, 0.0);
+                            gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                        }
                     }
                 },
 
-                // XObject (images)
+                // XObject (images) — suppressed when inside an excluded OCG layer
                 Operator::Do { name } => {
-                    let gs = gs_stack.current();
-                    let transform = combine_transforms(base_transform, &gs.ctm);
-                    let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    log::debug!("Do: rendering XObject '{}'", name);
-                    self.render_xobject(
-                        pixmap, name, transform, gs, resources, doc, page_num, clip,
-                    )?;
+                    if excluded_layer_depth == 0 {
+                        let gs = gs_stack.current();
+                        let transform = combine_transforms(base_transform, &gs.ctm);
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        log::debug!("Do: rendering XObject '{}'", name);
+                        self.render_xobject(
+                            pixmap, name, transform, gs, resources, doc, page_num, clip,
+                        )?;
+                    }
                 },
 
                 // Text positioning
@@ -1364,12 +1403,41 @@ impl PageRenderer {
                     current_path = PathBuilder::new();
                 },
 
-                // Shading (gradient) operator
+                // Shading (gradient) operator — suppressed when inside excluded layer
                 Operator::PaintShading { name } => {
-                    let gs = gs_stack.current();
-                    let transform = combine_transforms(base_transform, &gs.ctm);
-                    let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    self.render_shading(pixmap, name, transform, gs, resources, doc, clip)?;
+                    if excluded_layer_depth == 0 {
+                        let gs = gs_stack.current();
+                        let transform = combine_transforms(base_transform, &gs.ctm);
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        self.render_shading(pixmap, name, transform, gs, resources, doc, clip)?;
+                    }
+                },
+
+                // Marked content operators — track OCG layer exclusion
+                Operator::BeginMarkedContent { .. } => {
+                    marked_content_is_excluded.push(false);
+                },
+                Operator::BeginMarkedContentDict { tag, properties } => {
+                    let mut is_excluded = false;
+                    if tag == "OC" && !excluded_layers.is_empty() {
+                        is_excluded = resolve_and_check_ocg_excluded(
+                            properties,
+                            resources,
+                            doc,
+                            excluded_layers,
+                        );
+                    }
+                    if is_excluded {
+                        excluded_layer_depth += 1;
+                    }
+                    marked_content_is_excluded.push(is_excluded);
+                },
+                Operator::EndMarkedContent => {
+                    if let Some(was_excluded) = marked_content_is_excluded.pop() {
+                        if was_excluded && excluded_layer_depth > 0 {
+                            excluded_layer_depth -= 1;
+                        }
+                    }
                 },
 
                 _ => {},
@@ -2464,6 +2532,127 @@ fn encode_png(pixmap: &Pixmap) -> Result<Vec<u8>> {
 /// Combine two transformations.
 fn combine_transforms(base: Transform, ctm: &Matrix) -> Transform {
     base.pre_concat(Transform::from_row(ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f))
+}
+
+/// Resolve BDC properties and check whether the referenced OCG/OCMD is excluded.
+///
+/// Mirrors the logic from `TextExtractor::check_ocg_excluded` but operates as
+/// a standalone function for the renderer (which doesn't hold a TextExtractor).
+fn resolve_and_check_ocg_excluded(
+    properties: &Object,
+    resources: &Object,
+    doc: &PdfDocument,
+    excluded_layers: &HashSet<String>,
+) -> bool {
+    let props_dict = match resolve_bdc_properties_for_render(properties, resources, doc) {
+        Some(d) => d,
+        None => return false,
+    };
+    check_ocg_excluded_render(&props_dict, doc, excluded_layers)
+}
+
+/// Resolve BDC properties: inline dict or name reference into /Properties resource.
+fn resolve_bdc_properties_for_render(
+    properties: &Object,
+    resources: &Object,
+    doc: &PdfDocument,
+) -> Option<HashMap<String, Object>> {
+    if let Some(dict) = properties.as_dict() {
+        return Some(dict.clone());
+    }
+
+    let prop_name = properties.as_name()?;
+    let res_dict = resources.as_dict()?;
+    let properties_dict_obj = res_dict.get("Properties")?;
+    let properties_dict = match properties_dict_obj.as_reference() {
+        Some(r) => doc.load_object(r).ok()?,
+        None => properties_dict_obj.clone(),
+    };
+    let properties_dict = properties_dict.as_dict()?;
+    let prop_obj = properties_dict.get(prop_name)?;
+    let resolved = match prop_obj.as_reference() {
+        Some(r) => doc.load_object(r).ok()?,
+        None => prop_obj.clone(),
+    };
+    resolved.as_dict().cloned()
+}
+
+/// Check whether a resolved BDC properties dict represents an excluded OCG or OCMD.
+fn check_ocg_excluded_render(
+    props_dict: &HashMap<String, Object>,
+    doc: &PdfDocument,
+    excluded_layers: &HashSet<String>,
+) -> bool {
+    if let Some(ocg_name) = props_dict.get("Name") {
+        return ocg_name_is_excluded_render(ocg_name, excluded_layers);
+    }
+
+    if let Some(Object::Name(t)) = props_dict.get("Type") {
+        if t == "OCMD" {
+            if let Some(ocgs_obj) = props_dict.get("OCGs") {
+                return ocmd_ocgs_excluded_render(ocgs_obj, doc, excluded_layers);
+            }
+        }
+    }
+
+    false
+}
+
+fn ocg_name_is_excluded_render(name_obj: &Object, excluded_layers: &HashSet<String>) -> bool {
+    if let Some(name_str) = name_obj.as_name() {
+        return excluded_layers.contains(name_str);
+    }
+    if let Some(name_bytes) = name_obj.as_string() {
+        let name_str = decode_pdf_text_string_simple(name_bytes);
+        return excluded_layers.contains(&name_str);
+    }
+    false
+}
+
+fn ocmd_ocgs_excluded_render(
+    ocgs_obj: &Object,
+    doc: &PdfDocument,
+    excluded_layers: &HashSet<String>,
+) -> bool {
+    let refs: Vec<&Object> = if let Some(arr) = ocgs_obj.as_array() {
+        arr.iter().collect()
+    } else {
+        vec![ocgs_obj]
+    };
+
+    for obj in refs {
+        let resolved = if let Some(r) = obj.as_reference() {
+            match doc.load_object(r) {
+                Ok(o) => o,
+                Err(_) => continue,
+            }
+        } else {
+            obj.clone()
+        };
+        if let Some(d) = resolved.as_dict() {
+            if let Some(name_obj) = d.get("Name") {
+                if ocg_name_is_excluded_render(name_obj, excluded_layers) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Minimal PDF text string decoder (UTF-16BE BOM or latin-1 fallback).
+fn decode_pdf_text_string_simple(bytes: &[u8]) -> String {
+    if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
+        let utf16_pairs: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .collect();
+        String::from_utf16(&utf16_pairs)
+            .unwrap_or_else(|_| String::from_utf8_lossy(bytes).to_string())
+    } else {
+        String::from_utf8(bytes.to_vec())
+            .unwrap_or_else(|_| bytes.iter().map(|&b| b as char).collect())
+    }
 }
 
 /// Convert DeviceCMYK (0.0–1.0) to DeviceRGB (0.0–1.0) per ISO 32000-1:2008

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -578,6 +578,52 @@ impl TextRasterizer {
         filtered
     }
 
+    /// Measure-only: compute the horizontal advance of a Tj text string
+    /// without painting any glyphs.
+    ///
+    /// Used by the operator loop when a text-showing operator falls inside an
+    /// excluded OCG scope: glyphs must not be rasterised, but the text matrix
+    /// still needs to advance so that any subsequent visible text in the same
+    /// BT/ET block paints at the correct X position.
+    ///
+    /// Implements the PDF text advance formula `tx = ((w0 * Tfs) + Tc + Tw) * Th`
+    /// per ISO 32000-1 §9.4.4, summing across the source-character widths exposed
+    /// by [`crate::fonts::FontInfo::get_glyph_width`].
+    pub fn measure_text(
+        &self,
+        text: &[u8],
+        gs: &GraphicsState,
+        font_cache: &HashMap<String, Arc<crate::fonts::FontInfo>>,
+    ) -> f32 {
+        let font_info = gs.font_name.as_ref().and_then(|n| font_cache.get(n).cloned());
+        measure_text_bytes(text, gs, font_info.as_deref())
+    }
+
+    /// Measure-only: compute the horizontal advance of a TJ array without
+    /// painting any glyphs.
+    pub fn measure_tj_array(
+        &self,
+        array: &[TextElement],
+        gs: &GraphicsState,
+        font_cache: &HashMap<String, Arc<crate::fonts::FontInfo>>,
+    ) -> f32 {
+        let font_info = gs.font_name.as_ref().and_then(|n| font_cache.get(n).cloned());
+        let mut total: f32 = 0.0;
+        for element in array {
+            match element {
+                TextElement::String(text) => {
+                    total += measure_text_bytes(text, gs, font_info.as_deref());
+                },
+                TextElement::Offset(offset) => {
+                    // PDF offsets are in 1/1000th of a unit, positive shifts to the left.
+                    let shift = (-offset / 1000.0) * gs.font_size;
+                    total += shift;
+                },
+            }
+        }
+        total
+    }
+
     /// Render a TJ array (text with positioning adjustments).
     /// Returns the total horizontal advance in PDF points.
     pub fn render_tj_array(
@@ -1448,4 +1494,52 @@ impl Default for TextRasterizer {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Compute the PDF-spec horizontal text advance for `bytes` without painting.
+///
+/// Mirrors the advance math in [`TextRasterizer::render_unicode_text`] but
+/// without any glyph outline work. Per ISO 32000-1 §9.4.4:
+///
+/// `tx = ((w0 * Tfs) + Tc + Tw) * Th`
+///
+/// where w0 is the glyph width in 1000ths of an em, Tfs is the font size,
+/// Tc is char_space, Tw is word_space (only added at byte 0x20), and Th is
+/// horizontal_scaling/100.
+///
+/// When no font metrics are available we fall back to a half-em estimate per
+/// character — same constant `render_text_fallback` uses for the visible path,
+/// so the suppressed branch stays consistent with the painted branch.
+fn measure_text_bytes(
+    bytes: &[u8],
+    gs: &GraphicsState,
+    font_info: Option<&crate::fonts::FontInfo>,
+) -> f32 {
+    let font_size = gs.font_size;
+    let h_scale = gs.horizontal_scaling / 100.0;
+    let mut advance: f32 = 0.0;
+
+    if let Some(font) = font_info {
+        for (char_code, _) in TextCharIter::new(bytes, Some(font)) {
+            let w = font.get_glyph_width(char_code);
+            let glyph_adv = w * font_size / 1000.0;
+            advance += (glyph_adv + gs.char_space) * h_scale;
+            // PDF word_space applies to byte value 0x20 (ASCII space) under the
+            // current font's encoding. For Type0 fonts this is rarely a real
+            // word boundary, but we follow the visible-path convention.
+            if char_code == 0x20 {
+                advance += gs.word_space * h_scale;
+            }
+        }
+    } else {
+        // No font info — half-em estimate per byte, matching render_text_fallback.
+        let char_width = font_size * 0.6;
+        for &b in bytes {
+            advance += (char_width + gs.char_space) * h_scale;
+            if b == 0x20 {
+                advance += gs.word_space * h_scale;
+            }
+        }
+    }
+    advance
 }

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -595,7 +595,10 @@ impl TextRasterizer {
         gs: &GraphicsState,
         font_cache: &HashMap<String, Arc<crate::fonts::FontInfo>>,
     ) -> f32 {
-        let font_info = gs.font_name.as_ref().and_then(|n| font_cache.get(n).cloned());
+        let font_info = gs
+            .font_name
+            .as_ref()
+            .and_then(|n| font_cache.get(n).cloned());
         measure_text_bytes(text, gs, font_info.as_deref())
     }
 
@@ -607,7 +610,10 @@ impl TextRasterizer {
         gs: &GraphicsState,
         font_cache: &HashMap<String, Arc<crate::fonts::FontInfo>>,
     ) -> f32 {
-        let font_info = gs.font_name.as_ref().and_then(|n| font_cache.get(n).cloned());
+        let font_info = gs
+            .font_name
+            .as_ref()
+            .and_then(|n| font_cache.get(n).cloned());
         let mut total: f32 = 0.0;
         for element in array {
             match element {

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -642,3 +642,94 @@ fn test_empty_filters_fall_through_to_normal_extraction() {
         "Empty filters should produce identical output to unfiltered extraction"
     );
 }
+
+// ============================================================================
+// Task 2: OCMD (Optional Content Membership Dictionary) support
+// ============================================================================
+
+fn build_pdf_with_ocmd() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [7 0 R] /D << /ON [7 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+    let content = b"BT /F1 12 Tf 50 700 Td (ALWAYS) Tj ET /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (MEMBER) Tj ET EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    // Obj 6: OCMD referencing OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n",
+    );
+    // Obj 7: OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /MemberLayer >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ocmd_layer_filtering() {
+    let pdf_bytes = build_pdf_with_ocmd();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let layers = doc.get_layers().expect("get_layers");
+    assert!(
+        layers.contains(&"MemberLayer".to_string()),
+        "got: {:?}",
+        layers
+    );
+
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
+    assert!(text_all.contains("MEMBER"), "got: {:?}", text_all);
+
+    let excluded = HashSet::from(["MemberLayer".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered");
+    assert!(
+        text_filtered.contains("ALWAYS"),
+        "got: {:?}",
+        text_filtered
+    );
+    assert!(
+        !text_filtered.contains("MEMBER"),
+        "MEMBER should be excluded via OCMD resolution, got: {:?}",
+        text_filtered
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -733,3 +733,96 @@ fn test_ocmd_layer_filtering() {
         text_filtered
     );
 }
+
+// ============================================================================
+// Task 3: DeviceN all-or-nothing semantics
+// ============================================================================
+
+fn build_pdf_with_devicen() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >>\n\
+           /ColorSpace << /CS1 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"BT /F1 12 Tf 50 700 Td (PLAIN) Tj ET \
+                    /CS1 cs 1 0 scn BT /F1 12 Tf 50 650 Td (MIXED_INK) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n",
+    );
+
+    let tint_fn = b"{ 0 exch }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "7 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0 0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
+    // Documents the all-or-nothing DeviceN behavior:
+    // Excluding "SpotGold" suppresses ALL text in the DeviceN space,
+    // even though Cyan (a process color) is also part of the space.
+    let pdf_bytes = build_pdf_with_devicen();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded_inks = HashSet::from(["SpotGold".to_string()]);
+    let text = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered");
+
+    assert!(
+        text.contains("PLAIN"),
+        "PLAIN (DeviceGray) should survive, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("MIXED_INK"),
+        "MIXED_INK should be suppressed (DeviceN contains excluded SpotGold), got: {:?}",
+        text
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -84,9 +84,7 @@ fn build_pdf_with_ocg_in_xobject() -> Vec<u8> {
 
     // Obj 8: OCG dictionary
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n");
 
     // Xref
     let xref_offset = pdf.len();
@@ -140,7 +138,8 @@ fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
     );
 
     // Obj 4: Page content — text before XObject, invoke XObject, text after
-    let page_content = b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
+    let page_content =
+        b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
     offsets.push(pdf.len());
     let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
     pdf.extend_from_slice(hdr.as_bytes());
@@ -170,9 +169,7 @@ fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
 
     // Obj 7: Separation color space [/Separation /SpotRed /DeviceRGB <tint fn>]
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n");
 
     // Obj 8: Tint transform function (Type 4 PostScript calculator)
     let tint_fn = b"{ 0 0 }";
@@ -337,9 +334,7 @@ fn build_pdf_with_inline_separation() -> Vec<u8> {
 
     // Obj 6: Separation color space array
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n");
 
     // Obj 7: Tint transform function
     let tint_fn = b"{ 0 0 }";
@@ -679,9 +674,7 @@ fn build_pdf_with_ocmd() -> Vec<u8> {
     );
     // Obj 6: OCMD referencing OCG
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n");
     // Obj 7: OCG
     offsets.push(pdf.len());
     pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /MemberLayer >>\nendobj\n\n");
@@ -708,11 +701,7 @@ fn test_ocmd_layer_filtering() {
     let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
 
     let layers = doc.get_layers().expect("get_layers");
-    assert!(
-        layers.contains(&"MemberLayer".to_string()),
-        "got: {:?}",
-        layers
-    );
+    assert!(layers.contains(&"MemberLayer".to_string()), "got: {:?}", layers);
 
     let text_all = doc.extract_text(0).expect("unfiltered");
     assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
@@ -722,11 +711,7 @@ fn test_ocmd_layer_filtering() {
     let text_filtered = doc
         .extract_text_filtered(0, excluded, HashSet::new())
         .expect("filtered");
-    assert!(
-        text_filtered.contains("ALWAYS"),
-        "got: {:?}",
-        text_filtered
-    );
+    assert!(text_filtered.contains("ALWAYS"), "got: {:?}", text_filtered);
     assert!(
         !text_filtered.contains("MEMBER"),
         "MEMBER should be excluded via OCMD resolution, got: {:?}",
@@ -771,9 +756,7 @@ fn build_pdf_with_devicen() -> Vec<u8> {
     );
 
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n");
 
     let tint_fn = b"{ 0 exch }";
     offsets.push(pdf.len());
@@ -815,11 +798,7 @@ fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
         .extract_text_filtered(0, HashSet::new(), excluded_inks)
         .expect("filtered");
 
-    assert!(
-        text.contains("PLAIN"),
-        "PLAIN (DeviceGray) should survive, got: {:?}",
-        text
-    );
+    assert!(text.contains("PLAIN"), "PLAIN (DeviceGray) should survive, got: {:?}", text);
     assert!(
         !text.contains("MIXED_INK"),
         "MIXED_INK should be suppressed (DeviceN contains excluded SpotGold), got: {:?}",
@@ -896,11 +875,7 @@ fn test_filtering_unrelated_layer_produces_identical_output() {
 
     let text_normal = doc.extract_text(0).expect("unfiltered");
     let text_filtered = doc
-        .extract_text_filtered(
-            0,
-            HashSet::from(["Dieline".to_string()]),
-            HashSet::new(),
-        )
+        .extract_text_filtered(0, HashSet::from(["Dieline".to_string()]), HashSet::new())
         .expect("filtered with non-matching layer");
 
     assert_eq!(

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -826,3 +826,88 @@ fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
         text
     );
 }
+
+// ============================================================================
+// Pipeline parity: filtering non-matching layers must not alter output
+// ============================================================================
+
+/// Build a PDF with a table-like layout and an OCG layer that doesn't
+/// overlap with any content. Filtering this layer should produce output
+/// identical to unfiltered extraction.
+fn build_pdf_with_table_and_unrelated_layer() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Content: multiple text lines (simulating rows), plus an empty OCG layer
+    let content = b"BT /F1 12 Tf 50 700 Td (Name) Tj 200 0 Td (Age) Tj ET \
+                    BT /F1 12 Tf 50 680 Td (Alice) Tj 200 0 Td (30) Tj ET \
+                    BT /F1 12 Tf 50 660 Td (Bob) Tj 200 0 Td (25) Tj ET \
+                    /OC /MC0 BDC EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Dieline >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_filtering_unrelated_layer_produces_identical_output() {
+    let pdf_bytes = build_pdf_with_table_and_unrelated_layer();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let text_normal = doc.extract_text(0).expect("unfiltered");
+    let text_filtered = doc
+        .extract_text_filtered(
+            0,
+            HashSet::from(["Dieline".to_string()]),
+            HashSet::new(),
+        )
+        .expect("filtered with non-matching layer");
+
+    assert_eq!(
+        text_normal, text_filtered,
+        "Excluding a layer with no content must produce identical output.\n\
+         Unfiltered: {:?}\n\
+         Filtered:   {:?}",
+        text_normal, text_filtered
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -416,6 +416,98 @@ fn test_ink_filtering_blocked_by_text_only_parser() {
 // ============================================================================
 // Basic OCG filtering (no XObject cache involvement)
 // ============================================================================
+// Task 1: region + filter combo
+// ============================================================================
+
+fn build_pdf_for_region_and_filter() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"BT /F1 12 Tf 50 700 Td (TOP_VISIBLE) Tj ET \
+                    /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (TOP_HIDDEN) Tj ET EMC \
+                    BT /F1 12 Tf 50 100 Td (BOT_VISIBLE) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Overlay >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_extract_text_filtered_respects_region() {
+    let pdf_bytes = build_pdf_for_region_and_filter();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded = HashSet::from(["Overlay".to_string()]);
+    let chars = doc
+        .extract_chars_filtered(0, excluded, HashSet::new())
+        .expect("filtered chars");
+
+    use pdf_oxide::geometry::Rect;
+    use pdf_oxide::layout::{RectFilterMode, SpatialCollectionFiltering};
+    let region = Rect::new(0.0, 600.0, 612.0, 200.0);
+    let filtered: Vec<_> = chars.filter_by_rect(&region, RectFilterMode::Intersects);
+    let text: String = filtered.iter().map(|c| c.char).collect();
+
+    assert!(
+        text.contains("TOP_VISIBLE"),
+        "TOP_VISIBLE should survive both filters, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("TOP_HIDDEN"),
+        "TOP_HIDDEN should be excluded by layer filter, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("BOT_VISIBLE"),
+        "BOT_VISIBLE should be excluded by region filter, got: {:?}",
+        text
+    );
+}
+
+// ============================================================================
+// Basic OCG filtering (no XObject cache involvement)
+// ============================================================================
 
 /// Build a minimal PDF with inline OCG-tagged text (no XObjects).
 fn build_pdf_with_inline_ocg() -> Vec<u8> {

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -1,0 +1,552 @@
+//! Tests for OCG layer and Separation ink filtering in text extraction.
+//!
+//! Bug 1: XObject cached spans bypass suppression — filtered extraction
+//!         replays unfiltered cached spans, leaking excluded content.
+//! Bug 2: `inside_excluded_ink` not re-evaluated after Form XObject restore —
+//!         ink exclusion state lost after XObject processing.
+//! Bug 3: `get_layers` doc comment bleeds into `extract_chars` — verified
+//!         separately via `cargo doc`.
+
+use std::collections::HashSet;
+
+use pdf_oxide::document::PdfDocument;
+
+// ============================================================================
+// Helper: build a PDF with an OCG layer wrapping text inside a Form XObject
+// ============================================================================
+
+/// Build a PDF where a Form XObject contains OCG-tagged text.
+///
+/// Page content:  /Fm0 Do
+/// Form XObject:  BDC /OC /MC0  →  BT (LAYERED) Tj ET  →  EMC
+///                                  BT (VISIBLE) Tj ET
+///
+/// The OCG "HiddenLayer" is defined in OCProperties and referenced via
+/// the Form XObject's /Resources /Properties.
+fn build_pdf_with_ocg_in_xobject() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog with OCProperties
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [8 0 R] /D << /ON [8 0 R] >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Page content — just invoke the Form XObject
+    let page_content = b"/Fm0 Do";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject with OCG-tagged text + untagged text
+    // BDC syntax: /Tag /PropertiesName BDC ... EMC
+    let form_stream =
+        b"/OC /MC0 BDC BT /F1 12 Tf 50 700 Td (LAYERED) Tj ET EMC BT /F1 12 Tf 50 650 Td (VISIBLE) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >> /Properties << /MC0 8 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: (unused, keep numbering simple)
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\nnull\nendobj\n\n");
+
+    // Obj 8: OCG dictionary
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n",
+    );
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+// ============================================================================
+// Helper: build a PDF with Separation ink color space in a Form XObject
+// ============================================================================
+
+/// Build a PDF where a Form XObject switches to a Separation ink, renders text,
+/// then returns. After the XObject, the page renders more text in DeviceGray.
+///
+/// Page content:  BT (BEFORE) Tj ET  /Fm0 Do  BT (AFTER) Tj ET
+/// Form XObject:  /CS1 cs  BT (SPOT_INK) Tj ET
+///
+/// /CS1 is [/Separation /SpotRed /DeviceRGB ...].
+fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Page content — text before XObject, invoke XObject, text after
+    let page_content = b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject — sets Separation color space, then renders text
+    let form_stream = b"/CS1 cs 1 scn BT /F1 12 Tf 50 650 Td (SPOT_INK) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >>\n\
+            /ColorSpace << /CS1 7 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: Separation color space [/Separation /SpotRed /DeviceRGB <tint fn>]
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n",
+    );
+
+    // Obj 8: Tint transform function (Type 4 PostScript calculator)
+    let tint_fn = b"{ 0 0 }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "8 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+// ============================================================================
+// Bug 1: XObject cached spans bypass suppression
+// ============================================================================
+
+#[test]
+fn test_xobject_cache_does_not_leak_filtered_content() {
+    let pdf_bytes = build_pdf_with_ocg_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // First: unfiltered extraction — caches XObject spans
+    let text_all = doc.extract_text(0).expect("unfiltered extract");
+    assert!(
+        text_all.contains("LAYERED"),
+        "Unfiltered should contain LAYERED, got: {:?}",
+        text_all
+    );
+    assert!(
+        text_all.contains("VISIBLE"),
+        "Unfiltered should contain VISIBLE, got: {:?}",
+        text_all
+    );
+
+    // Second: filtered extraction excluding "HiddenLayer"
+    // BUG: cached XObject spans from first call are replayed verbatim,
+    // so LAYERED text leaks through despite being in excluded layer.
+    let excluded = HashSet::from(["HiddenLayer".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered extract");
+
+    assert!(
+        text_filtered.contains("VISIBLE"),
+        "Filtered should still contain VISIBLE, got: {:?}",
+        text_filtered
+    );
+    assert!(
+        !text_filtered.contains("LAYERED"),
+        "Filtered must NOT contain LAYERED (XObject cache leak), got: {:?}",
+        text_filtered
+    );
+}
+
+// ============================================================================
+// Bug 2: inside_excluded_ink not re-evaluated after XObject restore
+// ============================================================================
+
+#[test]
+fn test_ink_exclusion_restored_after_xobject() {
+    let pdf_bytes = build_pdf_with_ink_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Extract with "SpotRed" excluded
+    let excluded_inks = HashSet::from(["SpotRed".to_string()]);
+    let text = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered extract");
+
+    // SPOT_INK should be suppressed (it's in SpotRed color space)
+    assert!(
+        !text.contains("SPOT_INK"),
+        "SPOT_INK should be suppressed by ink filter, got: {:?}",
+        text
+    );
+
+    // BEFORE and AFTER are in DeviceGray — should NOT be suppressed.
+    // BUG: the Form XObject sets inside_excluded_ink=true for SpotRed,
+    // but after XObject restore, inside_excluded_ink is not re-evaluated
+    // back to false. So AFTER text is incorrectly suppressed.
+    assert!(
+        text.contains("BEFORE"),
+        "BEFORE should be visible (DeviceGray), got: {:?}",
+        text
+    );
+    assert!(
+        text.contains("AFTER"),
+        "AFTER should be visible (DeviceGray, post-XObject restore), got: {:?}",
+        text
+    );
+}
+
+// ============================================================================
+// Bug 3: text-only parser skips color operators — ink filtering is inert
+// ============================================================================
+
+/// Build a PDF with Separation ink color space directly in the page stream.
+/// No XObjects — isolates the parser from caching.
+///
+/// Page content:
+///   BT (PROCESS) Tj ET          ← default (DeviceGray) fill
+///   /CS1 cs 1 scn               ← switch to Separation /SpotRed
+///   BT (SPOT) Tj ET             ← text in SpotRed ink
+///   0 g                         ← switch back to DeviceGray
+///   BT (RESTORED) Tj ET         ← text in DeviceGray again
+fn build_pdf_with_inline_separation() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page with ColorSpace in resources
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >>\n\
+           /ColorSpace << /CS1 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Content stream
+    let content = b"BT /F1 12 Tf 50 700 Td (PROCESS) Tj ET /CS1 cs 1 scn BT /F1 12 Tf 50 650 Td (SPOT) Tj ET 0 g BT /F1 12 Tf 50 600 Td (RESTORED) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: Separation color space array
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n",
+    );
+
+    // Obj 7: Tint transform function
+    let tint_fn = b"{ 0 0 }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "7 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ink_filtering_blocked_by_text_only_parser() {
+    // The text-only parser (parse_and_execute_text_only) skips color operators
+    // (cs, rg, g, k) for performance. This means the SetFillColorSpace handler
+    // never fires, and ink filtering is completely inert.
+    //
+    // This test proves the bug: excluding "SpotRed" has no effect because the
+    // `cs` operator is never delivered to the extractor.
+    let pdf_bytes = build_pdf_with_inline_separation();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Unfiltered: all three texts present
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("PROCESS"), "got: {:?}", text_all);
+    assert!(text_all.contains("SPOT"), "got: {:?}", text_all);
+    assert!(text_all.contains("RESTORED"), "got: {:?}", text_all);
+
+    // Filtered: exclude SpotRed ink
+    let excluded_inks = HashSet::from(["SpotRed".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered");
+
+    // PROCESS and RESTORED are in DeviceGray — must survive
+    assert!(
+        text_filtered.contains("PROCESS"),
+        "PROCESS (DeviceGray) should survive ink filter, got: {:?}",
+        text_filtered
+    );
+    assert!(
+        text_filtered.contains("RESTORED"),
+        "RESTORED (DeviceGray after `0 g`) should survive ink filter, got: {:?}",
+        text_filtered
+    );
+
+    // SPOT is in SpotRed Separation — must be suppressed
+    assert!(
+        !text_filtered.contains("SPOT"),
+        "SPOT (SpotRed ink) must be suppressed by ink filter, got: {:?}",
+        text_filtered
+    );
+}
+
+// ============================================================================
+// Basic OCG filtering (no XObject cache involvement)
+// ============================================================================
+
+/// Build a minimal PDF with inline OCG-tagged text (no XObjects).
+fn build_pdf_with_inline_ocg() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog with OCProperties
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Content stream with OCG-tagged and untagged text
+    // BDC syntax: /Tag /PropertiesName BDC ... EMC
+    let content =
+        b"BT /F1 12 Tf 50 700 Td (ALWAYS) Tj ET /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (HIDDEN) Tj ET EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Overlay >>\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ocg_layer_filtering_inline() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Unfiltered: both texts present
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
+    assert!(text_all.contains("HIDDEN"), "got: {:?}", text_all);
+
+    // Filtered: exclude "Overlay" layer
+    let excluded = HashSet::from(["Overlay".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered");
+    assert!(text_filtered.contains("ALWAYS"), "got: {:?}", text_filtered);
+    assert!(
+        !text_filtered.contains("HIDDEN"),
+        "HIDDEN should be excluded, got: {:?}",
+        text_filtered
+    );
+}
+
+#[test]
+fn test_get_layers_returns_ocg_names() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let layers = doc.get_layers().expect("get_layers");
+    assert!(
+        layers.contains(&"Overlay".to_string()),
+        "Should find 'Overlay' layer, got: {:?}",
+        layers
+    );
+}
+
+#[test]
+fn test_get_page_inks_returns_separation_names() {
+    let pdf_bytes = build_pdf_with_ink_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // The Separation color space is in the Form XObject's resources, not the
+    // page's direct resources. get_page_inks only checks page resources, so
+    // it won't find SpotRed here. This is a known limitation — the test
+    // documents expected behavior.
+    let inks = doc.get_page_inks(0).expect("get_page_inks");
+    // SpotRed is in XObject resources, not page resources — empty is correct
+    assert!(
+        !inks.contains(&"SpotRed".to_string()),
+        "SpotRed is in XObject resources, not page, got: {:?}",
+        inks
+    );
+}
+
+#[test]
+fn test_empty_filters_fall_through_to_normal_extraction() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let text_normal = doc.extract_text(0).expect("normal");
+    let text_filtered = doc
+        .extract_text_filtered(0, HashSet::new(), HashSet::new())
+        .expect("empty filters");
+
+    assert_eq!(
+        text_normal, text_filtered,
+        "Empty filters should produce identical output to unfiltered extraction"
+    );
+}

--- a/tests/test_render_ocg_filtering.rs
+++ b/tests/test_render_ocg_filtering.rs
@@ -1,0 +1,391 @@
+//! Tests for OCG layer filtering in the rendering pipeline.
+//!
+//! Verifies that `RenderOptions::excluded_layers` suppresses graphical content
+//! (rectangles, text) drawn inside OCG-tagged BDC scopes while preserving
+//! content outside those scopes.
+
+use std::collections::HashSet;
+
+use pdf_oxide::document::PdfDocument;
+use pdf_oxide::rendering::{ImageFormat, RenderOptions};
+
+// ============================================================================
+// Helper: build a PDF with a colored rectangle inside an OCG layer + text outside
+// ============================================================================
+
+/// Build a PDF where:
+/// - A red rectangle is drawn inside BDC /OC /MC0 scope (OCG "Background")
+/// - Text "HELLO" is drawn outside any layer scope
+///
+/// The rectangle fills a 200x200 area at (50, 550) in PDF coords.
+fn build_pdf_with_ocg_rect_and_text() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog with OCProperties
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Content stream
+    // Red rectangle inside OCG "Background", then text outside any layer
+    let content = b"/OC /MC0 BDC q 1 0 0 rg 50 550 200 200 re f Q EMC \
+                    BT /F1 24 Tf 300 650 Td (HELLO) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: OCG dictionary
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Background >>\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+/// Build a PDF with an OCMD-referenced rectangle.
+fn build_pdf_with_ocmd_rect() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [7 0 R] /D << /ON [7 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Blue rectangle inside OCMD scope, green rectangle outside
+    let content = b"/OC /MC0 BDC 0 0 1 rg 50 550 200 200 re f EMC \
+                    0 1 0 rg 300 550 200 200 re f";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    // Obj 6: OCMD referencing OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n");
+    // Obj 7: OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /Watermark >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+/// Build a PDF with OCG-tagged content inside a Form XObject.
+fn build_pdf_with_ocg_in_form_xobject() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [7 0 R] /D << /ON [7 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Page content: just invoke Form XObject, then draw green rect outside
+    let page_content = b"/Fm0 Do 0 1 0 rg 300 550 200 200 re f";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject with OCG-tagged red rect
+    let form_stream = b"/OC /MC0 BDC 1 0 0 rg 50 550 200 200 re f EMC";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >> /Properties << /MC0 7 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: OCG dictionary
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /Background >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+// ============================================================================
+// Helper: render a PDF and get raw RGBA pixel data
+// ============================================================================
+
+fn render_raw(doc: &PdfDocument, excluded: HashSet<String>) -> (Vec<u8>, u32, u32) {
+    let mut options = RenderOptions::with_dpi(72);
+    options.format = ImageFormat::RawRgba8;
+    options.excluded_layers = excluded;
+    let img = pdf_oxide::rendering::render_page(doc, 0, &options).expect("render");
+    (img.data, img.width, img.height)
+}
+
+/// Sample the average color in a rectangular pixel region.
+/// Returns (r, g, b, a) as floats in 0..255.
+fn sample_region(data: &[u8], width: u32, x: u32, y: u32, w: u32, h: u32) -> (f32, f32, f32, f32) {
+    let mut r_sum = 0u64;
+    let mut g_sum = 0u64;
+    let mut b_sum = 0u64;
+    let mut a_sum = 0u64;
+    let mut count = 0u64;
+    for py in y..(y + h).min(width) {
+        for px in x..(x + w).min(width) {
+            let idx = ((py * width + px) * 4) as usize;
+            if idx + 3 < data.len() {
+                // tiny-skia stores premultiplied RGBA; un-premultiply for comparison
+                let a = data[idx + 3] as f32;
+                if a > 0.0 {
+                    let scale = 255.0 / a;
+                    r_sum += (data[idx] as f32 * scale).round().min(255.0) as u64;
+                    g_sum += (data[idx + 1] as f32 * scale).round().min(255.0) as u64;
+                    b_sum += (data[idx + 2] as f32 * scale).round().min(255.0) as u64;
+                } else {
+                    r_sum += data[idx] as u64;
+                    g_sum += data[idx + 1] as u64;
+                    b_sum += data[idx + 2] as u64;
+                }
+                a_sum += data[idx + 3] as u64;
+                count += 1;
+            }
+        }
+    }
+    if count == 0 {
+        return (0.0, 0.0, 0.0, 0.0);
+    }
+    (
+        r_sum as f32 / count as f32,
+        g_sum as f32 / count as f32,
+        b_sum as f32 / count as f32,
+        a_sum as f32 / count as f32,
+    )
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn test_render_ocg_rect_visible_without_filter() {
+    let pdf_bytes = build_pdf_with_ocg_rect_and_text();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let (data, width, _height) = render_raw(&doc, HashSet::new());
+
+    // The red rectangle region (PDF coords 50,550 to 250,750 mapped to 72 DPI pixels)
+    // At 72 DPI, 1pt = 1px. PDF y=550..750 → pixel y = 792-750..792-550 = 42..242
+    let (r, g, b, a) = sample_region(&data, width, 100, 80, 50, 50);
+    assert!(r > 200.0, "Red channel should be high in rect region, got {r}");
+    assert!(g < 50.0, "Green should be low, got {g}");
+    assert!(b < 50.0, "Blue should be low, got {b}");
+    assert!(a > 200.0, "Alpha should be high, got {a}");
+}
+
+#[test]
+fn test_render_ocg_rect_hidden_with_filter() {
+    let pdf_bytes = build_pdf_with_ocg_rect_and_text();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded = HashSet::from(["Background".to_string()]);
+    let (data, width, _height) = render_raw(&doc, excluded);
+
+    // The red rectangle region should now be white (background)
+    let (r, g, b, a) = sample_region(&data, width, 100, 80, 50, 50);
+    assert!(
+        r > 250.0 && g > 250.0 && b > 250.0,
+        "Rect region should be white background when layer excluded, got ({r}, {g}, {b})"
+    );
+    assert!(a > 250.0, "Alpha should still be high (white bg), got {a}");
+}
+
+#[test]
+fn test_render_unrelated_layer_filter_preserves_content() {
+    let pdf_bytes = build_pdf_with_ocg_rect_and_text();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Exclude a layer that doesn't exist — should not affect rendering
+    let excluded = HashSet::from(["NonExistentLayer".to_string()]);
+    let (data_filtered, _width, _) = render_raw(&doc, excluded);
+    let (data_unfiltered, _, _) = render_raw(&doc, HashSet::new());
+
+    // Both renders should be identical
+    assert_eq!(
+        data_filtered, data_unfiltered,
+        "Filtering a non-existent layer must not change the rendered output"
+    );
+}
+
+#[test]
+fn test_render_ocmd_rect_hidden_with_filter() {
+    let pdf_bytes = build_pdf_with_ocmd_rect();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Without filter: blue rect at (50,550) should be visible
+    let (data_unfiltered, width, _) = render_raw(&doc, HashSet::new());
+    let (r, g, b, _a) = sample_region(&data_unfiltered, width, 100, 80, 50, 50);
+    assert!(b > 200.0, "Blue rect should be visible without filter, got b={b}");
+    assert!(r < 50.0 && g < 50.0, "Should be blue, got r={r} g={g}");
+
+    // Green rect at (300,550) should be visible
+    let (_r, g, _b, _a) = sample_region(&data_unfiltered, width, 350, 80, 50, 50);
+    assert!(g > 200.0, "Green rect should be visible, got g={g}");
+
+    // With filter: exclude "Watermark" → blue rect gone, green rect remains
+    let excluded = HashSet::from(["Watermark".to_string()]);
+    let (data_filtered, width, _) = render_raw(&doc, excluded);
+
+    // Blue rect region should now be white
+    let (r, g, b, _) = sample_region(&data_filtered, width, 100, 80, 50, 50);
+    assert!(
+        r > 250.0 && g > 250.0 && b > 250.0,
+        "Blue rect should be hidden, got ({r}, {g}, {b})"
+    );
+
+    // Green rect should still be visible
+    let (_r, g, _b, _) = sample_region(&data_filtered, width, 350, 80, 50, 50);
+    assert!(g > 200.0, "Green rect should survive filter, got g={g}");
+}
+
+#[test]
+fn test_render_ocg_in_form_xobject_filtered() {
+    let pdf_bytes = build_pdf_with_ocg_in_form_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Without filter: red rect from Form XObject should be visible
+    let (data_unfiltered, width, _) = render_raw(&doc, HashSet::new());
+    let (r, _g, _b, _a) = sample_region(&data_unfiltered, width, 100, 80, 50, 50);
+    assert!(r > 200.0, "Red rect from XObject should be visible, got r={r}");
+
+    // With filter: exclude "Background" → red rect gone, green rect remains
+    let excluded = HashSet::from(["Background".to_string()]);
+    let (data_filtered, width, _) = render_raw(&doc, excluded);
+
+    // Red rect region should now be white
+    let (r, g, b, _) = sample_region(&data_filtered, width, 100, 80, 50, 50);
+    assert!(
+        r > 250.0 && g > 250.0 && b > 250.0,
+        "Red rect from XObject should be hidden, got ({r}, {g}, {b})"
+    );
+
+    // Green rect at (300,550) should still be visible
+    let (_r, g, _b, _) = sample_region(&data_filtered, width, 350, 80, 50, 50);
+    assert!(g > 200.0, "Green rect should survive filter, got g={g}");
+}
+
+#[test]
+fn test_render_empty_excluded_layers_matches_default() {
+    let pdf_bytes = build_pdf_with_ocg_rect_and_text();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let (data_default, _, _) = render_raw(&doc, HashSet::new());
+
+    let mut options = RenderOptions::with_dpi(72);
+    options.format = ImageFormat::RawRgba8;
+    // excluded_layers defaults to empty
+    let img = pdf_oxide::rendering::render_page(&doc, 0, &options).expect("render");
+
+    assert_eq!(
+        data_default, img.data,
+        "Default excluded_layers (empty) should match explicit empty HashSet"
+    );
+}

--- a/tests/test_render_ocg_filtering.rs
+++ b/tests/test_render_ocg_filtering.rs
@@ -222,14 +222,25 @@ fn render_raw(doc: &PdfDocument, excluded: HashSet<String>) -> (Vec<u8>, u32, u3
 }
 
 /// Sample the average color in a rectangular pixel region.
-/// Returns (r, g, b, a) as floats in 0..255.
-fn sample_region(data: &[u8], width: u32, x: u32, y: u32, w: u32, h: u32) -> (f32, f32, f32, f32) {
+/// Returns (r, g, b, a) as straight-alpha floats in 0..255.
+///
+/// Panics on an empty region (caller bug) so out-of-frame coordinates are
+/// detected rather than silently returning black.
+fn sample_region(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+) -> (f32, f32, f32, f32) {
     let mut r_sum = 0u64;
     let mut g_sum = 0u64;
     let mut b_sum = 0u64;
     let mut a_sum = 0u64;
     let mut count = 0u64;
-    for py in y..(y + h).min(width) {
+    for py in y..(y + h).min(height) {
         for px in x..(x + w).min(width) {
             let idx = ((py * width + px) * 4) as usize;
             if idx + 3 < data.len() {
@@ -250,9 +261,10 @@ fn sample_region(data: &[u8], width: u32, x: u32, y: u32, w: u32, h: u32) -> (f3
             }
         }
     }
-    if count == 0 {
-        return (0.0, 0.0, 0.0, 0.0);
-    }
+    assert!(
+        count > 0,
+        "sample_region({x},{y},{w},{h}) selected zero pixels in a {width}x{height} image"
+    );
     (
         r_sum as f32 / count as f32,
         g_sum as f32 / count as f32,
@@ -270,11 +282,11 @@ fn test_render_ocg_rect_visible_without_filter() {
     let pdf_bytes = build_pdf_with_ocg_rect_and_text();
     let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
 
-    let (data, width, _height) = render_raw(&doc, HashSet::new());
+    let (data, width, height) = render_raw(&doc, HashSet::new());
 
     // The red rectangle region (PDF coords 50,550 to 250,750 mapped to 72 DPI pixels)
     // At 72 DPI, 1pt = 1px. PDF y=550..750 → pixel y = 792-750..792-550 = 42..242
-    let (r, g, b, a) = sample_region(&data, width, 100, 80, 50, 50);
+    let (r, g, b, a) = sample_region(&data, width, height, 100, 80, 50, 50);
     assert!(r > 200.0, "Red channel should be high in rect region, got {r}");
     assert!(g < 50.0, "Green should be low, got {g}");
     assert!(b < 50.0, "Blue should be low, got {b}");
@@ -287,10 +299,10 @@ fn test_render_ocg_rect_hidden_with_filter() {
     let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
 
     let excluded = HashSet::from(["Background".to_string()]);
-    let (data, width, _height) = render_raw(&doc, excluded);
+    let (data, width, height) = render_raw(&doc, excluded);
 
     // The red rectangle region should now be white (background)
-    let (r, g, b, a) = sample_region(&data, width, 100, 80, 50, 50);
+    let (r, g, b, a) = sample_region(&data, width, height, 100, 80, 50, 50);
     assert!(
         r > 250.0 && g > 250.0 && b > 250.0,
         "Rect region should be white background when layer excluded, got ({r}, {g}, {b})"
@@ -321,28 +333,28 @@ fn test_render_ocmd_rect_hidden_with_filter() {
     let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
 
     // Without filter: blue rect at (50,550) should be visible
-    let (data_unfiltered, width, _) = render_raw(&doc, HashSet::new());
-    let (r, g, b, _a) = sample_region(&data_unfiltered, width, 100, 80, 50, 50);
+    let (data_unfiltered, width, height) = render_raw(&doc, HashSet::new());
+    let (r, g, b, _a) = sample_region(&data_unfiltered, width, height, 100, 80, 50, 50);
     assert!(b > 200.0, "Blue rect should be visible without filter, got b={b}");
     assert!(r < 50.0 && g < 50.0, "Should be blue, got r={r} g={g}");
 
     // Green rect at (300,550) should be visible
-    let (_r, g, _b, _a) = sample_region(&data_unfiltered, width, 350, 80, 50, 50);
+    let (_r, g, _b, _a) = sample_region(&data_unfiltered, width, height, 350, 80, 50, 50);
     assert!(g > 200.0, "Green rect should be visible, got g={g}");
 
     // With filter: exclude "Watermark" → blue rect gone, green rect remains
     let excluded = HashSet::from(["Watermark".to_string()]);
-    let (data_filtered, width, _) = render_raw(&doc, excluded);
+    let (data_filtered, width, height) = render_raw(&doc, excluded);
 
     // Blue rect region should now be white
-    let (r, g, b, _) = sample_region(&data_filtered, width, 100, 80, 50, 50);
+    let (r, g, b, _) = sample_region(&data_filtered, width, height, 100, 80, 50, 50);
     assert!(
         r > 250.0 && g > 250.0 && b > 250.0,
         "Blue rect should be hidden, got ({r}, {g}, {b})"
     );
 
     // Green rect should still be visible
-    let (_r, g, _b, _) = sample_region(&data_filtered, width, 350, 80, 50, 50);
+    let (_r, g, _b, _) = sample_region(&data_filtered, width, height, 350, 80, 50, 50);
     assert!(g > 200.0, "Green rect should survive filter, got g={g}");
 }
 
@@ -352,23 +364,23 @@ fn test_render_ocg_in_form_xobject_filtered() {
     let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
 
     // Without filter: red rect from Form XObject should be visible
-    let (data_unfiltered, width, _) = render_raw(&doc, HashSet::new());
-    let (r, _g, _b, _a) = sample_region(&data_unfiltered, width, 100, 80, 50, 50);
+    let (data_unfiltered, width, height) = render_raw(&doc, HashSet::new());
+    let (r, _g, _b, _a) = sample_region(&data_unfiltered, width, height, 100, 80, 50, 50);
     assert!(r > 200.0, "Red rect from XObject should be visible, got r={r}");
 
     // With filter: exclude "Background" → red rect gone, green rect remains
     let excluded = HashSet::from(["Background".to_string()]);
-    let (data_filtered, width, _) = render_raw(&doc, excluded);
+    let (data_filtered, width, height) = render_raw(&doc, excluded);
 
     // Red rect region should now be white
-    let (r, g, b, _) = sample_region(&data_filtered, width, 100, 80, 50, 50);
+    let (r, g, b, _) = sample_region(&data_filtered, width, height, 100, 80, 50, 50);
     assert!(
         r > 250.0 && g > 250.0 && b > 250.0,
         "Red rect from XObject should be hidden, got ({r}, {g}, {b})"
     );
 
     // Green rect at (300,550) should still be visible
-    let (_r, g, _b, _) = sample_region(&data_filtered, width, 350, 80, 50, 50);
+    let (_r, g, _b, _) = sample_region(&data_filtered, width, height, 350, 80, 50, 50);
     assert!(g > 200.0, "Green rect should survive filter, got g={g}");
 }
 

--- a/tests/test_render_ocg_filtering.rs
+++ b/tests/test_render_ocg_filtering.rs
@@ -1111,3 +1111,152 @@ fn test_prepress_fixture_combinations() {
     let (vr, vg, vb, _) = sample_region(&data, w, h, 370, 80, 30, 30);
     assert!(vr > 200.0 && vg > 200.0 && vb < 80.0, "Varnish must remain: ({vr}, {vg}, {vb})");
 }
+
+// ---------------------------------------------------------------------------
+// /VE visibility expression coverage
+// ---------------------------------------------------------------------------
+
+/// Build a PDF whose OCMD uses a `/VE` visibility expression.
+///
+/// The expression is `[/<op> <ocg_ref> ...]`. We test:
+///   /Not  — visible iff the OCG is excluded (inverted)
+///   /And  — visible iff all referenced OCGs are on
+///   /Or   — visible iff any referenced OCG is on
+/// Two OCGs ("A", "B") are defined. A blue rect is inside the OCMD scope, a
+/// green rect is always visible.
+fn build_pdf_with_ve(expr: &[u8]) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [7 0 R 8 0 R] /D << /ON [7 0 R 8 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"/OC /MC0 BDC 0 0 1 rg 50 550 200 200 re f EMC \
+                    0 1 0 rg 300 550 200 200 re f";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: OCMD with /VE expression
+    offsets.push(pdf.len());
+    let ocmd = format!(
+        "6 0 obj\n<< /Type /OCMD /VE {} >>\nendobj\n\n",
+        std::str::from_utf8(expr).unwrap()
+    );
+    pdf.extend_from_slice(ocmd.as_bytes());
+
+    // Obj 7 & 8: OCGs
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /A >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"8 0 obj\n<< /Type /OCG /Name /B >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+fn ocmd_scope_is_visible(doc: &PdfDocument, excluded: HashSet<String>) -> bool {
+    let (data, w, h) = render_raw(doc, excluded);
+    let (r, g, b, _) = sample_region(&data, w, h, 100, 100, 30, 30);
+    // Blue rect is inside the OCMD scope. Visible -> blue (b high, r/g low).
+    // Hidden -> white background (all high).
+    b > 200.0 && r < 80.0 && g < 80.0
+}
+
+#[test]
+fn test_ve_not_operator() {
+    // /VE = [/Not 7 0 R]
+    // Visible iff OCG "A" is off (i.e. "A" is excluded).
+    let doc = PdfDocument::from_bytes(build_pdf_with_ve(b"[/Not 7 0 R]")).unwrap();
+    assert!(
+        !ocmd_scope_is_visible(&doc, HashSet::new()),
+        "Not(A): with A on, scope should be hidden"
+    );
+    assert!(
+        ocmd_scope_is_visible(&doc, HashSet::from(["A".to_string()])),
+        "Not(A): with A excluded (off), scope should be visible"
+    );
+}
+
+#[test]
+fn test_ve_and_operator() {
+    // /VE = [/And 7 0 R 8 0 R]
+    // Visible iff both A and B are on.
+    let doc = PdfDocument::from_bytes(build_pdf_with_ve(b"[/And 7 0 R 8 0 R]")).unwrap();
+    assert!(ocmd_scope_is_visible(&doc, HashSet::new()), "And(A,B): both on -> visible");
+    assert!(
+        !ocmd_scope_is_visible(&doc, HashSet::from(["A".to_string()])),
+        "And(A,B): A excluded -> hidden"
+    );
+    assert!(
+        !ocmd_scope_is_visible(&doc, HashSet::from(["B".to_string()])),
+        "And(A,B): B excluded -> hidden"
+    );
+}
+
+#[test]
+fn test_ve_or_operator() {
+    // /VE = [/Or 7 0 R 8 0 R]
+    // Visible iff A or B is on.
+    let doc = PdfDocument::from_bytes(build_pdf_with_ve(b"[/Or 7 0 R 8 0 R]")).unwrap();
+    assert!(ocmd_scope_is_visible(&doc, HashSet::new()), "Or(A,B): both on -> visible");
+    assert!(
+        ocmd_scope_is_visible(&doc, HashSet::from(["A".to_string()])),
+        "Or(A,B): A excluded but B on -> visible"
+    );
+    assert!(
+        !ocmd_scope_is_visible(&doc, HashSet::from(["A".to_string(), "B".to_string()])),
+        "Or(A,B): both excluded -> hidden"
+    );
+}
+
+#[test]
+fn test_ve_nested_expression() {
+    // /VE = [/And 7 0 R [/Not 8 0 R]]   — A on AND B off
+    let doc = PdfDocument::from_bytes(build_pdf_with_ve(b"[/And 7 0 R [/Not 8 0 R]]")).unwrap();
+    assert!(
+        !ocmd_scope_is_visible(&doc, HashSet::new()),
+        "And(A, Not(B)): A on, B on -> hidden"
+    );
+    assert!(
+        ocmd_scope_is_visible(&doc, HashSet::from(["B".to_string()])),
+        "And(A, Not(B)): A on, B excluded -> visible"
+    );
+    assert!(
+        !ocmd_scope_is_visible(&doc, HashSet::from(["A".to_string(), "B".to_string()])),
+        "And(A, Not(B)): A excluded -> hidden"
+    );
+}

--- a/tests/test_render_ocg_filtering.rs
+++ b/tests/test_render_ocg_filtering.rs
@@ -401,3 +401,713 @@ fn test_render_empty_excluded_layers_matches_default() {
         "Default excluded_layers (empty) should match explicit empty HashSet"
     );
 }
+
+// ============================================================================
+// Additional realistic regression tests for the OCG render fix-up.
+// ============================================================================
+
+/// Append the standard xref + trailer block for a single-page test PDF.
+fn write_xref_trailer(pdf: &mut Vec<u8>, offsets: &[usize]) {
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+}
+
+/// Build a PDF where a `W n` clip is issued inside an excluded BDC scope
+/// (no surrounding `q/Q`). Outside the scope, a green rect tries to fill the
+/// whole page. If the clip leaked from the excluded scope, the green fill
+/// would be restricted to the clipped sub-region; with the fix, the green
+/// fills the whole page.
+fn build_pdf_with_clip_inside_excluded_bdc() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [5 0 R] /D << /ON [5 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Properties << /MC0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Inside excluded layer: build a path covering only the top-left 100x100,
+    // then `W n` to set it as a clip. No q/Q, no fill. Outside: paint a
+    // green rect 200x200 at (200,200) — it must be visible if the clip was
+    // properly gated.
+    //
+    // Note: the path uses moveto/lineto and clip with the non-zero rule.
+    let content: &[u8] = b"/OC /MC0 BDC \
+                           0 700 m 100 700 l 100 800 l 0 800 l h W n \
+                           EMC \
+                           0 1 0 rg 200 200 200 200 re f";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"5 0 obj\n<< /Type /OCG /Name /ClipLeak >>\nendobj\n\n");
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+#[test]
+fn test_clip_does_not_leak_from_excluded_layer() {
+    let pdf_bytes = build_pdf_with_clip_inside_excluded_bdc();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // With "ClipLeak" excluded, the green rect (PDF coords 200..400 x 200..400,
+    // pixel y = 792-400..792-200 = 392..592 at 72 DPI) must paint freely.
+    let excluded = HashSet::from(["ClipLeak".to_string()]);
+    let (data, w, h) = render_raw(&doc, excluded);
+
+    // Sample near the centre of the green rect: pixel x ~ 300, pixel y ~ 492.
+    let (r, g, b, _) = sample_region(&data, w, h, 290, 480, 20, 20);
+    assert!(
+        g > 240.0 && r < 30.0 && b < 30.0,
+        "Green rect should paint unclipped after excluded BDC closes; got ({r}, {g}, {b})"
+    );
+}
+
+/// Build a PDF where an annotation (a "Square" annotation with /AP) carries
+/// an /OC entry referencing an excluded OCG.
+fn build_pdf_with_oc_annotation() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // 1 Catalog, 2 Pages, 3 Page, 4 Annot, 5 AP /N stream, 6 OCG.
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 7 0 R /Annots [4 0 R] >>\nendobj\n\n",
+    );
+    // Annotation with /OC referencing OCG 6.
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"4 0 obj\n<< /Type /Annot /Subtype /Square /Rect [50 550 250 750]\n\
+           /AP << /N 5 0 R >> /OC 6 0 R /F 4 >>\nendobj\n\n",
+    );
+    // Appearance stream: a red 200x200 fill matching the /Rect.
+    let ap_content: &[u8] = b"q 1 0 0 rg 0 0 200 200 re f Q";
+    offsets.push(pdf.len());
+    let ap_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 200 200]\n\
+           /Resources << >> /Length {} >>\nstream\n",
+        ap_content.len()
+    );
+    pdf.extend_from_slice(ap_hdr.as_bytes());
+    pdf.extend_from_slice(ap_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    // OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Watermark >>\nendobj\n\n");
+    // Empty content stream so only the annotation paints.
+    let content: &[u8] = b"";
+    offsets.push(pdf.len());
+    let hdr = format!("7 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+#[test]
+fn test_annotation_oc_is_filtered() {
+    let pdf_bytes = build_pdf_with_oc_annotation();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Without filter: red appearance fills the annot rect (PDF y=550..750
+    // -> pixel y=42..242 at 72 DPI), so sampling at pixel (100,80) sees red.
+    let (data_unfiltered, w, h) = render_raw(&doc, HashSet::new());
+    let (r, g, b, _) = sample_region(&data_unfiltered, w, h, 100, 80, 50, 50);
+    assert!(
+        r > 200.0 && g < 50.0 && b < 50.0,
+        "Annotation appearance should be red without filter, got ({r}, {g}, {b})"
+    );
+
+    // With filter: annotation must be skipped, region is white background.
+    let excluded = HashSet::from(["Watermark".to_string()]);
+    let (data_filtered, w, h) = render_raw(&doc, excluded);
+    let (r, g, b, _) = sample_region(&data_filtered, w, h, 100, 80, 50, 50);
+    assert!(
+        r > 250.0 && g > 250.0 && b > 250.0,
+        "Annotation with /OC pointing at excluded OCG must be hidden; got ({r}, {g}, {b})"
+    );
+}
+
+/// Build a PDF where a layer's /Name is encoded as UTF-16LE with BOM.
+/// Catches the renderer's previously-lossy decoder (which only handled
+/// UTF-16BE BOM).
+fn build_pdf_with_utf16le_layer_name() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [5 0 R] /D << /ON [5 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Properties << /MC0 5 0 R >> >> >>\nendobj\n\n",
+    );
+    let content: &[u8] = b"/OC /MC0 BDC 1 0 0 rg 50 550 200 200 re f EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // OCG /Name = UTF-16LE BOM + "Layer" — hex string <FFFE 4C00 6100 7900 6500 7200>.
+    // Decoded that's "Layer". (No trailing NUL.)
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /OCG /Name <FFFE4C006100790065007200> >>\nendobj\n\n",
+    );
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+#[test]
+fn test_utf16le_layer_name_is_filtered() {
+    let pdf_bytes = build_pdf_with_utf16le_layer_name();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Filter on the decoded layer name. Without the UTF-16LE-BOM fix in the
+    // renderer this would silently fail to match and the red rect would
+    // still paint.
+    let excluded = HashSet::from(["Layer".to_string()]);
+    let (data, w, h) = render_raw(&doc, excluded);
+    let (r, g, b, _) = sample_region(&data, w, h, 100, 80, 50, 50);
+    assert!(
+        r > 250.0 && g > 250.0 && b > 250.0,
+        "UTF-16LE-named OCG must be filtered; rect region got ({r}, {g}, {b})"
+    );
+}
+
+/// Build a PDF with two text runs in a single BT/ET, where the first run is
+/// inside an excluded OCG scope. The second run must paint at the correct
+/// X position — i.e. shifted by the advance of the first run.
+fn build_pdf_with_text_split_by_bdc() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // BT /F1 24 Tf 100 400 Td
+    //   (Hello ) Tj                     ← visible, in black
+    //   /OC /MC0 BDC (SECRET) Tj EMC    ← inside excluded layer
+    //   (World) Tj                       ← must paint to the RIGHT of the
+    //                                      hidden (SECRET) glyphs, not under
+    //                                      the trailing space of "Hello "
+    // ET
+    let content: &[u8] = b"BT /F1 24 Tf 100 400 Td \
+                           (Hello ) Tj \
+                           /OC /MC0 BDC (SECRET) Tj EMC \
+                           (World) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Hidden >>\nendobj\n\n");
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+#[test]
+fn test_text_advance_preserved_through_excluded_run() {
+    let pdf_bytes = build_pdf_with_text_split_by_bdc();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Helvetica widths at 24pt: "Hello " advance ≈ 65pt, "SECRET" ≈ 100pt.
+    // Without the fix, "World" overlaps "Hello " starting at ~x=165 (pixel
+    // y around 792-400 = 392). With the fix, "World" must paint at x ≈ 265
+    // (i.e. clearly to the right of pixel 220).
+    let excluded = HashSet::from(["Hidden".to_string()]);
+    let (data, w, h) = render_raw(&doc, excluded);
+
+    // Sample two horizontal strips around y=400 in PDF coords (pixel y ≈ 392)
+    // both before pixel 200 (where Hello sits and World must not bleed) and
+    // after pixel 240 (where World should land after the suppressed SECRET).
+    let baseline_y: u32 = 386; // a few pixels around the glyph baseline area
+    let h_strip: u32 = 18;
+
+    // Region under (or just to the right of) the visible "Hello " text:
+    // pixel x ≈ 100..200. Sample the rightmost 30 pixels — these are right
+    // before SECRET begins. There may be background or trailing whitespace.
+    let (_hr, _hg, _hb, _ha) = sample_region(&data, w, h, 100, baseline_y, 60, h_strip);
+
+    // Region where SECRET would have rasterised — must be empty/white.
+    let secret_x: u32 = 180;
+    let (sr, sg, sb, _) = sample_region(&data, w, h, secret_x, baseline_y, 60, h_strip);
+    assert!(
+        sr > 240.0 && sg > 240.0 && sb > 240.0,
+        "SECRET run must not paint; region sampled at x={secret_x} got ({sr}, {sg}, {sb})"
+    );
+
+    // Region where "World" must paint AFTER the suppressed SECRET. If the
+    // text advance was skipped (bug #4), "World" would have painted under
+    // SECRET's slot (around x≈165..200) and this far-right region would be
+    // pure background. With the fix, dark glyph ink shows up here.
+    let world_x: u32 = 275;
+    let (wr, wg, wb, _) = sample_region(&data, w, h, world_x, baseline_y, 50, h_strip);
+    let world_brightness = (wr + wg + wb) / 3.0;
+    assert!(
+        world_brightness < 245.0,
+        "World text should paint at x≈{world_x} after suppressed run; got brightness {world_brightness}"
+    );
+}
+
+/// Build a PDF with 12 levels of nested BDC/EMC, alternating excluded and
+/// non-excluded layers, with a fill at the innermost scope.
+fn build_pdf_with_deeply_nested_bdc() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [5 0 R 6 0 R] /D << /ON [5 0 R 6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Properties << /KEEP 5 0 R /DROP 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // 12-deep nesting:
+    //  /OC /KEEP BDC × 6 alternating with /OC /DROP BDC × 6.
+    // Innermost: paint a red rect. Because one or more /DROP scopes are on
+    // the stack, the rect must be suppressed.
+    let mut content: Vec<u8> = Vec::new();
+    for i in 0..12 {
+        if i % 2 == 0 {
+            content.extend_from_slice(b"/OC /KEEP BDC ");
+        } else {
+            content.extend_from_slice(b"/OC /DROP BDC ");
+        }
+    }
+    content.extend_from_slice(b"1 0 0 rg 50 550 200 200 re f ");
+    for _ in 0..12 {
+        content.extend_from_slice(b"EMC ");
+    }
+    // After all EMCs, paint a green rect that MUST be visible.
+    content.extend_from_slice(b"0 1 0 rg 300 550 200 200 re f");
+
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(&content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"5 0 obj\n<< /Type /OCG /Name /Keep >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Drop >>\nendobj\n\n");
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+#[test]
+fn test_deeply_nested_bdc_stack_unwinds_correctly() {
+    let pdf_bytes = build_pdf_with_deeply_nested_bdc();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded = HashSet::from(["Drop".to_string()]);
+    let (data, w, h) = render_raw(&doc, excluded);
+
+    // Red rect at PDF (50,550)-(250,750) → pixel x=50..250, y=42..242.
+    let (r, g, b, _) = sample_region(&data, w, h, 100, 80, 50, 50);
+    assert!(
+        r > 250.0 && g > 250.0 && b > 250.0,
+        "Inner red rect must be suppressed by /Drop scope on 12-level stack; got ({r}, {g}, {b})"
+    );
+    // Green rect at PDF (300,550)-(500,750) → pixel x=300..500, y=42..242.
+    let (gr, gg, gb, _) = sample_region(&data, w, h, 350, 80, 50, 50);
+    assert!(
+        gg > 200.0 && gr < 50.0 && gb < 50.0,
+        "After all 12 EMCs, depth must be 0 and green rect visible; got ({gr}, {gg}, {gb})"
+    );
+}
+
+/// Build a PDF whose two pages each have a different OCG usage.
+fn build_pdf_multi_page() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // 1 Catalog, 2 Pages, 3 Page1, 4 Content1, 5 Page2, 6 Content2,
+    // 7 OCG-PageOne, 8 OCG-PageTwo.
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [7 0 R 8 0 R] /D << /ON [7 0 R 8 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>\nendobj\n\n");
+    // Page 1
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Properties << /L1 7 0 R >> >> >>\nendobj\n\n",
+    );
+    let content1: &[u8] = b"/OC /L1 BDC 1 0 0 rg 50 550 200 200 re f EMC";
+    offsets.push(pdf.len());
+    let hdr1 = format!("4 0 obj\n<< /Length {} >>\nstream\n", content1.len());
+    pdf.extend_from_slice(hdr1.as_bytes());
+    pdf.extend_from_slice(content1);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    // Page 2
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 6 0 R\n\
+           /Resources << /Properties << /L2 8 0 R >> >> >>\nendobj\n\n",
+    );
+    let content2: &[u8] = b"/OC /L2 BDC 0 0 1 rg 50 550 200 200 re f EMC";
+    offsets.push(pdf.len());
+    let hdr2 = format!("6 0 obj\n<< /Length {} >>\nstream\n", content2.len());
+    pdf.extend_from_slice(hdr2.as_bytes());
+    pdf.extend_from_slice(content2);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /PageOne >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"8 0 obj\n<< /Type /OCG /Name /PageTwo >>\nendobj\n\n");
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+fn render_page_raw(
+    doc: &PdfDocument,
+    page: usize,
+    excluded: HashSet<String>,
+) -> (Vec<u8>, u32, u32) {
+    let mut options = RenderOptions::with_dpi(72);
+    options.format = ImageFormat::RawRgba8;
+    options.excluded_layers = excluded;
+    let img = pdf_oxide::rendering::render_page(doc, page, &options).expect("render");
+    (img.data, img.width, img.height)
+}
+
+#[test]
+fn test_multi_page_per_page_filtering() {
+    let pdf_bytes = build_pdf_multi_page();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Exclude PageOne only; page 1's red rect must vanish, page 2's blue rect remains.
+    let excluded = HashSet::from(["PageOne".to_string()]);
+
+    let (p1, w1, h1) = render_page_raw(&doc, 0, excluded.clone());
+    let (r1, g1, b1, _) = sample_region(&p1, w1, h1, 100, 80, 50, 50);
+    assert!(
+        r1 > 250.0 && g1 > 250.0 && b1 > 250.0,
+        "Page 1 rect must be hidden when PageOne excluded; got ({r1}, {g1}, {b1})"
+    );
+
+    let (p2, w2, h2) = render_page_raw(&doc, 1, excluded);
+    let (r2, g2, b2, _) = sample_region(&p2, w2, h2, 100, 80, 50, 50);
+    assert!(
+        b2 > 200.0 && r2 < 50.0 && g2 < 50.0,
+        "Page 2 blue rect must survive a PageOne-only filter; got ({r2}, {g2}, {b2})"
+    );
+}
+
+/// Build a PDF that exercises one specific OCMD /P policy.
+///
+/// Two OCGs ("A", "B") and one OCMD with the given policy.
+/// Two rects: one inside the OCMD scope (test color), one outside (yellow,
+/// always visible).
+fn build_pdf_with_ocmd_policy(policy: &str) -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // 1 Catalog, 2 Pages, 3 Page, 4 Content,
+    // 5 OCMD, 6 OCG /A, 7 OCG /B
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R 7 0 R] /D << /ON [6 0 R 7 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Properties << /MC0 5 0 R >> >> >>\nendobj\n\n",
+    );
+    let content: &[u8] = b"/OC /MC0 BDC 0 0 1 rg 50 550 200 200 re f EMC \
+                           1 1 0 rg 300 550 200 200 re f";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    // OCMD with chosen /P, referencing OCGs 6 and 7.
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        format!("5 0 obj\n<< /Type /OCMD /OCGs [6 0 R 7 0 R] /P /{} >>\nendobj\n\n", policy)
+            .as_bytes(),
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /A >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /B >>\nendobj\n\n");
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+/// For each (policy, excluded_state) combination, assert whether the OCMD
+/// rect is visible. The yellow rect outside the BDC scope is always visible
+/// and serves as a control.
+fn assert_ocmd_visibility(policy: &str, excluded: HashSet<String>, expect_visible: bool) {
+    let pdf_bytes = build_pdf_with_ocmd_policy(policy);
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let (data, w, h) = render_raw(&doc, excluded.clone());
+
+    // Blue rect at pixel (50..250, 42..242). Sample its centre.
+    let (r, g, b, _) = sample_region(&data, w, h, 100, 80, 50, 50);
+    if expect_visible {
+        assert!(
+            b > 200.0 && r < 50.0 && g < 50.0,
+            "[{policy} excluded={:?}] expected visible blue, got ({r}, {g}, {b})",
+            excluded
+        );
+    } else {
+        assert!(
+            r > 250.0 && g > 250.0 && b > 250.0,
+            "[{policy} excluded={:?}] expected hidden, got ({r}, {g}, {b})",
+            excluded
+        );
+    }
+
+    // Yellow control rect at pixel (300..500, 42..242) must always be visible.
+    let (yr, yg, yb, _) = sample_region(&data, w, h, 350, 80, 50, 50);
+    assert!(
+        yr > 200.0 && yg > 200.0 && yb < 50.0,
+        "[{policy} excluded={:?}] yellow control rect missing: ({yr}, {yg}, {yb})",
+        excluded
+    );
+}
+
+// Note: the renderer short-circuits the OCMD evaluation when the user
+// supplied no excluded layers (the common "render everything" path). The
+// tests below therefore exercise each /P policy with at least one OCG
+// excluded — the realistic prepress use case.
+
+#[test]
+fn test_ocmd_policy_anyon() {
+    // AnyOn (default): visible iff any referenced OCG is on. Hide iff all off.
+    // A on, B on  -> visible
+    assert_ocmd_visibility("AnyOn", HashSet::from(["X".to_string()]), true);
+    // A off, B on -> visible (B still on)
+    assert_ocmd_visibility("AnyOn", HashSet::from(["A".to_string()]), true);
+    // A off, B off -> hidden
+    assert_ocmd_visibility("AnyOn", HashSet::from(["A".to_string(), "B".to_string()]), false);
+}
+
+#[test]
+fn test_ocmd_policy_allon() {
+    // AllOn: visible iff all on. Hide iff any off.
+    assert_ocmd_visibility("AllOn", HashSet::from(["X".to_string()]), true);
+    // A off -> any off -> hidden
+    assert_ocmd_visibility("AllOn", HashSet::from(["A".to_string()]), false);
+    assert_ocmd_visibility("AllOn", HashSet::from(["A".to_string(), "B".to_string()]), false);
+}
+
+#[test]
+fn test_ocmd_policy_anyoff() {
+    // AnyOff: visible iff any off. Hide iff all on.
+    // A off, B on -> visible
+    assert_ocmd_visibility("AnyOff", HashSet::from(["A".to_string()]), true);
+    // A off, B off -> visible
+    assert_ocmd_visibility("AnyOff", HashSet::from(["A".to_string(), "B".to_string()]), true);
+}
+
+#[test]
+fn test_ocmd_policy_alloff() {
+    // AllOff: visible iff all off. Hide iff any on.
+    // A off, B on -> hidden (B still on)
+    assert_ocmd_visibility("AllOff", HashSet::from(["A".to_string()]), false);
+    // A off, B off -> visible
+    assert_ocmd_visibility("AllOff", HashSet::from(["A".to_string(), "B".to_string()]), true);
+}
+
+/// Build a synthetic prepress-style PDF: dieline (cyan), varnish (yellow),
+/// and a CMYK process magenta artwork rect, each on its own OCG layer, plus
+/// a text overlay on no layer.
+fn build_pdf_prepress_layers() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // 1 Catalog, 2 Pages, 3 Page, 4 Content, 5 Font,
+    // 6 OCG Dieline, 7 OCG Varnish, 8 OCG Artwork.
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R 7 0 R 8 0 R]\n\
+                           /D << /ON [6 0 R 7 0 R 8 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >>\n\
+                         /Properties << /D 6 0 R /V 7 0 R /A 8 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Layered content:
+    //   Artwork (magenta-ish, RGB 1 0 1): big rect at (50,550)-(250,750)
+    //   Dieline (cyan, RGB 0 1 1): thin rect at (260,550)-(310,750)
+    //   Varnish (yellow, RGB 1 1 0): rect at (320,550)-(520,750)
+    //   Text: "PRINT" overlaid, no OCG
+    let content: &[u8] = b"\
+        /OC /A BDC 1 0 1 rg 50 550 200 200 re f EMC \
+        /OC /D BDC 0 1 1 rg 260 550 50 200 re f EMC \
+        /OC /V BDC 1 1 0 rg 320 550 200 200 re f EMC \
+        BT /F1 24 Tf 100 400 Td (PRINT) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Dieline >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /Varnish >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"8 0 obj\n<< /Type /OCG /Name /Artwork >>\nendobj\n\n");
+
+    write_xref_trailer(&mut pdf, &offsets);
+    pdf
+}
+
+#[test]
+fn test_prepress_fixture_combinations() {
+    let pdf_bytes = build_pdf_prepress_layers();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Default render: all three layer rects must be visible.
+    let (data_all, w, h) = render_raw(&doc, HashSet::new());
+    let (ar, ag, ab, _) = sample_region(&data_all, w, h, 100, 80, 30, 30);
+    assert!(
+        ar > 200.0 && ab > 200.0 && ag < 80.0,
+        "Artwork (magenta) missing: ({ar}, {ag}, {ab})"
+    );
+    let (dr, dg, db, _) = sample_region(&data_all, w, h, 270, 80, 30, 30);
+    assert!(
+        dr < 80.0 && dg > 200.0 && db > 200.0,
+        "Dieline (cyan) missing: ({dr}, {dg}, {db})"
+    );
+    let (vr, vg, vb, _) = sample_region(&data_all, w, h, 370, 80, 30, 30);
+    assert!(
+        vr > 200.0 && vg > 200.0 && vb < 80.0,
+        "Varnish (yellow) missing: ({vr}, {vg}, {vb})"
+    );
+
+    // Drop Dieline + Varnish (a typical "show me the artwork only" view).
+    let excluded = HashSet::from(["Dieline".to_string(), "Varnish".to_string()]);
+    let (data, w, h) = render_raw(&doc, excluded);
+    let (ar, ag, ab, _) = sample_region(&data, w, h, 100, 80, 30, 30);
+    assert!(
+        ar > 200.0 && ab > 200.0 && ag < 80.0,
+        "Artwork should remain when only finishing layers dropped: ({ar}, {ag}, {ab})"
+    );
+    let (dr, dg, db, _) = sample_region(&data, w, h, 270, 80, 30, 30);
+    assert!(
+        dr > 240.0 && dg > 240.0 && db > 240.0,
+        "Dieline must be hidden: ({dr}, {dg}, {db})"
+    );
+    let (vr, vg, vb, _) = sample_region(&data, w, h, 370, 80, 30, 30);
+    assert!(
+        vr > 240.0 && vg > 240.0 && vb > 240.0,
+        "Varnish must be hidden: ({vr}, {vg}, {vb})"
+    );
+
+    // Drop Artwork only — finishing layers remain (typical "tech-pack only" view).
+    let excluded = HashSet::from(["Artwork".to_string()]);
+    let (data, w, h) = render_raw(&doc, excluded);
+    let (ar, ag, ab, _) = sample_region(&data, w, h, 100, 80, 30, 30);
+    assert!(
+        ar > 240.0 && ag > 240.0 && ab > 240.0,
+        "Artwork must be hidden: ({ar}, {ag}, {ab})"
+    );
+    let (dr, dg, db, _) = sample_region(&data, w, h, 270, 80, 30, 30);
+    assert!(dr < 80.0 && dg > 200.0 && db > 200.0, "Dieline must remain: ({dr}, {dg}, {db})");
+    let (vr, vg, vb, _) = sample_region(&data, w, h, 370, 80, 30, 30);
+    assert!(vr > 200.0 && vg > 200.0 && vb < 80.0, "Varnish must remain: ({vr}, {vg}, {vb})");
+}

--- a/tests/test_render_ocg_filtering.rs
+++ b/tests/test_render_ocg_filtering.rs
@@ -1243,6 +1243,81 @@ fn test_ve_or_operator() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// /D default-off respect — ISO 32000-1 §8.11.4
+// ---------------------------------------------------------------------------
+
+/// PDF whose /OCProperties/D entry marks an OCG as off by default.
+fn build_pdf_with_default_off_layer() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /BaseState /ON /OFF [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"/OC /MC0 BDC 0 0 1 rg 50 550 200 200 re f EMC \
+                    0 1 0 rg 300 550 200 200 re f";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Watermark >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_default_off_layer_hidden_with_empty_exclusions() {
+    // /D/OFF marks Watermark off — content should be hidden even when the
+    // caller passes no excluded_layers.
+    let doc = PdfDocument::from_bytes(build_pdf_with_default_off_layer()).unwrap();
+    let (data, w, h) = render_raw(&doc, HashSet::new());
+    let (r, g, b, _) = sample_region(&data, w, h, 100, 100, 30, 30);
+    assert!(
+        r > 240.0 && g > 240.0 && b > 240.0,
+        "Default-off OCG content should be hidden: ({r}, {g}, {b})"
+    );
+    let (r2, g2, b2, _) = sample_region(&data, w, h, 350, 100, 30, 30);
+    assert!(
+        r2 < 80.0 && g2 > 200.0 && b2 < 80.0,
+        "Unrelated content should remain: ({r2}, {g2}, {b2})"
+    );
+}
+
 #[test]
 fn test_ve_nested_expression() {
     // /VE = [/And 7 0 R [/Not 8 0 R]]   — A on AND B off


### PR DESCRIPTION
## Description

Adds OCG (Optional Content Group) layer filtering to the PDF rendering pipeline. Callers can pass `excluded_layers` to render with specific layers suppressed — content within `/OC` marked-content scopes referencing those OCGs (and annotations with `/OC` entries) is omitted from the rendered output.

The renderer also respects the PDF's default OCG visibility configuration (`/OCProperties/D`) per ISO 32000-1 §8.11.4 — OCGs that are off in the default state are hidden during rendering even when the caller passes no explicit exclusions. This matches what a PDF viewer would display by default.

This is the rendering counterpart to the OCG layer filtering already supported in text extraction. The primary use case is prepress workflows where a single PDF carries multiple layers (artwork, dieline, varnish, watermark, "DRAFT" stamps) and downstream consumers need a specific subset rendered.

Also extracts a shared `optional_content` module so the text extractor and renderer use one canonical implementation of OCG/OCMD resolution, eliminating duplication and a non-ASCII-name decoding regression that existed in the renderer's earlier inline copy.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [x] Tests

## Related Issues

Builds on `feature/ocg-ink-filtering-and-cache-fix` (OCG text extraction). No specific issue.

## Changes Made

### New shared module: `src/optional_content.rs`

Both the text extractor and renderer previously had near-duplicate OCG/OCMD resolution code (the renderer's copy was missing UTF-16LE BOM and PDFDocEncoding fallback in its text-string decoder — a silent correctness regression). Consolidated into:

- `compute_default_off_ocgs(doc)` — reads `/OCProperties/D` (`BaseState`, `/ON`, `/OFF`) and returns OCG names off in the default state
- `decode_pdf_text_string(bytes: &[u8]) -> String` — UTF-16BE/LE BOM, UTF-8, PDFDocEncoding fallback
- `ocg_name_is_excluded(name_obj, excluded)` — handles `Name` and `String` OCG names
- `check_ocg_excluded(props_dict, doc, excluded)` — direct OCG and OCMD dispatch
- `resolve_bdc_properties(properties, resources, doc)` — handles inline dicts and `/Resources/Properties` name references, with indirect-reference resolution at every level
- `annotation_is_excluded(annot_dict, doc, excluded)` — for annotation `/OC` entries
- `OcmdPolicy` enum + `ocmd_is_hidden()` — full `/P` policy implementation (`AnyOn`, `AllOn`, `AnyOff`, `AllOff`)
- `evaluate_visibility_expression()` — full `/VE` boolean expression evaluator (`/And`, `/Or`, `/Not`, nested expressions, OCG references) with bounded recursion depth

### Renderer changes (`src/rendering/page_renderer.rs`)

- `RenderOptions.excluded_layers: HashSet<String>` field
- Per-render snapshot combines `compute_default_off_ocgs(doc)` with caller's `excluded_layers` — the effective "off" set respects both the PDF's default state and the caller's overrides
- BDC/BMC/EMC tracking via a `Vec<bool>` stack (correctly handles nested mixed-exclusion scopes — a flat depth counter would be wrong for `BDC excluded BDC not_excluded EMC EMC`)
- Suppression applied at all paint sites: paths (`S`, `s`, `f`, `F`, `f*`, `B`, `B*`, `b`, `b*`, `n`), text (`Tj`, `TJ`, `'`, `"`), XObjects (`Do`), shadings (`sh`), and clip operators (`W`, `W*`)
- Clip operators are no-ops inside excluded scopes (prevents clip leakage when `W n` appears without surrounding `q/Q`)
- Text advance is computed and applied even when suppressed, via new `TextRasterizer::measure_text` / `measure_tj_array` — visible text following a suppressed run paints at the correct X
- Annotation `/OC` consulted in `render_annotations` — watermark annotations tagged with their OCG are correctly filtered
- Form XObject recursion preserves the marked-content stack scope
- `Arc<HashSet<String>>` snapshot eliminates per-recursion clone of the exclusion set

### Python bindings (`src/python.rs`)

- `excluded_layers: Optional[List[str]]` keyword argument on `PdfDocument.render_page`, `PdfDocument.render_page_fit`, and `Page.render`

### FFI (`src/ffi.rs`)

- New `pdf_render_page_with_options_ex` entry point accepting UTF-8 layer name strings
- Original ABI preserved for backward compatibility

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

22 tests in `tests/test_render_ocg_filtering.rs`, all asserting on actual pixel data from synthetic PDFs:

- Rectangle visibility with/without filter
- Unrelated layer exclusion produces identical output (pipeline parity)
- OCMD-referenced content
- Form XObject containing OCG-tagged content (scope crossing)
- Empty exclusion set short-circuits cleanly
- Nested mixed-exclusion BDC scopes (stack correctness)
- Clip path inside excluded scope doesn't leak
- Annotation with `/OC` is filtered
- Text positioning preserved when intermediate run is suppressed
- Non-ASCII OCG `/Name` stored as UTF-16LE BOM PDF string
- All four OCMD `/P` policies (`AnyOn`, `AllOn`, `AnyOff`, `AllOff`)
- All three `/VE` operators (`/Not`, `/And`, `/Or`) plus nested `[/And refA [/Not refB]]`
- Default-off OCG (`/D/OFF`) hidden with empty user exclusions

Full test suite: 5,281 lib tests + integration tests pass. Clippy clean.

## Python Bindings (if applicable)

- [x] Python bindings updated (if needed)
- [ ] Python tests pass - No - pre-existing failures
- [x] Python code formatted with `ruff format`
- [x] Python code linted with `ruff check`

Existing `extract_text` / `extract_chars` kwargs (`exclude_layers`) were already in place from the prior PR — this PR mirrors that surface on `render_page` and `render_page_fit`.

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

Doc comments on all new public APIs and the shared `optional_content` module. `OcmdPolicy` enum documents each variant's semantics with PDF spec §8.11.2.2 references. `evaluate_visibility_expression` references §8.11.2.4. `compute_default_off_ocgs` references §8.11.4.

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)
<img width="1700" height="2200" alt="01_baseline" src="https://github.com/user-attachments/assets/9b6dcc85-71a6-43c6-839f-dae6f04f56c6" />
<img width="1700" height="2200" alt="02_no_background" src="https://github.com/user-attachments/assets/fe523766-7d72-4c27-9992-613f677a561a" />
<img width="1700" height="2200" alt="03_no_annotations" src="https://github.com/user-attachments/assets/2015668b-a7f6-417f-8849-bb0c9895304a" />
<img width="1700" height="2200" alt="04_production_view" src="https://github.com/user-attachments/assets/78109637-91ef-45e8-9733-565871b27a79" />

Each PNG was rendered at 200 DPI from the same synthetic PDF.
The PDF has three OCG layers:
  Background   — light-blue rectangle covering most of the page
  Annotations  — red 'DRAFT - DO NOT USE' stamp
  Watermark    — large gray 'CONFIDENTIAL' text
Always-visible content: black title 'Sample Document' and body text.

Files:
  01_baseline.png  (205 KB)
    Baseline: all layers visible (Background, Annotations, Watermark)
  02_no_background.png  (190 KB)
    No Background: light-blue rect hidden; title, body, DRAFT stamp and CONFIDENTIAL still visible
  03_no_annotations.png  (173 KB)
    No Annotations: red DRAFT stamp hidden; everything else visible
  04_production_view.png  (147 KB)
    Production view: both DRAFT stamp and CONFIDENTIAL watermark hidden (real-world prepress use case)



## Additional Notes

**Default OCG state respected (spec-correct).** Per ISO 32000-1 §8.11.4, OCGs have a default visibility set by `/OCProperties/D/BaseState`, `/D/ON`, and `/D/OFF`. The renderer reads these on every render and treats OCGs that are off in the default config as hidden, even when the caller passes empty `excluded_layers`. Caller exclusions compose with this default state (additional offs). `/D/BaseState /Unchanged` is treated as `/ON` since libraries have no prior viewer state to preserve.

**Forced inclusion not supported.** The current API only supports excluding layers. A PDF with `/D/OFF [ref]` will render that OCG hidden, with no way to force it visible. If that's needed, an additional `included_layers` parameter can be added in a follow-up.

**Shared module benefit.** Extracting `optional_content` resolved a latent silent bug — the renderer's previous inline copy of `decode_pdf_text_string` was missing UTF-16LE BOM and PDFDocEncoding fallback, so OCG names stored as non-ASCII PDF strings would silently fail to match. The shared module fixes this for both text extraction and rendering simultaneously.