### PR TITLE
fix: treat null byte (0x00) as PDF whitespace in inline image EI dete…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## next-version
+
+### Fixed
+
+- **Inline images whose data ends with a null byte now parse correctly** — the EI end-of-data marker detection did not recognise NUL (0x00) as whitespace; PDFs that terminate inline image data with a null byte would silently drop the image and/or misparse subsequent content. All six PDF whitespace bytes (NUL, HT, LF, FF, CR, SP — ISO 32000-1 Table 1) are now recognised.
+
 ## [0.3.57] - 2026-05-30
 
 > Community contributions + extraction-quality sweep — separation plates, OCG ink filtering, two-phase images, rendered-advance metrics, plus multi-column reading order, page-rotation, CJK/UTF-8 CMap decoding, RTL logical order, indirect-ref page boxes, and font-cache correctness

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -2299,9 +2299,9 @@ fn find_and_extract_image_data(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
     Ok((inp, input[..ei_pos].to_vec()))
 }
 
-/// Check if a byte is whitespace (space, tab, CR, LF, FF).
+/// Check if a byte is whitespace (null, tab, LF, FF, CR, space — PDF spec Table 1).
 fn is_whitespace(byte: u8) -> bool {
-    matches!(byte, b' ' | b'\t' | b'\r' | b'\n' | b'\x0C')
+    matches!(byte, b'\x00' | b'\t' | b'\r' | b'\n' | b'\x0C' | b' ')
 }
 
 /// Check if a byte is whitespace or a PDF delimiter.
@@ -4198,6 +4198,20 @@ mod tests {
             .iter()
             .any(|op| matches!(op, Operator::InlineImage { .. })));
         assert!(ops.iter().any(|op| matches!(op, Operator::RestoreState)));
+    }
+
+    #[test]
+    fn test_parse_inline_image_null_before_ei() {
+        // PDF spec Table 1 lists NULL (0x00) as whitespace.
+        let mut stream = b"q BI /W 2 /H 2 ID AB".to_vec();
+        stream.extend_from_slice(b"\x00EI Q BT (Hi) Tj ET");
+        let ops = parse_content_stream(&stream).unwrap();
+        assert!(ops
+            .iter()
+            .any(|op| matches!(op, Operator::InlineImage { .. })));
+        assert!(ops.iter().any(|op| matches!(op, Operator::RestoreState)));
+        // Text after the inline image must still be extracted
+        assert!(ops.iter().any(|op| matches!(op, Operator::Tj { .. })));
     }
 
     // ── Number parsing edge cases ───────────────────────────────────


### PR DESCRIPTION
## Description

The inline image end-of-data marker (EI) must be preceded by a whitespace character per the PDF spec.  The previous detection code did not recognise the null byte (0x00) as whitespace, causing inline images whose data ended with a null byte to fail to parse correctly.

Aligns the whitespace set with Table 1 of ISO 32000: NUL (0x00), HT (0x09), LF (0x0A), FF (0x0C), CR (0x0D), SP (0x20).

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Changes Made

- Added `\x00` to the list of whitespace characters
- Added a test that includes the pattern where I saw this in the wild.

## Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests pass locally
- [X] I have run `cargo test --all-features`
- [X] I have run `cargo clippy -- -D warnings`
- [X] I have run `cargo fmt`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [X] I have updated CHANGELOG.md

## Checklist

- [X] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)