### PR TITLE
fix: process ToUnicode bfchar and bfrange sections in document order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## next-version
+
+### Fixed
+
+- **ToUnicode CMap `bfchar` and `bfrange` sections are now processed in document order** — previously all `bfchar` sections were processed before all `bfrange` sections, so `bfrange` entries always silently discarded any `bfchar` correction for the same code. Sections are now processed in the order they appear in the stream (last entry wins), matching the behaviour of pdf.js, MuPDF, and Poppler.
+
 ## [0.3.57] - 2026-05-30
 
 > Community contributions + extraction-quality sweep — separation plates, OCG ink filtering, two-phase images, rendered-advance metrics, plus multi-column reading order, page-rotation, CJK/UTF-8 CMap decoding, RTL logical order, indirect-ref page boxes, and font-cache correctness

--- a/src/fonts/cmap.rs
+++ b/src/fonts/cmap.rs
@@ -484,31 +484,32 @@ pub fn parse_tounicode_cmap(data: &[u8]) -> Result<CMap> {
         }
     }
 
-    // Parse bfchar sections
-    // PDF Spec: ISO 32000-1:2008, Section 9.10.3 - ToUnicode CMaps
-    // Format: <srcCode> <dstString>
-    for section in extract_sections(&content, "beginbfchar", "endbfchar") {
-        for line in section.lines() {
-            for (src, dst) in parse_bfchar_line(line) {
-                log::trace!("ToUnicode bfchar: 0x{:02X} -> {:?}", src, dst);
-                cmap.insert(src, dst);
-            }
-        }
-    }
-
-    // Parse bfrange sections
-    // PDF Spec: ISO 32000-1:2008, Section 9.10.3 - ToUnicode CMaps
-    // Format: <srcCodeLo> <srcCodeHi> [<dstString0> <dstString1> ... <dstStringN>]
-    //     or: <srcCodeLo> <srcCodeHi> <dstString>
-    for section in extract_sections(&content, "beginbfrange", "endbfrange") {
-        for line in section.lines() {
-            if let Some(mappings) = parse_bfrange_line(line) {
-                log::trace!("ToUnicode bfrange: {} mappings parsed", mappings.len());
-                // Store as range entry for binary search
-                for (src, dst) in mappings {
-                    cmap.insert(src, dst);
+    // Parse bfchar and bfrange sections in document order so that later entries
+    // overwrite earlier ones for the same code (ISO 32000-1:2008 §9.10.3).
+    // pdf.js, MuPDF, and Poppler all use this last-wins, document-order semantics.
+    for (kind, section) in bf_sections_in_document_order(&content) {
+        match kind {
+            BfSectionKind::Char => {
+                // Format: <srcCode> <dstString>
+                for line in section.lines() {
+                    for (src, dst) in parse_bfchar_line(line) {
+                        log::trace!("ToUnicode bfchar: 0x{:02X} -> {:?}", src, dst);
+                        cmap.insert(src, dst);
+                    }
                 }
-            }
+            },
+            BfSectionKind::Range => {
+                // Format: <srcCodeLo> <srcCodeHi> [<dstString0> <dstString1> ... <dstStringN>]
+                //     or: <srcCodeLo> <srcCodeHi> <dstString>
+                for line in section.lines() {
+                    if let Some(mappings) = parse_bfrange_line(line) {
+                        log::trace!("ToUnicode bfrange: {} mappings parsed", mappings.len());
+                        for (src, dst) in mappings {
+                            cmap.insert(src, dst);
+                        }
+                    }
+                }
+            },
         }
     }
 
@@ -531,6 +532,38 @@ pub fn parse_tounicode_cmap(data: &[u8]) -> Result<CMap> {
     }
 
     Ok(cmap)
+}
+
+enum BfSectionKind {
+    Char,
+    Range,
+}
+
+/// Yield `beginbfchar` and `beginbfrange` sections in the order they appear in
+/// the CMap stream, so that callers can process them with document-order,
+/// last-wins semantics (matching pdf.js, MuPDF, and Poppler).
+fn bf_sections_in_document_order(content: &str) -> impl Iterator<Item = (BfSectionKind, &str)> {
+    let mut remaining = content;
+    std::iter::from_fn(move || {
+        loop {
+            let pos = remaining.find("beginbf")?;
+            let after = &remaining[pos + "beginbf".len()..];
+
+            if let Some(body) = after.strip_prefix("char") {
+                if let Some(end) = body.find("endbfchar") {
+                    remaining = &body[end + "endbfchar".len()..];
+                    return Some((BfSectionKind::Char, &body[..end]));
+                }
+            } else if let Some(body) = after.strip_prefix("range") {
+                if let Some(end) = body.find("endbfrange") {
+                    remaining = &body[end + "endbfrange".len()..];
+                    return Some((BfSectionKind::Range, &body[..end]));
+                }
+            }
+            // Unrecognised "beginbf…" token or missing end marker; skip past it.
+            remaining = after;
+        }
+    })
 }
 
 /// Extract sections between begin and end markers.

--- a/tests/test_tounicode_cmap_bfchar_override.rs
+++ b/tests/test_tounicode_cmap_bfchar_override.rs
@@ -1,0 +1,148 @@
+//! Tests for ToUnicode CMap document-order processing.
+//!
+//! pdf.js, MuPDF, and Poppler all parse bfchar and bfrange sections in document
+//! order with last-wins semantics.  When the same code appears in multiple
+//! sections, whichever section appears last in the stream provides the
+//! authoritative mapping.
+
+use pdf_oxide::fonts::cmap::parse_tounicode_cmap;
+
+/// bfchar entries that overlap with a bfrange must take precedence.
+///
+/// Setup:
+///   - bfrange: codes 0x41..0x5A → 'A'..'Z'  (ASCII uppercase letters)
+///   - bfchar:  code  0x41       → '!'         (specific override for 'A')
+///
+/// Expected: code 0x41 resolves to '!', not 'A'.
+#[test]
+fn bfchar_overrides_bfrange_for_same_code() {
+    let cmap_data = b"\
+/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Test def\n\
+1 begincodespacerange\n\
+<00> <FF>\n\
+endcodespacerange\n\
+1 beginbfrange\n\
+<41> <5A> <0041>\n\
+endbfrange\n\
+1 beginbfchar\n\
+<41> <0021>\n\
+endbfchar\n\
+endcmap\n\
+end\n\
+end\n";
+
+    let cmap = parse_tounicode_cmap(cmap_data).expect("parse CMap");
+
+    // Code 0x41 must use the bfchar override ('!' = U+0021), not the bfrange value ('A').
+    let val = cmap.get(&0x41).expect("code 0x41 must be mapped");
+    assert_eq!(
+        val, "!",
+        "bfchar <41>=<0021> must override bfrange <41>-<5A>=<0041>; got {:?}",
+        val
+    );
+
+    // Other codes in the bfrange still use the bfrange mapping.
+    let b_val = cmap.get(&0x42).expect("code 0x42 must be mapped");
+    assert_eq!(b_val, "B", "code 0x42 should still resolve to 'B' from the bfrange");
+}
+
+/// A bfrange without an overlapping bfchar is unaffected.
+#[test]
+fn bfrange_codes_without_bfchar_override_use_range_value() {
+    let cmap_data = b"\
+/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Test def\n\
+1 begincodespacerange\n\
+<00> <FF>\n\
+endcodespacerange\n\
+1 beginbfrange\n\
+<41> <45> <0041>\n\
+endbfrange\n\
+1 beginbfchar\n\
+<41> <0021>\n\
+endbfchar\n\
+endcmap\n\
+end\n\
+end\n";
+
+    let cmap = parse_tounicode_cmap(cmap_data).expect("parse CMap");
+
+    // Codes 0x42..0x45 have no bfchar override — bfrange value prevails.
+    assert_eq!(cmap.get(&0x42).map(|s| s.as_str()), Some("B"));
+    assert_eq!(cmap.get(&0x43).map(|s| s.as_str()), Some("C"));
+    assert_eq!(cmap.get(&0x44).map(|s| s.as_str()), Some("D"));
+    assert_eq!(cmap.get(&0x45).map(|s| s.as_str()), Some("E"));
+}
+
+/// bfchar entries that do not overlap with any bfrange are still mapped.
+#[test]
+fn bfchar_without_bfrange_overlap_is_mapped() {
+    let cmap_data = b"\
+/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Test def\n\
+1 begincodespacerange\n\
+<00> <FF>\n\
+endcodespacerange\n\
+1 beginbfrange\n\
+<41> <45> <0041>\n\
+endbfrange\n\
+1 beginbfchar\n\
+<61> <0078>\n\
+endbfchar\n\
+endcmap\n\
+end\n\
+end\n";
+
+    let cmap = parse_tounicode_cmap(cmap_data).expect("parse CMap");
+
+    // Code 0x61 ('a' area) has only a bfchar entry → must resolve to 'x' (U+0078).
+    assert_eq!(
+        cmap.get(&0x61).map(|s| s.as_str()),
+        Some("x"),
+        "bfchar-only code 0x61 should map to 'x'"
+    );
+}
+
+/// When bfchar appears *before* bfrange in the stream and both map the same
+/// code, the bfrange entry wins because it comes later (document order).
+///
+/// This is the mirror of `bfchar_overrides_bfrange_for_same_code` and
+/// confirms that the implementation is truly document-order rather than
+/// always favouring one section type over the other.
+#[test]
+fn bfrange_overrides_bfchar_when_bfrange_comes_last() {
+    let cmap_data = b"\
+/CIDInit /ProcSet findresource begin\n\
+12 dict begin\n\
+begincmap\n\
+/CMapName /Test def\n\
+1 begincodespacerange\n\
+<00> <FF>\n\
+endcodespacerange\n\
+1 beginbfchar\n\
+<41> <0021>\n\
+endbfchar\n\
+1 beginbfrange\n\
+<41> <5A> <0041>\n\
+endbfrange\n\
+endcmap\n\
+end\n\
+end\n";
+
+    let cmap = parse_tounicode_cmap(cmap_data).expect("parse CMap");
+
+    // bfrange comes last in the stream, so it wins: code 0x41 → 'A', not '!'.
+    let val = cmap.get(&0x41).expect("code 0x41 must be mapped");
+    assert_eq!(
+        val, "A",
+        "bfrange <41>-<5A>=<0041> must win over earlier bfchar <41>=<0021>; got {:?}",
+        val
+    );
+}


### PR DESCRIPTION
## Description

CMap parsing previously processed all bfchar sections before all
bfrange sections.  For any code present in both, the bfrange mapping
was applied second and silently discarded the bfchar correction.

Replace the two-pass approach with a single scan that processes
beginbfchar and beginbfrange sections in the order they appear in 
the CMap stream (ISO 32000-1:2008 §9.10.3).  Later entries overwrite
earlier ones for the same code, matching the last-wins document-order
semantics of pdf.js, MuPDF, and Poppler.

Also removes a stale comment "Store as range entry for binary search"
from the bfrange loop: `CMap::insert()` has always written into the
`chars` HashMap, not into any sorted-Vec range structure.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Changes Made

- Changed bfrange and bfchar processing to use document order
- Added tests to verify.

## Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests pass locally
- [X] I have run `cargo test --all-features`
- [X] I have run `cargo clippy -- -D warnings`
- [X] I have run `cargo fmt`

## Documentation

- [X] I have updated the documentation (README, docs/, code comments)
- [X] I have added/updated examples (if applicable)
- [X] I have updated CHANGELOG.md

## Checklist

- [X] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)