### PR TITLE
feat: separation plate rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [Unreleased]
+
+### Added
+- **Separation plate rendering** — new `render_separations(page, dpi)` and
+  `render_separation(page, ink_name, dpi)` APIs (Rust + Python) that emit
+  one grayscale image per ink. Pixel value equals ink coverage (0 = no ink,
+  255 = full tint). Routes DeviceCMYK, Separation, and DeviceN content
+  per ISO 32000-1 §8.6; handles the reserved colorant names `/All` and
+  `/None` per §8.6.6.4 (registration / crop marks correctly appear on
+  every plate). New `SeparationPlate` namedtuple in Python.
+
 ## [0.3.55] - 2026-05-25
 
 > Ruby + PHP language bindings + multi-line heading reading-order fix

--- a/python/pdf_oxide/__init__.py
+++ b/python/pdf_oxide/__init__.py
@@ -110,6 +110,27 @@ class RenderedPixmap(NamedTuple):
     height: int
 
 
+class SeparationPlate(NamedTuple):
+    """A single ink separation plate rendered as grayscale.
+
+    Pixel intensity (0-255) represents the tint percentage of one ink at
+    each point. Used in prepress workflows, ink coverage analysis, and ML
+    pipelines that process packaging/label PDFs.
+
+    Attributes:
+        ink_name (str): Ink name (e.g., "Cyan", "PANTONE 185 C", "Dieline").
+        data (bytes): Grayscale pixels, row-major, top-left origin.
+            ``len(data) == width * height``. 0 = no ink, 255 = full tint.
+        width (int): Image width in pixels.
+        height (int): Image height in pixels.
+    """
+
+    ink_name: str
+    data: bytes
+    width: int
+    height: int
+
+
 from ._async import (  # noqa: E402
     AsyncOfficeConverter,
     AsyncPdf,
@@ -182,6 +203,7 @@ from .pdf_oxide import (  # noqa: E402
 
 __all__ = [
     "RenderedPixmap",
+    "SeparationPlate",
     "PdfDocument",
     "AsyncPdfDocument",
     "AsyncPdf",

--- a/python/pdf_oxide/__init__.py
+++ b/python/pdf_oxide/__init__.py
@@ -117,6 +117,11 @@ class SeparationPlate(NamedTuple):
     each point. Used in prepress workflows, ink coverage analysis, and ML
     pipelines that process packaging/label PDFs.
 
+    The pixel convention is ML/QC-friendly: ``value == ink coverage``.
+    0 means no ink, 255 means full tint coverage. To display the plate as
+    black ink on white paper (prepress viewer convention), invert before
+    showing: ``display = 255 - value``.
+
     Attributes:
         ink_name (str): Ink name (e.g., "Cyan", "PANTONE 185 C", "Dieline").
         data (bytes): Grayscale pixels, row-major, top-left origin.

--- a/src/document.rs
+++ b/src/document.rs
@@ -8652,9 +8652,19 @@ impl PdfDocument {
 
     /// Extract text from a page, excluding content from specified layers and inks.
     ///
-    /// Uses a simplified text assembly pipeline (no structure-tree ordering or
-    /// table detection). For most layer/ink filtering use cases this is
-    /// sufficient since the caller is performing targeted extraction.
+    /// # Text assembly differences
+    ///
+    /// This method uses a simplified text assembly pipeline compared to
+    /// [`extract_text`](Self::extract_text): spans are sorted by row-aware reading order and joined
+    /// with line breaks based on Y-gap heuristics. The full pipeline's
+    /// structure-tree ordering, table detection, and column detection are
+    /// **not** applied. This means:
+    /// - Multi-column layouts may interleave columns
+    /// - Tables will not be reconstructed
+    /// - Reading order depends on coordinate sorting, not document structure
+    ///
+    /// For precise spatial control, use [`extract_chars_filtered`](Self::extract_chars_filtered) and assemble
+    /// text yourself, or apply region filtering on top.
     ///
     /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
     /// ANY ink in the DeviceN array matches an excluded ink name. Tint values

--- a/src/document.rs
+++ b/src/document.rs
@@ -4694,9 +4694,19 @@ impl PdfDocument {
         page_index: usize,
         options: &crate::converters::ConversionOptions,
     ) -> Result<String> {
+        let base_spans = self.extract_spans(page_index)?;
+        self.assemble_text_from_spans(page_index, base_spans, options)
+    }
+
+    fn assemble_text_from_spans(
+        &self,
+        page_index: usize,
+        base_spans: Vec<crate::layout::TextSpan>,
+        options: &crate::converters::ConversionOptions,
+    ) -> Result<String> {
         self.require_authenticated()?;
 
-        let mut base_spans = self.extract_spans(page_index)?;
+        let mut base_spans = base_spans;
 
         // Drop spans that fall inside any caller-specified exclusion region.
         // This runs before the structure-tree and table pipelines so that
@@ -7989,7 +7999,26 @@ impl PdfDocument {
     /// # }
     /// ```
     pub fn extract_spans(&self, page_index: usize) -> Result<Vec<crate::layout::TextSpan>> {
-        let mut spans = self.extract_spans_raw(page_index)?;
+        let spans = self.extract_spans_raw(page_index)?;
+        self.postprocess_spans(page_index, spans)
+    }
+
+    fn extract_spans_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        let spans = self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
+        self.postprocess_spans(page_index, spans)
+    }
+
+    fn postprocess_spans(
+        &self,
+        page_index: usize,
+        raw_spans: Vec<crate::layout::TextSpan>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        let mut spans = raw_spans;
 
         // Drop spans whose bbox lies entirely outside the page's MediaBox.
         // PDFs that reuse one big Form XObject across pages (ExpertPdf and
@@ -8652,19 +8681,9 @@ impl PdfDocument {
 
     /// Extract text from a page, excluding content from specified layers and inks.
     ///
-    /// # Text assembly differences
-    ///
-    /// This method uses a simplified text assembly pipeline compared to
-    /// [`extract_text`](Self::extract_text): spans are sorted by row-aware reading order and joined
-    /// with line breaks based on Y-gap heuristics. The full pipeline's
-    /// structure-tree ordering, table detection, and column detection are
-    /// **not** applied. This means:
-    /// - Multi-column layouts may interleave columns
-    /// - Tables will not be reconstructed
-    /// - Reading order depends on coordinate sorting, not document structure
-    ///
-    /// For precise spatial control, use [`extract_chars_filtered`](Self::extract_chars_filtered) and assemble
-    /// text yourself, or apply region filtering on top.
+    /// Uses the same full text assembly pipeline as [`extract_text`](Self::extract_text)
+    /// (structure-tree ordering, table detection, column detection), but with
+    /// layer/ink-excluded spans removed before assembly.
     ///
     /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
     /// ANY ink in the DeviceN array matches an excluded ink name. Tint values
@@ -8685,48 +8704,12 @@ impl PdfDocument {
             return self.extract_text(page_index);
         }
 
-        let mut spans =
-            self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
-
-        // Apply media-box clipping (same as extract_spans)
-        if let Ok((llx, lly, urx, ury)) = self.get_page_media_box(page_index) {
-            const EDGE_TOLERANCE_PT: f32 = 2.0;
-            let left = llx - EDGE_TOLERANCE_PT;
-            let bottom = lly - EDGE_TOLERANCE_PT;
-            let right = urx + EDGE_TOLERANCE_PT;
-            let top = ury + EDGE_TOLERANCE_PT;
-            spans.retain(|span| {
-                let sx1 = span.bbox.x;
-                let sx2 = span.bbox.x + span.bbox.width;
-                let sy1 = span.bbox.y;
-                let sy2 = span.bbox.y + span.bbox.height;
-                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
-            });
-        }
-
-        // Row-aware reading order sort
-        spans.sort_by(|a, b| {
-            crate::utils::row_aware_span_cmp(a.bbox.y, a.bbox.x, b.bbox.y, b.bbox.x)
-        });
-
-        // Build text from spans
-        let mut text = String::new();
-        let mut last_y: Option<f32> = None;
-        for span in &spans {
-            if let Some(prev_y) = last_y {
-                let y_gap = (prev_y - span.bbox.y).abs();
-                if y_gap > span.bbox.height.max(1.0) * 0.5 {
-                    text.push('\n');
-                }
-            }
-            if !text.is_empty() && !text.ends_with('\n') && !text.ends_with(' ') {
-                text.push(' ');
-            }
-            text.push_str(&span.text);
-            last_y = Some(span.bbox.y);
-        }
-
-        Ok(text)
+        let spans = self.extract_spans_filtered(page_index, excluded_layers, excluded_inks)?;
+        let options = crate::converters::ConversionOptions {
+            extract_tables: true,
+            ..Default::default()
+        };
+        self.assemble_text_from_spans(page_index, spans, &options)
     }
 
     /// Extract text spans from a page using a specified reading order strategy.

--- a/src/document.rs
+++ b/src/document.rs
@@ -8624,6 +8624,129 @@ impl PdfDocument {
         extractor.extract_text_spans(&content_data)
     }
 
+    /// Extract raw text spans with layer and ink exclusion filtering.
+    ///
+    /// Same as [`extract_spans_raw`] but configures the extractor to suppress
+    /// content from specified OCG layers and Separation/DeviceN ink color spaces.
+    fn extract_spans_raw_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        self.require_authenticated()?;
+        use crate::extractors::TextExtractor;
+
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        if self.page_cannot_have_text(page_dict) {
+            return Ok(Vec::new());
+        }
+
+        let content_data = match self.get_page_content_data(page_index) {
+            Ok(data) => data,
+            Err(e) => {
+                log::warn!(
+                    "Failed to decode content stream for page {}: {}, returning empty",
+                    page_index,
+                    e
+                );
+                return Ok(Vec::new());
+            },
+        };
+
+        if !Self::may_contain_text(&content_data) {
+            return Ok(Vec::new());
+        }
+
+        let mut extractor =
+            TextExtractor::with_config(crate::extractors::TextExtractionConfig::default());
+        extractor.set_excluded_layers(excluded_layers);
+        extractor.set_excluded_inks(excluded_inks);
+        if let Some(resources) = page_dict.get("Resources") {
+            extractor.set_resources(resources.clone());
+            extractor.set_document(self);
+            if let Err(e) = self.load_fonts(resources, &mut extractor) {
+                log::warn!(
+                    "Failed to load fonts for page {}: {}, continuing with defaults",
+                    page_index,
+                    e
+                );
+            }
+        }
+
+        extractor.extract_text_spans(&content_data)
+    }
+
+    /// Extract text from a page, excluding content from specified layers and inks.
+    ///
+    /// Uses a simplified text assembly pipeline (no structure-tree ordering or
+    /// table detection). For most layer/ink filtering use cases this is
+    /// sufficient since the caller is performing targeted extraction.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_index` - Zero-based page index
+    /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
+    /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
+    pub fn extract_text_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<String> {
+        if excluded_layers.is_empty() && excluded_inks.is_empty() {
+            return self.extract_text(page_index);
+        }
+
+        let mut spans =
+            self.extract_spans_raw_filtered(page_index, excluded_layers, excluded_inks)?;
+
+        // Apply media-box clipping (same as extract_spans)
+        if let Ok((llx, lly, urx, ury)) = self.get_page_media_box(page_index) {
+            const EDGE_TOLERANCE_PT: f32 = 2.0;
+            let left = llx - EDGE_TOLERANCE_PT;
+            let bottom = lly - EDGE_TOLERANCE_PT;
+            let right = urx + EDGE_TOLERANCE_PT;
+            let top = ury + EDGE_TOLERANCE_PT;
+            spans.retain(|span| {
+                let sx1 = span.bbox.x;
+                let sx2 = span.bbox.x + span.bbox.width;
+                let sy1 = span.bbox.y;
+                let sy2 = span.bbox.y + span.bbox.height;
+                sx2 > left && sx1 < right && sy2 > bottom && sy1 < top
+            });
+        }
+
+        // Row-aware reading order sort
+        spans.sort_by(|a, b| {
+            crate::utils::row_aware_span_cmp(a.bbox.y, a.bbox.x, b.bbox.y, b.bbox.x)
+        });
+
+        // Build text from spans
+        let mut text = String::new();
+        let mut last_y: Option<f32> = None;
+        for span in &spans {
+            if let Some(prev_y) = last_y {
+                let y_gap = (prev_y - span.bbox.y).abs();
+                if y_gap > span.bbox.height.max(1.0) * 0.5 {
+                    text.push('\n');
+                }
+            }
+            if !text.is_empty() && !text.ends_with('\n') && !text.ends_with(' ') {
+                text.push(' ');
+            }
+            text.push_str(&span.text);
+            last_y = Some(span.bbox.y);
+        }
+
+        Ok(text)
+    }
+
     /// Extract text spans from a page using a specified reading order strategy.
     ///
     /// This method extracts text spans identically to [`extract_spans`](Self::extract_spans),
@@ -8884,6 +9007,162 @@ impl PdfDocument {
     /// # }
     /// ```
     ///
+    /// List all Optional Content Group (OCG) layer names in the document.
+    ///
+    /// Reads `/OCProperties` from the document catalog and returns the `/Name`
+    /// of each OCG dictionary listed in `/OCGs`. These names can be passed to
+    /// `extract_text_filtered` / `extract_chars_filtered` via `excluded_layers`.
+    ///
+    /// Returns an empty vec if the document has no optional content.
+    pub fn get_layers(&self) -> Result<Vec<String>> {
+        let catalog = self.catalog()?;
+        let catalog_dict = catalog
+            .as_dict()
+            .ok_or_else(|| Error::InvalidPdf("Catalog is not a dictionary".to_string()))?;
+
+        let oc_props = match catalog_dict.get("OCProperties") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let oc_dict = match oc_props.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let ocgs_obj = match oc_dict.get("OCGs") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let ocgs_arr = match ocgs_obj.as_array() {
+            Some(a) => a,
+            None => return Ok(Vec::new()),
+        };
+
+        let mut names = Vec::new();
+        for item in ocgs_arr {
+            let ocg_obj = if let Some(r) = item.as_reference() {
+                match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                item.clone()
+            };
+            if let Some(d) = ocg_obj.as_dict() {
+                if let Some(Object::Name(n)) = d.get("Name") {
+                    names.push(n.clone());
+                } else if let Some(Object::String(s)) = d.get("Name") {
+                    if let Ok(text) = String::from_utf8(s.clone()) {
+                        names.push(text);
+                    }
+                }
+            }
+        }
+        Ok(names)
+    }
+
+    /// List ink / separation names used on a specific page.
+    ///
+    /// Scans the page's `/Resources /ColorSpace` dictionary for `/Separation`
+    /// and `/DeviceN` color space definitions and returns their ink names.
+    /// These names can be passed to `extract_text_filtered` /
+    /// `extract_chars_filtered` via `excluded_inks`.
+    pub fn get_page_inks(&self, page_index: usize) -> Result<Vec<String>> {
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        let resources = match page_dict.get("Resources") {
+            Some(r) => {
+                if let Some(rr) = r.as_reference() {
+                    self.load_object(rr)?
+                } else {
+                    r.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let res_dict = match resources.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let cs_obj = match res_dict.get("ColorSpace") {
+            Some(obj) => {
+                if let Some(r) = obj.as_reference() {
+                    self.load_object(r)?
+                } else {
+                    obj.clone()
+                }
+            },
+            None => return Ok(Vec::new()),
+        };
+
+        let cs_dict = match cs_obj.as_dict() {
+            Some(d) => d,
+            None => return Ok(Vec::new()),
+        };
+
+        let mut ink_names = Vec::new();
+        for (_name, cs_def) in cs_dict.iter() {
+            let cs_arr_obj = if let Some(r) = cs_def.as_reference() {
+                match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                cs_def.clone()
+            };
+
+            if let Some(arr) = cs_arr_obj.as_array() {
+                if arr.len() >= 2 {
+                    if let Some(Object::Name(cs_type)) = arr.first() {
+                        match cs_type.as_str() {
+                            "Separation" => {
+                                // [/Separation /InkName /AlternateCS /TintTransform]
+                                if let Some(Object::Name(ink)) = arr.get(1) {
+                                    ink_names.push(ink.clone());
+                                }
+                            },
+                            "DeviceN" => {
+                                // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
+                                if let Some(Object::Array(inks)) = arr.get(1) {
+                                    for ink_obj in inks {
+                                        if let Object::Name(ink) = ink_obj {
+                                            ink_names.push(ink.clone());
+                                        }
+                                    }
+                                }
+                            },
+                            _ => {},
+                        }
+                    }
+                }
+            }
+        }
+
+        ink_names.sort();
+        ink_names.dedup();
+        Ok(ink_names)
+    }
+
     /// # Performance Note
     ///
     /// Character extraction is typically 30-50% faster than span extraction
@@ -8946,6 +9225,73 @@ impl PdfDocument {
                 return y_cmp;
             }
             // X-ascending (left-to-right)
+            crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
+        });
+
+        Ok(chars)
+    }
+
+    /// Extract characters from a page, excluding content from specified layers and inks.
+    ///
+    /// # Arguments
+    ///
+    /// * `page_index` - Zero-based page index
+    /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
+    /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
+    pub fn extract_chars_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextChar>> {
+        use crate::extractors::TextExtractor;
+
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+
+        let content_data = match self.get_page_content_data(page_index) {
+            Ok(data) => data,
+            Err(e) => {
+                log::warn!(
+                    "Failed to decode content stream for page {}: {}, returning empty",
+                    page_index,
+                    e
+                );
+                return Ok(Vec::new());
+            },
+        };
+
+        if !Self::may_contain_text(&content_data) {
+            return Ok(Vec::new());
+        }
+
+        let mut extractor = TextExtractor::new();
+        extractor.set_excluded_layers(excluded_layers);
+        extractor.set_excluded_inks(excluded_inks);
+
+        if let Some(resources) = page_dict.get("Resources") {
+            extractor.set_resources(resources.clone());
+            extractor.set_document(self);
+
+            if let Err(e) = self.load_fonts(resources, &mut extractor) {
+                log::warn!(
+                    "Failed to load fonts for page {}: {}, continuing with defaults",
+                    page_index,
+                    e
+                );
+            }
+        }
+
+        let mut chars = extractor.extract(&content_data)?;
+
+        chars.sort_by(|a, b| {
+            let y_cmp = crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y);
+            if y_cmp != std::cmp::Ordering::Equal {
+                return y_cmp;
+            }
             crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
         });
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -9006,7 +9006,7 @@ impl PdfDocument {
     /// # Ok(())
     /// # }
     /// ```
-    ///
+
     /// List all Optional Content Group (OCG) layer names in the document.
     ///
     /// Reads `/OCProperties` from the document catalog and returns the `/Name`

--- a/src/document.rs
+++ b/src/document.rs
@@ -8688,6 +8688,10 @@ impl PdfDocument {
     /// table detection). For most layer/ink filtering use cases this is
     /// sufficient since the caller is performing targeted extraction.
     ///
+    /// **Ink filtering note:** For DeviceN color spaces, text is suppressed if
+    /// ANY ink in the DeviceN array matches an excluded ink name. Tint values
+    /// are not evaluated — this is an all-or-nothing match.
+    ///
     /// # Arguments
     ///
     /// * `page_index` - Zero-based page index

--- a/src/document.rs
+++ b/src/document.rs
@@ -8575,62 +8575,27 @@ impl PdfDocument {
         page_index: usize,
         config: crate::extractors::TextExtractionConfig,
     ) -> Result<Vec<crate::layout::TextSpan>> {
-        self.require_authenticated()?;
-        use crate::extractors::TextExtractor;
-
-        // Get page object
-        let page = self.get_page(page_index)?;
-        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
-            offset: 0,
-            reason: "Page is not a dictionary".to_string(),
-        })?;
-
-        // Fast pre-check: skip pages that cannot produce text based on resources alone.
-        if self.page_cannot_have_text(page_dict) {
-            return Ok(Vec::new());
-        }
-
-        // Get content stream data — skip page on decode failure (Annex I)
-        let content_data = match self.get_page_content_data(page_index) {
-            Ok(data) => data,
-            Err(e) => {
-                log::warn!(
-                    "Failed to decode content stream for page {}: {}, returning empty",
-                    page_index,
-                    e
-                );
-                return Ok(Vec::new());
-            },
-        };
-
-        if !Self::may_contain_text(&content_data) {
-            return Ok(Vec::new());
-        }
-
-        // Single-pass extraction with the provided config
-        let mut extractor = TextExtractor::with_config(config);
-        if let Some(resources) = page_dict.get("Resources") {
-            extractor.set_resources(resources.clone());
-            extractor.set_document(self);
-            if let Err(e) = self.load_fonts(resources, &mut extractor) {
-                log::warn!(
-                    "Failed to load fonts for page {}: {}, continuing with defaults",
-                    page_index,
-                    e
-                );
-            }
-        }
-
-        extractor.extract_text_spans(&content_data)
+        self.extract_spans_impl(page_index, config, HashSet::new(), HashSet::new())
     }
 
-    /// Extract raw text spans with layer and ink exclusion filtering.
-    ///
-    /// Same as [`extract_spans_raw`] but configures the extractor to suppress
-    /// content from specified OCG layers and Separation/DeviceN ink color spaces.
     fn extract_spans_raw_filtered(
         &self,
         page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextSpan>> {
+        self.extract_spans_impl(
+            page_index,
+            crate::extractors::TextExtractionConfig::default(),
+            excluded_layers,
+            excluded_inks,
+        )
+    }
+
+    fn extract_spans_impl(
+        &self,
+        page_index: usize,
+        config: crate::extractors::TextExtractionConfig,
         excluded_layers: HashSet<String>,
         excluded_inks: HashSet<String>,
     ) -> Result<Vec<crate::layout::TextSpan>> {
@@ -8663,10 +8628,13 @@ impl PdfDocument {
             return Ok(Vec::new());
         }
 
-        let mut extractor =
-            TextExtractor::with_config(crate::extractors::TextExtractionConfig::default());
-        extractor.set_excluded_layers(excluded_layers);
-        extractor.set_excluded_inks(excluded_inks);
+        let mut extractor = TextExtractor::with_config(config);
+        if !excluded_layers.is_empty() {
+            extractor.set_excluded_layers(excluded_layers);
+        }
+        if !excluded_inks.is_empty() {
+            extractor.set_excluded_inks(excluded_inks);
+        }
         if let Some(resources) = page_dict.get("Resources") {
             extractor.set_resources(resources.clone());
             extractor.set_document(self);
@@ -9172,67 +9140,7 @@ impl PdfDocument {
     /// Character extraction is typically 30-50% faster than span extraction
     /// because it skips the text grouping and merging logic.
     pub fn extract_chars(&self, page_index: usize) -> Result<Vec<crate::layout::TextChar>> {
-        use crate::extractors::TextExtractor;
-
-        // Get page object
-        let page = self.get_page(page_index)?;
-        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
-            offset: 0,
-            reason: "Page is not a dictionary".to_string(),
-        })?;
-
-        // Get content stream data — skip page on decode failure (Annex I)
-        let content_data = match self.get_page_content_data(page_index) {
-            Ok(data) => data,
-            Err(e) => {
-                log::warn!(
-                    "Failed to decode content stream for page {}: {}, returning empty",
-                    page_index,
-                    e
-                );
-                return Ok(Vec::new());
-            },
-        };
-
-        // Early-out for pages with no text content (§9.4.3)
-        if !Self::may_contain_text(&content_data) {
-            return Ok(Vec::new());
-        }
-
-        // Create text extractor for character-level extraction
-        let mut extractor = TextExtractor::new();
-
-        // Load fonts from page resources and set resources for XObject access
-        if let Some(resources) = page_dict.get("Resources") {
-            extractor.set_resources(resources.clone());
-            extractor.set_document(self);
-
-            // Load fonts
-            if let Err(e) = self.load_fonts(resources, &mut extractor) {
-                log::warn!(
-                    "Failed to load fonts for page {}: {}, continuing with defaults",
-                    page_index,
-                    e
-                );
-            }
-        }
-
-        // Extract characters directly (single-pass, no document classification)
-        let mut chars = extractor.extract(&content_data)?;
-
-        // Sort characters by reading order (Y-descending, then X-ascending)
-        // This ensures extract_words and extract_text_lines process them in logical order.
-        chars.sort_by(|a, b| {
-            // Y-descending (top-to-bottom)
-            let y_cmp = crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y);
-            if y_cmp != std::cmp::Ordering::Equal {
-                return y_cmp;
-            }
-            // X-ascending (left-to-right)
-            crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x)
-        });
-
-        Ok(chars)
+        self.extract_chars_impl(page_index, HashSet::new(), HashSet::new())
     }
 
     /// Extract characters from a page, excluding content from specified layers and inks.
@@ -9243,6 +9151,15 @@ impl PdfDocument {
     /// * `excluded_layers` - OCG layer names to suppress (empty = no layer filtering)
     /// * `excluded_inks` - Separation/DeviceN ink names to suppress (empty = no ink filtering)
     pub fn extract_chars_filtered(
+        &self,
+        page_index: usize,
+        excluded_layers: HashSet<String>,
+        excluded_inks: HashSet<String>,
+    ) -> Result<Vec<crate::layout::TextChar>> {
+        self.extract_chars_impl(page_index, excluded_layers, excluded_inks)
+    }
+
+    fn extract_chars_impl(
         &self,
         page_index: usize,
         excluded_layers: HashSet<String>,
@@ -9273,13 +9190,16 @@ impl PdfDocument {
         }
 
         let mut extractor = TextExtractor::new();
-        extractor.set_excluded_layers(excluded_layers);
-        extractor.set_excluded_inks(excluded_inks);
+        if !excluded_layers.is_empty() {
+            extractor.set_excluded_layers(excluded_layers);
+        }
+        if !excluded_inks.is_empty() {
+            extractor.set_excluded_inks(excluded_inks);
+        }
 
         if let Some(resources) = page_dict.get("Resources") {
             extractor.set_resources(resources.clone());
             extractor.set_document(self);
-
             if let Err(e) = self.load_fonts(resources, &mut extractor) {
                 log::warn!(
                     "Failed to load fonts for page {}: {}, continuing with defaults",

--- a/src/document.rs
+++ b/src/document.rs
@@ -9102,8 +9102,12 @@ impl PdfDocument {
                         match cs_type.as_str() {
                             "Separation" => {
                                 // [/Separation /InkName /AlternateCS /TintTransform]
+                                // §8.6.6.4: /All and /None are reserved colorant names
+                                // (paint to all / paint to none) and never name a plate.
                                 if let Some(Object::Name(ink)) = arr.get(1) {
-                                    ink_names.push(ink.clone());
+                                    if ink != "All" && ink != "None" {
+                                        ink_names.push(ink.clone());
+                                    }
                                 }
                             },
                             "DeviceN" => {
@@ -9111,7 +9115,9 @@ impl PdfDocument {
                                 if let Some(Object::Array(inks)) = arr.get(1) {
                                     for ink_obj in inks {
                                         if let Object::Name(ink) = ink_obj {
-                                            ink_names.push(ink.clone());
+                                            if ink != "All" && ink != "None" {
+                                                ink_names.push(ink.clone());
+                                            }
                                         }
                                     }
                                 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -8971,7 +8971,7 @@ impl PdfDocument {
     /// # Ok(())
     /// # }
     /// ```
-
+    ///
     /// List all Optional Content Group (OCG) layer names in the document.
     ///
     /// Reads `/OCProperties` from the document catalog and returns the `/Name`

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2673,6 +2673,73 @@ impl<'doc> TextExtractor<'doc> {
         false
     }
 
+    /// Check whether a BDC properties dict represents an excluded OCG or OCMD.
+    ///
+    /// Handles two cases per ISO 32000-1 Section 8.11.2:
+    /// - Direct OCG: dict has `/Name` -> check against excluded layers
+    /// - OCMD: dict has `/Type /OCMD` and `/OCGs` array -> resolve each
+    ///   referenced OCG and check its `/Name` against excluded layers
+    fn check_ocg_excluded(&self, props_dict: &std::collections::HashMap<String, Object>) -> bool {
+        if let Some(ocg_name) = props_dict.get("Name") {
+            return self.ocg_name_is_excluded(ocg_name);
+        }
+
+        if let Some(Object::Name(t)) = props_dict.get("Type") {
+            if t == "OCMD" {
+                if let Some(ocgs_obj) = props_dict.get("OCGs") {
+                    return self.ocmd_ocgs_excluded(ocgs_obj);
+                }
+            }
+        }
+
+        false
+    }
+
+    fn ocg_name_is_excluded(&self, name_obj: &Object) -> bool {
+        if let Some(name_str) = name_obj.as_name() {
+            return self.excluded_layers.contains(name_str);
+        }
+        if let Some(name_bytes) = name_obj.as_string() {
+            let name_str = Self::decode_pdf_text_string(name_bytes);
+            return self.excluded_layers.contains(&name_str);
+        }
+        false
+    }
+
+    /// Resolve OCMD /OCGs and check if any referenced OCG is excluded.
+    /// /OCGs can be a single reference or an array of references.
+    fn ocmd_ocgs_excluded(&self, ocgs_obj: &Object) -> bool {
+        let doc = match self.document {
+            Some(d) => d,
+            None => return false,
+        };
+
+        let refs: Vec<&Object> = if let Some(arr) = ocgs_obj.as_array() {
+            arr.iter().collect()
+        } else {
+            vec![ocgs_obj]
+        };
+
+        for obj in refs {
+            let resolved = if let Some(r) = obj.as_reference() {
+                match doc.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                }
+            } else {
+                obj.clone()
+            };
+            if let Some(d) = resolved.as_dict() {
+                if let Some(name_obj) = d.get("Name") {
+                    if self.ocg_name_is_excluded(name_obj) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
     ///
     /// Searches from the innermost marked content context outward, returning
@@ -5081,25 +5148,12 @@ impl<'doc> TextExtractor<'doc> {
                         artifact_type = Self::parse_artifact_type(&props_dict);
                     }
 
-                    // OCG (Optional Content Group / layer) filtering.
-                    // Per ISO 32000-1:2008 Section 8.11.2, content within a BDC
-                    // tagged "OC" references an OCG dictionary with /Type /OCG
-                    // and /Name <layer-name>.
+                    // OCG / OCMD (Optional Content) filtering.
+                    // Per ISO 32000-1:2008 Section 8.11.2:
+                    //  - Direct OCG: << /Type /OCG /Name /LayerName >>
+                    //  - OCMD:       << /Type /OCMD /OCGs [refs...] /P /policy >>
                     if tag == "OC" && !self.excluded_layers.is_empty() {
-                        if let Some(ocg_name) = props_dict.get("Name") {
-                            if let Some(name_str) = ocg_name.as_name() {
-                                if self.excluded_layers.contains(name_str) {
-                                    is_excluded_layer = true;
-                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
-                                }
-                            } else if let Some(name_bytes) = ocg_name.as_string() {
-                                let name_str = Self::decode_pdf_text_string(name_bytes);
-                                if self.excluded_layers.contains(&name_str) {
-                                    is_excluded_layer = true;
-                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
-                                }
-                            }
-                        }
+                        is_excluded_layer = self.check_ocg_excluded(&props_dict);
                     }
                 }
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -1999,6 +1999,10 @@ struct MarkedContentContext {
     /// The /E entry provides the expansion of an abbreviation or acronym.
     /// e.g., "PDF" might expand to "Portable Document Format"
     expansion: Option<String>,
+    /// Whether this marked content context is an excluded Optional Content Group (layer).
+    ///
+    /// Set when tag is "OC" and the OCG /Name matches one of the excluded layers.
+    is_excluded_layer: bool,
 }
 
 /// Text extractor that processes content streams.
@@ -2057,6 +2061,25 @@ pub struct TextExtractor<'doc> {
     /// Per PDF Spec Section 14.6, artifact content should be excluded from text extraction.
     /// This flag is true when any ancestor in the marked_content_stack has is_artifact=true.
     inside_artifact: bool,
+    /// Layer names (Optional Content Groups) to exclude from extraction.
+    ///
+    /// When a BDC operator with tag "OC" references an OCG whose /Name matches
+    /// one of these entries, all content within that marked content scope is suppressed.
+    excluded_layers: HashSet<String>,
+    /// Whether we're currently inside an excluded OCG layer.
+    ///
+    /// True when any ancestor in the marked_content_stack has is_excluded_layer=true.
+    inside_excluded_layer: bool,
+    /// Ink / separation names to exclude from extraction.
+    ///
+    /// When a `cs` operator sets a Separation or DeviceN color space whose ink name(s)
+    /// match one of these entries, subsequent text is suppressed until the color space changes.
+    excluded_inks: HashSet<String>,
+    /// Whether the current fill color space is an excluded ink.
+    ///
+    /// Set when SetFillColorSpace resolves to a Separation or DeviceN color space
+    /// whose ink name(s) intersect with `excluded_inks`.
+    inside_excluded_ink: bool,
     /// Extraction mode: true for spans, false for characters
     extract_spans: bool,
     /// Buffer for accumulating consecutive Tj operators into single spans
@@ -2167,6 +2190,10 @@ impl<'doc> TextExtractor<'doc> {
             span_sequence_counter: 0, // Initialize sequence counter
             marked_content_stack: Vec::new(), // Track marked content contexts
             inside_artifact: false,   // Track artifact state
+            excluded_layers: HashSet::new(),
+            inside_excluded_layer: false,
+            excluded_inks: HashSet::new(),
+            inside_excluded_ink: false,
             tj_offset_history: Vec::with_capacity(1000), // Track TJ offsets for statistical analysis
             tj_character_array: Vec::new(),              // Character tracking for word boundaries
             current_x_position: 0.0,                     // Start at origin
@@ -2208,6 +2235,23 @@ impl<'doc> TextExtractor<'doc> {
     /// Set the document reference for loading XObjects.
     pub fn set_document(&mut self, document: &'doc crate::document::PdfDocument) {
         self.document = Some(document);
+    }
+
+    /// Set layer names (Optional Content Groups) to exclude from extraction.
+    ///
+    /// Content within BDC/EMC scopes tagged "OC" whose OCG /Name matches one of
+    /// the provided names will be suppressed during text extraction.
+    pub fn set_excluded_layers(&mut self, layers: HashSet<String>) {
+        self.excluded_layers = layers;
+    }
+
+    /// Set ink / separation names to exclude from extraction.
+    ///
+    /// When the fill color space is a Separation or DeviceN whose ink name(s)
+    /// intersect with any of the provided names, subsequent text is suppressed
+    /// until the color space changes to a non-excluded one.
+    pub fn set_excluded_inks(&mut self, inks: HashSet<String>) {
+        self.excluded_inks = inks;
     }
 
     // ========================================================================
@@ -2402,6 +2446,30 @@ impl<'doc> TextExtractor<'doc> {
         self.inside_artifact = self.marked_content_stack.iter().any(|ctx| ctx.is_artifact);
     }
 
+    /// Update the excluded-layer state based on the marked content stack.
+    ///
+    /// True if any ancestor in the stack is an excluded OCG layer.
+    /// Called each time a marked content boundary is crossed (BMC/BDC/EMC).
+    fn update_layer_state(&mut self) {
+        self.inside_excluded_layer = self
+            .marked_content_stack
+            .iter()
+            .any(|ctx| ctx.is_excluded_layer);
+    }
+
+    /// Whether content emission should be suppressed.
+    ///
+    /// Returns true when the current graphics/marked-content state means
+    /// extracted text should be discarded. Currently checks:
+    /// - Inside an excluded OCG layer (`inside_excluded_layer`)
+    /// - Inside an excluded ink / separation color space (`inside_excluded_ink`)
+    ///
+    /// Note: artifact filtering is handled separately via span metadata and
+    /// downstream filtering, so `inside_artifact` is intentionally not checked here.
+    fn is_content_suppressed(&self) -> bool {
+        self.inside_excluded_layer || self.inside_excluded_ink
+    }
+
     /// Parse artifact type and subtype from artifact properties dictionary.
     ///
     /// Per PDF Spec Section 14.8.2.2, artifacts have optional /Type and /Subtype entries:
@@ -2528,6 +2596,80 @@ impl<'doc> TextExtractor<'doc> {
             prop_obj.clone()
         };
         resolved.as_dict().cloned()
+    }
+
+    /// Resolve a named color space from the /Resources /ColorSpace dictionary.
+    ///
+    /// PDF content streams reference color spaces by name (e.g. `cs /CS1`).
+    /// Device color spaces like "DeviceRGB" are built-in, but Separation and
+    /// DeviceN color spaces live in the page resources:
+    ///
+    /// ```text
+    /// /Resources << /ColorSpace << /CS1 [/Separation /PANTONE_Red /DeviceCMYK ...] >> >>
+    /// ```
+    ///
+    /// Returns the resolved color space array if the name refers to a resource entry.
+    fn resolve_color_space(&self, name: &str) -> Option<Vec<Object>> {
+        let resources = self.resources.as_ref()?;
+        let res_dict = if let Some(res_ref) = resources.as_reference() {
+            self.document?.load_object(res_ref).ok()?
+        } else {
+            resources.clone()
+        };
+        let res_dict = res_dict.as_dict()?;
+        let cs_dict_obj = res_dict.get("ColorSpace")?;
+        let cs_dict = if let Some(r) = cs_dict_obj.as_reference() {
+            self.document?.load_object(r).ok()?
+        } else {
+            cs_dict_obj.clone()
+        };
+        let cs_dict = cs_dict.as_dict()?;
+        let cs_obj = cs_dict.get(name)?;
+        let resolved = if let Some(r) = cs_obj.as_reference() {
+            self.document?.load_object(r).ok()?
+        } else {
+            cs_obj.clone()
+        };
+        resolved.as_array().cloned()
+    }
+
+    /// Check if a color space name refers to an excluded ink.
+    ///
+    /// Resolves the color space from resources and checks:
+    /// - `[/Separation /InkName /AlternateCS /TintTransform]` — single ink name
+    /// - `[/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]` — multiple ink names
+    ///
+    /// Returns true if any ink name in the color space matches `excluded_inks`.
+    fn is_excluded_ink_color_space(&self, name: &str) -> bool {
+        if self.excluded_inks.is_empty() {
+            return false;
+        }
+        if let Some(cs_array) = self.resolve_color_space(name) {
+            if cs_array.len() >= 2 {
+                if let Some(cs_type) = cs_array[0].as_name() {
+                    match cs_type {
+                        "Separation" => {
+                            // [/Separation /InkName /AlternateCS /TintTransform]
+                            if let Some(ink_name) = cs_array[1].as_name() {
+                                return self.excluded_inks.contains(ink_name);
+                            }
+                        },
+                        "DeviceN" => {
+                            // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
+                            if let Some(ink_names) = cs_array[1].as_array() {
+                                return ink_names.iter().any(|obj| {
+                                    obj.as_name()
+                                        .map(|n| self.excluded_inks.contains(n))
+                                        .unwrap_or(false)
+                                });
+                            }
+                        },
+                        _ => {},
+                    }
+                }
+            }
+        }
+        false
     }
 
     /// Get current ActualText from marked content stack (PDF Spec Section 14.9.4).
@@ -4149,7 +4291,9 @@ impl<'doc> TextExtractor<'doc> {
                                                 final_matrix.f,
                                             ]),
                                         };
-                                        self.chars.push(space_char);
+                                        if !self.is_content_suppressed() {
+                                            self.chars.push(space_char);
+                                        }
                                     }
 
                                     let state_mut = self.state_stack.current_mut();
@@ -4257,6 +4401,11 @@ impl<'doc> TextExtractor<'doc> {
                     .as_ref()
                     .and_then(|name| self.fonts.get(name))
                     .cloned();
+                // Re-evaluate ink exclusion for the restored color space
+                if !self.excluded_inks.is_empty() {
+                    let cs = self.state_stack.current().fill_color_space.clone();
+                    self.inside_excluded_ink = self.is_excluded_ink_color_space(&cs);
+                }
             },
             Operator::Cm { a, b, c, d, e, f } => {
                 let state = self.state_stack.current_mut();
@@ -4267,26 +4416,30 @@ impl<'doc> TextExtractor<'doc> {
 
             // Color operators
             Operator::SetFillRgb { r, g, b } => {
+                // rg operator implicitly sets DeviceRGB — a process color.
+                self.inside_excluded_ink = false;
                 self.state_stack.current_mut().fill_color_rgb = (r, g, b);
             },
             Operator::SetStrokeRgb { r, g, b } => {
                 self.state_stack.current_mut().stroke_color_rgb = (r, g, b);
             },
             Operator::SetFillGray { gray } => {
+                // g operator implicitly sets DeviceGray — a process color,
+                // so clear any active ink exclusion.
+                self.inside_excluded_ink = false;
                 self.state_stack.current_mut().fill_color_rgb = (gray, gray, gray);
             },
             Operator::SetStrokeGray { gray } => {
                 self.state_stack.current_mut().stroke_color_rgb = (gray, gray, gray);
             },
             Operator::SetFillCmyk { c, m, y, k } => {
-                // Store CMYK and convert to RGB for rendering
-                // CMYK to RGB conversion: R = 1 - min(1, C*(1-K) + K)
+                // k operator implicitly sets DeviceCMYK — a process color.
+                self.inside_excluded_ink = false;
                 let state = self.state_stack.current_mut();
                 state.fill_color_cmyk = Some((c, m, y, k));
                 state.fill_color_rgb = cmyk_to_rgb(c, m, y, k);
             },
             Operator::SetStrokeCmyk { c, m, y, k } => {
-                // Store CMYK and convert to RGB for rendering
                 let state = self.state_stack.current_mut();
                 state.stroke_color_cmyk = Some((c, m, y, k));
                 state.stroke_color_rgb = cmyk_to_rgb(c, m, y, k);
@@ -4294,6 +4447,16 @@ impl<'doc> TextExtractor<'doc> {
 
             // Color space operators
             Operator::SetFillColorSpace { name } => {
+                // Check for excluded ink before mutating state (needs &self)
+                let ink_excluded = self.is_excluded_ink_color_space(&name);
+                self.inside_excluded_ink = ink_excluded;
+                if ink_excluded {
+                    log::debug!(
+                        "Fill color space {:?} matches excluded ink, suppressing text",
+                        name
+                    );
+                }
+
                 let state = self.state_stack.current_mut();
                 state.fill_color_space = name.clone();
                 // Reset color when changing color space
@@ -4867,6 +5030,7 @@ impl<'doc> TextExtractor<'doc> {
                     artifact_type: None, // No artifact classification; None for backward compatibility
                     actual_text: None,   // BMC doesn't have ActualText
                     expansion: None,     // BMC doesn't have expansion
+                    is_excluded_layer: false, // BMC cannot carry OCG properties
                 });
                 self.update_artifact_state();
 
@@ -4881,6 +5045,8 @@ impl<'doc> TextExtractor<'doc> {
                 let mut actual_text = None;
                 let mut artifact_type = None;
                 let mut expansion = None;
+
+                let mut is_excluded_layer = false;
 
                 if let Some(props_dict) = self.resolve_bdc_properties(&properties) {
                     if let Some(mcid_obj) = props_dict.get("MCID") {
@@ -4907,6 +5073,27 @@ impl<'doc> TextExtractor<'doc> {
                     if tag == "Artifact" {
                         artifact_type = Self::parse_artifact_type(&props_dict);
                     }
+
+                    // OCG (Optional Content Group / layer) filtering.
+                    // Per ISO 32000-1:2008 Section 8.11.2, content within a BDC
+                    // tagged "OC" references an OCG dictionary with /Type /OCG
+                    // and /Name <layer-name>.
+                    if tag == "OC" && !self.excluded_layers.is_empty() {
+                        if let Some(ocg_name) = props_dict.get("Name") {
+                            if let Some(name_str) = ocg_name.as_name() {
+                                if self.excluded_layers.contains(name_str) {
+                                    is_excluded_layer = true;
+                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
+                                }
+                            } else if let Some(name_bytes) = ocg_name.as_string() {
+                                let name_str = Self::decode_pdf_text_string(name_bytes);
+                                if self.excluded_layers.contains(&name_str) {
+                                    is_excluded_layer = true;
+                                    log::debug!("Entering excluded OCG layer: {:?}", name_str);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Check if this is an artifact (per PDF Spec Section 14.6)
@@ -4917,8 +5104,10 @@ impl<'doc> TextExtractor<'doc> {
                     artifact_type: artifact_type.clone(),
                     actual_text,
                     expansion,
+                    is_excluded_layer,
                 });
                 self.update_artifact_state();
+                self.update_layer_state();
 
                 if is_artifact {
                     if let Some(ref atype) = artifact_type {
@@ -4936,10 +5125,11 @@ impl<'doc> TextExtractor<'doc> {
                 }
                 self.current_mcid = None;
 
-                // Pop from marked content stack and update artifact state
+                // Pop from marked content stack and update artifact/layer state
                 if !self.marked_content_stack.is_empty() {
                     self.marked_content_stack.pop();
                     self.update_artifact_state();
+                    self.update_layer_state();
                 }
             },
 
@@ -5484,7 +5674,9 @@ impl<'doc> TextExtractor<'doc> {
         };
         self.span_sequence_counter += 1;
 
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
         Ok(())
     }
 
@@ -5980,7 +6172,9 @@ impl<'doc> TextExtractor<'doc> {
 
         // Step 6: Increment sequence counter and add to spans
         self.span_sequence_counter += 1;
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
 
         Ok(())
     }
@@ -6582,7 +6776,9 @@ impl<'doc> TextExtractor<'doc> {
 
         log::trace!("PUSH space span with offset_semantic={}", span.offset_semantic);
 
-        self.spans.push(span);
+        if !self.is_content_suppressed() {
+            self.spans.push(span);
+        }
 
         // Advance position per ISO 32000-1:2008 §9.4.4
         let state = self.state_stack.current_mut();
@@ -6741,7 +6937,9 @@ impl<'doc> TextExtractor<'doc> {
                     span.offset_semantic
                 );
 
-                self.spans.push(span);
+                if !self.is_content_suppressed() {
+                    self.spans.push(span);
+                }
             }
         }
         Ok(())
@@ -6895,7 +7093,9 @@ impl<'doc> TextExtractor<'doc> {
                         ]),
                     };
 
-                    self.chars.push(text_char);
+                    if !self.is_content_suppressed() {
+                        self.chars.push(text_char);
+                    }
                 }
             }
 
@@ -8451,6 +8651,7 @@ mod tests {
             is_artifact: true,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.update_artifact_state();
         assert!(extractor.inside_artifact);
@@ -8465,6 +8666,7 @@ mod tests {
             is_artifact: true,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.marked_content_stack.push(MarkedContentContext {
             artifact_type: None,
@@ -8472,6 +8674,7 @@ mod tests {
             is_artifact: false,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
         extractor.update_artifact_state();
         // Should still be inside artifact because parent is artifact
@@ -12594,6 +12797,7 @@ mod tests {
             is_artifact: false,
             actual_text: None,
             expansion: None,
+            is_excluded_layer: false,
         });
 
         extractor
@@ -13125,6 +13329,7 @@ fn test_marked_content_context_with_actual_text() {
         is_artifact: false,
         actual_text: Some("fi".to_string()), // Ligature expansion
         expansion: None,
+        is_excluded_layer: false,
     };
 
     assert_eq!(ctx.actual_text, Some("fi".to_string()));
@@ -13140,6 +13345,7 @@ fn test_marked_content_context_with_expansion() {
         is_artifact: false,
         actual_text: None,
         expansion: Some("Portable Document Format".to_string()),
+        is_excluded_layer: false,
     };
 
     assert_eq!(ctx.expansion, Some("Portable Document Format".to_string()));
@@ -13154,6 +13360,7 @@ fn test_marked_content_context_artifact_with_actual_text() {
         artifact_type: Some(ArtifactType::Pagination(PaginationSubtype::Header)),
         actual_text: Some("Header text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     };
 
     assert!(ctx.is_artifact);
@@ -13172,6 +13379,7 @@ fn test_get_current_actual_text_finds_first() {
         is_artifact: false,
         actual_text: Some("outer text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     extractor.marked_content_stack.push(MarkedContentContext {
@@ -13180,6 +13388,7 @@ fn test_get_current_actual_text_finds_first() {
         is_artifact: false,
         actual_text: Some("inner text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Should return innermost (most recent) ActualText
@@ -13199,6 +13408,7 @@ fn test_get_current_actual_text_skips_none() {
         is_artifact: false,
         actual_text: Some("replacement text".to_string()),
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Push context without ActualText
@@ -13208,6 +13418,7 @@ fn test_get_current_actual_text_skips_none() {
         is_artifact: false,
         actual_text: None,
         expansion: None,
+        is_excluded_layer: false,
     });
 
     // Should find the ActualText from outer context

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -10,6 +10,7 @@ use crate::config::ExtractionProfile;
 use crate::content::graphics_state::{GraphicsStateStack, Matrix};
 use crate::content::operators::{Operator, TextElement};
 use crate::content::parse_and_execute_text_only;
+use crate::content::parse_content_stream;
 use crate::content::parse_content_stream_text_only;
 use crate::error::Result;
 use crate::extract_log_debug;
@@ -2907,12 +2908,17 @@ impl<'doc> TextExtractor<'doc> {
         self.spans.clear();
         self.span_sequence_counter = 0; // Reset sequence counter for this page
 
-        // Streaming parse+execute: operators are processed immediately without
-        // building an intermediate Vec<Operator>. This eliminates allocation of
-        // potentially huge vectors (196K+ operators for graphics-heavy pages)
-        // and improves cache locality.
         extract_log_debug!("Parsing content stream for text extraction");
-        parse_and_execute_text_only(content_stream, |op| self.execute_operator(op))?;
+        if self.excluded_inks.is_empty() {
+            parse_and_execute_text_only(content_stream, |op| self.execute_operator(op))?;
+        } else {
+            // Ink filtering requires color operators (cs, rg, g, k) which the
+            // text-only parser skips. Fall back to the full parser.
+            let operators = parse_content_stream(content_stream)?;
+            for op in operators {
+                self.execute_operator(op)?;
+            }
+        }
 
         // Flush any remaining Tj buffer at end of content stream
         self.flush_tj_span_buffer()?;
@@ -2955,10 +2961,11 @@ impl<'doc> TextExtractor<'doc> {
         self.chars.clear();
         self.spans.clear(); // Ensure spans are clear so they don't poison xobject_spans_cache
 
-        // Parse content stream into operators
-        let operators = parse_content_stream_text_only(content_stream)?;
-
-        // Execute each operator
+        let operators = if self.excluded_inks.is_empty() {
+            parse_content_stream_text_only(content_stream)?
+        } else {
+            parse_content_stream(content_stream)?
+        };
         for op in operators {
             self.execute_operator(op)?;
         }
@@ -5301,7 +5308,8 @@ impl<'doc> TextExtractor<'doc> {
         //
         // `ctm_key` was already computed above for the `processed_xobjects` guard.
         let spans_cache_key = (xobject_ref, ctm_key);
-        if self.extract_spans {
+        let has_filters = !self.excluded_layers.is_empty() || !self.excluded_inks.is_empty();
+        if self.extract_spans && !has_filters {
             let cached_spans = {
                 doc.xobject_spans_cache
                     .lock()
@@ -5506,10 +5514,21 @@ impl<'doc> TextExtractor<'doc> {
                 let state = self.state_stack.current_mut();
                 state.ctm = form_matrix.multiply(&state.ctm);
 
-                // Streaming parse+execute: avoids allocating Vec<Operator>
                 self.xobject_depth += 1;
-                let parse_result =
-                    parse_and_execute_text_only(&stream_data, |op| self.execute_operator(op));
+                let parse_result = if self.excluded_inks.is_empty() {
+                    parse_and_execute_text_only(&stream_data, |op| self.execute_operator(op))
+                } else {
+                    let ops = parse_content_stream(&stream_data);
+                    match ops {
+                        Ok(ops) => {
+                            for op in ops {
+                                self.execute_operator(op)?;
+                            }
+                            Ok(())
+                        },
+                        Err(e) => Err(e),
+                    }
+                };
                 self.xobject_depth -= 1;
                 if let Err(e) = parse_result {
                     log::debug!(
@@ -5530,7 +5549,7 @@ impl<'doc> TextExtractor<'doc> {
                 // We still require `has_own_resources` so that font lookups are
                 // self-contained; XObjects that inherit page-level fonts would
                 // produce spans whose glyph mappings depend on caller context.
-                if has_own_resources && self.extract_spans {
+                if has_own_resources && self.extract_spans && !has_filters {
                     let new_spans = if self.spans.len() > spans_before {
                         Some(self.spans[spans_before..].to_vec())
                     } else {
@@ -5562,6 +5581,13 @@ impl<'doc> TextExtractor<'doc> {
                 }
                 if let Some(cache) = saved_xobj_cache {
                     self.cached_xobject_refs = cache;
+                }
+                // Re-evaluate ink exclusion against the restored color space
+                // and resources. The XObject may have set an excluded ink that
+                // must not persist into the caller's scope.
+                if !self.excluded_inks.is_empty() {
+                    let cs = self.state_stack.current().fill_color_space.clone();
+                    self.inside_excluded_ink = self.is_excluded_ink_color_space(&cs);
                 }
 
                 // Keep xobject_ref in processed_xobjects permanently.

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2251,6 +2251,11 @@ impl<'doc> TextExtractor<'doc> {
     /// When the fill color space is a Separation or DeviceN whose ink name(s)
     /// intersect with any of the provided names, subsequent text is suppressed
     /// until the color space changes to a non-excluded one.
+    ///
+    /// **DeviceN behavior:** For DeviceN color spaces (e.g.
+    /// `[/DeviceN [/Cyan /SpotGold] ...]`), text is suppressed if ANY ink in
+    /// the array matches — even process colors sharing the DeviceN definition.
+    /// This is because tint values are not evaluated during extraction.
     pub fn set_excluded_inks(&mut self, inks: HashSet<String>) {
         self.excluded_inks = inks;
     }
@@ -2641,6 +2646,9 @@ impl<'doc> TextExtractor<'doc> {
     /// - `[/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]` — multiple ink names
     ///
     /// Returns true if any ink name in the color space matches `excluded_inks`.
+    ///
+    /// **Note:** For DeviceN, this is all-or-nothing — if any ink matches, the
+    /// entire color space is treated as excluded. Tint values are not evaluated.
     fn is_excluded_ink_color_space(&self, name: &str) -> bool {
         if self.excluded_inks.is_empty() {
             return false;

--- a/src/python.rs
+++ b/src/python.rs
@@ -232,11 +232,10 @@ impl PyPdfDocument {
     ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
     ///
     /// Note:
-    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, a simplified
-    ///     text assembly pipeline is used (no structure-tree ordering, table
-    ///     detection, or column detection). For precise results with complex
-    ///     layouts, use ``extract_chars()`` with the same filter parameters
-    ///     and assemble text from the positioned characters.
+    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, the same
+    ///     full text assembly pipeline is used (structure-tree ordering, table
+    ///     detection, column detection) — excluded content is simply removed
+    ///     before assembly.
     #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,

--- a/src/python.rs
+++ b/src/python.rs
@@ -230,6 +230,13 @@ impl PyPdfDocument {
     ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
     ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
     ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    ///
+    /// Note:
+    ///     When ``exclude_layers`` or ``exclude_inks`` are specified, a simplified
+    ///     text assembly pipeline is used (no structure-tree ordering, table
+    ///     detection, or column detection). For precise results with complex
+    ///     layouts, use ``extract_chars()`` with the same filter parameters
+    ///     and assemble text from the positioned characters.
     #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,

--- a/src/python.rs
+++ b/src/python.rs
@@ -261,7 +261,11 @@ impl PyPdfDocument {
                     &crate::geometry::Rect::new(x, y, w, h),
                     crate::layout::RectFilterMode::Intersects,
                 );
-                Ok(filtered.iter().map(|c| c.char.to_string()).collect::<Vec<_>>().join(""))
+                Ok(filtered
+                    .iter()
+                    .map(|c| c.char.to_string())
+                    .collect::<Vec<_>>()
+                    .join(""))
             } else {
                 self.inner
                     .extract_text_in_rect(

--- a/src/python.rs
+++ b/src/python.rs
@@ -3,6 +3,7 @@
 //! This module provides Python bindings for the PDF library, exposing the core functionality
 //! through a Python-friendly API with proper error handling and type hints.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use pyo3::exceptions::{PyIOError, PyNotImplementedError, PyRuntimeError, PyValueError};
@@ -154,6 +155,39 @@ impl PyPdfDocument {
         }
     }
 
+    /// List all Optional Content Group (OCG) layer names in the document.
+    ///
+    /// Returns:
+    ///     list[str]: Layer names from /OCProperties. Empty if no layers.
+    ///
+    /// Example:
+    ///     layers = doc.get_layers()
+    ///     # ['Dieline', 'Varnish', 'Text', 'Barcode']
+    ///     text = doc.extract_text(0, exclude_layers=['Dieline', 'Varnish'])
+    fn get_layers(&mut self) -> PyResult<Vec<String>> {
+        self.inner
+            .get_layers()
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get layers: {}", e)))
+    }
+
+    /// List ink / separation names used on a specific page.
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///
+    /// Returns:
+    ///     list[str]: Ink names from Separation/DeviceN color spaces.
+    ///
+    /// Example:
+    ///     inks = doc.get_page_inks(0)
+    ///     # ['PANTONE 186 C', 'Spot Varnish', 'Die Cut']
+    ///     text = doc.extract_text(0, exclude_inks=['Spot Varnish', 'Die Cut'])
+    fn get_page_inks(&mut self, page: usize) -> PyResult<Vec<String>> {
+        self.inner
+            .get_page_inks(page)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page inks: {}", e)))
+    }
+
     /// Enumerate existing PDF signatures. Returns a list of
     /// `Signature` objects — empty list when the document has no
     /// AcroForm or no signed signature fields.
@@ -190,21 +224,55 @@ impl PyPdfDocument {
     }
 
     /// Extract text from a page.
-    #[pyo3(signature = (page, region=None))]
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
+    ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
+    ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_text(
         &mut self,
         page: usize,
         region: Option<(f32, f32, f32, f32)>,
+        exclude_layers: Option<Vec<String>>,
+        exclude_inks: Option<Vec<String>>,
     ) -> PyResult<String> {
+        let has_filters = exclude_layers.is_some() || exclude_inks.is_some();
+        let layers: HashSet<String> = exclude_layers.unwrap_or_default().into_iter().collect();
+        let inks: HashSet<String> = exclude_inks.unwrap_or_default().into_iter().collect();
+
         if let Some((x, y, w, h)) = region {
+            if has_filters {
+                // Filtered extraction with region: extract filtered text, then
+                // filter chars by rect from the result. For region + filter combos
+                // we do filtered span extraction and then apply the region filter.
+                let text = self
+                    .inner
+                    .extract_text_filtered(page, layers, inks)
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
+                    })?;
+                // When both region and filters are specified, the region filter
+                // is best-effort since extract_text_filtered returns a string.
+                // For precise region + filter, use extract_chars with both params.
+                Ok(text)
+            } else {
+                self.inner
+                    .extract_text_in_rect(
+                        page,
+                        crate::geometry::Rect::new(x, y, w, h),
+                        crate::layout::RectFilterMode::Intersects,
+                    )
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("Failed to extract text in region: {}", e))
+                    })
+            }
+        } else if has_filters {
             self.inner
-                .extract_text_in_rect(
-                    page,
-                    crate::geometry::Rect::new(x, y, w, h),
-                    crate::layout::RectFilterMode::Intersects,
-                )
+                .extract_text_filtered(page, layers, inks)
                 .map_err(|e| {
-                    PyRuntimeError::new_err(format!("Failed to extract text in region: {}", e))
+                    PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
                 })
         } else {
             self.inner
@@ -531,13 +599,42 @@ impl PyPdfDocument {
     }
 
     /// Extract low-level characters.
-    #[pyo3(signature = (page, region=None))]
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///     region (tuple, optional): Bounding box (x, y, width, height) to restrict extraction
+    ///     exclude_layers (list[str], optional): OCG layer names to exclude from extraction
+    ///     exclude_inks (list[str], optional): Separation/DeviceN ink names to exclude
+    #[pyo3(signature = (page, region=None, exclude_layers=None, exclude_inks=None))]
     fn extract_chars(
         &mut self,
         page: usize,
         region: Option<(f32, f32, f32, f32)>,
+        exclude_layers: Option<Vec<String>>,
+        exclude_inks: Option<Vec<String>>,
     ) -> PyResult<Vec<PyTextChar>> {
-        let chars_result = if let Some((x, y, w, h)) = region {
+        let has_filters = exclude_layers.is_some() || exclude_inks.is_some();
+        let layers: HashSet<String> = exclude_layers.unwrap_or_default().into_iter().collect();
+        let inks: HashSet<String> = exclude_inks.unwrap_or_default().into_iter().collect();
+
+        let chars_result = if has_filters {
+            let chars = self
+                .inner
+                .extract_chars_filtered(page, layers, inks)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to extract characters: {}", e))
+                })?;
+            // Apply region filter on top if specified
+            if let Some((x, y, w, h)) = region {
+                use crate::layout::SpatialCollectionFiltering;
+                Ok(chars.filter_by_rect(
+                    &crate::geometry::Rect::new(x, y, w, h),
+                    crate::layout::RectFilterMode::Intersects,
+                ))
+            } else {
+                Ok(chars)
+            }
+        } else if let Some((x, y, w, h)) = region {
             self.inner.extract_chars_in_rect(
                 page,
                 crate::geometry::Rect::new(x, y, w, h),
@@ -2658,12 +2755,16 @@ impl PyDocPage {
 
     #[getter]
     fn text(&self, py: Python<'_>) -> PyResult<String> {
-        self.doc.borrow_mut(py).extract_text(self.page_index, None)
+        self.doc
+            .borrow_mut(py)
+            .extract_text(self.page_index, None, None, None)
     }
 
     #[getter]
     fn chars(&self, py: Python<'_>) -> PyResult<Vec<PyTextChar>> {
-        self.doc.borrow_mut(py).extract_chars(self.page_index, None)
+        self.doc
+            .borrow_mut(py)
+            .extract_chars(self.page_index, None, None, None)
     }
 
     #[getter]
@@ -3266,7 +3367,7 @@ impl PyPdfPageRegion {
     }
     fn extract_text(&self, py: Python<'_>) -> PyResult<String> {
         let mut d = self.doc.bind(py).borrow_mut();
-        d.extract_text(self.page_index, Some(self.bbox()))
+        d.extract_text(self.page_index, Some(self.bbox()), None, None)
     }
     fn extract_words(&self, py: Python<'_>) -> PyResult<Vec<PyWord>> {
         let mut d = self.doc.bind(py).borrow_mut();

--- a/src/python.rs
+++ b/src/python.rs
@@ -607,6 +607,106 @@ impl PyPdfDocument {
         }
     }
 
+    /// Render all ink separation plates for a page.
+    ///
+    /// Each plate is a grayscale image where pixel intensity (0-255) represents
+    /// the tint percentage of one ink at each point. Process inks (Cyan, Magenta,
+    /// Yellow, Black) are included if the page uses DeviceCMYK content; spot
+    /// colors are taken from Separation and DeviceN color spaces.
+    ///
+    /// Args:
+    ///     page (int): Zero-based page index.
+    ///     dpi (int, optional): Resolution in DPI (default 150).
+    ///
+    /// Returns:
+    ///     list[SeparationPlate]: One plate per ink. Each has ``ink_name``,
+    ///     ``data`` (grayscale bytes), ``width``, and ``height``.
+    ///
+    /// Example:
+    ///     plates = doc.render_separations(0, dpi=150)
+    ///     for plate in plates:
+    ///         print(f"{plate.ink_name}: {plate.width}x{plate.height}")
+    #[pyo3(signature = (page, dpi=None))]
+    fn render_separations(
+        &mut self,
+        py: Python<'_>,
+        page: usize,
+        dpi: Option<u32>,
+    ) -> PyResult<Vec<Py<pyo3::PyAny>>> {
+        #[cfg(feature = "rendering")]
+        {
+            let dpi_value = dpi.unwrap_or(150);
+            let plates = crate::rendering::render_separations(&self.inner, page, dpi_value)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to render separations: {e}"))
+                })?;
+            let plate_mod = py.import("pdf_oxide")?;
+            let plate_cls = plate_mod.getattr("SeparationPlate")?;
+            let mut out = Vec::with_capacity(plates.len());
+            for plate in plates {
+                let data = pyo3::types::PyBytes::new(py, &plate.data);
+                let result = plate_cls.call1((
+                    plate.ink_name,
+                    data,
+                    plate.width as i64,
+                    plate.height as i64,
+                ))?;
+                out.push(result.into());
+            }
+            Ok(out)
+        }
+        #[cfg(not(feature = "rendering"))]
+        {
+            let _ = (py, page, dpi);
+            Err(PyRuntimeError::new_err("Rendering feature not enabled."))
+        }
+    }
+
+    /// Render a single ink separation plate for a page.
+    ///
+    /// Returns a grayscale image where pixel intensity (0-255) = tint
+    /// percentage of the named ink. If the ink is not present on the
+    /// page, the plate is all zeros.
+    ///
+    /// Args:
+    ///     page (int): Zero-based page index.
+    ///     ink_name (str): Ink name (e.g., "Cyan", "PANTONE 185 C", "Dieline").
+    ///     dpi (int, optional): Resolution in DPI (default 150).
+    ///
+    /// Returns:
+    ///     SeparationPlate: The plate with ``ink_name``, ``data``, ``width``, ``height``.
+    ///
+    /// Example:
+    ///     dieline = doc.render_separation(0, "Dieline", dpi=150)
+    #[pyo3(signature = (page, ink_name, dpi=None))]
+    fn render_separation(
+        &mut self,
+        py: Python<'_>,
+        page: usize,
+        ink_name: &str,
+        dpi: Option<u32>,
+    ) -> PyResult<Py<pyo3::PyAny>> {
+        #[cfg(feature = "rendering")]
+        {
+            let dpi_value = dpi.unwrap_or(150);
+            let plate = crate::rendering::render_separation(&self.inner, page, ink_name, dpi_value)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to render separation: {e}"))
+                })?;
+            let plate_mod = py.import("pdf_oxide")?;
+            let plate_cls = plate_mod.getattr("SeparationPlate")?;
+            let data = pyo3::types::PyBytes::new(py, &plate.data);
+            let result =
+                plate_cls.call1((plate.ink_name, data, plate.width as i64, plate.height as i64))?;
+            Ok(result.into())
+        }
+        #[cfg(not(feature = "rendering"))]
+        {
+            let _ = (py, page, ink_name, dpi);
+            Err(PyRuntimeError::new_err("Rendering feature not enabled."))
+        }
+    }
+
     /// Extract low-level characters.
     ///
     /// Args:

--- a/src/python.rs
+++ b/src/python.rs
@@ -609,14 +609,16 @@ impl PyPdfDocument {
 
     /// Render all ink separation plates for a page.
     ///
-    /// Each plate is a grayscale image where pixel intensity (0-255) represents
-    /// the tint percentage of one ink at each point. Process inks (Cyan, Magenta,
+    /// Each plate is a grayscale image where pixel intensity (0-255) = ink
+    /// coverage (0 = no ink, 255 = full tint). Process inks (Cyan, Magenta,
     /// Yellow, Black) are included if the page uses DeviceCMYK content; spot
-    /// colors are taken from Separation and DeviceN color spaces.
+    /// colors are taken from Separation and DeviceN color spaces. To display
+    /// a plate as black ink on white paper, invert: ``display = 255 - value``.
     ///
     /// Args:
     ///     page (int): Zero-based page index.
-    ///     dpi (int, optional): Resolution in DPI (default 150).
+    ///     dpi (int, optional): Resolution in DPI (default 150 — the Rust API
+    ///         has no default; Python defaults to 150 for convenience).
     ///
     /// Returns:
     ///     list[SeparationPlate]: One plate per ink. Each has ``ink_name``,
@@ -664,14 +666,16 @@ impl PyPdfDocument {
 
     /// Render a single ink separation plate for a page.
     ///
-    /// Returns a grayscale image where pixel intensity (0-255) = tint
-    /// percentage of the named ink. If the ink is not present on the
-    /// page, the plate is all zeros.
+    /// Returns a grayscale image where pixel intensity (0-255) = ink coverage
+    /// of the named ink (0 = no ink, 255 = full tint). If the ink is not
+    /// present on the page, the plate is all zeros. To display the plate as
+    /// black ink on white paper, invert: ``display = 255 - value``.
     ///
     /// Args:
     ///     page (int): Zero-based page index.
     ///     ink_name (str): Ink name (e.g., "Cyan", "PANTONE 185 C", "Dieline").
-    ///     dpi (int, optional): Resolution in DPI (default 150).
+    ///     dpi (int, optional): Resolution in DPI (default 150 — the Rust API
+    ///         has no default; Python defaults to 150 for convenience).
     ///
     /// Returns:
     ///     SeparationPlate: The plate with ``ink_name``, ``data``, ``width``, ``height``.

--- a/src/python.rs
+++ b/src/python.rs
@@ -244,19 +244,18 @@ impl PyPdfDocument {
 
         if let Some((x, y, w, h)) = region {
             if has_filters {
-                // Filtered extraction with region: extract filtered text, then
-                // filter chars by rect from the result. For region + filter combos
-                // we do filtered span extraction and then apply the region filter.
-                let text = self
+                let chars = self
                     .inner
-                    .extract_text_filtered(page, layers, inks)
+                    .extract_chars_filtered(page, layers, inks)
                     .map_err(|e| {
                         PyRuntimeError::new_err(format!("Failed to extract filtered text: {}", e))
                     })?;
-                // When both region and filters are specified, the region filter
-                // is best-effort since extract_text_filtered returns a string.
-                // For precise region + filter, use extract_chars with both params.
-                Ok(text)
+                use crate::layout::SpatialCollectionFiltering;
+                let filtered = chars.filter_by_rect(
+                    &crate::geometry::Rect::new(x, y, w, h),
+                    crate::layout::RectFilterMode::Intersects,
+                );
+                Ok(filtered.iter().map(|c| c.char.to_string()).collect::<Vec<_>>().join(""))
             } else {
                 self.inner
                     .extract_text_in_rect(

--- a/src/rendering/ext_gstate.rs
+++ b/src/rendering/ext_gstate.rs
@@ -1,0 +1,79 @@
+//! Shared parser for PDF `ExtGState` dictionary entries.
+//!
+//! Both the page renderer and the separation-plate renderer need to apply
+//! transparency / blend-mode overrides from `gs` operators. Keeping the
+//! parser in a single module avoids drift between the two renderers and
+//! removes the `pub(crate)` leak that previously crossed module boundaries.
+
+use crate::content::graphics_state::GraphicsState;
+use crate::document::PdfDocument;
+use crate::error::Result;
+use crate::object::Object;
+
+/// Parsed effects of a PDF `ExtGState` dictionary. Only the fields actually
+/// applied during rendering are captured (fill/stroke alpha and blend mode).
+/// Anything else (TK / SMask / AIS) is intentionally ignored so the cached
+/// entry stays tiny.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ParsedExtGState {
+    pub(crate) fill_alpha: Option<f32>,
+    pub(crate) stroke_alpha: Option<f32>,
+    pub(crate) blend_mode: Option<String>,
+}
+
+impl ParsedExtGState {
+    /// Apply this dictionary's fields to `gs`. Fields that were not present
+    /// in the source dictionary are left untouched on `gs`.
+    pub(crate) fn apply(&self, gs: &mut GraphicsState) {
+        if let Some(a) = self.fill_alpha {
+            gs.fill_alpha = a;
+        }
+        if let Some(a) = self.stroke_alpha {
+            gs.stroke_alpha = a;
+        }
+        if let Some(ref m) = self.blend_mode {
+            gs.blend_mode = m.clone();
+        }
+    }
+}
+
+/// Parse the fields we need from an `ExtGState` *entry* (the inner dict, not
+/// the resource dict that holds it). Resolves `state_obj` once if it is a
+/// reference.
+pub(crate) fn parse_ext_g_state_inner(
+    state_obj: &Object,
+    doc: &PdfDocument,
+) -> Result<ParsedExtGState> {
+    let mut out = ParsedExtGState::default();
+    let state_resolved = doc.resolve_object(state_obj)?;
+    let state_dict = match state_resolved.as_dict() {
+        Some(d) => d,
+        None => return Ok(out),
+    };
+
+    if let Some(ca) = state_dict.get("ca") {
+        out.fill_alpha = ca
+            .as_real()
+            .map(|v| v as f32)
+            .or_else(|| ca.as_integer().map(|v| v as f32));
+    }
+    if let Some(ca_upper) = state_dict.get("CA") {
+        out.stroke_alpha = ca_upper
+            .as_real()
+            .map(|v| v as f32)
+            .or_else(|| ca_upper.as_integer().map(|v| v as f32));
+    }
+    if let Some(bm) = state_dict.get("BM") {
+        let mode = match bm {
+            Object::Name(n) => n.clone(),
+            Object::Array(arr) => arr
+                .first()
+                .and_then(|o| o.as_name())
+                .unwrap_or("Normal")
+                .to_string(),
+            _ => "Normal".to_string(),
+        };
+        out.blend_mode = Some(mode);
+    }
+    Ok(out)
+}

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -30,11 +30,13 @@
 //! 3. Rasterize paths, text, and images to tiny-skia pixmap
 //! 4. Convert to output format (PNG/JPEG)
 
-mod page_renderer;
+pub(crate) mod page_renderer;
 mod path_rasterizer;
+mod separation_renderer;
 mod text_rasterizer;
 
 pub use page_renderer::{ImageFormat, PageRenderer, RenderOptions, RenderedImage};
+pub use separation_renderer::{render_separation, render_separations, SeparationPlate};
 
 use crate::content::GraphicsState;
 use crate::error::Result;

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -30,6 +30,7 @@
 //! 3. Rasterize paths, text, and images to tiny-skia pixmap
 //! 4. Convert to output format (PNG/JPEG)
 
+pub(crate) mod ext_gstate;
 pub(crate) mod page_renderer;
 mod path_rasterizer;
 mod separation_renderer;

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -2317,14 +2317,14 @@ impl PageRenderer {
 /// (TK / SMask / AIS) is logged as debug only and not used yet, so it doesn't
 /// need to be cached.
 #[derive(Clone, Debug, Default)]
-struct ParsedExtGState {
-    fill_alpha: Option<f32>,
-    stroke_alpha: Option<f32>,
-    blend_mode: Option<String>,
+pub(crate) struct ParsedExtGState {
+    pub(crate) fill_alpha: Option<f32>,
+    pub(crate) stroke_alpha: Option<f32>,
+    pub(crate) blend_mode: Option<String>,
 }
 
 impl ParsedExtGState {
-    fn apply(&self, gs: &mut GraphicsState) {
+    pub(crate) fn apply(&self, gs: &mut GraphicsState) {
         if let Some(a) = self.fill_alpha {
             gs.fill_alpha = a;
         }
@@ -2372,7 +2372,10 @@ fn parse_ext_g_state(
 /// Parse the fields we need from an ExtGState **entry** (the inner dict, not
 /// the resource dict that holds it). Resolves once if `state_obj` is a
 /// reference. This is the hot helper called per `gs` op in the operator loop.
-fn parse_ext_g_state_inner(state_obj: &Object, doc: &PdfDocument) -> Result<ParsedExtGState> {
+pub(crate) fn parse_ext_g_state_inner(
+    state_obj: &Object,
+    doc: &PdfDocument,
+) -> Result<ParsedExtGState> {
     let mut out = ParsedExtGState::default();
     let state_resolved = doc.resolve_object(state_obj)?;
     let state_dict = match state_resolved.as_dict() {

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -19,6 +19,7 @@ use crate::content::parser::parse_content_stream;
 use crate::document::PdfDocument;
 use crate::error::{Error, Result};
 use crate::object::{Object, ObjectRef};
+use crate::rendering::ext_gstate::{parse_ext_g_state_inner, ParsedExtGState};
 use crate::rendering::path_rasterizer::PathRasterizer;
 use crate::rendering::text_rasterizer::TextRasterizer;
 
@@ -2312,31 +2313,6 @@ impl PageRenderer {
     }
 }
 
-/// Parsed effects of a PDF ExtGState dictionary. Only the fields actually
-/// applied during rendering are captured (alpha + blend mode). Anything else
-/// (TK / SMask / AIS) is logged as debug only and not used yet, so it doesn't
-/// need to be cached.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct ParsedExtGState {
-    pub(crate) fill_alpha: Option<f32>,
-    pub(crate) stroke_alpha: Option<f32>,
-    pub(crate) blend_mode: Option<String>,
-}
-
-impl ParsedExtGState {
-    pub(crate) fn apply(&self, gs: &mut GraphicsState) {
-        if let Some(a) = self.fill_alpha {
-            gs.fill_alpha = a;
-        }
-        if let Some(a) = self.stroke_alpha {
-            gs.stroke_alpha = a;
-        }
-        if let Some(ref m) = self.blend_mode {
-            gs.blend_mode = m.clone();
-        }
-    }
-}
-
 /// Resolve the named ExtGState entry from `resources` and parse the fields we
 /// need. Kept as a thin wrapper that re-resolves the resource dict per call —
 /// the hot path in `execute_operators` uses `parse_ext_g_state_inner` against
@@ -2367,47 +2343,6 @@ fn parse_ext_g_state(
         None => return Ok(out),
     };
     parse_ext_g_state_inner(state_obj, doc)
-}
-
-/// Parse the fields we need from an ExtGState **entry** (the inner dict, not
-/// the resource dict that holds it). Resolves once if `state_obj` is a
-/// reference. This is the hot helper called per `gs` op in the operator loop.
-pub(crate) fn parse_ext_g_state_inner(
-    state_obj: &Object,
-    doc: &PdfDocument,
-) -> Result<ParsedExtGState> {
-    let mut out = ParsedExtGState::default();
-    let state_resolved = doc.resolve_object(state_obj)?;
-    let state_dict = match state_resolved.as_dict() {
-        Some(d) => d,
-        None => return Ok(out),
-    };
-
-    if let Some(ca) = state_dict.get("ca") {
-        out.fill_alpha = ca
-            .as_real()
-            .map(|v| v as f32)
-            .or_else(|| ca.as_integer().map(|v| v as f32));
-    }
-    if let Some(ca_upper) = state_dict.get("CA") {
-        out.stroke_alpha = ca_upper
-            .as_real()
-            .map(|v| v as f32)
-            .or_else(|| ca_upper.as_integer().map(|v| v as f32));
-    }
-    if let Some(bm) = state_dict.get("BM") {
-        let mode = match bm {
-            Object::Name(n) => n.clone(),
-            Object::Array(arr) => arr
-                .first()
-                .and_then(|o| o.as_name())
-                .unwrap_or("Normal")
-                .to_string(),
-            _ => "Normal".to_string(),
-        };
-        out.blend_mode = Some(mode);
-    }
-    Ok(out)
 }
 
 /// Resize an RGBA (straight-alpha) byte buffer using SIMD-accelerated bilinear filtering.

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -101,6 +101,13 @@ pub struct SeparationPlate {
 ///
 /// Each plate is a grayscale image where pixel intensity equals the
 /// tint percentage of that ink (255 = full tint, 0 = no ink).
+///
+/// # Performance
+///
+/// The content stream is parsed **once** and the operator walk dispatches
+/// paint operations to all referenced plates in parallel. Form XObjects
+/// are also recursed into once per page. Unreferenced inks short-circuit
+/// to an all-zero plate before any pixmap is allocated.
 pub fn render_separations(
     doc: &PdfDocument,
     page_num: usize,
@@ -116,16 +123,7 @@ pub fn render_separations(
     // pixmap and skip the per-plate operator walk entirely (O6).
     let referenced = collect_referenced_inks(doc, page_num)?;
 
-    let mut plates = Vec::with_capacity(inks.len());
-    for ink in &inks {
-        let plate = if referenced.contains(ink) {
-            render_single_separation(doc, page_num, ink, dpi)?
-        } else {
-            empty_plate_for(doc, page_num, ink, dpi)?
-        };
-        plates.push(plate);
-    }
-    Ok(plates)
+    render_plates_for_inks(doc, page_num, dpi, &inks, &referenced)
 }
 
 /// Render a single ink separation plate for a page.
@@ -133,13 +131,122 @@ pub fn render_separations(
 /// Returns a grayscale image where pixel intensity = tint percentage
 /// of the named ink. If the ink is not present on the page, the plate
 /// is all zeros.
+///
+/// This is a thin wrapper over the multi-ink path; if you need every
+/// plate on a page, call [`render_separations`] instead — it walks the
+/// content stream once for all inks together.
 pub fn render_separation(
     doc: &PdfDocument,
     page_num: usize,
     ink_name: &str,
     dpi: u32,
 ) -> Result<SeparationPlate> {
-    render_single_separation(doc, page_num, ink_name, dpi)
+    // Always walk operators for the requested ink — the per-page short-circuit
+    // in [`render_separations`] is an optimisation that scans the resource
+    // declarations to skip inks that are *definitely* unused. For the single-ink
+    // entry point the caller has already named the ink they want, and the
+    // scanner can miss inks reached via DefaultRGB/DefaultGray remapping
+    // through colour operators like `rg`/`g`. Treat the named ink as referenced
+    // and let the operator walk produce an honest plate.
+    let inks = vec![ink_name.to_string()];
+    let referenced = inks.clone();
+    let mut plates = render_plates_for_inks(doc, page_num, dpi, &inks, &referenced)?;
+    plates
+        .pop()
+        .ok_or_else(|| Error::InvalidPdf("render_separation: no plate produced".to_string()))
+}
+
+/// Core multi-ink rendering: allocate one pixmap per referenced ink,
+/// walk the content stream once, and extract grayscale data from each.
+fn render_plates_for_inks(
+    doc: &PdfDocument,
+    page_num: usize,
+    dpi: u32,
+    inks: &[String],
+    referenced: &[String],
+) -> Result<Vec<SeparationPlate>> {
+    let (width, height, base_transform) = compute_page_extent(doc, page_num, dpi)?;
+
+    // Partition inks into "needs rendering" vs "short-circuit to empty plate".
+    // We track the original index so the output order matches `inks`.
+    let mut render_indices: Vec<usize> = Vec::new();
+    let mut empty_indices: Vec<usize> = Vec::new();
+    for (i, ink) in inks.iter().enumerate() {
+        if referenced.iter().any(|r| r == ink) {
+            render_indices.push(i);
+        } else {
+            empty_indices.push(i);
+        }
+    }
+
+    // Build pixmaps and a parallel `target_inks` slice for the inks we
+    // actually need to walk operators for.
+    let mut pixmaps: Vec<Pixmap> = Vec::with_capacity(render_indices.len());
+    for _ in &render_indices {
+        let pixmap = Pixmap::new(width, height)
+            .ok_or_else(|| Error::InvalidPdf("Failed to create separation pixmap".to_string()))?;
+        pixmaps.push(pixmap);
+    }
+    let target_inks: Vec<&str> = render_indices.iter().map(|&i| inks[i].as_str()).collect();
+
+    if !pixmaps.is_empty() {
+        let resources = doc.get_page_resources(page_num)?;
+        let color_spaces = load_color_spaces(doc, &resources)?;
+        let fonts = load_fonts(doc, &resources);
+        let text_rasterizer = TextRasterizer::new();
+
+        let content_data = doc.get_page_content_data(page_num)?;
+        let operators = parse_content_stream(&content_data)?;
+
+        let mut ctx = SeparationContext {
+            doc,
+            text_rasterizer: &text_rasterizer,
+            fonts: &fonts,
+        };
+
+        execute_separation_operators(
+            &mut pixmaps,
+            base_transform,
+            &operators,
+            &mut ctx,
+            &resources,
+            &color_spaces,
+            None,
+            &target_inks,
+        )?;
+    }
+
+    // Re-assemble in original ink order: empty plates for unreferenced
+    // inks, extracted R channel for rendered ones.
+    let pixel_count = (width as usize) * (height as usize);
+    let mut result: Vec<Option<SeparationPlate>> = (0..inks.len()).map(|_| None).collect();
+
+    for (k, &i) in render_indices.iter().enumerate() {
+        let mut data = vec![0u8; pixel_count];
+        let rgba = pixmaps[k].data();
+        for j in 0..pixel_count {
+            data[j] = rgba[j * 4];
+        }
+        result[i] = Some(SeparationPlate {
+            ink_name: inks[i].clone(),
+            data,
+            width,
+            height,
+        });
+    }
+    for &i in &empty_indices {
+        result[i] = Some(SeparationPlate {
+            ink_name: inks[i].clone(),
+            data: vec![0u8; pixel_count],
+            width,
+            height,
+        });
+    }
+
+    Ok(result
+        .into_iter()
+        .map(|o| o.expect("plate filled"))
+        .collect())
 }
 
 /// Collect all ink names present on a page.
@@ -166,25 +273,6 @@ fn collect_page_inks(doc: &PdfDocument, page_num: usize) -> Result<Vec<String>> 
     }
 
     Ok(inks)
-}
-
-/// Build a (width × height) all-zero plate without walking the operator
-/// stream. Used when [`collect_referenced_inks`] proves the ink is not
-/// touched anywhere on the page.
-fn empty_plate_for(
-    doc: &PdfDocument,
-    page_num: usize,
-    ink_name: &str,
-    dpi: u32,
-) -> Result<SeparationPlate> {
-    let (width, height, _) = compute_page_extent(doc, page_num, dpi)?;
-    let pixel_count = (width as usize) * (height as usize);
-    Ok(SeparationPlate {
-        ink_name: ink_name.to_string(),
-        data: vec![0u8; pixel_count],
-        width,
-        height,
-    })
 }
 
 /// Walk the content stream (and any Form XObjects it references) and
@@ -370,59 +458,6 @@ fn compute_page_extent(
     };
 
     Ok((width, height, base_transform))
-}
-
-/// Core rendering logic for a single separation plate.
-fn render_single_separation(
-    doc: &PdfDocument,
-    page_num: usize,
-    ink_name: &str,
-    dpi: u32,
-) -> Result<SeparationPlate> {
-    let (width, height, base_transform) = compute_page_extent(doc, page_num, dpi)?;
-
-    let mut pixmap = Pixmap::new(width, height)
-        .ok_or_else(|| Error::InvalidPdf("Failed to create separation pixmap".to_string()))?;
-
-    let resources = doc.get_page_resources(page_num)?;
-    let color_spaces = load_color_spaces(doc, &resources)?;
-    let fonts = load_fonts(doc, &resources);
-    let text_rasterizer = TextRasterizer::new();
-
-    let content_data = doc.get_page_content_data(page_num)?;
-    let operators = parse_content_stream(&content_data)?;
-
-    let _ = page_num; // kept in the public API surface; not needed past extent computation
-    let mut ctx = SeparationContext {
-        doc,
-        target_ink: ink_name,
-        text_rasterizer: &text_rasterizer,
-        fonts: &fonts,
-    };
-
-    execute_separation_operators(
-        &mut pixmap,
-        base_transform,
-        &operators,
-        &mut ctx,
-        &resources,
-        &color_spaces,
-        None,
-    )?;
-
-    let pixel_count = (width * height) as usize;
-    let mut data = vec![0u8; pixel_count];
-    let rgba = pixmap.data();
-    for i in 0..pixel_count {
-        data[i] = rgba[i * 4];
-    }
-
-    Ok(SeparationPlate {
-        ink_name: ink_name.to_string(),
-        data,
-        width,
-        height,
-    })
 }
 
 /// Resolved colour-space classification used by the separation pipeline.
@@ -694,9 +729,14 @@ fn tint_for_ink(
 
 /// Per-render shared context (read-only) passed through the operator
 /// walk and into recursive Form XObject invocations.
+///
+/// The set of target inks is **not** stored here; instead it is passed
+/// as a separate `target_inks: &[&str]` slice alongside the `&mut [Pixmap]`
+/// to [`execute_separation_operators`]. This keeps the borrow checker
+/// happy: the pixmaps slice is the only `&mut` in play, while everything
+/// in `SeparationContext` is `&`.
 struct SeparationContext<'a> {
     doc: &'a PdfDocument,
-    target_ink: &'a str,
     text_rasterizer: &'a TextRasterizer,
     fonts: &'a HashMap<String, Arc<FontInfo>>,
 }
@@ -754,16 +794,26 @@ struct InheritedState {
     stroke_components: Vec<f32>,
 }
 
-/// Execute operators for separation plate rendering.
+/// Execute operators for separation plate rendering, dispatching paint
+/// operations to **all** target inks in parallel.
+///
+/// `pixmaps` and `target_inks` are parallel slices: `pixmaps[i]` receives
+/// paint for ink `target_inks[i]`. The operator stream is walked exactly
+/// once; every paint site (fill, stroke, text, Form XObject) iterates the
+/// pair list and contributes to each plate whose ink the current colour
+/// touches.
+#[allow(clippy::too_many_arguments)]
 fn execute_separation_operators(
-    pixmap: &mut Pixmap,
+    pixmaps: &mut [Pixmap],
     base_transform: Transform,
     operators: &[Operator],
     ctx: &mut SeparationContext<'_>,
     resources: &Object,
     color_spaces: &HashMap<String, Object>,
     inherited: Option<&InheritedState>,
+    target_inks: &[&str],
 ) -> Result<()> {
+    debug_assert_eq!(pixmaps.len(), target_inks.len());
     let mut gs_stack = GraphicsStateStack::new();
     {
         let gs = gs_stack.current_mut();
@@ -811,6 +861,14 @@ fn execute_separation_operators(
             .and_then(|o| ctx.doc.resolve_object(o).ok()),
         _ => None,
     };
+
+    // Pixmap extent — every plate shares the same dimensions because they
+    // all originate from a single allocation in `render_plates_for_inks`.
+    // If `pixmaps` is empty (no inks to render), use a zero extent; the
+    // operator walk still progresses for graphics-state tracking but
+    // paint loops are no-ops because there are no targets.
+    let pixmap_width = pixmaps.first().map(|p| p.width()).unwrap_or(0);
+    let pixmap_height = pixmaps.first().map(|p| p.height()).unwrap_or(0);
 
     for op in operators {
         match op {
@@ -1018,7 +1076,8 @@ fn execute_separation_operators(
                 apply_separation_clip(
                     &mut pending_clip,
                     &mut clip_stack,
-                    pixmap,
+                    pixmap_width,
+                    pixmap_height,
                     base_transform,
                     &gs_stack,
                 );
@@ -1026,19 +1085,21 @@ fn execute_separation_operators(
                     let gs = gs_stack.current();
                     let empty = SeparationColorState::new();
                     let cs = color_state_stack.last().unwrap_or(&empty);
-                    if let Some(tint) = tint_for_ink(
-                        false,
-                        gs,
-                        color_spaces,
-                        resources,
-                        ctx.doc,
-                        ctx.target_ink,
-                        &cs.fill_components,
-                        &cs.stroke_components,
-                    ) {
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        let clip = clip_stack.last().and_then(|c| c.as_ref());
-                        stroke_separation(pixmap, &path, transform, gs, tint, clip);
+                    let transform = combine_transforms(base_transform, &gs.ctm);
+                    let clip = clip_stack.last().and_then(|c| c.as_ref());
+                    for (i, &ink) in target_inks.iter().enumerate() {
+                        if let Some(tint) = tint_for_ink(
+                            false,
+                            gs,
+                            color_spaces,
+                            resources,
+                            ctx.doc,
+                            ink,
+                            &cs.fill_components,
+                            &cs.stroke_components,
+                        ) {
+                            stroke_separation(&mut pixmaps[i], &path, transform, gs, tint, clip);
+                        }
                     }
                 }
                 current_path = PathBuilder::new();
@@ -1047,7 +1108,8 @@ fn execute_separation_operators(
                 apply_separation_clip(
                     &mut pending_clip,
                     &mut clip_stack,
-                    pixmap,
+                    pixmap_width,
+                    pixmap_height,
                     base_transform,
                     &gs_stack,
                 );
@@ -1055,19 +1117,28 @@ fn execute_separation_operators(
                     let gs = gs_stack.current();
                     let empty = SeparationColorState::new();
                     let cs = color_state_stack.last().unwrap_or(&empty);
-                    if let Some(tint) = tint_for_ink(
-                        true,
-                        gs,
-                        color_spaces,
-                        resources,
-                        ctx.doc,
-                        ctx.target_ink,
-                        &cs.fill_components,
-                        &cs.stroke_components,
-                    ) {
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        let clip = clip_stack.last().and_then(|c| c.as_ref());
-                        fill_separation(pixmap, &path, transform, tint, FillRule::Winding, clip);
+                    let transform = combine_transforms(base_transform, &gs.ctm);
+                    let clip = clip_stack.last().and_then(|c| c.as_ref());
+                    for (i, &ink) in target_inks.iter().enumerate() {
+                        if let Some(tint) = tint_for_ink(
+                            true,
+                            gs,
+                            color_spaces,
+                            resources,
+                            ctx.doc,
+                            ink,
+                            &cs.fill_components,
+                            &cs.stroke_components,
+                        ) {
+                            fill_separation(
+                                &mut pixmaps[i],
+                                &path,
+                                transform,
+                                tint,
+                                FillRule::Winding,
+                                clip,
+                            );
+                        }
                     }
                 }
                 current_path = PathBuilder::new();
@@ -1076,7 +1147,8 @@ fn execute_separation_operators(
                 apply_separation_clip(
                     &mut pending_clip,
                     &mut clip_stack,
-                    pixmap,
+                    pixmap_width,
+                    pixmap_height,
                     base_transform,
                     &gs_stack,
                 );
@@ -1084,19 +1156,28 @@ fn execute_separation_operators(
                     let gs = gs_stack.current();
                     let empty = SeparationColorState::new();
                     let cs = color_state_stack.last().unwrap_or(&empty);
-                    if let Some(tint) = tint_for_ink(
-                        true,
-                        gs,
-                        color_spaces,
-                        resources,
-                        ctx.doc,
-                        ctx.target_ink,
-                        &cs.fill_components,
-                        &cs.stroke_components,
-                    ) {
-                        let transform = combine_transforms(base_transform, &gs.ctm);
-                        let clip = clip_stack.last().and_then(|c| c.as_ref());
-                        fill_separation(pixmap, &path, transform, tint, FillRule::EvenOdd, clip);
+                    let transform = combine_transforms(base_transform, &gs.ctm);
+                    let clip = clip_stack.last().and_then(|c| c.as_ref());
+                    for (i, &ink) in target_inks.iter().enumerate() {
+                        if let Some(tint) = tint_for_ink(
+                            true,
+                            gs,
+                            color_spaces,
+                            resources,
+                            ctx.doc,
+                            ink,
+                            &cs.fill_components,
+                            &cs.stroke_components,
+                        ) {
+                            fill_separation(
+                                &mut pixmaps[i],
+                                &path,
+                                transform,
+                                tint,
+                                FillRule::EvenOdd,
+                                clip,
+                            );
+                        }
                     }
                 }
                 current_path = PathBuilder::new();
@@ -1105,7 +1186,8 @@ fn execute_separation_operators(
                 apply_separation_clip(
                     &mut pending_clip,
                     &mut clip_stack,
-                    pixmap,
+                    pixmap_width,
+                    pixmap_height,
                     base_transform,
                     &gs_stack,
                 );
@@ -1115,29 +1197,38 @@ fn execute_separation_operators(
                     let cs = color_state_stack.last().unwrap_or(&empty);
                     let transform = combine_transforms(base_transform, &gs.ctm);
                     let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    if let Some(tint) = tint_for_ink(
-                        true,
-                        gs,
-                        color_spaces,
-                        resources,
-                        ctx.doc,
-                        ctx.target_ink,
-                        &cs.fill_components,
-                        &cs.stroke_components,
-                    ) {
-                        fill_separation(pixmap, &path, transform, tint, FillRule::Winding, clip);
-                    }
-                    if let Some(tint) = tint_for_ink(
-                        false,
-                        gs,
-                        color_spaces,
-                        resources,
-                        ctx.doc,
-                        ctx.target_ink,
-                        &cs.fill_components,
-                        &cs.stroke_components,
-                    ) {
-                        stroke_separation(pixmap, &path, transform, gs, tint, clip);
+                    for (i, &ink) in target_inks.iter().enumerate() {
+                        if let Some(tint) = tint_for_ink(
+                            true,
+                            gs,
+                            color_spaces,
+                            resources,
+                            ctx.doc,
+                            ink,
+                            &cs.fill_components,
+                            &cs.stroke_components,
+                        ) {
+                            fill_separation(
+                                &mut pixmaps[i],
+                                &path,
+                                transform,
+                                tint,
+                                FillRule::Winding,
+                                clip,
+                            );
+                        }
+                        if let Some(tint) = tint_for_ink(
+                            false,
+                            gs,
+                            color_spaces,
+                            resources,
+                            ctx.doc,
+                            ink,
+                            &cs.fill_components,
+                            &cs.stroke_components,
+                        ) {
+                            stroke_separation(&mut pixmaps[i], &path, transform, gs, tint, clip);
+                        }
                     }
                 }
                 current_path = PathBuilder::new();
@@ -1146,7 +1237,8 @@ fn execute_separation_operators(
                 apply_separation_clip(
                     &mut pending_clip,
                     &mut clip_stack,
-                    pixmap,
+                    pixmap_width,
+                    pixmap_height,
                     base_transform,
                     &gs_stack,
                 );
@@ -1156,29 +1248,38 @@ fn execute_separation_operators(
                     let cs = color_state_stack.last().unwrap_or(&empty);
                     let transform = combine_transforms(base_transform, &gs.ctm);
                     let clip = clip_stack.last().and_then(|c| c.as_ref());
-                    if let Some(tint) = tint_for_ink(
-                        true,
-                        gs,
-                        color_spaces,
-                        resources,
-                        ctx.doc,
-                        ctx.target_ink,
-                        &cs.fill_components,
-                        &cs.stroke_components,
-                    ) {
-                        fill_separation(pixmap, &path, transform, tint, FillRule::EvenOdd, clip);
-                    }
-                    if let Some(tint) = tint_for_ink(
-                        false,
-                        gs,
-                        color_spaces,
-                        resources,
-                        ctx.doc,
-                        ctx.target_ink,
-                        &cs.fill_components,
-                        &cs.stroke_components,
-                    ) {
-                        stroke_separation(pixmap, &path, transform, gs, tint, clip);
+                    for (i, &ink) in target_inks.iter().enumerate() {
+                        if let Some(tint) = tint_for_ink(
+                            true,
+                            gs,
+                            color_spaces,
+                            resources,
+                            ctx.doc,
+                            ink,
+                            &cs.fill_components,
+                            &cs.stroke_components,
+                        ) {
+                            fill_separation(
+                                &mut pixmaps[i],
+                                &path,
+                                transform,
+                                tint,
+                                FillRule::EvenOdd,
+                                clip,
+                            );
+                        }
+                        if let Some(tint) = tint_for_ink(
+                            false,
+                            gs,
+                            color_spaces,
+                            resources,
+                            ctx.doc,
+                            ink,
+                            &cs.fill_components,
+                            &cs.stroke_components,
+                        ) {
+                            stroke_separation(&mut pixmaps[i], &path, transform, gs, tint, clip);
+                        }
                     }
                 }
                 current_path = PathBuilder::new();
@@ -1187,7 +1288,8 @@ fn execute_separation_operators(
                 apply_separation_clip(
                     &mut pending_clip,
                     &mut clip_stack,
-                    pixmap,
+                    pixmap_width,
+                    pixmap_height,
                     base_transform,
                     &gs_stack,
                 );
@@ -1287,7 +1389,7 @@ fn execute_separation_operators(
             Operator::Tj { text } => {
                 if in_text_object {
                     let advance = render_text_to_plate(
-                        pixmap,
+                        pixmaps,
                         text,
                         base_transform,
                         &mut gs_stack,
@@ -1296,6 +1398,7 @@ fn execute_separation_operators(
                         resources,
                         ctx,
                         clip_stack.last().and_then(|c| c.as_ref()),
+                        target_inks,
                     )?;
                     let gs_mut = gs_stack.current_mut();
                     let advance_matrix = Matrix::translation(advance, 0.0);
@@ -1305,7 +1408,7 @@ fn execute_separation_operators(
             Operator::TJ { array } => {
                 if in_text_object {
                     let advance = render_tj_to_plate(
-                        pixmap,
+                        pixmaps,
                         array,
                         base_transform,
                         &mut gs_stack,
@@ -1314,6 +1417,7 @@ fn execute_separation_operators(
                         resources,
                         ctx,
                         clip_stack.last().and_then(|c| c.as_ref()),
+                        target_inks,
                     )?;
                     let gs_mut = gs_stack.current_mut();
                     let advance_matrix = Matrix::translation(advance, 0.0);
@@ -1329,7 +1433,7 @@ fn execute_separation_operators(
                     gs_mut.text_matrix = gs_mut.text_line_matrix;
 
                     let advance = render_text_to_plate(
-                        pixmap,
+                        pixmaps,
                         text,
                         base_transform,
                         &mut gs_stack,
@@ -1338,6 +1442,7 @@ fn execute_separation_operators(
                         resources,
                         ctx,
                         clip_stack.last().and_then(|c| c.as_ref()),
+                        target_inks,
                     )?;
                     let gs_mut = gs_stack.current_mut();
                     let advance_matrix = Matrix::translation(advance, 0.0);
@@ -1359,7 +1464,7 @@ fn execute_separation_operators(
                     gs_mut.text_matrix = gs_mut.text_line_matrix;
 
                     let advance = render_text_to_plate(
-                        pixmap,
+                        pixmaps,
                         text,
                         base_transform,
                         &mut gs_stack,
@@ -1368,6 +1473,7 @@ fn execute_separation_operators(
                         resources,
                         ctx,
                         clip_stack.last().and_then(|c| c.as_ref()),
+                        target_inks,
                     )?;
                     let gs_mut = gs_stack.current_mut();
                     let advance_matrix = Matrix::translation(advance, 0.0);
@@ -1439,13 +1545,14 @@ fn execute_separation_operators(
 
                                         let form_ops = parse_content_stream(&stream_data)?;
                                         execute_separation_operators(
-                                            pixmap,
+                                            pixmaps,
                                             combined,
                                             &form_ops,
                                             ctx,
                                             &form_resources,
                                             &merged_cs,
                                             Some(&inherited),
+                                            target_inks,
                                         )?;
                                     }
                                 }
@@ -1461,14 +1568,21 @@ fn execute_separation_operators(
     Ok(())
 }
 
-/// Render text into the separation pixmap, routing each glyph through the
-/// current ink's tint. The strategy is to clone the GraphicsState, replace
-/// its fill colour with a grayscale paint equal to the tint, and reuse
-/// the standard [`TextRasterizer`]. This preserves glyph shape, kerning,
-/// and anti-aliasing — the same fidelity as the page renderer.
+/// Render text into every target separation pixmap, routing each glyph
+/// through the per-ink tint. The strategy is to clone the GraphicsState,
+/// replace its fill colour with a grayscale paint equal to the tint, and
+/// reuse the standard [`TextRasterizer`]. This preserves glyph shape,
+/// kerning, and anti-aliasing — the same fidelity as the page renderer.
+///
+/// The returned advance is shared across all plates (the rasteriser is
+/// deterministic for a given font/text/state, so each plate's advance
+/// agrees) — we use the last computed value, matching the single-plate
+/// behaviour. If no plate is touched (all tints are `None` or render
+/// mode 3) the advance is computed from the font metrics so the text
+/// matrix still progresses correctly.
 #[allow(clippy::too_many_arguments)]
 fn render_text_to_plate(
-    pixmap: &mut Pixmap,
+    pixmaps: &mut [Pixmap],
     text: &[u8],
     base_transform: Transform,
     gs_stack: &mut GraphicsStateStack,
@@ -1477,6 +1591,7 @@ fn render_text_to_plate(
     resources: &Object,
     ctx: &mut SeparationContext<'_>,
     clip: Option<&Mask>,
+    target_inks: &[&str],
 ) -> Result<f32> {
     let gs = gs_stack.current();
     let empty = SeparationColorState::new();
@@ -1487,40 +1602,58 @@ fn render_text_to_plate(
         return measure_text_advance(text, gs, ctx.fonts);
     }
 
-    let tint = tint_for_ink(
-        true,
-        gs,
-        color_spaces,
-        resources,
-        ctx.doc,
-        ctx.target_ink,
-        &cs.fill_components,
-        &cs.stroke_components,
-    );
-    if tint.is_none() {
-        // Colour doesn't touch this plate — advance but don't paint.
-        return measure_text_advance(text, gs, ctx.fonts);
-    }
-    let tint = tint.unwrap();
-
-    // Build a faked-grayscale GraphicsState so the rasteriser paints in
-    // (tint, tint, tint) which becomes the plate value in the R channel.
-    let mut faux = gs.clone();
-    faux.fill_color_rgb = (tint, tint, tint);
-    faux.fill_alpha = 1.0;
-    faux.blend_mode = "Normal".to_string();
-
     let transform = combine_transforms(base_transform, &gs.ctm);
-    ctx.text_rasterizer
-        .render_text(pixmap, text, transform, &faux, resources, ctx.doc, clip, ctx.fonts)
+    let mut painted_advance: Option<f32> = None;
+
+    for (i, &ink) in target_inks.iter().enumerate() {
+        let tint = match tint_for_ink(
+            true,
+            gs,
+            color_spaces,
+            resources,
+            ctx.doc,
+            ink,
+            &cs.fill_components,
+            &cs.stroke_components,
+        ) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        // Build a faked-grayscale GraphicsState so the rasteriser paints in
+        // (tint, tint, tint) which becomes the plate value in the R channel.
+        let mut faux = gs.clone();
+        faux.fill_color_rgb = (tint, tint, tint);
+        faux.fill_alpha = 1.0;
+        faux.blend_mode = "Normal".to_string();
+
+        let advance = ctx.text_rasterizer.render_text(
+            &mut pixmaps[i],
+            text,
+            transform,
+            &faux,
+            resources,
+            ctx.doc,
+            clip,
+            ctx.fonts,
+        )?;
+        painted_advance = Some(advance);
+    }
+
+    match painted_advance {
+        Some(a) => Ok(a),
+        // No plate was touched by this text — still advance the matrix so
+        // subsequent glyphs land at the correct position.
+        None => measure_text_advance(text, gs, ctx.fonts),
+    }
 }
 
-/// Render a TJ array (sequence of strings + offsets) into the plate.
-/// Walks the array applying offsets between strings, painting each
-/// string component via [`render_text_to_plate`].
+/// Render a TJ array (sequence of strings + offsets) into all target
+/// plates. Walks the array applying offsets between strings, painting
+/// each string component via [`render_text_to_plate`].
 #[allow(clippy::too_many_arguments)]
 fn render_tj_to_plate(
-    pixmap: &mut Pixmap,
+    pixmaps: &mut [Pixmap],
     array: &[TextElement],
     base_transform: Transform,
     gs_stack: &mut GraphicsStateStack,
@@ -1529,13 +1662,14 @@ fn render_tj_to_plate(
     resources: &Object,
     ctx: &mut SeparationContext<'_>,
     clip: Option<&Mask>,
+    target_inks: &[&str],
 ) -> Result<f32> {
     let mut total_advance = 0.0;
     for element in array {
         match element {
             TextElement::String(text) => {
                 let advance = render_text_to_plate(
-                    pixmap,
+                    pixmaps,
                     text,
                     base_transform,
                     gs_stack,
@@ -1544,6 +1678,7 @@ fn render_tj_to_plate(
                     resources,
                     ctx,
                     clip,
+                    target_inks,
                 )?;
                 let gs_mut = gs_stack.current_mut();
                 let advance_matrix = Matrix::translation(advance, 0.0);
@@ -1672,19 +1807,29 @@ fn stroke_separation(
 }
 
 /// Apply a pending clip path to the clip stack.
+///
+/// The clip mask is identical across all plates — it depends only on the
+/// path, fill rule, current transform, and pixmap dimensions (which are
+/// shared). So we build it once and store it on the shared clip stack.
 fn apply_separation_clip(
     pending: &mut Option<(tiny_skia::Path, FillRule)>,
     clip_stack: &mut Vec<Option<Mask>>,
-    pixmap: &Pixmap,
+    pixmap_width: u32,
+    pixmap_height: u32,
     base_transform: Transform,
     gs_stack: &GraphicsStateStack,
 ) {
     if let Some((path, fill_rule)) = pending.take() {
+        // No pixmaps means no plates to clip — bail out early. Width/height
+        // would be zero and Mask::new would refuse them anyway.
+        if pixmap_width == 0 || pixmap_height == 0 {
+            return;
+        }
         let gs = gs_stack.current();
         let transform = combine_transforms(base_transform, &gs.ctm);
 
         if let Some(path_transformed) = path.transform(transform) {
-            let mut new_mask = Mask::new(pixmap.width(), pixmap.height()).unwrap();
+            let mut new_mask = Mask::new(pixmap_width, pixmap_height).unwrap();
             new_mask.fill_path(&path_transformed, fill_rule, true, Transform::identity());
 
             if let Some(Some(current_mask)) = clip_stack.last() {

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -4,6 +4,43 @@
 //! pixel intensity represents the tint percentage of that ink at each point.
 //! Used in prepress workflows, ink coverage analysis, and ML pipelines
 //! that process packaging/label PDFs.
+//!
+//! # ICCBased heuristic
+//!
+//! When a fill color space resolves to an `ICCBased` array, this renderer
+//! does **not** parse the embedded ICC profile. Instead it inspects the
+//! component count of the current fill/stroke color: a 4-component
+//! `ICCBased` space is treated as CMYK (component order C, M, Y, K), a
+//! 3-component space is treated as RGB (skipped — no separation routing),
+//! and a 1-component space is treated as Gray (skipped). This matches
+//! the convention used by Adobe Illustrator and InDesign when exporting
+//! to PDF/X-1a and PDF/X-4 with CMYK working spaces. PDFs that rely on
+//! lab-CMYK profile interpretation for separation routing are out of
+//! scope for this renderer; they are rare in prepress workflows that
+//! ship separated artwork.
+//!
+//! # Limitations
+//!
+//! The following classes of content are recognised by the operator
+//! walker but not actually painted into the plate:
+//!
+//! - **Raster image XObjects** (`Do` with `Subtype /Image`), including
+//!   DeviceN / Separation-encoded TIFFs and CMYK photographs. The
+//!   sample data is dropped. Vector artwork inside Form XObjects is
+//!   recursed into and rendered normally.
+//! - **Shading patterns** (`sh` operator) — gradients used as fills.
+//! - **Tiling and shading patterns** invoked via `scn` / `SCN` with a
+//!   `/Pattern` colour space.
+//! - **Inline images** (`BI` / `ID` / `EI`).
+//! - **Page annotations.** [`render_separations`] renders only the
+//!   page's content stream; annotation appearance streams are not
+//!   walked, in contrast to [`super::page_renderer`] which composites
+//!   annotation appearances on top of the page.
+//!
+//! These are intentional v1 omissions: the primary use case is
+//! vector-based prepress artwork (dielines, varnish layers, spot-PMS
+//! text and shapes). PDFs that rely on raster spot-channel data will
+//! produce incomplete plates and should be flagged at the caller.
 #![allow(
     clippy::field_reassign_with_default,
     clippy::ptr_arg,
@@ -11,15 +48,20 @@
 )]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tiny_skia::{FillRule, Mask, PathBuilder, Pixmap, Transform};
 
 use crate::content::graphics_state::{GraphicsState, GraphicsStateStack, Matrix};
-use crate::content::operators::Operator;
+use crate::content::operators::{Operator, TextElement};
 use crate::content::parser::parse_content_stream;
 use crate::document::PdfDocument;
 use crate::error::{Error, Result};
+use crate::fonts::FontInfo;
 use crate::object::Object;
+
+use super::ext_gstate::{parse_ext_g_state_inner, ParsedExtGState};
+use super::text_rasterizer::TextRasterizer;
 
 /// A rendered separation plate for a single ink.
 #[derive(Debug, Clone)]
@@ -37,9 +79,14 @@ pub struct SeparationPlate {
 
 /// Render all separation plates for a page.
 ///
-/// Returns one `SeparationPlate` per ink found on the page (process CMYK
-/// inks are included when the page uses DeviceCMYK content). Each plate is
-/// a grayscale image where pixel intensity = tint percentage of that ink.
+/// Returns one [`SeparationPlate`] per ink. Process inks (Cyan, Magenta,
+/// Yellow, Black) are always emitted; if the page uses no CMYK content
+/// those plates will be all-zero. Spot inks are emitted only when the
+/// page's resource dictionary declares a `Separation` or `DeviceN` colour
+/// space that names them.
+///
+/// Each plate is a grayscale image where pixel intensity equals the
+/// tint percentage of that ink (255 = full tint, 0 = no ink).
 pub fn render_separations(
     doc: &PdfDocument,
     page_num: usize,
@@ -50,9 +97,18 @@ pub fn render_separations(
         return Ok(Vec::new());
     }
 
+    // Pre-parse the content stream once to detect which inks are actually
+    // referenced. Plates for unreferenced inks short-circuit to an empty
+    // pixmap and skip the per-plate operator walk entirely (O6).
+    let referenced = collect_referenced_inks(doc, page_num)?;
+
     let mut plates = Vec::with_capacity(inks.len());
     for ink in &inks {
-        let plate = render_single_separation(doc, page_num, ink, dpi)?;
+        let plate = if referenced.contains(ink) {
+            render_single_separation(doc, page_num, ink, dpi)?
+        } else {
+            empty_plate_for(doc, page_num, ink, dpi)?
+        };
         plates.push(plate);
     }
     Ok(plates)
@@ -72,25 +128,22 @@ pub fn render_separation(
     render_single_separation(doc, page_num, ink_name, dpi)
 }
 
-/// Collect all ink names present on a page, including process CMYK.
+/// Collect all ink names present on a page.
+///
+/// CMYK is always returned regardless of whether the page actually
+/// uses CMYK content — emitting four extra all-zero plates is much
+/// cheaper than the recursive operator walk that would be required to
+/// detect CMYK content nested inside Form XObjects (the previous
+/// shallow scan missed those, RED #1). Unused CMYK plates are filtered
+/// out by the short-circuit in [`render_separations`].
 fn collect_page_inks(doc: &PdfDocument, page_num: usize) -> Result<Vec<String>> {
-    let mut inks = Vec::new();
+    let mut inks = vec![
+        "Cyan".to_string(),
+        "Magenta".to_string(),
+        "Yellow".to_string(),
+        "Black".to_string(),
+    ];
 
-    // Check for DeviceCMYK content by scanning the content stream
-    let content_data = doc.get_page_content_data(page_num)?;
-    let operators = parse_content_stream(&content_data)?;
-    let has_cmyk = has_cmyk_content(&operators);
-
-    if has_cmyk {
-        inks.extend_from_slice(&[
-            "Cyan".to_string(),
-            "Magenta".to_string(),
-            "Yellow".to_string(),
-            "Black".to_string(),
-        ]);
-    }
-
-    // Get spot color inks from color space resources
     let spot_inks = doc.get_page_inks(page_num)?;
     for ink in spot_inks {
         if !inks.contains(&ink) {
@@ -101,42 +154,165 @@ fn collect_page_inks(doc: &PdfDocument, page_num: usize) -> Result<Vec<String>> 
     Ok(inks)
 }
 
-/// Check whether a content stream references DeviceCMYK content.
-fn has_cmyk_content(operators: &[Operator]) -> bool {
-    for op in operators {
-        match op {
-            Operator::SetFillCmyk { .. } | Operator::SetStrokeCmyk { .. } => return true,
-            Operator::SetFillColorSpace { name } | Operator::SetStrokeColorSpace { name } => {
-                if name == "DeviceCMYK" || name == "CMYK" {
-                    return true;
-                }
-            },
-            _ => {},
-        }
-    }
-    false
-}
-
-/// Core rendering logic for a single separation plate.
-///
-/// This uses the page renderer to rasterize the full page once via
-/// the standard RGBA pipeline, but instead of using the composited result,
-/// we walk the operator stream ourselves to track which ink is active
-/// for each drawing operation, then render only the operations that
-/// contribute to the target ink into a grayscale buffer.
-///
-/// We implement this by:
-/// 1. Computing page dimensions and transform (same as the normal renderer)
-/// 2. Walking the operator stream to track color state
-/// 3. For each path painting operation, checking if the current color
-///    contributes to the target ink
-/// 4. If so, painting the path into a grayscale pixmap with the tint value
-fn render_single_separation(
+/// Build a (width × height) all-zero plate without walking the operator
+/// stream. Used when [`collect_referenced_inks`] proves the ink is not
+/// touched anywhere on the page.
+fn empty_plate_for(
     doc: &PdfDocument,
     page_num: usize,
     ink_name: &str,
     dpi: u32,
 ) -> Result<SeparationPlate> {
+    let (width, height, _) = compute_page_extent(doc, page_num, dpi)?;
+    let pixel_count = (width as usize) * (height as usize);
+    Ok(SeparationPlate {
+        ink_name: ink_name.to_string(),
+        data: vec![0u8; pixel_count],
+        width,
+        height,
+    })
+}
+
+/// Walk the content stream (and any Form XObjects it references) and
+/// collect every ink name that could possibly appear on the page.
+fn collect_referenced_inks(doc: &PdfDocument, page_num: usize) -> Result<Vec<String>> {
+    let resources = doc.get_page_resources(page_num)?;
+    let color_spaces = load_color_spaces(doc, &resources)?;
+    let content_data = doc.get_page_content_data(page_num)?;
+    let operators = parse_content_stream(&content_data)?;
+    let mut referenced: Vec<String> = Vec::new();
+    let mut visited: Vec<String> = Vec::new();
+    scan_operators_for_inks(
+        &operators,
+        doc,
+        &resources,
+        &color_spaces,
+        &mut referenced,
+        &mut visited,
+    )?;
+    Ok(referenced)
+}
+
+fn scan_operators_for_inks(
+    operators: &[Operator],
+    doc: &PdfDocument,
+    resources: &Object,
+    color_spaces: &HashMap<String, Object>,
+    referenced: &mut Vec<String>,
+    visited: &mut Vec<String>,
+) -> Result<()> {
+    let xobjects = match resources {
+        Object::Dictionary(rd) => rd.get("XObject").and_then(|o| doc.resolve_object(o).ok()),
+        _ => None,
+    };
+
+    let push = |list: &mut Vec<String>, name: &str| {
+        if !list.iter().any(|s| s == name) {
+            list.push(name.to_string());
+        }
+    };
+
+    for op in operators {
+        match op {
+            Operator::SetFillCmyk { .. } | Operator::SetStrokeCmyk { .. } => {
+                push(referenced, "Cyan");
+                push(referenced, "Magenta");
+                push(referenced, "Yellow");
+                push(referenced, "Black");
+            },
+            Operator::SetFillColorSpace { name } | Operator::SetStrokeColorSpace { name } => {
+                inks_from_space(name, color_spaces, resources, doc, referenced);
+            },
+            Operator::Do { name } => {
+                if visited.iter().any(|s| s == name) {
+                    continue;
+                }
+                visited.push(name.clone());
+                if let Some(xobj_dict) = xobjects.as_ref().and_then(|o| o.as_dict()) {
+                    if let Some(xobj_ref_obj) = xobj_dict.get(name) {
+                        if let Ok(xobj) = doc.resolve_object(xobj_ref_obj) {
+                            if let Object::Stream { ref dict, .. } = xobj {
+                                let subtype = dict.get("Subtype").and_then(|o| o.as_name());
+                                if subtype == Some("Form") {
+                                    let stream_data = if let Some(r) = xobj_ref_obj.as_reference() {
+                                        doc.decode_stream_with_encryption(&xobj, r)?
+                                    } else {
+                                        xobj.decode_stream_data()?
+                                    };
+                                    let form_resources = if let Some(res) = dict.get("Resources") {
+                                        doc.resolve_object(res)?
+                                    } else {
+                                        resources.clone()
+                                    };
+                                    let form_cs = load_color_spaces(doc, &form_resources)?;
+                                    let mut merged_cs = color_spaces.clone();
+                                    merged_cs.extend(form_cs);
+                                    if let Ok(form_ops) = parse_content_stream(&stream_data) {
+                                        scan_operators_for_inks(
+                                            &form_ops,
+                                            doc,
+                                            &form_resources,
+                                            &merged_cs,
+                                            referenced,
+                                            visited,
+                                        )?;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+    Ok(())
+}
+
+fn inks_from_space(
+    space_name: &str,
+    color_spaces: &HashMap<String, Object>,
+    resources: &Object,
+    doc: &PdfDocument,
+    out: &mut Vec<String>,
+) {
+    // Honour DefaultCMYK/RGB/Gray remap (RED #2 — see resolve_color_space).
+    let space = resolve_color_space(space_name, color_spaces, resources, doc);
+    match space {
+        ResolvedSpace::Cmyk | ResolvedSpace::IccCmyk => {
+            for ink in ["Cyan", "Magenta", "Yellow", "Black"] {
+                if !out.iter().any(|s| s == ink) {
+                    out.push(ink.to_string());
+                }
+            }
+        },
+        ResolvedSpace::Separation(name) => {
+            if !out.iter().any(|s| s == &name) {
+                out.push(name);
+            }
+        },
+        ResolvedSpace::DeviceN(names) => {
+            for n in names {
+                if !out.iter().any(|s| s == &n) {
+                    out.push(n);
+                }
+            }
+        },
+        ResolvedSpace::Rgb
+        | ResolvedSpace::Gray
+        | ResolvedSpace::IccRgb
+        | ResolvedSpace::IccGray
+        | ResolvedSpace::Unknown => {},
+    }
+}
+
+/// Page extent computation (width/height in pixels and the base
+/// transform that maps PDF user space into the pixmap).
+fn compute_page_extent(
+    doc: &PdfDocument,
+    page_num: usize,
+    dpi: u32,
+) -> Result<(u32, u32, Transform)> {
     let page_info = doc.get_page_info(page_num)?;
     let media_box = page_info.media_box;
 
@@ -164,38 +340,51 @@ fn render_single_separation(
             .post_translate(0.0, page_h * scale),
     };
 
-    // Create an RGBA pixmap for rasterization via tiny-skia.
-    // We render in white-on-black: tint -> white channel (255 = full tint).
+    Ok((width, height, base_transform))
+}
+
+/// Core rendering logic for a single separation plate.
+fn render_single_separation(
+    doc: &PdfDocument,
+    page_num: usize,
+    ink_name: &str,
+    dpi: u32,
+) -> Result<SeparationPlate> {
+    let (width, height, base_transform) = compute_page_extent(doc, page_num, dpi)?;
+
     let mut pixmap = Pixmap::new(width, height)
         .ok_or_else(|| Error::InvalidPdf("Failed to create separation pixmap".to_string()))?;
 
-    // Load page resources and color spaces
     let resources = doc.get_page_resources(page_num)?;
     let color_spaces = load_color_spaces(doc, &resources)?;
+    let fonts = load_fonts(doc, &resources);
+    let text_rasterizer = TextRasterizer::new();
 
-    // Parse content stream
     let content_data = doc.get_page_content_data(page_num)?;
     let operators = parse_content_stream(&content_data)?;
 
-    // Execute operators, painting only the target ink
+    let _ = page_num; // kept in the public API surface; not needed past extent computation
+    let mut ctx = SeparationContext {
+        doc,
+        target_ink: ink_name,
+        text_rasterizer: &text_rasterizer,
+        fonts: &fonts,
+    };
+
     execute_separation_operators(
         &mut pixmap,
         base_transform,
         &operators,
-        doc,
-        page_num,
+        &mut ctx,
         &resources,
         &color_spaces,
-        ink_name,
+        None,
     )?;
 
-    // Extract the grayscale channel from the RGBA pixmap.
-    // We used R channel to carry tint values.
     let pixel_count = (width * height) as usize;
     let mut data = vec![0u8; pixel_count];
     let rgba = pixmap.data();
     for i in 0..pixel_count {
-        // Red channel holds the tint value
         data[i] = rgba[i * 4];
     }
 
@@ -205,6 +394,136 @@ fn render_single_separation(
         width,
         height,
     })
+}
+
+/// Resolved colour-space classification used by the separation pipeline.
+#[derive(Debug, Clone)]
+enum ResolvedSpace {
+    Cmyk,
+    Rgb,
+    Gray,
+    Separation(String),
+    DeviceN(Vec<String>),
+    /// ICCBased with a 4-component profile (treated as CMYK by heuristic).
+    IccCmyk,
+    /// ICCBased with 3 components (RGB).
+    IccRgb,
+    /// ICCBased with 1 component (Gray).
+    IccGray,
+    Unknown,
+}
+
+/// Resolve a colour-space name to a known classification.
+///
+/// Handles ISO 32000-1 §8.6.5.6: when the named space is one of the
+/// Device families and the resource dictionary defines a corresponding
+/// `Default*` entry, the Default mapping is consulted instead.
+fn resolve_color_space(
+    space_name: &str,
+    color_spaces: &HashMap<String, Object>,
+    resources: &Object,
+    doc: &PdfDocument,
+) -> ResolvedSpace {
+    // Direct Device* names — try DefaultCMYK / DefaultRGB / DefaultGray remap first.
+    let default_key = match space_name {
+        "DeviceCMYK" | "CMYK" => Some("DefaultCMYK"),
+        "DeviceRGB" | "RGB" => Some("DefaultRGB"),
+        "DeviceGray" | "G" => Some("DefaultGray"),
+        _ => None,
+    };
+    if let Some(key) = default_key {
+        if let Some(default) = color_spaces.get(key) {
+            // Walk into the default array as a fresh classification.
+            return classify_resolved(default, color_spaces, resources, doc);
+        }
+        return match key {
+            "DefaultCMYK" => ResolvedSpace::Cmyk,
+            "DefaultRGB" => ResolvedSpace::Rgb,
+            _ => ResolvedSpace::Gray,
+        };
+    }
+
+    if let Some(cs_obj) = color_spaces.get(space_name) {
+        classify_resolved(cs_obj, color_spaces, resources, doc)
+    } else {
+        ResolvedSpace::Unknown
+    }
+}
+
+/// Classify a colour-space object (either an array or a name) into a
+/// [`ResolvedSpace`]. Used both as the entry point from a resource-dict
+/// lookup and recursively when an array starts with a name that is
+/// itself a device alias.
+fn classify_resolved(
+    cs_obj: &Object,
+    color_spaces: &HashMap<String, Object>,
+    resources: &Object,
+    doc: &PdfDocument,
+) -> ResolvedSpace {
+    // Plain name (e.g. /DeviceCMYK as the array's tail target).
+    if let Some(name) = cs_obj.as_name() {
+        return match name {
+            "DeviceCMYK" | "CMYK" => ResolvedSpace::Cmyk,
+            "DeviceRGB" | "RGB" => ResolvedSpace::Rgb,
+            "DeviceGray" | "G" => ResolvedSpace::Gray,
+            _ => resolve_color_space(name, color_spaces, resources, doc),
+        };
+    }
+
+    let arr = match cs_obj.as_array() {
+        Some(a) => a,
+        None => return ResolvedSpace::Unknown,
+    };
+    let type_name = match arr.first().and_then(|o| o.as_name()) {
+        Some(n) => n,
+        None => return ResolvedSpace::Unknown,
+    };
+    match type_name {
+        "DeviceCMYK" | "CMYK" => ResolvedSpace::Cmyk,
+        "DeviceRGB" | "RGB" => ResolvedSpace::Rgb,
+        "DeviceGray" | "G" => ResolvedSpace::Gray,
+        "Separation" => {
+            let ink = arr
+                .get(1)
+                .and_then(|o| o.as_name())
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            ResolvedSpace::Separation(ink)
+        },
+        "DeviceN" => {
+            if let Some(Object::Array(ink_names)) = arr.get(1) {
+                let names = ink_names
+                    .iter()
+                    .filter_map(|o| o.as_name().map(|s| s.to_string()))
+                    .collect();
+                ResolvedSpace::DeviceN(names)
+            } else {
+                ResolvedSpace::Unknown
+            }
+        },
+        "ICCBased" => {
+            // ICCBased: try to read /N from the stream dict to pick the
+            // right component-count interpretation. Falls back to the
+            // 4-comp = CMYK heuristic when the stream isn't reachable.
+            if let Some(stream_obj) = arr.get(1) {
+                if let Ok(resolved) = doc.resolve_object(stream_obj) {
+                    if let Object::Stream { ref dict, .. } = resolved {
+                        if let Some(n) = dict.get("N").and_then(|o| o.as_integer()) {
+                            return match n {
+                                4 => ResolvedSpace::IccCmyk,
+                                3 => ResolvedSpace::IccRgb,
+                                1 => ResolvedSpace::IccGray,
+                                _ => ResolvedSpace::Unknown,
+                            };
+                        }
+                    }
+                }
+            }
+            // Unknown component count — caller decides via component vector length.
+            ResolvedSpace::IccCmyk
+        },
+        _ => ResolvedSpace::Unknown,
+    }
 }
 
 /// Load color space definitions from page resources.
@@ -225,14 +544,37 @@ fn load_color_spaces(doc: &PdfDocument, resources: &Object) -> Result<HashMap<St
     Ok(color_spaces)
 }
 
-/// Determine the tint value for the target ink given the current color state.
-///
-/// Returns `Some(tint)` where tint is 0.0..=1.0 if the current color
-/// contributes to the target ink, or `None` if it does not.
+/// Load font resources for the page. Failures are swallowed (text using
+/// unloadable fonts is dropped); this matches the page renderer's
+/// best-effort behaviour and keeps separation rendering robust on PDFs
+/// with corrupt or missing fonts.
+fn load_fonts(doc: &PdfDocument, resources: &Object) -> HashMap<String, Arc<FontInfo>> {
+    let mut fonts = HashMap::new();
+    if let Object::Dictionary(res_dict) = resources {
+        if let Some(font_obj) = res_dict.get("Font") {
+            if let Ok(font_dict_obj) = doc.resolve_object(font_obj) {
+                if let Some(font_dict) = font_dict_obj.as_dict() {
+                    for (name, f_obj) in font_dict {
+                        if let Ok(info) = doc.get_or_load_font_for_rendering(f_obj) {
+                            fonts.insert(name.clone(), info);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    fonts
+}
+
+/// Compute the tint contribution to `target_ink` for the current colour
+/// state. Returns `None` if the current colour does not touch this
+/// plate; `Some(tint)` otherwise, with `tint` in 0.0..=1.0.
 fn tint_for_ink(
     fill: bool,
     gs: &GraphicsState,
     color_spaces: &HashMap<String, Object>,
+    resources: &Object,
+    doc: &PdfDocument,
     target_ink: &str,
     fill_components: &[f32],
     stroke_components: &[f32],
@@ -248,82 +590,79 @@ fn tint_for_ink(
         stroke_components
     };
 
-    match space_name.as_str() {
-        "DeviceCMYK" | "CMYK" => {
-            let cmyk = if fill {
+    let resolved = resolve_color_space(space_name, color_spaces, resources, doc);
+    match resolved {
+        ResolvedSpace::Cmyk => {
+            let cmyk_state = if fill {
                 gs.fill_color_cmyk
             } else {
                 gs.stroke_color_cmyk
             };
-            if let Some((c, m, y, k)) = cmyk {
+            let (c, m, y, k) = if let Some(v) = cmyk_state {
+                v
+            } else if components.len() >= 4 {
+                (components[0], components[1], components[2], components[3])
+            } else {
+                return None;
+            };
+            match target_ink {
+                "Cyan" => Some(c),
+                "Magenta" => Some(m),
+                "Yellow" => Some(y),
+                "Black" => Some(k),
+                _ => None,
+            }
+        },
+        ResolvedSpace::Rgb
+        | ResolvedSpace::Gray
+        | ResolvedSpace::IccRgb
+        | ResolvedSpace::IccGray => {
+            // RGB / Gray content does not contribute to ink plates.
+            // Converting RGB → CMYK is intentionally not done: prepress
+            // workflows want artwork that was authored in process or
+            // spot colours, not synthesised process from RGB.
+            None
+        },
+        ResolvedSpace::Separation(ink) => {
+            if ink == target_ink && !components.is_empty() {
+                Some(components[0])
+            } else {
+                None
+            }
+        },
+        ResolvedSpace::DeviceN(names) => {
+            for (i, n) in names.iter().enumerate() {
+                if n == target_ink && i < components.len() {
+                    return Some(components[i]);
+                }
+            }
+            None
+        },
+        ResolvedSpace::IccCmyk => {
+            // Heuristic: 4-component ICC space = CMYK. See module docs.
+            if components.len() >= 4 {
                 match target_ink {
-                    "Cyan" => Some(c),
-                    "Magenta" => Some(m),
-                    "Yellow" => Some(y),
-                    "Black" => Some(k),
+                    "Cyan" => Some(components[0]),
+                    "Magenta" => Some(components[1]),
+                    "Yellow" => Some(components[2]),
+                    "Black" => Some(components[3]),
                     _ => None,
                 }
             } else {
                 None
             }
         },
-        "DeviceRGB" | "RGB" | "DeviceGray" | "G" => None,
-        _ => {
-            // Check resolved color space
-            if let Some(cs_obj) = color_spaces.get(space_name) {
-                if let Some(arr) = cs_obj.as_array() {
-                    if let Some(type_name) = arr.first().and_then(|o| o.as_name()) {
-                        match type_name {
-                            "Separation" => {
-                                let sep_ink = arr.get(1).and_then(|o| o.as_name()).unwrap_or("");
-                                if sep_ink == target_ink && !components.is_empty() {
-                                    Some(components[0])
-                                } else {
-                                    None
-                                }
-                            },
-                            "DeviceN" => {
-                                if let Some(Object::Array(ink_names)) = arr.get(1) {
-                                    for (i, ink_obj) in ink_names.iter().enumerate() {
-                                        if let Object::Name(ink) = ink_obj {
-                                            if ink == target_ink && i < components.len() {
-                                                return Some(components[i]);
-                                            }
-                                        }
-                                    }
-                                }
-                                None
-                            },
-                            "ICCBased" if arr.len() > 1 => {
-                                // ICCBased with N=4 maps to CMYK
-                                // We need the doc to resolve the ICC stream dict, but since
-                                // this is a hot path, we use a heuristic: if 4 components
-                                // are present, treat as CMYK.
-                                if components.len() >= 4 {
-                                    match target_ink {
-                                        "Cyan" => Some(components[0]),
-                                        "Magenta" => Some(components[1]),
-                                        "Yellow" => Some(components[2]),
-                                        "Black" => Some(components[3]),
-                                        _ => None,
-                                    }
-                                } else {
-                                    None
-                                }
-                            },
-                            _ => None,
-                        }
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        },
+        ResolvedSpace::Unknown => None,
     }
+}
+
+/// Per-render shared context (read-only) passed through the operator
+/// walk and into recursive Form XObject invocations.
+struct SeparationContext<'a> {
+    doc: &'a PdfDocument,
+    target_ink: &'a str,
+    text_rasterizer: &'a TextRasterizer,
+    fonts: &'a HashMap<String, Arc<FontInfo>>,
 }
 
 /// Color state tracked alongside the graphics state for separation rendering.
@@ -342,50 +681,103 @@ impl SeparationColorState {
     }
 }
 
+/// Compute the initial colour components for a colour space per
+/// ISO 32000-1 §8.6.4.2. `cs`/`CS` resets the current colour to these
+/// values when entering the space.
+fn initial_components_for_space(
+    space_name: &str,
+    color_spaces: &HashMap<String, Object>,
+    resources: &Object,
+    doc: &PdfDocument,
+) -> (Vec<f32>, Option<(f32, f32, f32, f32)>) {
+    let resolved = resolve_color_space(space_name, color_spaces, resources, doc);
+    match resolved {
+        ResolvedSpace::Cmyk | ResolvedSpace::IccCmyk => {
+            (vec![0.0, 0.0, 0.0, 1.0], Some((0.0, 0.0, 0.0, 1.0)))
+        },
+        ResolvedSpace::Rgb | ResolvedSpace::IccRgb => (vec![0.0, 0.0, 0.0], None),
+        ResolvedSpace::Gray | ResolvedSpace::IccGray => (vec![0.0], None),
+        ResolvedSpace::Separation(_) => (vec![1.0], None),
+        ResolvedSpace::DeviceN(names) => {
+            let n = names.len().max(1);
+            (vec![1.0; n], None)
+        },
+        ResolvedSpace::Unknown => (Vec::new(), None),
+    }
+}
+
+/// State inherited from a calling context when recursing into a Form
+/// XObject (PDF §8.10.1: a Form XObject's initial graphics state is
+/// the calling context's graphics state).
+struct InheritedState {
+    fill_color_space: String,
+    stroke_color_space: String,
+    fill_color_cmyk: Option<(f32, f32, f32, f32)>,
+    stroke_color_cmyk: Option<(f32, f32, f32, f32)>,
+    fill_components: Vec<f32>,
+    stroke_components: Vec<f32>,
+}
+
 /// Execute operators for separation plate rendering.
 fn execute_separation_operators(
     pixmap: &mut Pixmap,
     base_transform: Transform,
     operators: &[Operator],
-    doc: &PdfDocument,
-    page_num: usize,
+    ctx: &mut SeparationContext<'_>,
     resources: &Object,
     color_spaces: &HashMap<String, Object>,
-    target_ink: &str,
+    inherited: Option<&InheritedState>,
 ) -> Result<()> {
     let mut gs_stack = GraphicsStateStack::new();
     {
         let gs = gs_stack.current_mut();
-        gs.fill_color_space = "DeviceGray".to_string();
-        gs.stroke_color_space = "DeviceGray".to_string();
+        if let Some(inh) = inherited {
+            gs.fill_color_space = inh.fill_color_space.clone();
+            gs.stroke_color_space = inh.stroke_color_space.clone();
+            gs.fill_color_cmyk = inh.fill_color_cmyk;
+            gs.stroke_color_cmyk = inh.stroke_color_cmyk;
+        } else {
+            gs.fill_color_space = "DeviceGray".to_string();
+            gs.stroke_color_space = "DeviceGray".to_string();
+        }
         gs.fill_color_rgb = (0.0, 0.0, 0.0);
         gs.stroke_color_rgb = (0.0, 0.0, 0.0);
     }
 
-    let mut color_state_stack: Vec<SeparationColorState> = vec![SeparationColorState::new()];
+    let initial_cs = if let Some(inh) = inherited {
+        SeparationColorState {
+            fill_components: inh.fill_components.clone(),
+            stroke_components: inh.stroke_components.clone(),
+        }
+    } else {
+        SeparationColorState::new()
+    };
+    let mut color_state_stack: Vec<SeparationColorState> = vec![initial_cs];
     let mut current_path = PathBuilder::new();
     let mut pending_clip: Option<(tiny_skia::Path, FillRule)> = None;
     let mut clip_stack: Vec<Option<Mask>> = vec![None];
+    let mut in_text_object = false;
 
-    // Pre-resolve ExtGState
+    // Pre-resolve ExtGState for the gs cache.
     let ext_g_state_resolved: Option<Object> = match resources {
-        Object::Dictionary(rd) => rd.get("ExtGState").and_then(|o| doc.resolve_object(o).ok()),
+        Object::Dictionary(rd) => rd
+            .get("ExtGState")
+            .and_then(|o| ctx.doc.resolve_object(o).ok()),
         _ => None,
     };
     let ext_g_states: Option<&HashMap<String, Object>> =
         ext_g_state_resolved.as_ref().and_then(|o| o.as_dict());
-    let mut ext_g_state_cache: HashMap<String, super::page_renderer::ParsedExtGState> =
-        HashMap::new();
+    let mut ext_g_state_cache: HashMap<String, ParsedExtGState> = HashMap::new();
 
-    // Pre-resolve XObject resources for Do operator
     let xobjects_resolved: Option<Object> = match resources {
-        Object::Dictionary(rd) => rd.get("XObject").and_then(|o| doc.resolve_object(o).ok()),
+        Object::Dictionary(rd) => rd
+            .get("XObject")
+            .and_then(|o| ctx.doc.resolve_object(o).ok()),
         _ => None,
     };
 
     for op in operators {
         match op {
-            // Graphics state save/restore
             Operator::SaveState => {
                 gs_stack.save();
                 let cs = color_state_stack
@@ -405,7 +797,6 @@ fn execute_separation_operators(
                 }
             },
 
-            // CTM operators
             Operator::Cm { a, b, c, d, e, f } => {
                 let current = gs_stack.current_mut();
                 let new_matrix = Matrix {
@@ -419,7 +810,6 @@ fn execute_separation_operators(
                 current.ctm = new_matrix.multiply(&current.ctm);
             },
 
-            // Color operators
             Operator::SetFillRgb { r, g, b } => {
                 let gs = gs_stack.current_mut();
                 gs.fill_color_rgb = (*r, *g, *b);
@@ -475,12 +865,24 @@ fn execute_separation_operators(
                 }
             },
             Operator::SetFillColorSpace { name } => {
-                gs_stack.current_mut().fill_color_space = name.clone();
-                gs_stack.current_mut().fill_color_cmyk = None;
+                let (components, cmyk) =
+                    initial_components_for_space(name, color_spaces, resources, ctx.doc);
+                let gs = gs_stack.current_mut();
+                gs.fill_color_space = name.clone();
+                gs.fill_color_cmyk = cmyk;
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.fill_components = components;
+                }
             },
             Operator::SetStrokeColorSpace { name } => {
-                gs_stack.current_mut().stroke_color_space = name.clone();
-                gs_stack.current_mut().stroke_color_cmyk = None;
+                let (components, cmyk) =
+                    initial_components_for_space(name, color_spaces, resources, ctx.doc);
+                let gs = gs_stack.current_mut();
+                gs.stroke_color_space = name.clone();
+                gs.stroke_color_cmyk = cmyk;
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.stroke_components = components;
+                }
             },
             Operator::SetFillColor { components } | Operator::SetFillColorN { components, .. } => {
                 let gs = gs_stack.current_mut();
@@ -512,7 +914,6 @@ fn execute_separation_operators(
                 }
             },
 
-            // Line style operators (passed through to GS)
             Operator::SetLineWidth { width } => {
                 gs_stack.current_mut().line_width = *width;
             },
@@ -529,7 +930,6 @@ fn execute_separation_operators(
                 gs_stack.current_mut().dash_pattern = (array.clone(), *phase);
             },
 
-            // Path construction
             Operator::MoveTo { x, y } => {
                 current_path.move_to(*x, *y);
             },
@@ -578,7 +978,6 @@ fn execute_separation_operators(
                 current_path.close();
             },
 
-            // Path painting
             Operator::Stroke => {
                 apply_separation_clip(
                     &mut pending_clip,
@@ -595,7 +994,9 @@ fn execute_separation_operators(
                         false,
                         gs,
                         color_spaces,
-                        target_ink,
+                        resources,
+                        ctx.doc,
+                        ctx.target_ink,
                         &cs.fill_components,
                         &cs.stroke_components,
                     ) {
@@ -622,7 +1023,9 @@ fn execute_separation_operators(
                         true,
                         gs,
                         color_spaces,
-                        target_ink,
+                        resources,
+                        ctx.doc,
+                        ctx.target_ink,
                         &cs.fill_components,
                         &cs.stroke_components,
                     ) {
@@ -649,7 +1052,9 @@ fn execute_separation_operators(
                         true,
                         gs,
                         color_spaces,
-                        target_ink,
+                        resources,
+                        ctx.doc,
+                        ctx.target_ink,
                         &cs.fill_components,
                         &cs.stroke_components,
                     ) {
@@ -678,7 +1083,9 @@ fn execute_separation_operators(
                         true,
                         gs,
                         color_spaces,
-                        target_ink,
+                        resources,
+                        ctx.doc,
+                        ctx.target_ink,
                         &cs.fill_components,
                         &cs.stroke_components,
                     ) {
@@ -688,7 +1095,9 @@ fn execute_separation_operators(
                         false,
                         gs,
                         color_spaces,
-                        target_ink,
+                        resources,
+                        ctx.doc,
+                        ctx.target_ink,
                         &cs.fill_components,
                         &cs.stroke_components,
                     ) {
@@ -715,7 +1124,9 @@ fn execute_separation_operators(
                         true,
                         gs,
                         color_spaces,
-                        target_ink,
+                        resources,
+                        ctx.doc,
+                        ctx.target_ink,
                         &cs.fill_components,
                         &cs.stroke_components,
                     ) {
@@ -725,7 +1136,9 @@ fn execute_separation_operators(
                         false,
                         gs,
                         color_spaces,
-                        target_ink,
+                        resources,
+                        ctx.doc,
+                        ctx.target_ink,
                         &cs.fill_components,
                         &cs.stroke_components,
                     ) {
@@ -745,7 +1158,6 @@ fn execute_separation_operators(
                 current_path = PathBuilder::new();
             },
 
-            // Clipping
             Operator::ClipNonZero => {
                 if let Some(path) = current_path.clone().finish() {
                     pending_clip = Some((path, FillRule::Winding));
@@ -757,6 +1169,176 @@ fn execute_separation_operators(
                 }
             },
 
+            // Text object
+            Operator::BeginText => {
+                in_text_object = true;
+                let gs = gs_stack.current_mut();
+                gs.text_matrix = Matrix::identity();
+                gs.text_line_matrix = Matrix::identity();
+            },
+            Operator::EndText => {
+                in_text_object = false;
+            },
+
+            // Text state
+            Operator::Tc { char_space } => {
+                gs_stack.current_mut().char_space = *char_space;
+            },
+            Operator::Tw { word_space } => {
+                gs_stack.current_mut().word_space = *word_space;
+            },
+            Operator::Tz { scale } => {
+                gs_stack.current_mut().horizontal_scaling = *scale;
+            },
+            Operator::TL { leading } => {
+                gs_stack.current_mut().leading = *leading;
+            },
+            Operator::Ts { rise } => {
+                gs_stack.current_mut().text_rise = *rise;
+            },
+            Operator::Tr { render } => {
+                gs_stack.current_mut().render_mode = *render;
+            },
+            Operator::Tf { font, size } => {
+                let gs = gs_stack.current_mut();
+                gs.font_name = Some(font.clone());
+                gs.font_size = *size;
+            },
+
+            // Text positioning
+            Operator::Td { tx, ty } => {
+                if in_text_object {
+                    let gs = gs_stack.current_mut();
+                    let translation = Matrix::translation(*tx, *ty);
+                    gs.text_line_matrix = translation.multiply(&gs.text_line_matrix);
+                    gs.text_matrix = gs.text_line_matrix;
+                }
+            },
+            Operator::TD { tx, ty } => {
+                if in_text_object {
+                    let gs = gs_stack.current_mut();
+                    gs.leading = -(*ty);
+                    let translation = Matrix::translation(*tx, *ty);
+                    gs.text_line_matrix = translation.multiply(&gs.text_line_matrix);
+                    gs.text_matrix = gs.text_line_matrix;
+                }
+            },
+            Operator::Tm { a, b, c, d, e, f } => {
+                if in_text_object {
+                    let gs = gs_stack.current_mut();
+                    gs.text_matrix = Matrix {
+                        a: *a,
+                        b: *b,
+                        c: *c,
+                        d: *d,
+                        e: *e,
+                        f: *f,
+                    };
+                    gs.text_line_matrix = gs.text_matrix;
+                }
+            },
+            Operator::TStar => {
+                if in_text_object {
+                    let gs = gs_stack.current_mut();
+                    let leading = gs.leading;
+                    let translation = Matrix::translation(0.0, -leading);
+                    gs.text_line_matrix = translation.multiply(&gs.text_line_matrix);
+                    gs.text_matrix = gs.text_line_matrix;
+                }
+            },
+
+            // Text showing
+            Operator::Tj { text } => {
+                if in_text_object {
+                    let advance = render_text_to_plate(
+                        pixmap,
+                        text,
+                        base_transform,
+                        &mut gs_stack,
+                        &color_state_stack,
+                        color_spaces,
+                        resources,
+                        ctx,
+                        clip_stack.last().and_then(|c| c.as_ref()),
+                    )?;
+                    let gs_mut = gs_stack.current_mut();
+                    let advance_matrix = Matrix::translation(advance, 0.0);
+                    gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                }
+            },
+            Operator::TJ { array } => {
+                if in_text_object {
+                    let advance = render_tj_to_plate(
+                        pixmap,
+                        array,
+                        base_transform,
+                        &mut gs_stack,
+                        &color_state_stack,
+                        color_spaces,
+                        resources,
+                        ctx,
+                        clip_stack.last().and_then(|c| c.as_ref()),
+                    )?;
+                    let gs_mut = gs_stack.current_mut();
+                    let advance_matrix = Matrix::translation(advance, 0.0);
+                    gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                }
+            },
+            Operator::Quote { text } => {
+                if in_text_object {
+                    let gs_mut = gs_stack.current_mut();
+                    let leading = gs_mut.leading;
+                    let translation = Matrix::translation(0.0, -leading);
+                    gs_mut.text_line_matrix = translation.multiply(&gs_mut.text_line_matrix);
+                    gs_mut.text_matrix = gs_mut.text_line_matrix;
+
+                    let advance = render_text_to_plate(
+                        pixmap,
+                        text,
+                        base_transform,
+                        &mut gs_stack,
+                        &color_state_stack,
+                        color_spaces,
+                        resources,
+                        ctx,
+                        clip_stack.last().and_then(|c| c.as_ref()),
+                    )?;
+                    let gs_mut = gs_stack.current_mut();
+                    let advance_matrix = Matrix::translation(advance, 0.0);
+                    gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                }
+            },
+            Operator::DoubleQuote {
+                word_space,
+                char_space,
+                text,
+            } => {
+                if in_text_object {
+                    let gs_mut = gs_stack.current_mut();
+                    gs_mut.word_space = *word_space;
+                    gs_mut.char_space = *char_space;
+                    let leading = gs_mut.leading;
+                    let translation = Matrix::translation(0.0, -leading);
+                    gs_mut.text_line_matrix = translation.multiply(&gs_mut.text_line_matrix);
+                    gs_mut.text_matrix = gs_mut.text_line_matrix;
+
+                    let advance = render_text_to_plate(
+                        pixmap,
+                        text,
+                        base_transform,
+                        &mut gs_stack,
+                        &color_state_stack,
+                        color_spaces,
+                        resources,
+                        ctx,
+                        clip_stack.last().and_then(|c| c.as_ref()),
+                    )?;
+                    let gs_mut = gs_stack.current_mut();
+                    let advance_matrix = Matrix::translation(advance, 0.0);
+                    gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                }
+            },
+
             // ExtGState
             Operator::SetExtGState { dict_name } => {
                 let entry = ext_g_state_cache
@@ -764,63 +1346,72 @@ fn execute_separation_operators(
                     .or_insert_with(|| {
                         if let Some(states) = ext_g_states {
                             if let Some(state_obj) = states.get(dict_name) {
-                                return super::page_renderer::parse_ext_g_state_inner(
-                                    state_obj, doc,
-                                )
-                                .unwrap_or_default();
+                                return parse_ext_g_state_inner(state_obj, ctx.doc)
+                                    .unwrap_or_default();
                             }
                         }
-                        super::page_renderer::ParsedExtGState::default()
+                        ParsedExtGState::default()
                     });
                 entry.apply(gs_stack.current_mut());
             },
 
-            // XObject (Form XObjects may contain ink-bearing content)
+            // XObject (Form XObjects may contain ink-bearing content).
+            // Image XObjects are dropped — see module-level Limitations.
             Operator::Do { name } => {
                 if let Some(xobjects) = xobjects_resolved.as_ref().and_then(|o| o.as_dict()) {
                     if let Some(xobj_ref_obj) = xobjects.get(name) {
-                        if let Ok(xobj) = doc.resolve_object(xobj_ref_obj) {
+                        if let Ok(xobj) = ctx.doc.resolve_object(xobj_ref_obj) {
                             if let Object::Stream { ref dict, .. } = xobj {
                                 if let Some(subtype) = dict.get("Subtype").and_then(|o| o.as_name())
                                 {
                                     if subtype == "Form" {
                                         let xobj_ref = xobj_ref_obj.as_reference();
                                         let stream_data = if let Some(r) = xobj_ref {
-                                            doc.decode_stream_with_encryption(&xobj, r)?
+                                            ctx.doc.decode_stream_with_encryption(&xobj, r)?
                                         } else {
                                             xobj.decode_stream_data()?
                                         };
 
                                         let form_resources =
                                             if let Some(res) = dict.get("Resources") {
-                                                doc.resolve_object(res)?
+                                                ctx.doc.resolve_object(res)?
                                             } else {
                                                 resources.clone()
                                             };
 
-                                        let form_cs = load_color_spaces(doc, &form_resources)?;
+                                        let form_cs = load_color_spaces(ctx.doc, &form_resources)?;
                                         let mut merged_cs = color_spaces.clone();
                                         merged_cs.extend(form_cs);
 
-                                        // Parse form matrix
                                         let form_matrix = parse_form_matrix(dict);
                                         let gs = gs_stack.current();
                                         let combined = combine_transforms(base_transform, &gs.ctm)
                                             .pre_concat(form_matrix);
+
+                                        // Inherit the calling context's colour state into the
+                                        // form's initial graphics state (PDF §8.10.1, O5).
+                                        let empty = SeparationColorState::new();
+                                        let cs = color_state_stack.last().unwrap_or(&empty);
+                                        let inherited = InheritedState {
+                                            fill_color_space: gs.fill_color_space.clone(),
+                                            stroke_color_space: gs.stroke_color_space.clone(),
+                                            fill_color_cmyk: gs.fill_color_cmyk,
+                                            stroke_color_cmyk: gs.stroke_color_cmyk,
+                                            fill_components: cs.fill_components.clone(),
+                                            stroke_components: cs.stroke_components.clone(),
+                                        };
 
                                         let form_ops = parse_content_stream(&stream_data)?;
                                         execute_separation_operators(
                                             pixmap,
                                             combined,
                                             &form_ops,
-                                            doc,
-                                            page_num,
+                                            ctx,
                                             &form_resources,
                                             &merged_cs,
-                                            target_ink,
+                                            Some(&inherited),
                                         )?;
                                     }
-                                    // Images are skipped for separation plates
                                 }
                             }
                         }
@@ -828,13 +1419,160 @@ fn execute_separation_operators(
                 }
             },
 
-            // Text and other operators are skipped for separation plates.
-            // Text rendering with spot colors is rare in separation use cases;
-            // we focus on path-based artwork which is the primary use.
             _ => {},
         }
     }
     Ok(())
+}
+
+/// Render text into the separation pixmap, routing each glyph through the
+/// current ink's tint. The strategy is to clone the GraphicsState, replace
+/// its fill colour with a grayscale paint equal to the tint, and reuse
+/// the standard [`TextRasterizer`]. This preserves glyph shape, kerning,
+/// and anti-aliasing — the same fidelity as the page renderer.
+#[allow(clippy::too_many_arguments)]
+fn render_text_to_plate(
+    pixmap: &mut Pixmap,
+    text: &[u8],
+    base_transform: Transform,
+    gs_stack: &mut GraphicsStateStack,
+    color_state_stack: &[SeparationColorState],
+    color_spaces: &HashMap<String, Object>,
+    resources: &Object,
+    ctx: &mut SeparationContext<'_>,
+    clip: Option<&Mask>,
+) -> Result<f32> {
+    let gs = gs_stack.current();
+    let empty = SeparationColorState::new();
+    let cs = color_state_stack.last().unwrap_or(&empty);
+
+    // Render mode 3 = invisible text. Still advance the text matrix but skip painting.
+    if gs.render_mode == 3 {
+        return measure_text_advance(text, gs, ctx.fonts);
+    }
+
+    let tint = tint_for_ink(
+        true,
+        gs,
+        color_spaces,
+        resources,
+        ctx.doc,
+        ctx.target_ink,
+        &cs.fill_components,
+        &cs.stroke_components,
+    );
+    if tint.is_none() {
+        // Colour doesn't touch this plate — advance but don't paint.
+        return measure_text_advance(text, gs, ctx.fonts);
+    }
+    let tint = tint.unwrap();
+
+    // Build a faked-grayscale GraphicsState so the rasteriser paints in
+    // (tint, tint, tint) which becomes the plate value in the R channel.
+    let mut faux = gs.clone();
+    faux.fill_color_rgb = (tint, tint, tint);
+    faux.fill_alpha = 1.0;
+    faux.blend_mode = "Normal".to_string();
+
+    let transform = combine_transforms(base_transform, &gs.ctm);
+    ctx.text_rasterizer
+        .render_text(pixmap, text, transform, &faux, resources, ctx.doc, clip, ctx.fonts)
+}
+
+/// Render a TJ array (sequence of strings + offsets) into the plate.
+/// Walks the array applying offsets between strings, painting each
+/// string component via [`render_text_to_plate`].
+#[allow(clippy::too_many_arguments)]
+fn render_tj_to_plate(
+    pixmap: &mut Pixmap,
+    array: &[TextElement],
+    base_transform: Transform,
+    gs_stack: &mut GraphicsStateStack,
+    color_state_stack: &[SeparationColorState],
+    color_spaces: &HashMap<String, Object>,
+    resources: &Object,
+    ctx: &mut SeparationContext<'_>,
+    clip: Option<&Mask>,
+) -> Result<f32> {
+    let mut total_advance = 0.0;
+    for element in array {
+        match element {
+            TextElement::String(text) => {
+                let advance = render_text_to_plate(
+                    pixmap,
+                    text,
+                    base_transform,
+                    gs_stack,
+                    color_state_stack,
+                    color_spaces,
+                    resources,
+                    ctx,
+                    clip,
+                )?;
+                let gs_mut = gs_stack.current_mut();
+                let advance_matrix = Matrix::translation(advance, 0.0);
+                gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                total_advance += advance;
+            },
+            TextElement::Offset(offset) => {
+                let gs = gs_stack.current();
+                let shift = (-*offset / 1000.0) * gs.font_size;
+                let advance_matrix = Matrix::translation(shift, 0.0);
+                let gs_mut = gs_stack.current_mut();
+                gs_mut.text_matrix = advance_matrix.multiply(&gs_mut.text_matrix);
+                total_advance += shift;
+            },
+        }
+    }
+    Ok(total_advance)
+}
+
+/// Compute the horizontal advance a [`TextRasterizer`] call would
+/// produce, without painting. Used for invisible/skipped text so the
+/// text matrix stays consistent with the painted ink plates.
+///
+/// Best-effort: when an embedded width table is unavailable we fall
+/// back to `font_size * len * 0.5` — close enough to keep glyph
+/// positions inside the rest of the line.
+fn measure_text_advance(
+    text: &[u8],
+    gs: &GraphicsState,
+    fonts: &HashMap<String, Arc<FontInfo>>,
+) -> Result<f32> {
+    let font_info = gs
+        .font_name
+        .as_ref()
+        .and_then(|n| fonts.get(n))
+        .map(Arc::clone);
+
+    // Sum widths from the font's width table (in glyph units / 1000)
+    // multiplied by font_size, plus per-char Tc spacing.
+    let mut units: f32 = 0.0;
+    let mut count: usize = 0;
+    if let Some(info) = font_info.as_ref() {
+        if info.subtype != "Type0" {
+            for &b in text {
+                units += info.get_glyph_width(b as u16);
+                count += 1;
+            }
+        } else {
+            // Type0: iterate 2-byte codes (approx).
+            let mut i = 0;
+            while i + 1 < text.len() {
+                let code = ((text[i] as u16) << 8) | text[i + 1] as u16;
+                units += info.get_glyph_width(code);
+                count += 1;
+                i += 2;
+            }
+        }
+    } else {
+        for _ in text {
+            units += 500.0;
+            count += 1;
+        }
+    }
+    let advance = units * gs.font_size / 1000.0 + (count as f32) * gs.char_space;
+    Ok(advance)
 }
 
 /// Fill a path into the separation pixmap with the given tint value.
@@ -851,7 +1589,11 @@ fn fill_separation(
     let mut paint = tiny_skia::Paint::default();
     paint.set_color(color);
     paint.anti_alias = true;
-    // Use SourceOver so overlapping shapes accumulate correctly
+    // SourceOver with opaque (alpha=255) source = replacement; this matches
+    // PDF's opaque painting model where each new fill overwrites the pixels
+    // under it within the path. Overlapping fills are *not* accumulated —
+    // PDF separation semantics dictate last-writer-wins per ink at the
+    // overlapping pixels, which SourceOver gives us for free.
     paint.blend_mode = tiny_skia::BlendMode::SourceOver;
 
     pixmap.fill_path(path, &paint, fill_rule, transform, clip);

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -1,0 +1,952 @@
+//! Separation plate renderer.
+//!
+//! Renders individual ink separation plates as grayscale images where
+//! pixel intensity represents the tint percentage of that ink at each point.
+//! Used in prepress workflows, ink coverage analysis, and ML pipelines
+//! that process packaging/label PDFs.
+#![allow(
+    clippy::field_reassign_with_default,
+    clippy::ptr_arg,
+    clippy::only_used_in_recursion
+)]
+
+use std::collections::HashMap;
+
+use tiny_skia::{FillRule, Mask, PathBuilder, Pixmap, Transform};
+
+use crate::content::graphics_state::{GraphicsState, GraphicsStateStack, Matrix};
+use crate::content::operators::Operator;
+use crate::content::parser::parse_content_stream;
+use crate::document::PdfDocument;
+use crate::error::{Error, Result};
+use crate::object::Object;
+
+/// A rendered separation plate for a single ink.
+#[derive(Debug, Clone)]
+pub struct SeparationPlate {
+    /// Ink name (e.g., "Cyan", "PANTONE 185 C", "Dieline").
+    pub ink_name: String,
+    /// Grayscale pixel data, row-major, top-left origin.
+    /// 0 = no ink, 255 = full tint. `data.len() == width * height`.
+    pub data: Vec<u8>,
+    /// Image width in pixels.
+    pub width: u32,
+    /// Image height in pixels.
+    pub height: u32,
+}
+
+/// Render all separation plates for a page.
+///
+/// Returns one `SeparationPlate` per ink found on the page (process CMYK
+/// inks are included when the page uses DeviceCMYK content). Each plate is
+/// a grayscale image where pixel intensity = tint percentage of that ink.
+pub fn render_separations(
+    doc: &PdfDocument,
+    page_num: usize,
+    dpi: u32,
+) -> Result<Vec<SeparationPlate>> {
+    let inks = collect_page_inks(doc, page_num)?;
+    if inks.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut plates = Vec::with_capacity(inks.len());
+    for ink in &inks {
+        let plate = render_single_separation(doc, page_num, ink, dpi)?;
+        plates.push(plate);
+    }
+    Ok(plates)
+}
+
+/// Render a single ink separation plate for a page.
+///
+/// Returns a grayscale image where pixel intensity = tint percentage
+/// of the named ink. If the ink is not present on the page, the plate
+/// is all zeros.
+pub fn render_separation(
+    doc: &PdfDocument,
+    page_num: usize,
+    ink_name: &str,
+    dpi: u32,
+) -> Result<SeparationPlate> {
+    render_single_separation(doc, page_num, ink_name, dpi)
+}
+
+/// Collect all ink names present on a page, including process CMYK.
+fn collect_page_inks(doc: &PdfDocument, page_num: usize) -> Result<Vec<String>> {
+    let mut inks = Vec::new();
+
+    // Check for DeviceCMYK content by scanning the content stream
+    let content_data = doc.get_page_content_data(page_num)?;
+    let operators = parse_content_stream(&content_data)?;
+    let has_cmyk = has_cmyk_content(&operators);
+
+    if has_cmyk {
+        inks.extend_from_slice(&[
+            "Cyan".to_string(),
+            "Magenta".to_string(),
+            "Yellow".to_string(),
+            "Black".to_string(),
+        ]);
+    }
+
+    // Get spot color inks from color space resources
+    let spot_inks = doc.get_page_inks(page_num)?;
+    for ink in spot_inks {
+        if !inks.contains(&ink) {
+            inks.push(ink);
+        }
+    }
+
+    Ok(inks)
+}
+
+/// Check whether a content stream references DeviceCMYK content.
+fn has_cmyk_content(operators: &[Operator]) -> bool {
+    for op in operators {
+        match op {
+            Operator::SetFillCmyk { .. } | Operator::SetStrokeCmyk { .. } => return true,
+            Operator::SetFillColorSpace { name } | Operator::SetStrokeColorSpace { name } => {
+                if name == "DeviceCMYK" || name == "CMYK" {
+                    return true;
+                }
+            },
+            _ => {},
+        }
+    }
+    false
+}
+
+/// Core rendering logic for a single separation plate.
+///
+/// This uses the page renderer to rasterize the full page once via
+/// the standard RGBA pipeline, but instead of using the composited result,
+/// we walk the operator stream ourselves to track which ink is active
+/// for each drawing operation, then render only the operations that
+/// contribute to the target ink into a grayscale buffer.
+///
+/// We implement this by:
+/// 1. Computing page dimensions and transform (same as the normal renderer)
+/// 2. Walking the operator stream to track color state
+/// 3. For each path painting operation, checking if the current color
+///    contributes to the target ink
+/// 4. If so, painting the path into a grayscale pixmap with the tint value
+fn render_single_separation(
+    doc: &PdfDocument,
+    page_num: usize,
+    ink_name: &str,
+    dpi: u32,
+) -> Result<SeparationPlate> {
+    let page_info = doc.get_page_info(page_num)?;
+    let media_box = page_info.media_box;
+
+    let rotation = page_info.rotation % 360;
+    let (page_w, page_h) = if rotation == 90 || rotation == 270 {
+        (media_box.height, media_box.width)
+    } else {
+        (media_box.width, media_box.height)
+    };
+    let scale = dpi as f32 / 72.0;
+    let width = (page_w * scale).ceil() as u32;
+    let height = (page_h * scale).ceil() as u32;
+
+    let base_transform = match rotation {
+        90 => Transform::from_translate(-media_box.x, -media_box.y)
+            .post_concat(Transform::from_row(0.0, scale, scale, 0.0, 0.0, 0.0)),
+        180 => Transform::from_translate(-media_box.x, -media_box.y)
+            .post_scale(-scale, scale)
+            .post_translate(media_box.width * scale, 0.0),
+        270 => Transform::from_translate(-media_box.x, -media_box.y).post_concat(
+            Transform::from_row(0.0, scale, -scale, 0.0, media_box.height * scale, 0.0),
+        ),
+        _ => Transform::from_translate(-media_box.x, -media_box.y)
+            .post_scale(scale, -scale)
+            .post_translate(0.0, page_h * scale),
+    };
+
+    // Create an RGBA pixmap for rasterization via tiny-skia.
+    // We render in white-on-black: tint -> white channel (255 = full tint).
+    let mut pixmap = Pixmap::new(width, height)
+        .ok_or_else(|| Error::InvalidPdf("Failed to create separation pixmap".to_string()))?;
+
+    // Load page resources and color spaces
+    let resources = doc.get_page_resources(page_num)?;
+    let color_spaces = load_color_spaces(doc, &resources)?;
+
+    // Parse content stream
+    let content_data = doc.get_page_content_data(page_num)?;
+    let operators = parse_content_stream(&content_data)?;
+
+    // Execute operators, painting only the target ink
+    execute_separation_operators(
+        &mut pixmap,
+        base_transform,
+        &operators,
+        doc,
+        page_num,
+        &resources,
+        &color_spaces,
+        ink_name,
+    )?;
+
+    // Extract the grayscale channel from the RGBA pixmap.
+    // We used R channel to carry tint values.
+    let pixel_count = (width * height) as usize;
+    let mut data = vec![0u8; pixel_count];
+    let rgba = pixmap.data();
+    for i in 0..pixel_count {
+        // Red channel holds the tint value
+        data[i] = rgba[i * 4];
+    }
+
+    Ok(SeparationPlate {
+        ink_name: ink_name.to_string(),
+        data,
+        width,
+        height,
+    })
+}
+
+/// Load color space definitions from page resources.
+fn load_color_spaces(doc: &PdfDocument, resources: &Object) -> Result<HashMap<String, Object>> {
+    let mut color_spaces = HashMap::new();
+    if let Object::Dictionary(res_dict) = resources {
+        if let Some(cs_obj) = res_dict.get("ColorSpace") {
+            let cs_dict_obj = doc.resolve_object(cs_obj)?;
+            if let Some(cs_dict) = cs_dict_obj.as_dict() {
+                for (name, o) in cs_dict {
+                    if let Ok(resolved_cs) = doc.resolve_object(o) {
+                        color_spaces.insert(name.clone(), resolved_cs);
+                    }
+                }
+            }
+        }
+    }
+    Ok(color_spaces)
+}
+
+/// Determine the tint value for the target ink given the current color state.
+///
+/// Returns `Some(tint)` where tint is 0.0..=1.0 if the current color
+/// contributes to the target ink, or `None` if it does not.
+fn tint_for_ink(
+    fill: bool,
+    gs: &GraphicsState,
+    color_spaces: &HashMap<String, Object>,
+    target_ink: &str,
+    fill_components: &[f32],
+    stroke_components: &[f32],
+) -> Option<f32> {
+    let space_name = if fill {
+        &gs.fill_color_space
+    } else {
+        &gs.stroke_color_space
+    };
+    let components = if fill {
+        fill_components
+    } else {
+        stroke_components
+    };
+
+    match space_name.as_str() {
+        "DeviceCMYK" | "CMYK" => {
+            let cmyk = if fill {
+                gs.fill_color_cmyk
+            } else {
+                gs.stroke_color_cmyk
+            };
+            if let Some((c, m, y, k)) = cmyk {
+                match target_ink {
+                    "Cyan" => Some(c),
+                    "Magenta" => Some(m),
+                    "Yellow" => Some(y),
+                    "Black" => Some(k),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        },
+        "DeviceRGB" | "RGB" | "DeviceGray" | "G" => None,
+        _ => {
+            // Check resolved color space
+            if let Some(cs_obj) = color_spaces.get(space_name) {
+                if let Some(arr) = cs_obj.as_array() {
+                    if let Some(type_name) = arr.first().and_then(|o| o.as_name()) {
+                        match type_name {
+                            "Separation" => {
+                                let sep_ink = arr.get(1).and_then(|o| o.as_name()).unwrap_or("");
+                                if sep_ink == target_ink && !components.is_empty() {
+                                    Some(components[0])
+                                } else {
+                                    None
+                                }
+                            },
+                            "DeviceN" => {
+                                if let Some(Object::Array(ink_names)) = arr.get(1) {
+                                    for (i, ink_obj) in ink_names.iter().enumerate() {
+                                        if let Object::Name(ink) = ink_obj {
+                                            if ink == target_ink && i < components.len() {
+                                                return Some(components[i]);
+                                            }
+                                        }
+                                    }
+                                }
+                                None
+                            },
+                            "ICCBased" if arr.len() > 1 => {
+                                // ICCBased with N=4 maps to CMYK
+                                // We need the doc to resolve the ICC stream dict, but since
+                                // this is a hot path, we use a heuristic: if 4 components
+                                // are present, treat as CMYK.
+                                if components.len() >= 4 {
+                                    match target_ink {
+                                        "Cyan" => Some(components[0]),
+                                        "Magenta" => Some(components[1]),
+                                        "Yellow" => Some(components[2]),
+                                        "Black" => Some(components[3]),
+                                        _ => None,
+                                    }
+                                } else {
+                                    None
+                                }
+                            },
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        },
+    }
+}
+
+/// Color state tracked alongside the graphics state for separation rendering.
+#[derive(Clone, Debug)]
+struct SeparationColorState {
+    fill_components: Vec<f32>,
+    stroke_components: Vec<f32>,
+}
+
+impl SeparationColorState {
+    fn new() -> Self {
+        Self {
+            fill_components: Vec::new(),
+            stroke_components: Vec::new(),
+        }
+    }
+}
+
+/// Execute operators for separation plate rendering.
+fn execute_separation_operators(
+    pixmap: &mut Pixmap,
+    base_transform: Transform,
+    operators: &[Operator],
+    doc: &PdfDocument,
+    page_num: usize,
+    resources: &Object,
+    color_spaces: &HashMap<String, Object>,
+    target_ink: &str,
+) -> Result<()> {
+    let mut gs_stack = GraphicsStateStack::new();
+    {
+        let gs = gs_stack.current_mut();
+        gs.fill_color_space = "DeviceGray".to_string();
+        gs.stroke_color_space = "DeviceGray".to_string();
+        gs.fill_color_rgb = (0.0, 0.0, 0.0);
+        gs.stroke_color_rgb = (0.0, 0.0, 0.0);
+    }
+
+    let mut color_state_stack: Vec<SeparationColorState> = vec![SeparationColorState::new()];
+    let mut current_path = PathBuilder::new();
+    let mut pending_clip: Option<(tiny_skia::Path, FillRule)> = None;
+    let mut clip_stack: Vec<Option<Mask>> = vec![None];
+
+    // Pre-resolve ExtGState
+    let ext_g_state_resolved: Option<Object> = match resources {
+        Object::Dictionary(rd) => rd.get("ExtGState").and_then(|o| doc.resolve_object(o).ok()),
+        _ => None,
+    };
+    let ext_g_states: Option<&HashMap<String, Object>> =
+        ext_g_state_resolved.as_ref().and_then(|o| o.as_dict());
+    let mut ext_g_state_cache: HashMap<String, super::page_renderer::ParsedExtGState> =
+        HashMap::new();
+
+    // Pre-resolve XObject resources for Do operator
+    let xobjects_resolved: Option<Object> = match resources {
+        Object::Dictionary(rd) => rd.get("XObject").and_then(|o| doc.resolve_object(o).ok()),
+        _ => None,
+    };
+
+    for op in operators {
+        match op {
+            // Graphics state save/restore
+            Operator::SaveState => {
+                gs_stack.save();
+                let cs = color_state_stack
+                    .last()
+                    .cloned()
+                    .unwrap_or_else(SeparationColorState::new);
+                color_state_stack.push(cs);
+                clip_stack.push(clip_stack.last().cloned().unwrap_or(None));
+            },
+            Operator::RestoreState => {
+                gs_stack.restore();
+                if color_state_stack.len() > 1 {
+                    color_state_stack.pop();
+                }
+                if clip_stack.len() > 1 {
+                    clip_stack.pop();
+                }
+            },
+
+            // CTM operators
+            Operator::Cm { a, b, c, d, e, f } => {
+                let current = gs_stack.current_mut();
+                let new_matrix = Matrix {
+                    a: *a,
+                    b: *b,
+                    c: *c,
+                    d: *d,
+                    e: *e,
+                    f: *f,
+                };
+                current.ctm = new_matrix.multiply(&current.ctm);
+            },
+
+            // Color operators
+            Operator::SetFillRgb { r, g, b } => {
+                let gs = gs_stack.current_mut();
+                gs.fill_color_rgb = (*r, *g, *b);
+                gs.fill_color_space = "DeviceRGB".to_string();
+                gs.fill_color_cmyk = None;
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.fill_components = vec![*r, *g, *b];
+                }
+            },
+            Operator::SetStrokeRgb { r, g, b } => {
+                let gs = gs_stack.current_mut();
+                gs.stroke_color_rgb = (*r, *g, *b);
+                gs.stroke_color_space = "DeviceRGB".to_string();
+                gs.stroke_color_cmyk = None;
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.stroke_components = vec![*r, *g, *b];
+                }
+            },
+            Operator::SetFillGray { gray } => {
+                let g = *gray;
+                let gs = gs_stack.current_mut();
+                gs.fill_color_rgb = (g, g, g);
+                gs.fill_color_space = "DeviceGray".to_string();
+                gs.fill_color_cmyk = None;
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.fill_components = vec![g];
+                }
+            },
+            Operator::SetStrokeGray { gray } => {
+                let g = *gray;
+                let gs = gs_stack.current_mut();
+                gs.stroke_color_rgb = (g, g, g);
+                gs.stroke_color_space = "DeviceGray".to_string();
+                gs.stroke_color_cmyk = None;
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.stroke_components = vec![g];
+                }
+            },
+            Operator::SetFillCmyk { c, m, y, k } => {
+                let gs = gs_stack.current_mut();
+                gs.fill_color_cmyk = Some((*c, *m, *y, *k));
+                gs.fill_color_space = "DeviceCMYK".to_string();
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.fill_components = vec![*c, *m, *y, *k];
+                }
+            },
+            Operator::SetStrokeCmyk { c, m, y, k } => {
+                let gs = gs_stack.current_mut();
+                gs.stroke_color_cmyk = Some((*c, *m, *y, *k));
+                gs.stroke_color_space = "DeviceCMYK".to_string();
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.stroke_components = vec![*c, *m, *y, *k];
+                }
+            },
+            Operator::SetFillColorSpace { name } => {
+                gs_stack.current_mut().fill_color_space = name.clone();
+                gs_stack.current_mut().fill_color_cmyk = None;
+            },
+            Operator::SetStrokeColorSpace { name } => {
+                gs_stack.current_mut().stroke_color_space = name.clone();
+                gs_stack.current_mut().stroke_color_cmyk = None;
+            },
+            Operator::SetFillColor { components } | Operator::SetFillColorN { components, .. } => {
+                let gs = gs_stack.current_mut();
+                let space = gs.fill_color_space.clone();
+                match space.as_str() {
+                    "DeviceCMYK" | "CMYK" if components.len() >= 4 => {
+                        gs.fill_color_cmyk =
+                            Some((components[0], components[1], components[2], components[3]));
+                    },
+                    _ => {},
+                }
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.fill_components = components.clone();
+                }
+            },
+            Operator::SetStrokeColor { components }
+            | Operator::SetStrokeColorN { components, .. } => {
+                let gs = gs_stack.current_mut();
+                let space = gs.stroke_color_space.clone();
+                match space.as_str() {
+                    "DeviceCMYK" | "CMYK" if components.len() >= 4 => {
+                        gs.stroke_color_cmyk =
+                            Some((components[0], components[1], components[2], components[3]));
+                    },
+                    _ => {},
+                }
+                if let Some(cs) = color_state_stack.last_mut() {
+                    cs.stroke_components = components.clone();
+                }
+            },
+
+            // Line style operators (passed through to GS)
+            Operator::SetLineWidth { width } => {
+                gs_stack.current_mut().line_width = *width;
+            },
+            Operator::SetLineCap { cap_style } => {
+                gs_stack.current_mut().line_cap = *cap_style;
+            },
+            Operator::SetLineJoin { join_style } => {
+                gs_stack.current_mut().line_join = *join_style;
+            },
+            Operator::SetMiterLimit { limit } => {
+                gs_stack.current_mut().miter_limit = *limit;
+            },
+            Operator::SetDash { array, phase } => {
+                gs_stack.current_mut().dash_pattern = (array.clone(), *phase);
+            },
+
+            // Path construction
+            Operator::MoveTo { x, y } => {
+                current_path.move_to(*x, *y);
+            },
+            Operator::LineTo { x, y } => {
+                current_path.line_to(*x, *y);
+            },
+            Operator::CurveTo {
+                x1,
+                y1,
+                x2,
+                y2,
+                x3,
+                y3,
+            } => {
+                current_path.cubic_to(*x1, *y1, *x2, *y2, *x3, *y3);
+            },
+            Operator::CurveToV { x2, y2, x3, y3 } => {
+                if let Some(last) = current_path.last_point() {
+                    current_path.cubic_to(last.x, last.y, *x2, *y2, *x3, *y3);
+                }
+            },
+            Operator::CurveToY { x1, y1, x3, y3 } => {
+                current_path.cubic_to(*x1, *y1, *x3, *y3, *x3, *y3);
+            },
+            Operator::Rectangle {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                let (nx, nw) = if *width < 0.0 {
+                    (x + width, -width)
+                } else {
+                    (*x, *width)
+                };
+                let (ny, nh) = if *height < 0.0 {
+                    (y + height, -height)
+                } else {
+                    (*y, *height)
+                };
+                if let Some(rect) = tiny_skia::Rect::from_xywh(nx, ny, nw, nh) {
+                    current_path.push_rect(rect);
+                }
+            },
+            Operator::ClosePath => {
+                current_path.close();
+            },
+
+            // Path painting
+            Operator::Stroke => {
+                apply_separation_clip(
+                    &mut pending_clip,
+                    &mut clip_stack,
+                    pixmap,
+                    base_transform,
+                    &gs_stack,
+                );
+                if let Some(path) = current_path.finish() {
+                    let gs = gs_stack.current();
+                    let empty = SeparationColorState::new();
+                    let cs = color_state_stack.last().unwrap_or(&empty);
+                    if let Some(tint) = tint_for_ink(
+                        false,
+                        gs,
+                        color_spaces,
+                        target_ink,
+                        &cs.fill_components,
+                        &cs.stroke_components,
+                    ) {
+                        let transform = combine_transforms(base_transform, &gs.ctm);
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        stroke_separation(pixmap, &path, transform, gs, tint, clip);
+                    }
+                }
+                current_path = PathBuilder::new();
+            },
+            Operator::Fill => {
+                apply_separation_clip(
+                    &mut pending_clip,
+                    &mut clip_stack,
+                    pixmap,
+                    base_transform,
+                    &gs_stack,
+                );
+                if let Some(path) = current_path.finish() {
+                    let gs = gs_stack.current();
+                    let empty = SeparationColorState::new();
+                    let cs = color_state_stack.last().unwrap_or(&empty);
+                    if let Some(tint) = tint_for_ink(
+                        true,
+                        gs,
+                        color_spaces,
+                        target_ink,
+                        &cs.fill_components,
+                        &cs.stroke_components,
+                    ) {
+                        let transform = combine_transforms(base_transform, &gs.ctm);
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        fill_separation(pixmap, &path, transform, tint, FillRule::Winding, clip);
+                    }
+                }
+                current_path = PathBuilder::new();
+            },
+            Operator::FillEvenOdd => {
+                apply_separation_clip(
+                    &mut pending_clip,
+                    &mut clip_stack,
+                    pixmap,
+                    base_transform,
+                    &gs_stack,
+                );
+                if let Some(path) = current_path.finish() {
+                    let gs = gs_stack.current();
+                    let empty = SeparationColorState::new();
+                    let cs = color_state_stack.last().unwrap_or(&empty);
+                    if let Some(tint) = tint_for_ink(
+                        true,
+                        gs,
+                        color_spaces,
+                        target_ink,
+                        &cs.fill_components,
+                        &cs.stroke_components,
+                    ) {
+                        let transform = combine_transforms(base_transform, &gs.ctm);
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        fill_separation(pixmap, &path, transform, tint, FillRule::EvenOdd, clip);
+                    }
+                }
+                current_path = PathBuilder::new();
+            },
+            Operator::FillStroke | Operator::CloseFillStroke => {
+                apply_separation_clip(
+                    &mut pending_clip,
+                    &mut clip_stack,
+                    pixmap,
+                    base_transform,
+                    &gs_stack,
+                );
+                if let Some(path) = current_path.finish() {
+                    let gs = gs_stack.current();
+                    let empty = SeparationColorState::new();
+                    let cs = color_state_stack.last().unwrap_or(&empty);
+                    let transform = combine_transforms(base_transform, &gs.ctm);
+                    let clip = clip_stack.last().and_then(|c| c.as_ref());
+                    if let Some(tint) = tint_for_ink(
+                        true,
+                        gs,
+                        color_spaces,
+                        target_ink,
+                        &cs.fill_components,
+                        &cs.stroke_components,
+                    ) {
+                        fill_separation(pixmap, &path, transform, tint, FillRule::Winding, clip);
+                    }
+                    if let Some(tint) = tint_for_ink(
+                        false,
+                        gs,
+                        color_spaces,
+                        target_ink,
+                        &cs.fill_components,
+                        &cs.stroke_components,
+                    ) {
+                        stroke_separation(pixmap, &path, transform, gs, tint, clip);
+                    }
+                }
+                current_path = PathBuilder::new();
+            },
+            Operator::FillStrokeEvenOdd | Operator::CloseFillStrokeEvenOdd => {
+                apply_separation_clip(
+                    &mut pending_clip,
+                    &mut clip_stack,
+                    pixmap,
+                    base_transform,
+                    &gs_stack,
+                );
+                if let Some(path) = current_path.finish() {
+                    let gs = gs_stack.current();
+                    let empty = SeparationColorState::new();
+                    let cs = color_state_stack.last().unwrap_or(&empty);
+                    let transform = combine_transforms(base_transform, &gs.ctm);
+                    let clip = clip_stack.last().and_then(|c| c.as_ref());
+                    if let Some(tint) = tint_for_ink(
+                        true,
+                        gs,
+                        color_spaces,
+                        target_ink,
+                        &cs.fill_components,
+                        &cs.stroke_components,
+                    ) {
+                        fill_separation(pixmap, &path, transform, tint, FillRule::EvenOdd, clip);
+                    }
+                    if let Some(tint) = tint_for_ink(
+                        false,
+                        gs,
+                        color_spaces,
+                        target_ink,
+                        &cs.fill_components,
+                        &cs.stroke_components,
+                    ) {
+                        stroke_separation(pixmap, &path, transform, gs, tint, clip);
+                    }
+                }
+                current_path = PathBuilder::new();
+            },
+            Operator::EndPath => {
+                apply_separation_clip(
+                    &mut pending_clip,
+                    &mut clip_stack,
+                    pixmap,
+                    base_transform,
+                    &gs_stack,
+                );
+                current_path = PathBuilder::new();
+            },
+
+            // Clipping
+            Operator::ClipNonZero => {
+                if let Some(path) = current_path.clone().finish() {
+                    pending_clip = Some((path, FillRule::Winding));
+                }
+            },
+            Operator::ClipEvenOdd => {
+                if let Some(path) = current_path.clone().finish() {
+                    pending_clip = Some((path, FillRule::EvenOdd));
+                }
+            },
+
+            // ExtGState
+            Operator::SetExtGState { dict_name } => {
+                let entry = ext_g_state_cache
+                    .entry(dict_name.clone())
+                    .or_insert_with(|| {
+                        if let Some(states) = ext_g_states {
+                            if let Some(state_obj) = states.get(dict_name) {
+                                return super::page_renderer::parse_ext_g_state_inner(
+                                    state_obj, doc,
+                                )
+                                .unwrap_or_default();
+                            }
+                        }
+                        super::page_renderer::ParsedExtGState::default()
+                    });
+                entry.apply(gs_stack.current_mut());
+            },
+
+            // XObject (Form XObjects may contain ink-bearing content)
+            Operator::Do { name } => {
+                if let Some(xobjects) = xobjects_resolved.as_ref().and_then(|o| o.as_dict()) {
+                    if let Some(xobj_ref_obj) = xobjects.get(name) {
+                        if let Ok(xobj) = doc.resolve_object(xobj_ref_obj) {
+                            if let Object::Stream { ref dict, .. } = xobj {
+                                if let Some(subtype) = dict.get("Subtype").and_then(|o| o.as_name())
+                                {
+                                    if subtype == "Form" {
+                                        let xobj_ref = xobj_ref_obj.as_reference();
+                                        let stream_data = if let Some(r) = xobj_ref {
+                                            doc.decode_stream_with_encryption(&xobj, r)?
+                                        } else {
+                                            xobj.decode_stream_data()?
+                                        };
+
+                                        let form_resources =
+                                            if let Some(res) = dict.get("Resources") {
+                                                doc.resolve_object(res)?
+                                            } else {
+                                                resources.clone()
+                                            };
+
+                                        let form_cs = load_color_spaces(doc, &form_resources)?;
+                                        let mut merged_cs = color_spaces.clone();
+                                        merged_cs.extend(form_cs);
+
+                                        // Parse form matrix
+                                        let form_matrix = parse_form_matrix(dict);
+                                        let gs = gs_stack.current();
+                                        let combined = combine_transforms(base_transform, &gs.ctm)
+                                            .pre_concat(form_matrix);
+
+                                        let form_ops = parse_content_stream(&stream_data)?;
+                                        execute_separation_operators(
+                                            pixmap,
+                                            combined,
+                                            &form_ops,
+                                            doc,
+                                            page_num,
+                                            &form_resources,
+                                            &merged_cs,
+                                            target_ink,
+                                        )?;
+                                    }
+                                    // Images are skipped for separation plates
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+
+            // Text and other operators are skipped for separation plates.
+            // Text rendering with spot colors is rare in separation use cases;
+            // we focus on path-based artwork which is the primary use.
+            _ => {},
+        }
+    }
+    Ok(())
+}
+
+/// Fill a path into the separation pixmap with the given tint value.
+fn fill_separation(
+    pixmap: &mut Pixmap,
+    path: &tiny_skia::Path,
+    transform: Transform,
+    tint: f32,
+    fill_rule: FillRule,
+    clip: Option<&Mask>,
+) {
+    let gray = (tint.clamp(0.0, 1.0) * 255.0).round() as u8;
+    let color = tiny_skia::Color::from_rgba8(gray, gray, gray, 255);
+    let mut paint = tiny_skia::Paint::default();
+    paint.set_color(color);
+    paint.anti_alias = true;
+    // Use SourceOver so overlapping shapes accumulate correctly
+    paint.blend_mode = tiny_skia::BlendMode::SourceOver;
+
+    pixmap.fill_path(path, &paint, fill_rule, transform, clip);
+}
+
+/// Stroke a path into the separation pixmap with the given tint value.
+fn stroke_separation(
+    pixmap: &mut Pixmap,
+    path: &tiny_skia::Path,
+    transform: Transform,
+    gs: &GraphicsState,
+    tint: f32,
+    clip: Option<&Mask>,
+) {
+    let gray = (tint.clamp(0.0, 1.0) * 255.0).round() as u8;
+    let color = tiny_skia::Color::from_rgba8(gray, gray, gray, 255);
+    let mut paint = tiny_skia::Paint::default();
+    paint.set_color(color);
+    paint.anti_alias = true;
+
+    let mut stroke = tiny_skia::Stroke::default();
+    stroke.width = gs.line_width;
+    stroke.line_cap = match gs.line_cap {
+        1 => tiny_skia::LineCap::Round,
+        2 => tiny_skia::LineCap::Square,
+        _ => tiny_skia::LineCap::Butt,
+    };
+    stroke.line_join = match gs.line_join {
+        1 => tiny_skia::LineJoin::Round,
+        2 => tiny_skia::LineJoin::Bevel,
+        _ => tiny_skia::LineJoin::Miter,
+    };
+    stroke.miter_limit = gs.miter_limit;
+
+    if !gs.dash_pattern.0.is_empty() {
+        stroke.dash = tiny_skia::StrokeDash::new(gs.dash_pattern.0.clone(), gs.dash_pattern.1);
+    }
+
+    pixmap.stroke_path(path, &paint, &stroke, transform, clip);
+}
+
+/// Apply a pending clip path to the clip stack.
+fn apply_separation_clip(
+    pending: &mut Option<(tiny_skia::Path, FillRule)>,
+    clip_stack: &mut Vec<Option<Mask>>,
+    pixmap: &Pixmap,
+    base_transform: Transform,
+    gs_stack: &GraphicsStateStack,
+) {
+    if let Some((path, fill_rule)) = pending.take() {
+        let gs = gs_stack.current();
+        let transform = combine_transforms(base_transform, &gs.ctm);
+
+        if let Some(path_transformed) = path.transform(transform) {
+            let mut new_mask = Mask::new(pixmap.width(), pixmap.height()).unwrap();
+            new_mask.fill_path(&path_transformed, fill_rule, true, Transform::identity());
+
+            if let Some(Some(current_mask)) = clip_stack.last() {
+                let mut combined = current_mask.clone();
+                let combined_data = combined.data_mut();
+                let new_data = new_mask.data();
+                for i in 0..combined_data.len() {
+                    combined_data[i] = ((combined_data[i] as u32 * new_data[i] as u32) / 255) as u8;
+                }
+                *clip_stack.last_mut().unwrap() = Some(combined);
+            } else {
+                *clip_stack.last_mut().unwrap() = Some(new_mask);
+            }
+        }
+    }
+}
+
+/// Parse a form XObject matrix from its dictionary.
+fn parse_form_matrix(dict: &HashMap<String, Object>) -> Transform {
+    if let Some(Object::Array(arr)) = dict.get("Matrix") {
+        let get_f32 = |i: usize| -> f32 {
+            match arr.get(i) {
+                Some(Object::Real(v)) => *v as f32,
+                Some(Object::Integer(v)) => *v as f32,
+                _ => {
+                    if i == 0 || i == 3 {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                },
+            }
+        };
+        Transform::from_row(get_f32(0), get_f32(1), get_f32(2), get_f32(3), get_f32(4), get_f32(5))
+    } else {
+        Transform::identity()
+    }
+}
+
+/// Combine two transformations (base + CTM).
+fn combine_transforms(base: Transform, ctm: &Matrix) -> Transform {
+    base.pre_concat(Transform::from_row(ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f))
+}

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -287,13 +287,28 @@ fn inks_from_space(
             }
         },
         ResolvedSpace::Separation(name) => {
-            if !out.iter().any(|s| s == &name) {
+            // §8.6.6.4: /All marks every output separation — list CMYK so the
+            // per-plate short-circuit in render_separations doesn't skip them.
+            // /None paints nothing and never names a plate.
+            if name == "All" {
+                for ink in ["Cyan", "Magenta", "Yellow", "Black"] {
+                    if !out.iter().any(|s| s == ink) {
+                        out.push(ink.to_string());
+                    }
+                }
+            } else if name != "None" && !out.iter().any(|s| s == &name) {
                 out.push(name);
             }
         },
         ResolvedSpace::DeviceN(names) => {
             for n in names {
-                if !out.iter().any(|s| s == &n) {
+                if n == "All" {
+                    for ink in ["Cyan", "Magenta", "Yellow", "Black"] {
+                        if !out.iter().any(|s| s == ink) {
+                            out.push(ink.to_string());
+                        }
+                    }
+                } else if n != "None" && !out.iter().any(|s| s == &n) {
                     out.push(n);
                 }
             }
@@ -624,7 +639,11 @@ fn tint_for_ink(
             None
         },
         ResolvedSpace::Separation(ink) => {
-            if ink == target_ink && !components.is_empty() {
+            // §8.6.6.4: /All paints to every output separation; /None paints
+            // nothing. Treat the rest as a regular per-ink match.
+            if ink == "None" || components.is_empty() {
+                None
+            } else if ink == "All" || ink == target_ink {
                 Some(components[0])
             } else {
                 None
@@ -632,7 +651,10 @@ fn tint_for_ink(
         },
         ResolvedSpace::DeviceN(names) => {
             for (i, n) in names.iter().enumerate() {
-                if n == target_ink && i < components.len() {
+                if n == "None" {
+                    continue;
+                }
+                if (n == "All" || n == target_ink) && i < components.len() {
                     return Some(components[i]);
                 }
             }

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -41,6 +41,15 @@
 //! vector-based prepress artwork (dielines, varnish layers, spot-PMS
 //! text and shapes). PDFs that rely on raster spot-channel data will
 //! produce incomplete plates and should be flagged at the caller.
+//!
+//! # Transparency
+//!
+//! Plate output is opaque: the renderer treats `fill_alpha` / `stroke_alpha`
+//! from ExtGState (`/CA`, `/ca`) and the blend mode (`/BM`) as if both were
+//! `1.0` / `Normal`. This is intentional — a separation plate represents ink
+//! coverage on the press, not transparent compositing. Callers who need the
+//! transparent intent (e.g. a 50%-alpha spot text overlay) should evaluate it
+//! against the underlying content with [`super::page_renderer`] first.
 #![allow(
     clippy::field_reassign_with_default,
     clippy::ptr_arg,
@@ -64,6 +73,11 @@ use super::ext_gstate::{parse_ext_g_state_inner, ParsedExtGState};
 use super::text_rasterizer::TextRasterizer;
 
 /// A rendered separation plate for a single ink.
+///
+/// The pixel convention is **ML/QC-friendly**: `value == ink coverage`.
+/// 0 means no ink on paper at that pixel, 255 means full tint coverage.
+/// To display the plate as black ink on white paper (prepress viewer
+/// convention) invert before showing: `display = 255 - value`.
 #[derive(Debug, Clone)]
 pub struct SeparationPlate {
     /// Ink name (e.g., "Cyan", "PANTONE 185 C", "Dieline").
@@ -517,9 +531,10 @@ fn classify_resolved(
             }
         },
         "ICCBased" => {
-            // ICCBased: try to read /N from the stream dict to pick the
-            // right component-count interpretation. Falls back to the
-            // 4-comp = CMYK heuristic when the stream isn't reachable.
+            // ICCBased: read /N from the stream dict to pick the component-count
+            // interpretation. Unknown / unreachable / unsupported N → Unknown,
+            // since fabricating CMYK plate values from an N=2 or N=5 profile
+            // would silently corrupt output. tint_for_ink skips Unknown spaces.
             if let Some(stream_obj) = arr.get(1) {
                 if let Ok(resolved) = doc.resolve_object(stream_obj) {
                     if let Object::Stream { ref dict, .. } = resolved {
@@ -534,8 +549,7 @@ fn classify_resolved(
                     }
                 }
             }
-            // Unknown component count — caller decides via component vector length.
-            ResolvedSpace::IccCmyk
+            ResolvedSpace::Unknown
         },
         _ => ResolvedSpace::Unknown,
     }

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -642,3 +642,94 @@ fn test_empty_filters_fall_through_to_normal_extraction() {
         "Empty filters should produce identical output to unfiltered extraction"
     );
 }
+
+// ============================================================================
+// Task 2: OCMD (Optional Content Membership Dictionary) support
+// ============================================================================
+
+fn build_pdf_with_ocmd() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [7 0 R] /D << /ON [7 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+    let content = b"BT /F1 12 Tf 50 700 Td (ALWAYS) Tj ET /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (MEMBER) Tj ET EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    // Obj 6: OCMD referencing OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n",
+    );
+    // Obj 7: OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /MemberLayer >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ocmd_layer_filtering() {
+    let pdf_bytes = build_pdf_with_ocmd();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let layers = doc.get_layers().expect("get_layers");
+    assert!(
+        layers.contains(&"MemberLayer".to_string()),
+        "got: {:?}",
+        layers
+    );
+
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
+    assert!(text_all.contains("MEMBER"), "got: {:?}", text_all);
+
+    let excluded = HashSet::from(["MemberLayer".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered");
+    assert!(
+        text_filtered.contains("ALWAYS"),
+        "got: {:?}",
+        text_filtered
+    );
+    assert!(
+        !text_filtered.contains("MEMBER"),
+        "MEMBER should be excluded via OCMD resolution, got: {:?}",
+        text_filtered
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -733,3 +733,96 @@ fn test_ocmd_layer_filtering() {
         text_filtered
     );
 }
+
+// ============================================================================
+// Task 3: DeviceN all-or-nothing semantics
+// ============================================================================
+
+fn build_pdf_with_devicen() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >>\n\
+           /ColorSpace << /CS1 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"BT /F1 12 Tf 50 700 Td (PLAIN) Tj ET \
+                    /CS1 cs 1 0 scn BT /F1 12 Tf 50 650 Td (MIXED_INK) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n",
+    );
+
+    let tint_fn = b"{ 0 exch }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "7 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0 0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
+    // Documents the all-or-nothing DeviceN behavior:
+    // Excluding "SpotGold" suppresses ALL text in the DeviceN space,
+    // even though Cyan (a process color) is also part of the space.
+    let pdf_bytes = build_pdf_with_devicen();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded_inks = HashSet::from(["SpotGold".to_string()]);
+    let text = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered");
+
+    assert!(
+        text.contains("PLAIN"),
+        "PLAIN (DeviceGray) should survive, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("MIXED_INK"),
+        "MIXED_INK should be suppressed (DeviceN contains excluded SpotGold), got: {:?}",
+        text
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -84,9 +84,7 @@ fn build_pdf_with_ocg_in_xobject() -> Vec<u8> {
 
     // Obj 8: OCG dictionary
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n");
 
     // Xref
     let xref_offset = pdf.len();
@@ -140,7 +138,8 @@ fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
     );
 
     // Obj 4: Page content — text before XObject, invoke XObject, text after
-    let page_content = b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
+    let page_content =
+        b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
     offsets.push(pdf.len());
     let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
     pdf.extend_from_slice(hdr.as_bytes());
@@ -170,9 +169,7 @@ fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
 
     // Obj 7: Separation color space [/Separation /SpotRed /DeviceRGB <tint fn>]
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n");
 
     // Obj 8: Tint transform function (Type 4 PostScript calculator)
     let tint_fn = b"{ 0 0 }";
@@ -337,9 +334,7 @@ fn build_pdf_with_inline_separation() -> Vec<u8> {
 
     // Obj 6: Separation color space array
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n");
 
     // Obj 7: Tint transform function
     let tint_fn = b"{ 0 0 }";
@@ -679,9 +674,7 @@ fn build_pdf_with_ocmd() -> Vec<u8> {
     );
     // Obj 6: OCMD referencing OCG
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCMD /OCGs [7 0 R] /P /AllOn >>\nendobj\n\n");
     // Obj 7: OCG
     offsets.push(pdf.len());
     pdf.extend_from_slice(b"7 0 obj\n<< /Type /OCG /Name /MemberLayer >>\nendobj\n\n");
@@ -708,11 +701,7 @@ fn test_ocmd_layer_filtering() {
     let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
 
     let layers = doc.get_layers().expect("get_layers");
-    assert!(
-        layers.contains(&"MemberLayer".to_string()),
-        "got: {:?}",
-        layers
-    );
+    assert!(layers.contains(&"MemberLayer".to_string()), "got: {:?}", layers);
 
     let text_all = doc.extract_text(0).expect("unfiltered");
     assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
@@ -722,11 +711,7 @@ fn test_ocmd_layer_filtering() {
     let text_filtered = doc
         .extract_text_filtered(0, excluded, HashSet::new())
         .expect("filtered");
-    assert!(
-        text_filtered.contains("ALWAYS"),
-        "got: {:?}",
-        text_filtered
-    );
+    assert!(text_filtered.contains("ALWAYS"), "got: {:?}", text_filtered);
     assert!(
         !text_filtered.contains("MEMBER"),
         "MEMBER should be excluded via OCMD resolution, got: {:?}",
@@ -771,9 +756,7 @@ fn build_pdf_with_devicen() -> Vec<u8> {
     );
 
     offsets.push(pdf.len());
-    pdf.extend_from_slice(
-        b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n",
-    );
+    pdf.extend_from_slice(b"6 0 obj\n[/DeviceN [/Cyan /SpotGold] /DeviceRGB 7 0 R]\nendobj\n\n");
 
     let tint_fn = b"{ 0 exch }";
     offsets.push(pdf.len());
@@ -815,11 +798,7 @@ fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
         .extract_text_filtered(0, HashSet::new(), excluded_inks)
         .expect("filtered");
 
-    assert!(
-        text.contains("PLAIN"),
-        "PLAIN (DeviceGray) should survive, got: {:?}",
-        text
-    );
+    assert!(text.contains("PLAIN"), "PLAIN (DeviceGray) should survive, got: {:?}", text);
     assert!(
         !text.contains("MIXED_INK"),
         "MIXED_INK should be suppressed (DeviceN contains excluded SpotGold), got: {:?}",
@@ -896,11 +875,7 @@ fn test_filtering_unrelated_layer_produces_identical_output() {
 
     let text_normal = doc.extract_text(0).expect("unfiltered");
     let text_filtered = doc
-        .extract_text_filtered(
-            0,
-            HashSet::from(["Dieline".to_string()]),
-            HashSet::new(),
-        )
+        .extract_text_filtered(0, HashSet::from(["Dieline".to_string()]), HashSet::new())
         .expect("filtered with non-matching layer");
 
     assert_eq!(

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -826,3 +826,88 @@ fn test_devicen_excludes_entire_colorspace_if_any_ink_matches() {
         text
     );
 }
+
+// ============================================================================
+// Pipeline parity: filtering non-matching layers must not alter output
+// ============================================================================
+
+/// Build a PDF with a table-like layout and an OCG layer that doesn't
+/// overlap with any content. Filtering this layer should produce output
+/// identical to unfiltered extraction.
+fn build_pdf_with_table_and_unrelated_layer() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Content: multiple text lines (simulating rows), plus an empty OCG layer
+    let content = b"BT /F1 12 Tf 50 700 Td (Name) Tj 200 0 Td (Age) Tj ET \
+                    BT /F1 12 Tf 50 680 Td (Alice) Tj 200 0 Td (30) Tj ET \
+                    BT /F1 12 Tf 50 660 Td (Bob) Tj 200 0 Td (25) Tj ET \
+                    /OC /MC0 BDC EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Dieline >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_filtering_unrelated_layer_produces_identical_output() {
+    let pdf_bytes = build_pdf_with_table_and_unrelated_layer();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let text_normal = doc.extract_text(0).expect("unfiltered");
+    let text_filtered = doc
+        .extract_text_filtered(
+            0,
+            HashSet::from(["Dieline".to_string()]),
+            HashSet::new(),
+        )
+        .expect("filtered with non-matching layer");
+
+    assert_eq!(
+        text_normal, text_filtered,
+        "Excluding a layer with no content must produce identical output.\n\
+         Unfiltered: {:?}\n\
+         Filtered:   {:?}",
+        text_normal, text_filtered
+    );
+}

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -416,6 +416,98 @@ fn test_ink_filtering_blocked_by_text_only_parser() {
 // ============================================================================
 // Basic OCG filtering (no XObject cache involvement)
 // ============================================================================
+// Task 1: region + filter combo
+// ============================================================================
+
+fn build_pdf_for_region_and_filter() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    let content = b"BT /F1 12 Tf 50 700 Td (TOP_VISIBLE) Tj ET \
+                    /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (TOP_HIDDEN) Tj ET EMC \
+                    BT /F1 12 Tf 50 100 Td (BOT_VISIBLE) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Overlay >>\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_extract_text_filtered_respects_region() {
+    let pdf_bytes = build_pdf_for_region_and_filter();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded = HashSet::from(["Overlay".to_string()]);
+    let chars = doc
+        .extract_chars_filtered(0, excluded, HashSet::new())
+        .expect("filtered chars");
+
+    use pdf_oxide::geometry::Rect;
+    use pdf_oxide::layout::{RectFilterMode, SpatialCollectionFiltering};
+    let region = Rect::new(0.0, 600.0, 612.0, 200.0);
+    let filtered: Vec<_> = chars.filter_by_rect(&region, RectFilterMode::Intersects);
+    let text: String = filtered.iter().map(|c| c.char).collect();
+
+    assert!(
+        text.contains("TOP_VISIBLE"),
+        "TOP_VISIBLE should survive both filters, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("TOP_HIDDEN"),
+        "TOP_HIDDEN should be excluded by layer filter, got: {:?}",
+        text
+    );
+    assert!(
+        !text.contains("BOT_VISIBLE"),
+        "BOT_VISIBLE should be excluded by region filter, got: {:?}",
+        text
+    );
+}
+
+// ============================================================================
+// Basic OCG filtering (no XObject cache involvement)
+// ============================================================================
 
 /// Build a minimal PDF with inline OCG-tagged text (no XObjects).
 fn build_pdf_with_inline_ocg() -> Vec<u8> {

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -1,0 +1,552 @@
+//! Tests for OCG layer and Separation ink filtering in text extraction.
+//!
+//! Bug 1: XObject cached spans bypass suppression — filtered extraction
+//!         replays unfiltered cached spans, leaking excluded content.
+//! Bug 2: `inside_excluded_ink` not re-evaluated after Form XObject restore —
+//!         ink exclusion state lost after XObject processing.
+//! Bug 3: `get_layers` doc comment bleeds into `extract_chars` — verified
+//!         separately via `cargo doc`.
+
+use std::collections::HashSet;
+
+use pdf_oxide::document::PdfDocument;
+
+// ============================================================================
+// Helper: build a PDF with an OCG layer wrapping text inside a Form XObject
+// ============================================================================
+
+/// Build a PDF where a Form XObject contains OCG-tagged text.
+///
+/// Page content:  /Fm0 Do
+/// Form XObject:  BDC /OC /MC0  →  BT (LAYERED) Tj ET  →  EMC
+///                                  BT (VISIBLE) Tj ET
+///
+/// The OCG "HiddenLayer" is defined in OCProperties and referenced via
+/// the Form XObject's /Resources /Properties.
+fn build_pdf_with_ocg_in_xobject() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog with OCProperties
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [8 0 R] /D << /ON [8 0 R] >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Page content — just invoke the Form XObject
+    let page_content = b"/Fm0 Do";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject with OCG-tagged text + untagged text
+    // BDC syntax: /Tag /PropertiesName BDC ... EMC
+    let form_stream =
+        b"/OC /MC0 BDC BT /F1 12 Tf 50 700 Td (LAYERED) Tj ET EMC BT /F1 12 Tf 50 650 Td (VISIBLE) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >> /Properties << /MC0 8 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: (unused, keep numbering simple)
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\nnull\nendobj\n\n");
+
+    // Obj 8: OCG dictionary
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"8 0 obj\n<< /Type /OCG /Name /HiddenLayer >>\nendobj\n\n",
+    );
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+// ============================================================================
+// Helper: build a PDF with Separation ink color space in a Form XObject
+// ============================================================================
+
+/// Build a PDF where a Form XObject switches to a Separation ink, renders text,
+/// then returns. After the XObject, the page renders more text in DeviceGray.
+///
+/// Page content:  BT (BEFORE) Tj ET  /Fm0 Do  BT (AFTER) Tj ET
+/// Form XObject:  /CS1 cs  BT (SPOT_INK) Tj ET
+///
+/// /CS1 is [/Separation /SpotRed /DeviceRGB ...].
+fn build_pdf_with_ink_in_xobject() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Page content — text before XObject, invoke XObject, text after
+    let page_content = b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject — sets Separation color space, then renders text
+    let form_stream = b"/CS1 cs 1 scn BT /F1 12 Tf 50 650 Td (SPOT_INK) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >>\n\
+            /ColorSpace << /CS1 7 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: Separation color space [/Separation /SpotRed /DeviceRGB <tint fn>]
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"7 0 obj\n[/Separation /SpotRed /DeviceRGB 8 0 R]\nendobj\n\n",
+    );
+
+    // Obj 8: Tint transform function (Type 4 PostScript calculator)
+    let tint_fn = b"{ 0 0 }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "8 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+// ============================================================================
+// Bug 1: XObject cached spans bypass suppression
+// ============================================================================
+
+#[test]
+fn test_xobject_cache_does_not_leak_filtered_content() {
+    let pdf_bytes = build_pdf_with_ocg_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // First: unfiltered extraction — caches XObject spans
+    let text_all = doc.extract_text(0).expect("unfiltered extract");
+    assert!(
+        text_all.contains("LAYERED"),
+        "Unfiltered should contain LAYERED, got: {:?}",
+        text_all
+    );
+    assert!(
+        text_all.contains("VISIBLE"),
+        "Unfiltered should contain VISIBLE, got: {:?}",
+        text_all
+    );
+
+    // Second: filtered extraction excluding "HiddenLayer"
+    // BUG: cached XObject spans from first call are replayed verbatim,
+    // so LAYERED text leaks through despite being in excluded layer.
+    let excluded = HashSet::from(["HiddenLayer".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered extract");
+
+    assert!(
+        text_filtered.contains("VISIBLE"),
+        "Filtered should still contain VISIBLE, got: {:?}",
+        text_filtered
+    );
+    assert!(
+        !text_filtered.contains("LAYERED"),
+        "Filtered must NOT contain LAYERED (XObject cache leak), got: {:?}",
+        text_filtered
+    );
+}
+
+// ============================================================================
+// Bug 2: inside_excluded_ink not re-evaluated after XObject restore
+// ============================================================================
+
+#[test]
+fn test_ink_exclusion_restored_after_xobject() {
+    let pdf_bytes = build_pdf_with_ink_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Extract with "SpotRed" excluded
+    let excluded_inks = HashSet::from(["SpotRed".to_string()]);
+    let text = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered extract");
+
+    // SPOT_INK should be suppressed (it's in SpotRed color space)
+    assert!(
+        !text.contains("SPOT_INK"),
+        "SPOT_INK should be suppressed by ink filter, got: {:?}",
+        text
+    );
+
+    // BEFORE and AFTER are in DeviceGray — should NOT be suppressed.
+    // BUG: the Form XObject sets inside_excluded_ink=true for SpotRed,
+    // but after XObject restore, inside_excluded_ink is not re-evaluated
+    // back to false. So AFTER text is incorrectly suppressed.
+    assert!(
+        text.contains("BEFORE"),
+        "BEFORE should be visible (DeviceGray), got: {:?}",
+        text
+    );
+    assert!(
+        text.contains("AFTER"),
+        "AFTER should be visible (DeviceGray, post-XObject restore), got: {:?}",
+        text
+    );
+}
+
+// ============================================================================
+// Bug 3: text-only parser skips color operators — ink filtering is inert
+// ============================================================================
+
+/// Build a PDF with Separation ink color space directly in the page stream.
+/// No XObjects — isolates the parser from caching.
+///
+/// Page content:
+///   BT (PROCESS) Tj ET          ← default (DeviceGray) fill
+///   /CS1 cs 1 scn               ← switch to Separation /SpotRed
+///   BT (SPOT) Tj ET             ← text in SpotRed ink
+///   0 g                         ← switch back to DeviceGray
+///   BT (RESTORED) Tj ET         ← text in DeviceGray again
+fn build_pdf_with_inline_separation() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page with ColorSpace in resources
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >>\n\
+           /ColorSpace << /CS1 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Content stream
+    let content = b"BT /F1 12 Tf 50 700 Td (PROCESS) Tj ET /CS1 cs 1 scn BT /F1 12 Tf 50 650 Td (SPOT) Tj ET 0 g BT /F1 12 Tf 50 600 Td (RESTORED) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: Separation color space array
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n[/Separation /SpotRed /DeviceRGB 7 0 R]\nendobj\n\n",
+    );
+
+    // Obj 7: Tint transform function
+    let tint_fn = b"{ 0 0 }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "7 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ink_filtering_blocked_by_text_only_parser() {
+    // The text-only parser (parse_and_execute_text_only) skips color operators
+    // (cs, rg, g, k) for performance. This means the SetFillColorSpace handler
+    // never fires, and ink filtering is completely inert.
+    //
+    // This test proves the bug: excluding "SpotRed" has no effect because the
+    // `cs` operator is never delivered to the extractor.
+    let pdf_bytes = build_pdf_with_inline_separation();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Unfiltered: all three texts present
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("PROCESS"), "got: {:?}", text_all);
+    assert!(text_all.contains("SPOT"), "got: {:?}", text_all);
+    assert!(text_all.contains("RESTORED"), "got: {:?}", text_all);
+
+    // Filtered: exclude SpotRed ink
+    let excluded_inks = HashSet::from(["SpotRed".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered");
+
+    // PROCESS and RESTORED are in DeviceGray — must survive
+    assert!(
+        text_filtered.contains("PROCESS"),
+        "PROCESS (DeviceGray) should survive ink filter, got: {:?}",
+        text_filtered
+    );
+    assert!(
+        text_filtered.contains("RESTORED"),
+        "RESTORED (DeviceGray after `0 g`) should survive ink filter, got: {:?}",
+        text_filtered
+    );
+
+    // SPOT is in SpotRed Separation — must be suppressed
+    assert!(
+        !text_filtered.contains("SPOT"),
+        "SPOT (SpotRed ink) must be suppressed by ink filter, got: {:?}",
+        text_filtered
+    );
+}
+
+// ============================================================================
+// Basic OCG filtering (no XObject cache involvement)
+// ============================================================================
+
+/// Build a minimal PDF with inline OCG-tagged text (no XObjects).
+fn build_pdf_with_inline_ocg() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog with OCProperties
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R\n\
+           /OCProperties << /OCGs [6 0 R] /D << /ON [6 0 R] >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 5 0 R >> /Properties << /MC0 6 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Content stream with OCG-tagged and untagged text
+    // BDC syntax: /Tag /PropertiesName BDC ... EMC
+    let content =
+        b"BT /F1 12 Tf 50 700 Td (ALWAYS) Tj ET /OC /MC0 BDC BT /F1 12 Tf 50 650 Td (HIDDEN) Tj ET EMC";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 6: OCG
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"6 0 obj\n<< /Type /OCG /Name /Overlay >>\nendobj\n\n");
+
+    // Xref
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    let trailer = format!(
+        "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+        n_obj, xref_offset
+    );
+    pdf.extend_from_slice(trailer.as_bytes());
+    pdf
+}
+
+#[test]
+fn test_ocg_layer_filtering_inline() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // Unfiltered: both texts present
+    let text_all = doc.extract_text(0).expect("unfiltered");
+    assert!(text_all.contains("ALWAYS"), "got: {:?}", text_all);
+    assert!(text_all.contains("HIDDEN"), "got: {:?}", text_all);
+
+    // Filtered: exclude "Overlay" layer
+    let excluded = HashSet::from(["Overlay".to_string()]);
+    let text_filtered = doc
+        .extract_text_filtered(0, excluded, HashSet::new())
+        .expect("filtered");
+    assert!(text_filtered.contains("ALWAYS"), "got: {:?}", text_filtered);
+    assert!(
+        !text_filtered.contains("HIDDEN"),
+        "HIDDEN should be excluded, got: {:?}",
+        text_filtered
+    );
+}
+
+#[test]
+fn test_get_layers_returns_ocg_names() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let layers = doc.get_layers().expect("get_layers");
+    assert!(
+        layers.contains(&"Overlay".to_string()),
+        "Should find 'Overlay' layer, got: {:?}",
+        layers
+    );
+}
+
+#[test]
+fn test_get_page_inks_returns_separation_names() {
+    let pdf_bytes = build_pdf_with_ink_in_xobject();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    // The Separation color space is in the Form XObject's resources, not the
+    // page's direct resources. get_page_inks only checks page resources, so
+    // it won't find SpotRed here. This is a known limitation — the test
+    // documents expected behavior.
+    let inks = doc.get_page_inks(0).expect("get_page_inks");
+    // SpotRed is in XObject resources, not page resources — empty is correct
+    assert!(
+        !inks.contains(&"SpotRed".to_string()),
+        "SpotRed is in XObject resources, not page, got: {:?}",
+        inks
+    );
+}
+
+#[test]
+fn test_empty_filters_fall_through_to_normal_extraction() {
+    let pdf_bytes = build_pdf_with_inline_ocg();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let text_normal = doc.extract_text(0).expect("normal");
+    let text_filtered = doc
+        .extract_text_filtered(0, HashSet::new(), HashSet::new())
+        .expect("empty filters");
+
+    assert_eq!(
+        text_normal, text_filtered,
+        "Empty filters should produce identical output to unfiltered extraction"
+    );
+}

--- a/tests/test_separation_rendering.rs
+++ b/tests/test_separation_rendering.rs
@@ -319,4 +319,485 @@ mod tests {
 
         assert_eq!(center_val, 0, "Expected 0 for zero tint, got {}", center_val);
     }
+
+    /// Hand-rolled PDF builder used by the regression tests below.
+    /// `objects[i]` becomes object number `i + 1`.
+    fn assemble_pdf(objects: Vec<String>) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut offsets: Vec<usize> = Vec::new();
+        buf.extend_from_slice(b"%PDF-1.4\n");
+        for (i, body) in objects.iter().enumerate() {
+            offsets.push(buf.len());
+            let header = format!("{} 0 obj\n", i + 1);
+            buf.extend_from_slice(header.as_bytes());
+            buf.extend_from_slice(body.as_bytes());
+            buf.extend_from_slice(b"\nendobj\n");
+        }
+        let xref = buf.len();
+        buf.extend_from_slice(b"xref\n");
+        let header = format!("0 {}\n", offsets.len() + 1);
+        buf.extend_from_slice(header.as_bytes());
+        buf.extend_from_slice(b"0000000000 65535 f \n");
+        for offset in &offsets {
+            let entry = format!("{:010} 00000 n \n", offset);
+            buf.extend_from_slice(entry.as_bytes());
+        }
+        let trailer = format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len() + 1,
+            xref
+        );
+        buf.extend_from_slice(trailer.as_bytes());
+        buf
+    }
+
+    /// Build a page whose CMYK content is inside a Form XObject.
+    /// Regression for RED #1: the previous shallow scan missed
+    /// CMYK content nested inside Form XObjects and returned no
+    /// process plates for those pages.
+    fn build_cmyk_in_form_xobject_pdf() -> Vec<u8> {
+        let form_stream = "0.6 0.0 0.0 0.0 k\n25 25 50 50 re f\n";
+        let content_stream = "/F1 Do\n";
+        let form_header = format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Length {} >>\nstream\n{}\nendstream",
+            form_stream.len(),
+            form_stream
+        );
+        let content_header = format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content_stream.len(),
+            content_stream
+        );
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /XObject << /F1 5 0 R >> >> >>".to_string(),
+            content_header,
+            form_header,
+        ])
+    }
+
+    #[test]
+    fn cmyk_inside_form_xobject_produces_plates() {
+        let pdf_bytes = build_cmyk_in_form_xobject_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plates = render_separations(&doc, 0, 72).expect("render separations");
+        let cyan = plates
+            .iter()
+            .find(|p| p.ink_name == "Cyan")
+            .expect("Cyan plate must be returned even when content is inside a Form XObject");
+        let center = cyan.data[50 * cyan.width as usize + 50];
+        // 60% cyan via /k inside a form -> ~153
+        assert!(
+            center > 120 && center < 180,
+            "Form XObject CMYK content missing from Cyan plate (got {})",
+            center
+        );
+    }
+
+    /// Build a page that paints with DeviceCMYK (k operator) but
+    /// overrides it via /Resources/ColorSpace/DefaultCMYK pointing
+    /// at a Separation space named "OverrideInk".
+    fn build_default_cmyk_remap_pdf() -> Vec<u8> {
+        let content_stream = "0.7 0.0 0.0 0.0 k\n25 25 50 50 re f\n";
+        let content_obj = format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content_stream.len(),
+            content_stream
+        );
+        // Separation /OverrideInk /DeviceGray with identity tint transform.
+        // We can't really redirect CMYK to a single ink, but we can verify
+        // the lookup remaps to a Separation space and stops emitting CMYK.
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /DefaultCMYK 5 0 R >> >> >>".to_string(),
+            content_obj,
+            "[/Separation /OverrideInk /DeviceGray 6 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ])
+    }
+
+    #[test]
+    fn default_cmyk_remap_redirects_to_separation() {
+        let pdf_bytes = build_default_cmyk_remap_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plates = render_separations(&doc, 0, 72).expect("render separations");
+        // DefaultCMYK now routes through the Separation override, so the
+        // Cyan plate should be empty.
+        let cyan = plates.iter().find(|p| p.ink_name == "Cyan").unwrap();
+        let cyan_center = cyan.data[50 * cyan.width as usize + 50];
+        assert_eq!(
+            cyan_center, 0,
+            "DefaultCMYK should remap k -> Separation, leaving CMYK plates empty (got {})",
+            cyan_center
+        );
+    }
+
+    /// Two overlapping rectangles in the same ink. Per PDF opaque
+    /// painting model the later fill replaces the earlier one in the
+    /// overlapping region.
+    fn build_overlapping_separation_pdf() -> Vec<u8> {
+        // Rect A at (10,10)-(60,60) tint 0.3; Rect B at (40,40)-(90,90) tint 0.9.
+        // The overlap region (40,40)-(60,60) should end up with tint 0.9.
+        let content = "/CS1 cs\n0.3 scn\n10 10 50 50 re f\n0.9 scn\n40 40 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /CS1 5 0 R >> >> >>".to_string(),
+            content_obj,
+            "[/Separation /OverlapInk /DeviceGray 6 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ])
+    }
+
+    #[test]
+    fn overlapping_same_ink_last_writer_wins() {
+        let pdf_bytes = build_overlapping_separation_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plate = render_separation(&doc, 0, "OverlapInk", 72).expect("render plate");
+        // Overlap region center is around image pixel (50, 50). PDF y=50 -> image y=50.
+        let overlap_val = plate.data[50 * plate.width as usize + 50];
+        assert!(
+            overlap_val > 220,
+            "Overlap region should be the later tint (~230), got {}",
+            overlap_val
+        );
+
+        // Non-overlap region of A (e.g. PDF (20,20) -> image (20, 80))
+        let only_a = plate.data[80 * plate.width as usize + 20];
+        assert!(
+            only_a > 60 && only_a < 100,
+            "Non-overlap rect A region should be ~77 (0.3 tint), got {}",
+            only_a
+        );
+
+        // Non-overlap region of B (e.g. PDF (80,80) -> image (80, 20))
+        let only_b = plate.data[20 * plate.width as usize + 80];
+        assert!(
+            only_b > 220,
+            "Non-overlap rect B region should be ~230 (0.9 tint), got {}",
+            only_b
+        );
+    }
+
+    /// Anti-aliased edge produces intermediate plate values.
+    /// Uses a rotated rectangle (via cm) so the edges cannot fall on
+    /// integer pixel boundaries; AA must produce intermediate values.
+    #[test]
+    fn antialiased_edge_produces_intermediate_values() {
+        // Rotate by ~12 degrees: cos≈0.978, sin≈0.208.
+        // q cm <rotate> re f Q
+        let content = "/CS1 cs\n1.0 scn\nq\n0.978 0.208 -0.208 0.978 30 30 cm\n0 0 40 40 re f\nQ\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf_bytes = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /CS1 5 0 R >> >> >>".to_string(),
+            content_obj,
+            "[/Separation /AAEdge /DeviceGray 6 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plate = render_separation(&doc, 0, "AAEdge", 144).expect("render plate");
+        let mut has_partial = false;
+        for &v in plate.data.iter() {
+            if v > 10 && v < 245 {
+                has_partial = true;
+                break;
+            }
+        }
+        assert!(has_partial, "Expected at least one anti-aliased pixel value between 10 and 245");
+    }
+
+    /// DeviceRGB content must NOT be converted into CMYK plates —
+    /// the renderer intentionally skips RGB/Gray paths.
+    fn build_rgb_only_pdf() -> Vec<u8> {
+        let content = "0.5 0.5 0.5 rg\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << >> >>".to_string(),
+            content_obj,
+        ])
+    }
+
+    #[test]
+    fn devicergb_content_does_not_contribute_to_plates() {
+        let pdf_bytes = build_rgb_only_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+        let plates = render_separations(&doc, 0, 72).expect("render separations");
+        for plate in &plates {
+            let nonzero = plate.data.iter().filter(|&&v| v > 0).count();
+            assert_eq!(
+                nonzero, 0,
+                "Plate {} should be empty for RGB-only artwork, got {} non-zero pixels",
+                plate.ink_name, nonzero
+            );
+        }
+    }
+
+    /// q/Q must save and restore the colour state including the
+    /// chosen colour space and ink components.
+    fn build_save_restore_color_pdf() -> Vec<u8> {
+        // Outside q/Q: set colour space CS1 and tint 0.9, fill rect.
+        // Inside q/Q: change tint to 0.1, fill different rect.
+        // After Q: fill third rect — must use the outer tint 0.9.
+        let content = "/CS1 cs\n0.9 scn\n10 10 20 20 re f\nq\n0.1 scn\n40 40 20 20 re f\nQ\n70 70 20 20 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /CS1 5 0 R >> >> >>".to_string(),
+            content_obj,
+            "[/Separation /SR /DeviceGray 6 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ])
+    }
+
+    #[test]
+    fn q_restore_preserves_color_state() {
+        let pdf_bytes = build_save_restore_color_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plate = render_separation(&doc, 0, "SR", 72).expect("render plate");
+        // First rect (PDF 20,20 -> image 20, 80): tint 0.9 -> ~230
+        let outer1 = plate.data[80 * plate.width as usize + 20];
+        // Third rect (PDF 80,80 -> image 80, 20): should ALSO be tint 0.9 after Q restore.
+        let outer2 = plate.data[20 * plate.width as usize + 80];
+        assert!(outer1 > 220, "First rect tint 0.9 expected, got {}", outer1);
+        assert!(outer2 > 220, "After Q the color must restore to outer 0.9 tint, got {}", outer2);
+    }
+
+    /// Build a Form XObject whose initial colour state inherits from
+    /// the caller (PDF §8.10.1). Caller sets ink + tint, form just
+    /// fills a rect without re-stating colour — the inherited tint
+    /// must end up on the plate.
+    fn build_form_inherits_color_pdf() -> Vec<u8> {
+        let form_stream = "30 30 40 40 re f\n";
+        let content_stream = "/CS1 cs\n0.8 scn\n/F1 Do\n";
+        let form_header = format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Length {} >>\nstream\n{}\nendstream",
+            form_stream.len(),
+            form_stream
+        );
+        let content_obj = format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content_stream.len(),
+            content_stream
+        );
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /CS1 6 0 R >> /XObject << /F1 5 0 R >> >> >>".to_string(),
+            content_obj,
+            form_header,
+            "[/Separation /Inherit /DeviceGray 7 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ])
+    }
+
+    #[test]
+    fn form_xobject_inherits_caller_color_state() {
+        let pdf_bytes = build_form_inherits_color_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plate = render_separation(&doc, 0, "Inherit", 72).expect("render plate");
+        // Form's rect 30,30,40,40 -> image (30..70, 30..70).
+        // Center PDF (50,50) -> image (50, 50). Inherited tint 0.8 -> ~204
+        let center = plate.data[50 * plate.width as usize + 50];
+        assert!(
+            center > 170,
+            "Form XObject must inherit caller's spot tint 0.8 (~204), got {}",
+            center
+        );
+    }
+
+    /// Render at 90-degree rotation. The fill rect (25,25 50x50) should
+    /// land somewhere inside the rotated page.
+    fn build_rotated_separation_pdf(rotation: u16) -> Vec<u8> {
+        let content = "/CS1 cs\n1.0 scn\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let page_obj = format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Rotate {} /Contents 4 0 R /Resources << /ColorSpace << /CS1 5 0 R >> >> >>",
+            rotation
+        );
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            page_obj,
+            content_obj,
+            "[/Separation /RotInk /DeviceGray 6 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ])
+    }
+
+    #[test]
+    fn rotated_pages_render_separations() {
+        for rotation in [90u16, 180, 270] {
+            let pdf_bytes = build_rotated_separation_pdf(rotation);
+            let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+            let plate =
+                render_separation(&doc, 0, "RotInk", 72).expect("render rotated separation plate");
+            let nonzero = plate.data.iter().filter(|&&v| v > 200).count();
+            assert!(
+                nonzero > 1000,
+                "Rotation {} should still paint the rect somewhere on the plate, got {} bright pixels",
+                rotation,
+                nonzero
+            );
+        }
+    }
+
+    /// cs without setting a colour must reset to the space's initial
+    /// value. For Separation that initial is full tint (1.0). Drawing
+    /// after `/CS1 cs` with no `scn` should still produce ink at the
+    /// max tint.
+    fn build_cs_initial_value_pdf() -> Vec<u8> {
+        // `/CS1 cs` then directly fill — no scn between them. Per
+        // ISO 32000-1 §8.6.4.2 the initial Separation value is 1.0.
+        let content = "/CS1 cs\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /CS1 5 0 R >> >> >>".to_string(),
+            content_obj,
+            "[/Separation /CsInit /DeviceGray 6 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ])
+    }
+
+    #[test]
+    fn cs_resets_to_initial_color_value() {
+        let pdf_bytes = build_cs_initial_value_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+        let plate = render_separation(&doc, 0, "CsInit", 72).expect("render plate");
+        let center = plate.data[50 * plate.width as usize + 50];
+        assert!(
+            center > 240,
+            "cs without scn should leave initial tint 1.0 (~255), got {}",
+            center
+        );
+    }
+
+    /// `K` (uppercase) sets stroke CMYK; without an explicit `cs` the
+    /// initial DeviceCMYK colour is [0,0,0,1] — full Black on the K plate.
+    /// We verify the cs-resets-to-initial behaviour by switching to
+    /// DeviceCMYK and immediately filling.
+    #[test]
+    fn cmyk_cs_initial_is_full_black() {
+        let content = "/DeviceCMYK cs\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf_bytes = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << >> >>".to_string(),
+            content_obj,
+        ]);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+        let plate = render_separation(&doc, 0, "Black", 72).expect("render K plate");
+        let center = plate.data[50 * plate.width as usize + 50];
+        assert!(
+            center > 240,
+            "DeviceCMYK cs initial is [0,0,0,1] -> full K plate, got {}",
+            center
+        );
+        let cyan = render_separation(&doc, 0, "Cyan", 72).expect("render C plate");
+        let cyan_center = cyan.data[50 * cyan.width as usize + 50];
+        assert_eq!(cyan_center, 0, "Cyan must be 0 (initial CMYK is K-only)");
+    }
+
+    /// Spot-colour text on a plate. The test font is the standard
+    /// Helvetica (built-in PDF font), so a system font with the same
+    /// metrics is needed — we just verify *some* ink appears on the
+    /// plate inside the text region. Without text rendering this
+    /// region would be all-zero.
+    fn build_text_in_separation_pdf() -> Vec<u8> {
+        // BT ... ET block with Helvetica-Bold at 24pt, drawing a "SPOT"
+        // string inside a Separation colour space.
+        let content = "BT\n/F1 24 Tf\n20 50 Td\n/CS1 cs\n0.9 scn\n(SPOT) Tj\nET\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /Font << /F1 6 0 R >> /ColorSpace << /CS1 5 0 R >> >> >>".to_string(),
+            content_obj,
+            "[/Separation /TextSpot /DeviceGray 7 0 R]".to_string(),
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+        ])
+    }
+
+    #[test]
+    fn text_with_spot_color_appears_on_plate() {
+        let pdf_bytes = build_text_in_separation_pdf();
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+        let plate = render_separation(&doc, 0, "TextSpot", 144).expect("render plate");
+
+        // Text was placed roughly around the bottom half of the page.
+        // Count pixels that look like spot ink (tint ~0.9 -> >180).
+        let inked = plate.data.iter().filter(|&&v| v > 180).count();
+        assert!(
+            inked > 100,
+            "Spot-colour text should leave at least some inked pixels on the plate, got {}",
+            inked
+        );
+
+        // CMYK plates should be empty for the same page.
+        let cyan = render_separation(&doc, 0, "Cyan", 144).expect("render Cyan");
+        let cyan_inked = cyan.data.iter().filter(|&&v| v > 50).count();
+        assert_eq!(
+            cyan_inked, 0,
+            "Spot-only text should not appear on Cyan plate, got {}",
+            cyan_inked
+        );
+    }
+
+    #[test]
+    fn cmyk_text_routes_to_process_plates() {
+        // Pure cyan text via `k` operator. The Cyan plate must show
+        // ink in the text region; Black plate must remain empty.
+        let content = "BT\n/F1 24 Tf\n20 50 Td\n0.8 0.0 0.0 0.0 k\n(CYAN) Tj\nET\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf_bytes = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>".to_string(),
+            content_obj,
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let cyan = render_separation(&doc, 0, "Cyan", 144).expect("render Cyan");
+        let cyan_inked = cyan.data.iter().filter(|&&v| v > 150).count();
+        assert!(
+            cyan_inked > 100,
+            "CMYK text should paint to Cyan plate (got {} bright pixels)",
+            cyan_inked
+        );
+
+        let black = render_separation(&doc, 0, "Black", 144).expect("render Black");
+        let black_inked = black.data.iter().filter(|&&v| v > 50).count();
+        assert_eq!(
+            black_inked, 0,
+            "Pure-cyan text should not appear on Black plate, got {}",
+            black_inked
+        );
+    }
 }

--- a/tests/test_separation_rendering.rs
+++ b/tests/test_separation_rendering.rs
@@ -1,0 +1,322 @@
+//! Tests for separation plate rendering.
+//!
+//! Verifies that individual ink separation plates are rendered correctly
+//! as grayscale images where pixel intensity = tint percentage.
+
+#[cfg(feature = "rendering")]
+mod tests {
+    use pdf_oxide::document::PdfDocument;
+    use pdf_oxide::rendering::{render_separation, render_separations};
+
+    /// Build a minimal PDF with a Separation color space and a filled rectangle.
+    ///
+    /// The page is 100x100 pt with a 50x50 pt rectangle centered at (25,25)
+    /// filled with the given ink at the given tint.
+    fn build_separation_pdf(ink_name: &str, tint: f32) -> Vec<u8> {
+        let content = format!("/CS1 cs\n{} scn\n25 25 50 50 re f\n", tint);
+        let content_bytes = content.as_bytes();
+
+        let mut buf = Vec::new();
+        let mut offsets = Vec::new();
+
+        // Header
+        buf.extend_from_slice(b"%PDF-1.4\n");
+
+        // Obj 1: Catalog
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        // Obj 2: Pages
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+        // Obj 3: Page
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /CS1 5 0 R >> >> >>\nendobj\n",
+        );
+
+        // Obj 4: Content stream
+        offsets.push(buf.len());
+        let stream_header = format!("4 0 obj\n<< /Length {} >>\nstream\n", content_bytes.len());
+        buf.extend_from_slice(stream_header.as_bytes());
+        buf.extend_from_slice(content_bytes);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+        // Obj 5: Separation color space
+        offsets.push(buf.len());
+        let cs = format!("5 0 obj\n[/Separation /{} /DeviceGray 6 0 R]\nendobj\n", ink_name);
+        buf.extend_from_slice(cs.as_bytes());
+
+        // Obj 6: Tint transform (identity: input tint -> output tint)
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"6 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>\nendobj\n",
+        );
+
+        // Xref table
+        let xref_offset = buf.len();
+        buf.extend_from_slice(b"xref\n");
+        let line = format!("0 {}\n", offsets.len() + 1);
+        buf.extend_from_slice(line.as_bytes());
+        buf.extend_from_slice(b"0000000000 65535 f \n");
+        for offset in &offsets {
+            let entry = format!("{:010} 00000 n \n", offset);
+            buf.extend_from_slice(entry.as_bytes());
+        }
+
+        // Trailer
+        let trailer = format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len() + 1,
+            xref_offset
+        );
+        buf.extend_from_slice(trailer.as_bytes());
+
+        buf
+    }
+
+    /// Build a PDF with DeviceCMYK content (a filled rectangle).
+    fn build_cmyk_pdf(c: f32, m: f32, y: f32, k: f32) -> Vec<u8> {
+        let content = format!("{} {} {} {} k\n25 25 50 50 re f\n", c, m, y, k);
+        let content_bytes = content.as_bytes();
+
+        let mut buf = Vec::new();
+        let mut offsets = Vec::new();
+
+        buf.extend_from_slice(b"%PDF-1.4\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << >> >>\nendobj\n",
+        );
+
+        offsets.push(buf.len());
+        let stream_header = format!("4 0 obj\n<< /Length {} >>\nstream\n", content_bytes.len());
+        buf.extend_from_slice(stream_header.as_bytes());
+        buf.extend_from_slice(content_bytes);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+        let xref_offset = buf.len();
+        buf.extend_from_slice(b"xref\n");
+        let line = format!("0 {}\n", offsets.len() + 1);
+        buf.extend_from_slice(line.as_bytes());
+        buf.extend_from_slice(b"0000000000 65535 f \n");
+        for offset in &offsets {
+            let entry = format!("{:010} 00000 n \n", offset);
+            buf.extend_from_slice(entry.as_bytes());
+        }
+
+        let trailer = format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len() + 1,
+            xref_offset
+        );
+        buf.extend_from_slice(trailer.as_bytes());
+
+        buf
+    }
+
+    /// Build a PDF with a DeviceN color space containing multiple inks.
+    fn build_devicen_pdf(ink_names: &[&str], tints: &[f32]) -> Vec<u8> {
+        assert_eq!(ink_names.len(), tints.len());
+
+        // Build the scn components string
+        let tint_str: String = tints.iter().map(|t| format!("{} ", t)).collect();
+        let content = format!("/CS1 cs\n{}scn\n25 25 50 50 re f\n", tint_str);
+        let content_bytes = content.as_bytes();
+
+        // Build ink name array string
+        let inks_str: String = ink_names.iter().map(|n| format!("/{} ", n)).collect();
+
+        let mut buf = Vec::new();
+        let mut offsets = Vec::new();
+
+        buf.extend_from_slice(b"%PDF-1.4\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /CS1 5 0 R >> >> >>\nendobj\n",
+        );
+
+        offsets.push(buf.len());
+        let stream_header = format!("4 0 obj\n<< /Length {} >>\nstream\n", content_bytes.len());
+        buf.extend_from_slice(stream_header.as_bytes());
+        buf.extend_from_slice(content_bytes);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+        // DeviceN color space: [/DeviceN [/Ink1 /Ink2 ...] /DeviceGray /TintTransform]
+        offsets.push(buf.len());
+        let cs = format!("5 0 obj\n[/DeviceN [{}] /DeviceGray 6 0 R]\nendobj\n", inks_str.trim());
+        buf.extend_from_slice(cs.as_bytes());
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"6 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>\nendobj\n",
+        );
+
+        let xref_offset = buf.len();
+        buf.extend_from_slice(b"xref\n");
+        let line = format!("0 {}\n", offsets.len() + 1);
+        buf.extend_from_slice(line.as_bytes());
+        buf.extend_from_slice(b"0000000000 65535 f \n");
+        for offset in &offsets {
+            let entry = format!("{:010} 00000 n \n", offset);
+            buf.extend_from_slice(entry.as_bytes());
+        }
+
+        let trailer = format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len() + 1,
+            xref_offset
+        );
+        buf.extend_from_slice(trailer.as_bytes());
+
+        buf
+    }
+
+    #[test]
+    fn separation_ink_appears_in_plate() {
+        let pdf_bytes = build_separation_pdf("Dieline", 0.8);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plate = render_separation(&doc, 0, "Dieline", 72).expect("render Dieline plate");
+
+        assert_eq!(plate.ink_name, "Dieline");
+        assert_eq!(plate.width, 100);
+        assert_eq!(plate.height, 100);
+        assert_eq!(plate.data.len(), 100 * 100);
+
+        // The rectangle is from (25,25) to (75,75) in PDF coords.
+        // At 72 DPI, 1pt = 1px, so check pixel at center of rectangle.
+        // PDF y=50 -> image y = 100 - 50 = 50 (flipped y)
+        let center_x = 50usize;
+        let center_y = 50usize;
+        let center_val = plate.data[center_y * plate.width as usize + center_x];
+
+        // Tint 0.8 should give ~204 (0.8 * 255)
+        assert!(center_val > 180, "Expected tint ~204 at rectangle center, got {}", center_val);
+
+        // Check outside the rectangle is empty (no ink)
+        let outside_val = plate.data[5 * plate.width as usize + 5];
+        assert_eq!(outside_val, 0, "Expected zero tint outside rectangle, got {}", outside_val);
+    }
+
+    #[test]
+    fn cmyk_content_appears_in_process_plates() {
+        let pdf_bytes = build_cmyk_pdf(0.5, 0.0, 0.0, 0.0); // 50% Cyan
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plates = render_separations(&doc, 0, 72).expect("render separations");
+
+        // Should have CMYK plates
+        let ink_names: Vec<&str> = plates.iter().map(|p| p.ink_name.as_str()).collect();
+        assert!(ink_names.contains(&"Cyan"), "Expected Cyan plate, got {:?}", ink_names);
+        assert!(ink_names.contains(&"Magenta"), "Expected Magenta plate, got {:?}", ink_names);
+        assert!(ink_names.contains(&"Yellow"), "Expected Yellow plate, got {:?}", ink_names);
+        assert!(ink_names.contains(&"Black"), "Expected Black plate, got {:?}", ink_names);
+
+        let cyan_plate = plates.iter().find(|p| p.ink_name == "Cyan").unwrap();
+        let center_val = cyan_plate.data[50 * cyan_plate.width as usize + 50];
+        // 50% cyan should give ~128
+        assert!(
+            center_val > 100 && center_val < 160,
+            "Expected ~128 for 50% cyan, got {}",
+            center_val
+        );
+
+        // Magenta plate should be empty (0% magenta)
+        let magenta_plate = plates.iter().find(|p| p.ink_name == "Magenta").unwrap();
+        let magenta_center = magenta_plate.data[50 * magenta_plate.width as usize + 50];
+        assert_eq!(magenta_center, 0, "Expected zero magenta, got {}", magenta_center);
+    }
+
+    #[test]
+    fn empty_plate_for_missing_ink() {
+        let pdf_bytes = build_separation_pdf("Varnish", 1.0);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        // Request a plate for an ink that doesn't exist on the page
+        let plate = render_separation(&doc, 0, "Dieline", 72).expect("render Dieline plate");
+
+        assert_eq!(plate.ink_name, "Dieline");
+        // All pixels should be zero
+        let non_zero = plate.data.iter().filter(|&&v| v > 0).count();
+        assert_eq!(
+            non_zero, 0,
+            "Expected all-zero plate for missing ink, got {} non-zero pixels",
+            non_zero
+        );
+    }
+
+    #[test]
+    fn devicen_ink_routing() {
+        let pdf_bytes = build_devicen_pdf(&["SpotRed", "SpotBlue"], &[0.7, 0.3]);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let red_plate = render_separation(&doc, 0, "SpotRed", 72).expect("render SpotRed plate");
+        let blue_plate = render_separation(&doc, 0, "SpotBlue", 72).expect("render SpotBlue plate");
+
+        let red_center = red_plate.data[50 * red_plate.width as usize + 50];
+        let blue_center = blue_plate.data[50 * blue_plate.width as usize + 50];
+
+        // SpotRed at tint 0.7 -> ~179
+        assert!(red_center > 150, "Expected SpotRed tint ~179, got {}", red_center);
+        // SpotBlue at tint 0.3 -> ~77
+        assert!(
+            blue_center > 50 && blue_center < 110,
+            "Expected SpotBlue tint ~77, got {}",
+            blue_center
+        );
+    }
+
+    #[test]
+    fn render_separations_returns_all_inks() {
+        let pdf_bytes = build_separation_pdf("Dieline", 1.0);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plates = render_separations(&doc, 0, 72).expect("render all separations");
+
+        let ink_names: Vec<&str> = plates.iter().map(|p| p.ink_name.as_str()).collect();
+        assert!(
+            ink_names.contains(&"Dieline"),
+            "Expected Dieline in plates, got {:?}",
+            ink_names
+        );
+    }
+
+    #[test]
+    fn full_tint_separation_plate() {
+        let pdf_bytes = build_separation_pdf("FullInk", 1.0);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plate = render_separation(&doc, 0, "FullInk", 72).expect("render plate");
+        let center_val = plate.data[50 * plate.width as usize + 50];
+
+        // Full tint (1.0) -> 255
+        assert!(center_val > 240, "Expected ~255 for full tint, got {}", center_val);
+    }
+
+    #[test]
+    fn zero_tint_separation_plate() {
+        let pdf_bytes = build_separation_pdf("ZeroInk", 0.0);
+        let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+        let plate = render_separation(&doc, 0, "ZeroInk", 72).expect("render plate");
+        let center_val = plate.data[50 * plate.width as usize + 50];
+
+        assert_eq!(center_val, 0, "Expected 0 for zero tint, got {}", center_val);
+    }
+}

--- a/tests/test_separation_rendering.rs
+++ b/tests/test_separation_rendering.rs
@@ -396,43 +396,48 @@ mod tests {
         );
     }
 
-    /// Build a page that paints with DeviceCMYK (k operator) but
-    /// overrides it via /Resources/ColorSpace/DefaultCMYK pointing
-    /// at a Separation space named "OverrideInk".
+    /// Build a page that paints with DeviceCMYK (k operator) but overrides
+    /// CMYK via /Resources/ColorSpace/DefaultCMYK pointing at a 4-channel
+    /// DeviceN with renamed process colorants. Per ISO 32000-1 §8.6.5.6 a
+    /// DefaultCMYK remap must preserve arity, so we use 4 named inks.
     fn build_default_cmyk_remap_pdf() -> Vec<u8> {
+        // 0.7 cyan, 0 magenta, 0 yellow, 0 black -> should route to OverrideCyan
         let content_stream = "0.7 0.0 0.0 0.0 k\n25 25 50 50 re f\n";
         let content_obj = format!(
             "<< /Length {} >>\nstream\n{}\nendstream",
             content_stream.len(),
             content_stream
         );
-        // Separation /OverrideInk /DeviceGray with identity tint transform.
-        // We can't really redirect CMYK to a single ink, but we can verify
-        // the lookup remaps to a Separation space and stops emitting CMYK.
+        // DefaultCMYK -> 4-channel DeviceN with renamed process colorants.
         assemble_pdf(vec![
             "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
             "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R /Resources << /ColorSpace << /DefaultCMYK 5 0 R >> >> >>".to_string(),
             content_obj,
-            "[/Separation /OverrideInk /DeviceGray 6 0 R]".to_string(),
-            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".to_string(),
+            "[/DeviceN [/OverrideCyan /OverrideMagenta /OverrideYellow /OverrideBlack] /DeviceCMYK 6 0 R]".to_string(),
+            "<< /FunctionType 2 /Domain [0 1] /N 4 /C0 [0 0 0 0] /C1 [1 0 0 0] >>".to_string(),
         ])
     }
 
+    /// §8.6.5.6 DefaultCMYK currently has only partial support: the lookup
+    /// resolves but content from `k`/`K` operators is not routed through the
+    /// override color space. The override plate stays empty.
     #[test]
+    #[ignore = "spec gap: §8.6.5.6 DefaultCMYK lookup works but content routing through override target is incomplete"]
     fn default_cmyk_remap_redirects_to_separation() {
         let pdf_bytes = build_default_cmyk_remap_pdf();
         let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
-
         let plates = render_separations(&doc, 0, 72).expect("render separations");
-        // DefaultCMYK now routes through the Separation override, so the
-        // Cyan plate should be empty.
-        let cyan = plates.iter().find(|p| p.ink_name == "Cyan").unwrap();
-        let cyan_center = cyan.data[50 * cyan.width as usize + 50];
-        assert_eq!(
-            cyan_center, 0,
-            "DefaultCMYK should remap k -> Separation, leaving CMYK plates empty (got {})",
-            cyan_center
+
+        let override_cyan = plates
+            .iter()
+            .find(|p| p.ink_name == "OverrideCyan")
+            .expect("OverrideCyan plate should exist when DefaultCMYK remaps to it");
+        let override_center = override_cyan.data[50 * override_cyan.width as usize + 50];
+        assert!(
+            override_center > 150,
+            "OverrideCyan plate should receive the remapped cyan content (got {})",
+            override_center
         );
     }
 
@@ -799,5 +804,278 @@ mod tests {
             "Pure-cyan text should not appear on Black plate, got {}",
             black_inked
         );
+    }
+
+    // =====================================================================
+    // §8.6.6.4: Reserved colorant names /All and /None
+    // =====================================================================
+
+    /// Build a PDF with a Separation `/All` colorant (registration marks).
+    /// Paints a small rect with `/All` at full tint, plus a separate Pantone
+    /// rect on a known spot ink so the test can verify CMYK plates exist.
+    fn build_pdf_with_all_separation() -> Vec<u8> {
+        let content = b"/CS1 cs 1.0 scn 10 10 30 30 re f \
+                        /CS2 cs 1.0 scn 60 60 30 30 re f";
+        build_pdf_two_separations(b"All", b"PANTONE", content)
+    }
+
+    fn build_pdf_with_none_separation() -> Vec<u8> {
+        let content = b"/CS1 cs 1.0 scn 10 10 30 30 re f \
+                        /CS2 cs 1.0 scn 60 60 30 30 re f";
+        build_pdf_two_separations(b"None", b"PANTONE", content)
+    }
+
+    fn build_pdf_two_separations(ink_a: &[u8], ink_b: &[u8], content_stream: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut offsets = Vec::new();
+        buf.extend_from_slice(b"%PDF-1.4\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /CS1 5 0 R /CS2 6 0 R >> >> >>\nendobj\n",
+        );
+
+        offsets.push(buf.len());
+        let stream_header = format!("4 0 obj\n<< /Length {} >>\nstream\n", content_stream.len());
+        buf.extend_from_slice(stream_header.as_bytes());
+        buf.extend_from_slice(content_stream);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+        offsets.push(buf.len());
+        let cs1 = format!(
+            "5 0 obj\n[/Separation /{} /DeviceGray 7 0 R]\nendobj\n",
+            std::str::from_utf8(ink_a).unwrap()
+        );
+        buf.extend_from_slice(cs1.as_bytes());
+
+        offsets.push(buf.len());
+        let cs2 = format!(
+            "6 0 obj\n[/Separation /{} /DeviceGray 7 0 R]\nendobj\n",
+            std::str::from_utf8(ink_b).unwrap()
+        );
+        buf.extend_from_slice(cs2.as_bytes());
+
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"7 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>\nendobj\n",
+        );
+
+        let xref_offset = buf.len();
+        buf.extend_from_slice(b"xref\n");
+        let line = format!("0 {}\n", offsets.len() + 1);
+        buf.extend_from_slice(line.as_bytes());
+        buf.extend_from_slice(b"0000000000 65535 f \n");
+        for offset in &offsets {
+            let entry = format!("{:010} 00000 n \n", offset);
+            buf.extend_from_slice(entry.as_bytes());
+        }
+        let trailer = format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len() + 1,
+            xref_offset
+        );
+        buf.extend_from_slice(trailer.as_bytes());
+        buf
+    }
+
+    /// Helper: sample the center of a 30x30 rect at (10,10) at 144 DPI.
+    /// Page is 100x100 pt -> 200x200 px. Rect at (10,10)-(40,40) pt ->
+    /// (20,20)-(80,80) px, center ~ (50,50). PDF y-axis is bottom-up so we
+    /// sample at (height - py) on the buffer.
+    fn sample_plate_at(plate: &pdf_oxide::rendering::SeparationPlate, x_pt: f32, y_pt: f32) -> u8 {
+        let scale = plate.width as f32 / 100.0;
+        let px = (x_pt * scale) as u32;
+        let py = (y_pt * scale) as u32;
+        let idx = ((plate.height - 1 - py) * plate.width + px) as usize;
+        plate.data[idx]
+    }
+
+    #[test]
+    fn test_all_separation_paints_every_plate() {
+        // §8.6.6.4: /All is a reserved colorant — content painted with
+        // /Separation /All should appear on every output plate (CMYK + spots).
+        let doc = PdfDocument::from_bytes(build_pdf_with_all_separation()).unwrap();
+
+        // get_page_inks must not list "All" as a plate name.
+        let inks = doc.get_page_inks(0).unwrap();
+        assert!(!inks.contains(&"All".to_string()), "got: {:?}", inks);
+        assert!(inks.contains(&"PANTONE".to_string()), "got: {:?}", inks);
+
+        let plates = render_separations(&doc, 0, 144).unwrap();
+        let names: Vec<&str> = plates.iter().map(|p| p.ink_name.as_str()).collect();
+        assert!(!names.contains(&"All"), "no plate named 'All' should be materialized");
+
+        // The /All rect is at (10,10)-(40,40) pt. It should appear at full
+        // tint (255) on EVERY plate: Cyan, Magenta, Yellow, Black, PANTONE.
+        for plate in &plates {
+            let v = sample_plate_at(plate, 25.0, 25.0);
+            assert!(
+                v > 200,
+                "/All content missing from {} plate (got value {})",
+                plate.ink_name,
+                v
+            );
+        }
+
+        // The PANTONE rect at (60,60)-(90,90) should appear only on PANTONE.
+        let pantone = plates.iter().find(|p| p.ink_name == "PANTONE").unwrap();
+        assert!(sample_plate_at(pantone, 75.0, 75.0) > 200);
+        let cyan = plates.iter().find(|p| p.ink_name == "Cyan").unwrap();
+        assert!(
+            sample_plate_at(cyan, 75.0, 75.0) < 50,
+            "PANTONE-only rect should not be on Cyan plate"
+        );
+    }
+
+    #[test]
+    fn test_none_separation_paints_nothing() {
+        // §8.6.6.4: /None is a reserved colorant — produces no marks anywhere
+        // and never names a plate.
+        let doc = PdfDocument::from_bytes(build_pdf_with_none_separation()).unwrap();
+
+        let inks = doc.get_page_inks(0).unwrap();
+        assert!(!inks.contains(&"None".to_string()), "got: {:?}", inks);
+
+        let plates = render_separations(&doc, 0, 144).unwrap();
+        let names: Vec<&str> = plates.iter().map(|p| p.ink_name.as_str()).collect();
+        assert!(!names.contains(&"None"), "no plate named 'None' should be materialized");
+
+        // The /None rect must not appear on any plate.
+        for plate in &plates {
+            let v = sample_plate_at(plate, 25.0, 25.0);
+            assert!(v < 50, "/None content leaked onto {} plate (got value {})", plate.ink_name, v);
+        }
+
+        // PANTONE rect should still be visible on its own plate.
+        let pantone = plates.iter().find(|p| p.ink_name == "PANTONE").unwrap();
+        assert!(sample_plate_at(pantone, 75.0, 75.0) > 200);
+    }
+
+    // =====================================================================
+    // SPEC GAPS — foundation tests for the next iteration.
+    //
+    // These tests document spec-compliance gaps in the v1 separation
+    // renderer. They are #[ignore]'d so the suite passes; each one names
+    // the relevant ISO 32000-1 section and what real-world PDF feature it
+    // covers. Removing the #[ignore] after the underlying gap is fixed
+    // turns them into passing regression tests.
+    // =====================================================================
+
+    /// §11.7.4.4 — Overprint mode. With OP=true and OPM=0 (default), painting
+    /// a Separation ink on top of CMYK content should *add* to the spot plate
+    /// while leaving the underlying CMYK plates unchanged. Without overprint
+    /// the spot paint knocks out the CMYK at those pixels.
+    #[test]
+    #[ignore = "spec gap: overprint (/OP, /op, /OPM) — §11.7 not yet implemented"]
+    fn test_overprint_preserves_underlying_ink() {
+        // Paint 50% K rect, then paint a Separation rect on top with OP=true.
+        // Expected: Black plate retains 50% under the spot rect; Spot plate
+        // shows the spot ink. Current behavior: spot rect knocks out K.
+        let content = b"0 0 0 0.5 k 20 20 60 60 re f \
+                        /GS1 gs /CS1 cs 1.0 scn 30 30 40 40 re f";
+        let _pdf = build_pdf_with_extgstate_overprint(content);
+        unimplemented!("foundation test — overprint not yet supported");
+    }
+
+    fn build_pdf_with_extgstate_overprint(_content: &[u8]) -> Vec<u8> {
+        Vec::new()
+    }
+
+    /// §9.3.6 — Text rendering mode 3 = "neither fill nor stroke (invisible)".
+    /// Should advance the text matrix but contribute no pixels to any plate.
+    /// Common in tagged/searchable PDFs where invisible text underlies an
+    /// image of scanned content.
+    #[test]
+    #[ignore = "spec gap: render mode 3 (invisible text) may leak onto plates"]
+    fn test_render_mode_3_invisible_text_no_plate_pixels() {
+        unimplemented!("foundation test — render mode 3 not yet verified");
+    }
+
+    /// §9.3.6 — Text rendering modes 1, 2, 5, 6 stroke the glyphs. Stroke
+    /// color comes from the stroke color space + components, not fill.
+    /// A separation with `Tr 1 (text)` should route to the stroke ink's plate.
+    #[test]
+    #[ignore = "spec gap: stroke-mode text routes to fill color, not stroke"]
+    fn test_stroke_mode_text_uses_stroke_color() {
+        unimplemented!("foundation test — stroke-mode text color routing");
+    }
+
+    /// §8.6.5.6 — DefaultRGB remap. References to DeviceRGB should resolve
+    /// through /Resources/ColorSpace/DefaultRGB when present. Currently only
+    /// DefaultCMYK is honored.
+    #[test]
+    #[ignore = "spec gap: §8.6.5.6 /DefaultRGB and /DefaultGray remap"]
+    fn test_default_rgb_remap() {
+        unimplemented!("foundation test — DefaultRGB resolution");
+    }
+
+    /// §8.6.5.6 — DefaultGray remap (same as above).
+    #[test]
+    #[ignore = "spec gap: §8.6.5.6 /DefaultGray remap"]
+    fn test_default_gray_remap() {
+        unimplemented!("foundation test — DefaultGray resolution");
+    }
+
+    /// §8.10.1 — Form XObject inherits the COMPLETE graphics state at the
+    /// time of invocation, not just color. Line width, line cap/join,
+    /// dash pattern, font, ExtGState alpha/blend mode are all inherited.
+    /// Currently only color state is propagated into the recursive call.
+    #[test]
+    #[ignore = "spec gap: Form XObject inherits only color, not full GS (line width, etc.)"]
+    fn test_form_xobject_inherits_line_width() {
+        unimplemented!("foundation test — Form XObject non-color GS inheritance");
+    }
+
+    /// §8.6.6.5 — DeviceN can declare /Subtype /NChannel with /Process and
+    /// /Colorants entries describing additional per-component blending into
+    /// process inks. Plain DeviceN currently routes each named component to
+    /// its own plate without honoring /Process additive contributions.
+    #[test]
+    #[ignore = "spec gap: §8.6.6.5 NChannel /Process and /Colorants routing"]
+    fn test_nchannel_process_attributes() {
+        unimplemented!("foundation test — NChannel sub-type per-process routing");
+    }
+
+    /// §8.6.6 — Negative and >1.0 tint values. Spec permits them; some
+    /// prepress files use them for "more than 100% ink" effects. Currently
+    /// silently clamped to [0, 1] with no diagnostic.
+    #[test]
+    #[ignore = "spec gap: §8.6.6 tint values outside [0,1] silently clamped"]
+    fn test_out_of_range_tint_values_documented() {
+        unimplemented!("foundation test — tint clamp behavior documentation");
+    }
+
+    /// §12.5.4 — Annotations rendered via /AP appearance streams may contain
+    /// spot-color content. The composite renderer paints them; the separation
+    /// renderer currently does not, so spot-colored stamps/watermarks delivered
+    /// via annotation streams are dropped from plates.
+    #[test]
+    #[ignore = "spec gap: §12.5.4 annotations not rendered to plates"]
+    fn test_annotation_appearance_streams_contribute_to_plates() {
+        unimplemented!("foundation test — annotation appearance stream rendering");
+    }
+
+    /// §8.7 — Tiling and shading patterns. Patterns can use Separation/DeviceN
+    /// content. The current renderer drops /Pattern colors and shading
+    /// operators (`sh`) entirely.
+    #[test]
+    #[ignore = "spec gap: §8.7 Pattern color spaces and `sh` operator not supported"]
+    fn test_pattern_color_space() {
+        unimplemented!("foundation test — Pattern color space support");
+    }
+
+    /// §8.9 — Inline images (BI/ID/EI) can carry DeviceN samples. Currently
+    /// dropped by the operator walker.
+    #[test]
+    #[ignore = "spec gap: §8.9 inline images dropped"]
+    fn test_inline_image_devicen() {
+        unimplemented!("foundation test — inline image with DeviceN data");
     }
 }

--- a/tests/test_separation_rendering.rs
+++ b/tests/test_separation_rendering.rs
@@ -975,27 +975,74 @@ mod tests {
     #[test]
     #[ignore = "spec gap: overprint (/OP, /op, /OPM) — §11.7 not yet implemented"]
     fn test_overprint_preserves_underlying_ink() {
-        // Paint 50% K rect, then paint a Separation rect on top with OP=true.
-        // Expected: Black plate retains 50% under the spot rect; Spot plate
-        // shows the spot ink. Current behavior: spot rect knocks out K.
-        let content = b"0 0 0 0.5 k 20 20 60 60 re f \
-                        /GS1 gs /CS1 cs 1.0 scn 30 30 40 40 re f";
-        let _pdf = build_pdf_with_extgstate_overprint(content);
-        unimplemented!("foundation test — overprint not yet supported");
-    }
+        // K rect 50% under, Separation rect on top with OP=true via /GS1.
+        // Spec: spot paint with overprint preserves underlying K plate.
+        // Current: spot paint knocks out K (last-writer-wins per pixel).
+        let content = "0 0 0 0.5 k\n20 20 60 60 re f\n\
+                       /GS1 gs /CS1 cs 1.0 scn\n30 30 40 40 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /CS1 5 0 R >> /ExtGState << /GS1 7 0 R >> >> >>"
+                .into(),
+            content_obj,
+            "[/Separation /SpotInk /DeviceGray 6 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+            "<< /Type /ExtGState /OP true /op true /OPM 1 >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let plates = render_separations(&doc, 0, 144).unwrap();
 
-    fn build_pdf_with_extgstate_overprint(_content: &[u8]) -> Vec<u8> {
-        Vec::new()
+        // Sample center of the overlap region (where the spot rect sits on top of K).
+        let black = plates.iter().find(|p| p.ink_name == "Black").unwrap();
+        let bw = black.width as usize;
+        let center = black.data[(50 * bw) + 50];
+        assert!(
+            center >= 100 && center <= 140,
+            "Black plate at overlap should retain ~50% tint under overprinted spot, got {}",
+            center
+        );
+
+        let spot = plates.iter().find(|p| p.ink_name == "SpotInk").unwrap();
+        let sw = spot.width as usize;
+        assert!(spot.data[(50 * sw) + 50] > 200, "SpotInk plate should show the overprinted ink");
     }
 
     /// §9.3.6 — Text rendering mode 3 = "neither fill nor stroke (invisible)".
-    /// Should advance the text matrix but contribute no pixels to any plate.
+    /// Advances the text matrix but contributes no pixels to any plate.
     /// Common in tagged/searchable PDFs where invisible text underlies an
-    /// image of scanned content.
+    /// image of scanned content. Regression test for already-working behavior.
     #[test]
-    #[ignore = "spec gap: render mode 3 (invisible text) may leak onto plates"]
     fn test_render_mode_3_invisible_text_no_plate_pixels() {
-        unimplemented!("foundation test — render mode 3 not yet verified");
+        // Tr 3 = invisible: glyphs advance the text matrix but contribute
+        // no pixels. A separation plate must show zero ink for a Tr 3 run
+        // even when the active fill is a Separation at full tint.
+        let content = "/CS1 cs 1.0 scn\n\
+                       BT /F1 24 Tf 3 Tr 20 50 Td (HIDDEN) Tj ET\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /CS1 5 0 R >> \
+                           /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> >>"
+                .into(),
+            content_obj,
+            "[/Separation /Watermark /DeviceGray 6 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let watermark = render_separation(&doc, 0, "Watermark", 144).unwrap();
+        let inked = watermark.data.iter().filter(|&&v| v > 50).count();
+        assert_eq!(
+            inked, 0,
+            "Tr 3 (invisible) text must not contribute pixels to the Watermark plate, got {} inked",
+            inked
+        );
     }
 
     /// §9.3.6 — Text rendering modes 1, 2, 5, 6 stroke the glyphs. Stroke
@@ -1004,23 +1051,99 @@ mod tests {
     #[test]
     #[ignore = "spec gap: stroke-mode text routes to fill color, not stroke"]
     fn test_stroke_mode_text_uses_stroke_color() {
-        unimplemented!("foundation test — stroke-mode text color routing");
+        // Tr 1 (stroke text) uses the STROKE color space + components. Fill
+        // is /CS1 (FillInk), stroke is /CS2 (StrokeInk). Glyph outlines must
+        // appear on StrokeInk's plate, not FillInk's.
+        let content = "/CS1 cs 1.0 scn\n/CS2 CS 1.0 SCN\n\
+                       BT /F1 24 Tf 1 Tr 20 50 Td (X) Tj ET\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /CS1 5 0 R /CS2 6 0 R >> \
+                           /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> >>"
+                .into(),
+            content_obj,
+            "[/Separation /FillInk /DeviceGray 7 0 R]".into(),
+            "[/Separation /StrokeInk /DeviceGray 7 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let stroke_plate = render_separation(&doc, 0, "StrokeInk", 144).unwrap();
+        let stroke_inked = stroke_plate.data.iter().filter(|&&v| v > 50).count();
+        assert!(
+            stroke_inked > 100,
+            "StrokeInk plate should receive the Tr 1 stroked glyph, got {} inked",
+            stroke_inked
+        );
+        let fill_plate = render_separation(&doc, 0, "FillInk", 144).unwrap();
+        let fill_inked = fill_plate.data.iter().filter(|&&v| v > 50).count();
+        assert_eq!(
+            fill_inked, 0,
+            "FillInk plate should NOT receive Tr 1 text, got {} inked",
+            fill_inked
+        );
     }
 
-    /// §8.6.5.6 — DefaultRGB remap. References to DeviceRGB should resolve
-    /// through /Resources/ColorSpace/DefaultRGB when present. Currently only
-    /// DefaultCMYK is honored.
+    /// §8.6.5.6 — DefaultRGB remap. References to DeviceRGB resolve through
+    /// /Resources/ColorSpace/DefaultRGB when present.
     #[test]
-    #[ignore = "spec gap: §8.6.5.6 /DefaultRGB and /DefaultGray remap"]
     fn test_default_rgb_remap() {
-        unimplemented!("foundation test — DefaultRGB resolution");
+        // /Resources/ColorSpace/DefaultRGB -> Separation /SpotInk. A page that
+        // paints with `rg` should route content to SpotInk's plate, not
+        // be skipped as a display color.
+        let content = "1.0 0.0 0.0 rg\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /DefaultRGB 5 0 R >> >> >>"
+                .into(),
+            content_obj,
+            "[/DeviceN [/SpotR /SpotG /SpotB] /DeviceRGB 6 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 3 /C0 [0 0 0] /C1 [1 0 0] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let plate = render_separation(&doc, 0, "SpotR", 144).unwrap();
+        let center = plate.data
+            [(plate.height as usize / 2) * plate.width as usize + (plate.width as usize / 2)];
+        assert!(
+            center > 200,
+            "DefaultRGB should remap `rg` -> Separation; SpotR plate center got {}",
+            center
+        );
     }
 
-    /// §8.6.5.6 — DefaultGray remap (same as above).
+    /// §8.6.5.6 — DefaultGray remap. References to DeviceGray resolve through
+    /// /Resources/ColorSpace/DefaultGray when present.
     #[test]
-    #[ignore = "spec gap: §8.6.5.6 /DefaultGray remap"]
     fn test_default_gray_remap() {
-        unimplemented!("foundation test — DefaultGray resolution");
+        let content = "0.5 g\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /DefaultGray 5 0 R >> >> >>"
+                .into(),
+            content_obj,
+            "[/Separation /GraySpot /DeviceGray 6 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let plate = render_separation(&doc, 0, "GraySpot", 144).unwrap();
+        let center = plate.data
+            [(plate.height as usize / 2) * plate.width as usize + (plate.width as usize / 2)];
+        assert!(
+            center > 100 && center < 160,
+            "DefaultGray should remap `g 0.5` -> Separation; GraySpot center got {}",
+            center
+        );
     }
 
     /// §8.10.1 — Form XObject inherits the COMPLETE graphics state at the
@@ -1030,7 +1153,46 @@ mod tests {
     #[test]
     #[ignore = "spec gap: Form XObject inherits only color, not full GS (line width, etc.)"]
     fn test_form_xobject_inherits_line_width() {
-        unimplemented!("foundation test — Form XObject non-color GS inheritance");
+        // Caller sets line width to 10pt and a Separation color, then invokes
+        // a Form XObject that strokes a line WITHOUT setting line width.
+        // Per §8.10.1, the form should inherit width=10. Currently inherits
+        // only color, so the stroke renders at default 1pt (much thinner).
+        let form_content = "50 30 m 50 70 l S\n";
+        let form_obj = format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] /Length {} >>\n\
+             stream\n{}\nendstream",
+            form_content.len(),
+            form_content
+        );
+        let page_content = "/CS1 cs 1.0 scn /CS1 CS 1.0 SCN 10 w\n/Fm1 Do\n";
+        let page_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", page_content.len(), page_content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /XObject << /Fm1 5 0 R >> \
+                           /ColorSpace << /CS1 6 0 R >> >> >>"
+                .into(),
+            page_obj,
+            form_obj,
+            "[/Separation /InheritInk /DeviceGray 7 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let plate = render_separation(&doc, 0, "InheritInk", 144).unwrap();
+        // Count inked pixels in a horizontal slice through the stroke.
+        let row = plate.height as usize / 2;
+        let start = row * plate.width as usize;
+        let stroke_width: usize = (start..start + plate.width as usize)
+            .filter(|&i| plate.data[i] > 50)
+            .count();
+        // 10pt stroke at 144 DPI = 20 px wide. 1pt default would be 2 px.
+        assert!(
+            stroke_width >= 15,
+            "Stroke should inherit 10pt line width (≈20 px at 144 DPI); got {} inked px",
+            stroke_width
+        );
     }
 
     /// §8.6.6.5 — DeviceN can declare /Subtype /NChannel with /Process and
@@ -1040,7 +1202,45 @@ mod tests {
     #[test]
     #[ignore = "spec gap: §8.6.6.5 NChannel /Process and /Colorants routing"]
     fn test_nchannel_process_attributes() {
-        unimplemented!("foundation test — NChannel sub-type per-process routing");
+        // NChannel DeviceN with /Subtype /NChannel and /Process declaring a
+        // per-process-component contribution into CMYK. Painting with the
+        // NChannel space should ALSO add tint to the named process plates.
+        // Currently the renderer routes only to the named components.
+        let content = "/CS1 cs 1.0 scn\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /CS1 5 0 R >> >> >>"
+                .into(),
+            content_obj,
+            // NChannel with /Process pointing to DeviceCMYK with a tint
+            // transform that pushes 50% Cyan when the spot is at full tint.
+            "[/DeviceN [/SpotNC] /DeviceCMYK 6 0 R \
+              << /Subtype /NChannel \
+                 /Process << /ColorSpace /DeviceCMYK /Components [/Cyan] >> >>]"
+                .into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 4 /C0 [0 0 0 0] /C1 [0.5 0 0 0] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        // Spot plate should receive the named ink.
+        let spot = render_separation(&doc, 0, "SpotNC", 144).unwrap();
+        let sw = spot.width as usize;
+        assert!(
+            spot.data[(spot.height as usize / 2) * sw + sw / 2] > 200,
+            "SpotNC plate should receive tint"
+        );
+        // Cyan plate should ALSO have content per the /Process declaration.
+        let cyan = render_separation(&doc, 0, "Cyan", 144).unwrap();
+        let cw = cyan.width as usize;
+        let cyan_center = cyan.data[(cyan.height as usize / 2) * cw + cw / 2];
+        assert!(
+            cyan_center > 100,
+            "NChannel /Process should route additional tint to Cyan, got {}",
+            cyan_center
+        );
     }
 
     /// §8.6.6 — Negative and >1.0 tint values. Spec permits them; some
@@ -1049,7 +1249,35 @@ mod tests {
     #[test]
     #[ignore = "spec gap: §8.6.6 tint values outside [0,1] silently clamped"]
     fn test_out_of_range_tint_values_documented() {
-        unimplemented!("foundation test — tint clamp behavior documentation");
+        // PDF allows tint values outside [0,1] (e.g. for "150% ink" effects).
+        // Current renderer clamps to [0,1] silently. The right behavior is
+        // either to (a) clamp and emit a diagnostic, or (b) preserve the
+        // out-of-range data via a wider pixel format. This test pins the
+        // expectation: 1.5 tint produces > 1.0 ink coverage — currently
+        // capped at 255, indistinguishable from 1.0.
+        let content = "/CS1 cs 1.5 scn\n25 25 50 50 re f\n";
+        let content_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", content.len(), content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /CS1 5 0 R >> >> >>"
+                .into(),
+            content_obj,
+            "[/Separation /OverInk /DeviceGray 6 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let plate = render_separation(&doc, 0, "OverInk", 144).unwrap();
+        let center = plate.data
+            [(plate.height as usize / 2) * plate.width as usize + (plate.width as usize / 2)];
+        // Future behavior: the diagnostic / wider-format should make
+        // out-of-range detectable. For now this is documented as a gap.
+        assert_ne!(
+            center, 255,
+            "tint value 1.5 should be detectable as out-of-range (currently clamped to 255)"
+        );
     }
 
     /// §12.5.4 — Annotations rendered via /AP appearance streams may contain
@@ -1059,7 +1287,38 @@ mod tests {
     #[test]
     #[ignore = "spec gap: §12.5.4 annotations not rendered to plates"]
     fn test_annotation_appearance_streams_contribute_to_plates() {
-        unimplemented!("foundation test — annotation appearance stream rendering");
+        // A stamp annotation with a /N (normal) appearance stream that paints
+        // a Separation rect. The composite renderer paints annotations; the
+        // separation renderer currently skips them, so spot-colored stamps
+        // are dropped from plates.
+        let appearance = "/CS1 cs 1.0 scn\n0 0 50 50 re f\n";
+        let appearance_obj = format!(
+            "<< /Type /XObject /Subtype /Form /BBox [0 0 50 50] \
+              /Resources << /ColorSpace << /CS1 7 0 R >> >> /Length {} >>\n\
+             stream\n{}\nendstream",
+            appearance.len(),
+            appearance
+        );
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Annots [5 0 R] >>"
+                .into(),
+            "<< /Length 0 >>\nstream\n\nendstream".into(),
+            "<< /Type /Annot /Subtype /Stamp /Rect [25 25 75 75] /AP << /N 6 0 R >> >>".into(),
+            appearance_obj,
+            "[/Separation /StampInk /DeviceGray 8 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let plate = render_separation(&doc, 0, "StampInk", 144).unwrap();
+        let inked = plate.data.iter().filter(|&&v| v > 50).count();
+        assert!(
+            inked > 1000,
+            "StampInk plate should receive annotation appearance content, got {} inked",
+            inked
+        );
     }
 
     /// §8.7 — Tiling and shading patterns. Patterns can use Separation/DeviceN
@@ -1068,7 +1327,41 @@ mod tests {
     #[test]
     #[ignore = "spec gap: §8.7 Pattern color spaces and `sh` operator not supported"]
     fn test_pattern_color_space() {
-        unimplemented!("foundation test — Pattern color space support");
+        // Tiling pattern in a Separation ink. Spec says the pattern's
+        // contents are painted (tiled) to cover the filled area; that
+        // tiled content should contribute to the Separation plate.
+        let pattern = "/CS1 cs 1.0 scn\n0 0 10 10 re f\n";
+        let pattern_obj = format!(
+            "<< /Type /Pattern /PatternType 1 /PaintType 1 /TilingType 1 \
+              /BBox [0 0 10 10] /XStep 10 /YStep 10 \
+              /Resources << /ColorSpace << /CS1 7 0 R >> >> /Length {} >>\n\
+             stream\n{}\nendstream",
+            pattern.len(),
+            pattern
+        );
+        let page_content = "/Pattern cs /P1 scn\n25 25 50 50 re f\n";
+        let page_obj =
+            format!("<< /Length {} >>\nstream\n{}\nendstream", page_content.len(), page_content);
+        let pdf = assemble_pdf(vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /Pattern << /P1 5 0 R >> /ColorSpace << /CS1 7 0 R >> >> >>"
+                .into(),
+            page_obj,
+            pattern_obj,
+            "<< >>".into(), // Filler obj 6
+            "[/Separation /PatternInk /DeviceGray 8 0 R]".into(),
+            "<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>".into(),
+        ]);
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+        let plate = render_separation(&doc, 0, "PatternInk", 144).unwrap();
+        let inked = plate.data.iter().filter(|&&v| v > 50).count();
+        assert!(
+            inked > 1000,
+            "Pattern fill in Separation ink should populate the plate, got {} inked",
+            inked
+        );
     }
 
     /// §8.9 — Inline images (BI/ID/EI) can carry DeviceN samples. Currently
@@ -1076,6 +1369,57 @@ mod tests {
     #[test]
     #[ignore = "spec gap: §8.9 inline images dropped"]
     fn test_inline_image_devicen() {
-        unimplemented!("foundation test — inline image with DeviceN data");
+        // Inline image with single-component DeviceN-encoded data.
+        // Currently the operator walker drops BI/ID/EI entirely.
+        // Real DeviceN inline images carry one sample per ink-name per pixel.
+        let mut content: Vec<u8> = Vec::new();
+        content.extend_from_slice(b"/CS1 cs\nBI /W 10 /H 10 /BPC 8 /CS /DeviceGray ID\n");
+        content.extend(std::iter::repeat(0xFFu8).take(100));
+        content.extend_from_slice(b"\nEI\n");
+
+        // Assemble PDF bytes directly to keep the binary inline image intact.
+        let mut buf: Vec<u8> = Vec::new();
+        let mut offsets: Vec<usize> = Vec::new();
+        buf.extend_from_slice(b"%PDF-1.4\n");
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+              /Resources << /ColorSpace << /CS1 5 0 R >> >> >>\nendobj\n",
+        );
+        offsets.push(buf.len());
+        let stream_hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+        buf.extend_from_slice(stream_hdr.as_bytes());
+        buf.extend_from_slice(&content);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+        offsets.push(buf.len());
+        buf.extend_from_slice(b"5 0 obj\n[/Separation /InlineInk /DeviceGray 6 0 R]\nendobj\n");
+        offsets.push(buf.len());
+        buf.extend_from_slice(
+            b"6 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0] /C1 [1] >>\nendobj\n",
+        );
+
+        let xref = buf.len();
+        let n = offsets.len() + 1;
+        buf.extend_from_slice(format!("xref\n0 {}\n0000000000 65535 f \n", n).as_bytes());
+        for off in &offsets {
+            buf.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+        }
+        buf.extend_from_slice(
+            format!("trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n", n, xref)
+                .as_bytes(),
+        );
+
+        let doc = PdfDocument::from_bytes(buf).unwrap();
+        let plate = render_separation(&doc, 0, "InlineInk", 144).unwrap();
+        let inked = plate.data.iter().filter(|&&v| v > 50).count();
+        assert!(
+            inked > 0,
+            "Inline image in Separation should contribute to plate, got {} inked",
+            inked
+        );
     }
 }


### PR DESCRIPTION
NOTE: This builds on PR #600 

## Description

Adds a separation plate rendering API that produces one grayscale image per ink — the standard prepress output format used for color separations, plate-making, and ML pipelines that need per-ink masks. Each pixel value in a plate equals the tint coverage of that ink at that point (0 = no ink, 255 = full coverage), which is the right semantic for downstream consumers (RIPs, QC tools, segmentation models).

The primary use cases this targets:
- **Prepress QC** — per-plate ink coverage analysis, spot-color verification, dieline extraction
- **ML/AI training data** — free per-channel ground-truth masks from packaging/label PDFs (the dieline plate is a clean binary mask of all die-cut paths; varnish plate shows coating regions; each spot color plate isolates that ink)
- **Press workflows** — feeding individual plates to platemaking systems

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [x] Tests

## Related Issues

Builds on `feature/ocg-ink-filtering-and-cache-fix` (ink detection via `get_page_inks`). No specific issue.

## Changes Made

### New module: `src/rendering/separation_renderer.rs`

- `SeparationPlate { ink_name, data, width, height }` — public struct representing a single grayscale ink plate
- `render_separations(doc, page, dpi) -> Vec<SeparationPlate>` — all plates for a page
- `render_separation(doc, page, ink_name, dpi) -> SeparationPlate` — single targeted plate

Implementation approach: walks the page operator stream once per requested ink, tracking the current fill/stroke color space alongside the graphics-state stack, and rasterizes paths/text into a single-channel grayscale buffer via tiny-skia. Form XObjects recurse with the caller's color state inherited per §8.10.1. Clipping (`W`, `W*`), graphics state save/restore (`q`, `Q`), and ExtGState alpha are applied.

### Color routing per PDF spec ISO 32000-1 §8.6

| Color space | Routing |
|---|---|
| DeviceCMYK (`k`, `K`) | C/M/Y/K components route to their respective plates |
| Separation `[/Separation /InkName /Alt /Tint]` + `scn` | Tint routes to the named ink's plate |
| Separation `/All` (§8.6.6.4) | Tint paints to every output plate (CMYK + named spots) — used for registration marks, crop marks |
| Separation `/None` (§8.6.6.4) | Paints nothing; never materializes a plate |
| DeviceN `[/DeviceN [/Ink1 ...] /Alt /Tint]` + `scn` | Per-component tints route to per-ink plates |
| DeviceRGB, DeviceGray | Skipped (these are display color spaces) |
| ICCBased | N=4 routes as CMYK (with `/N` stream-dict probe + heuristic fallback); other arities skipped |
| DefaultCMYK / DefaultRGB / DefaultGray (§8.6.5.6) | Lookup resolved; `DefaultCMYK` content routing partially implemented (see foundation tests) |

### Text rendering to plates

Text glyphs are routed through the existing `TextRasterizer` with a faked-grayscale `GraphicsState` (`fill_color_rgb = (tint, tint, tint)`) so the R-channel rasterization carries the tint at full anti-aliasing fidelity. BT/ET, Tf, Td/TD/Tm/T*, Tj/TJ/'/" all handled. Text rendering mode 3 (invisible) advances the text matrix without painting.

### Spec-correct initial state

- `cs`/`CS` resets fill/stroke components to the space's initial value per §8.6.4.2 (DeviceCMYK = [0,0,0,1], Separation = [1.0], DeviceN = [1.0;n], etc.)
- Form XObject recursion inherits the caller's complete color state per §8.10.1

### Performance

- CMYK plates always emitted; unused ones short-circuit via `collect_referenced_inks` (no operator walk for an empty plate)
- Per-plate dispatch avoids re-parsing the page stream for each ink

### Shared infrastructure: `src/rendering/ext_gstate.rs`

Extracted `ParsedExtGState` and its parser from `page_renderer.rs` so both renderers share one implementation (was previously `pub(crate)` reaching across modules).

### Python bindings (`src/python.rs`)

- `PdfDocument.render_separations(page, dpi=...)` returns `List[SeparationPlate]`
- `PdfDocument.render_separation(page, ink_name, dpi=...)` returns single plate
- `SeparationPlate` namedtuple in `python/pdf_oxide/__init__.py`

### `/All` and `/None` handling in `src/document.rs`

`get_page_inks` filters reserved colorant names so they never appear as ink-name strings to callers.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

20 passing tests in `tests/test_separation_rendering.rs` covering:
- Separation ink tint appears in correct plate (linear ramp at 0%, 50%, 100%)
- CMYK content routes to C/M/Y/K plates with correct intensities
- CMYK content nested inside Form XObjects detected
- DeviceN per-component routing
- DeviceRGB / DeviceGray correctly skipped (not converted)
- Anti-aliased edges produce intermediate plate values
- Overlapping rects (last-writer-wins per opaque painting)
- `q`/`Q` saves and restores color state
- Page rotation 90/180/270
- Spot-color text appears on its plate
- CMYK text routes to process plates
- `/All` paints to every plate (registration-mark scenario)
- `/None` paints nothing
- Plus 7 more covering edge cases

12 `#[ignore]`'d foundation tests documenting remaining spec gaps. Each names the ISO 32000-1 section and turns into a passing regression test once the underlying gap is closed:

| Test | Spec | Gap |
|---|---|---|
| `test_overprint_preserves_underlying_ink` | §11.7 | `OP`/`op`/`OPM` overprint mode |
| `test_render_mode_3_invisible_text_no_plate_pixels` | §9.3.6 | Tr 3 may leak |
| `test_stroke_mode_text_uses_stroke_color` | §9.3.6 | Tr 1/2/5/6 use fill color |
| `test_default_rgb_remap` | §8.6.5.6 | DefaultRGB resolution |
| `test_default_gray_remap` | §8.6.5.6 | DefaultGray resolution |
| `default_cmyk_remap_redirects_to_separation` | §8.6.5.6 | DefaultCMYK content routing through override |
| `test_form_xobject_inherits_line_width` | §8.10.1 | Full GS inheritance (line width, dash, font) |
| `test_nchannel_process_attributes` | §8.6.6.5 | NChannel `/Process` per-component blending |
| `test_out_of_range_tint_values_documented` | §8.6.6 | Silent tint clamping |
| `test_annotation_appearance_streams_contribute_to_plates` | §12.5.4 | Annotation `/AP` not rendered |
| `test_pattern_color_space` | §8.7 | Patterns and `sh` operator |
| `test_inline_image_devicen` | §8.9 | Inline image DeviceN samples |

Verified each ignored test fails when un-ignored (`cargo test -- --ignored` produces 12/12 failures with the expected messages).

Full lib suite: 5,269 lib tests pass. Clippy clean.

## Python Bindings (if applicable)

- [x] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

`render_separations` and `render_separation` exposed with the same DPI/page argument shape as the existing `render_page`. `SeparationPlate` namedtuple gives Python callers direct access to the grayscale bytes, width, height, and ink name.

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

Module-level rustdoc enumerates dropped features (patterns, shadings, inline images, annotations) so callers know exactly what to expect. Color routing logic documented per spec section.

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Additional Notes

**Display convention.** The `SeparationPlate.data` returned by the API is ML-friendly: pixel value = ink coverage (0 = no ink, 255 = full tint). For human display in prepress workflows (dark = ink on white paper), callers should invert: `display_pixel = 255 - data[i]`. 

**Overprint not simulated.** Per §11.7, real prepress uses overprint (`OP`/`op`/`OPM`) to control whether a fresh paint replaces or adds to underlying ink. The current renderer is always last-writer-wins. This matters most when CMYK(0,0,0,0) "paper-white" text is drawn over a spot-color bar — in real production the white text "knocks out" the bar, but our renderer keeps the bar's full coverage. Foundation test `test_overprint_preserves_underlying_ink` is in place; flagged as a follow-up because correct overprint requires cross-plate compositing logic that's out of scope here.

**`/All` semantics.** Content drawn with `/Separation /All` (the spec's reserved colorant for "paint to every output plate") routes to every CMYK and spot plate simultaneously. This is exactly the encoding real PDFs use for registration marks and crop marks — a single mark on the page appears identically on every plate so the press operator can align them. It does not duplicate the entire page content per plate; only the specific drawing operations issued while `/All` is the active color space.

**Foundation-test pattern.** The 12 `#[ignore]`'d tests serve as both documentation and regression-test scaffolding. Each fails when un-ignored (verifying the gap is real, not a no-op test) and names the ISO 32000-1 section so the next iteration knows exactly what spec text to implement against. Removing the `#[ignore]` line after fixing the gap converts each one into a passing regression test.