### PR TITLE
feat: separation overprint

### DIFF
--- a/src/content/graphics_state.rs
+++ b/src/content/graphics_state.rs
@@ -254,6 +254,15 @@ pub struct GraphicsState {
     pub stroke_alpha: f32,
     /// Blend mode (BM): Normal, Multiply, Screen, Overlay, etc.
     pub blend_mode: String,
+
+    // Overprint parameters (from ExtGState, ISO 32000-1 §11.7.4)
+    /// Overprint for non-stroking ops (ExtGState `/op`). PDF default `false`.
+    pub fill_overprint: bool,
+    /// Overprint for stroking ops (ExtGState `/OP`). PDF default `false`.
+    pub stroke_overprint: bool,
+    /// Overprint mode (ExtGState `/OPM`): 0 = standard, 1 = nonzero
+    /// ("Adobe nonzero overprint"). PDF default `0`.
+    pub overprint_mode: u8,
 }
 
 impl GraphicsState {
@@ -297,6 +306,9 @@ impl GraphicsState {
             fill_alpha: 1.0,                 // Fully opaque (PDF default)
             stroke_alpha: 1.0,               // Fully opaque (PDF default)
             blend_mode: "Normal".to_string(), // Normal blend mode (PDF default)
+            fill_overprint: false,           // §11.7.4 default
+            stroke_overprint: false,         // §11.7.4 default
+            overprint_mode: 0,               // §11.7.4 default (standard mode)
         }
     }
 
@@ -641,5 +653,32 @@ mod tests {
         let m = Matrix::default();
         assert_eq!(m.a, 1.0);
         assert_eq!(m.d, 1.0);
+    }
+
+    #[test]
+    fn graphics_state_default_overprint_is_off() {
+        // ISO 32000-1 Table 128: OP/op default false, OPM default 0.
+        let gs = GraphicsState::default();
+        assert!(!gs.fill_overprint);
+        assert!(!gs.stroke_overprint);
+        assert_eq!(gs.overprint_mode, 0);
+    }
+
+    #[test]
+    fn graphics_state_overprint_survives_save_restore() {
+        let mut stack = GraphicsStateStack::new();
+        stack.current_mut().fill_overprint = true;
+        stack.current_mut().stroke_overprint = true;
+        stack.current_mut().overprint_mode = 1;
+
+        stack.save();
+        stack.current_mut().fill_overprint = false;
+        stack.current_mut().stroke_overprint = false;
+        stack.current_mut().overprint_mode = 0;
+
+        stack.restore();
+        assert!(stack.current().fill_overprint);
+        assert!(stack.current().stroke_overprint);
+        assert_eq!(stack.current().overprint_mode, 1);
     }
 }

--- a/src/rendering/ext_gstate.rs
+++ b/src/rendering/ext_gstate.rs
@@ -40,6 +40,15 @@ impl ParsedExtGState {
         if let Some(ref m) = self.blend_mode {
             gs.blend_mode = m.clone();
         }
+        if let Some(v) = self.fill_overprint {
+            gs.fill_overprint = v;
+        }
+        if let Some(v) = self.stroke_overprint {
+            gs.stroke_overprint = v;
+        }
+        if let Some(v) = self.overprint_mode {
+            gs.overprint_mode = v;
+        }
     }
 }
 

--- a/src/rendering/ext_gstate.rs
+++ b/src/rendering/ext_gstate.rs
@@ -11,14 +11,20 @@ use crate::error::Result;
 use crate::object::Object;
 
 /// Parsed effects of a PDF `ExtGState` dictionary. Only the fields actually
-/// applied during rendering are captured (fill/stroke alpha and blend mode).
-/// Anything else (TK / SMask / AIS) is intentionally ignored so the cached
-/// entry stays tiny.
+/// applied during rendering are captured (fill/stroke alpha, blend mode, and
+/// the overprint parameters from ISO 32000-1 §11.7.4). Anything else
+/// (TK / SMask / AIS) is intentionally ignored so the cached entry stays tiny.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ParsedExtGState {
     pub(crate) fill_alpha: Option<f32>,
     pub(crate) stroke_alpha: Option<f32>,
     pub(crate) blend_mode: Option<String>,
+    /// Overprint for stroking operations (ExtGState `/OP`, §11.7.4).
+    pub(crate) stroke_overprint: Option<bool>,
+    /// Overprint for non-stroking operations (ExtGState `/op`, §11.7.4).
+    pub(crate) fill_overprint: Option<bool>,
+    /// Overprint mode (ExtGState `/OPM`, §11.7.4). 0 = standard, 1 = nonzero.
+    pub(crate) overprint_mode: Option<u8>,
 }
 
 impl ParsedExtGState {
@@ -75,5 +81,121 @@ pub(crate) fn parse_ext_g_state_inner(
         };
         out.blend_mode = Some(mode);
     }
+
+    // ISO 32000-1 §11.7.4 / Table 128. `/OP` is the stroking overprint;
+    // `/op` (lowercase) is the non-stroking overprint. When `/OP` is
+    // present without `/op`, the spec says it sets both.
+    let op_stroke = state_dict.get("OP").and_then(Object::as_bool);
+    let op_fill = state_dict.get("op").and_then(Object::as_bool);
+    out.stroke_overprint = op_stroke;
+    out.fill_overprint = op_fill.or(op_stroke);
+
+    if let Some(opm) = state_dict.get("OPM").and_then(Object::as_integer) {
+        // Spec defines only 0 (standard) and 1 (nonzero). Any other
+        // value is undefined; clamp to 0 so a malformed PDF doesn't
+        // accidentally enable nonzero-overprint mode.
+        out.overprint_mode = Some(if opm == 1 { 1 } else { 0 });
+    }
+
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Minimal PDF document used purely as a `&PdfDocument` argument for
+    /// `parse_ext_g_state_inner`. The parser only calls `resolve_object`
+    /// on the input; when the input is already an inline dict (not a
+    /// `Reference`), that call short-circuits to a clone and never touches
+    /// the document's xref. So any successfully-parsed PDF is sufficient.
+    fn fixture_doc() -> PdfDocument {
+        // Construct the smallest valid PDF that `from_bytes` will accept.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(b"%PDF-1.4\n");
+        let cat_off = buf.len();
+        buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        let pages_off = buf.len();
+        buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n");
+        let xref_off = buf.len();
+        buf.extend_from_slice(b"xref\n0 3\n0000000000 65535 f \n");
+        buf.extend_from_slice(format!("{:010} 00000 n \n", cat_off).as_bytes());
+        buf.extend_from_slice(format!("{:010} 00000 n \n", pages_off).as_bytes());
+        buf.extend_from_slice(
+            format!(
+                "trailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+                xref_off
+            )
+            .as_bytes(),
+        );
+        PdfDocument::from_bytes(buf).expect("fixture PDF parses")
+    }
+
+    fn dict(entries: &[(&str, Object)]) -> Object {
+        let mut m = HashMap::new();
+        for (k, v) in entries {
+            m.insert((*k).to_string(), v.clone());
+        }
+        Object::Dictionary(m)
+    }
+
+    #[test]
+    fn parses_op_op_opm_from_extgstate_dict() {
+        let obj = dict(&[
+            ("OP", Object::Boolean(true)),
+            ("op", Object::Boolean(false)),
+            ("OPM", Object::Integer(1)),
+        ]);
+        let doc = fixture_doc();
+        let parsed = parse_ext_g_state_inner(&obj, &doc).expect("parses");
+        assert_eq!(parsed.stroke_overprint, Some(true));
+        assert_eq!(parsed.fill_overprint, Some(false));
+        assert_eq!(parsed.overprint_mode, Some(1));
+    }
+
+    #[test]
+    fn op_without_op_sets_both_overprints() {
+        // §11.7.4 / Table 128: "Specifying an OP entry sets both
+        // parameters unless there is also an op entry in the same
+        // graphics state parameter dictionary".
+        let obj = dict(&[("OP", Object::Boolean(true))]);
+        let doc = fixture_doc();
+        let parsed = parse_ext_g_state_inner(&obj, &doc).expect("parses");
+        assert_eq!(parsed.stroke_overprint, Some(true));
+        assert_eq!(parsed.fill_overprint, Some(true));
+    }
+
+    #[test]
+    fn op_without_op_uppercase_only_does_not_affect_stroke() {
+        // /op is the non-stroking parameter only; /OP is absent so the
+        // stroking overprint stays unset (caller falls back to gs default).
+        let obj = dict(&[("op", Object::Boolean(true))]);
+        let doc = fixture_doc();
+        let parsed = parse_ext_g_state_inner(&obj, &doc).expect("parses");
+        assert_eq!(parsed.stroke_overprint, None);
+        assert_eq!(parsed.fill_overprint, Some(true));
+    }
+
+    #[test]
+    fn opm_clamps_unknown_values_to_zero() {
+        // §11.7.4: OPM is 0 or 1; any other value is undefined. We clamp
+        // to 0 (standard mode) to preserve the spec-default behavior on
+        // malformed PDFs.
+        let obj = dict(&[("OPM", Object::Integer(42))]);
+        let doc = fixture_doc();
+        let parsed = parse_ext_g_state_inner(&obj, &doc).expect("parses");
+        assert_eq!(parsed.overprint_mode, Some(0));
+    }
+
+    #[test]
+    fn missing_overprint_keys_leave_options_none() {
+        // Empty dict → no fields touched. Apply() is a no-op on the gs.
+        let obj = dict(&[]);
+        let doc = fixture_doc();
+        let parsed = parse_ext_g_state_inner(&obj, &doc).expect("parses");
+        assert_eq!(parsed.stroke_overprint, None);
+        assert_eq!(parsed.fill_overprint, None);
+        assert_eq!(parsed.overprint_mode, None);
+    }
 }

--- a/src/rendering/ext_gstate.rs
+++ b/src/rendering/ext_gstate.rs
@@ -132,11 +132,8 @@ mod tests {
         buf.extend_from_slice(format!("{:010} 00000 n \n", cat_off).as_bytes());
         buf.extend_from_slice(format!("{:010} 00000 n \n", pages_off).as_bytes());
         buf.extend_from_slice(
-            format!(
-                "trailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
-                xref_off
-            )
-            .as_bytes(),
+            format!("trailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n", xref_off)
+                .as_bytes(),
         );
         PdfDocument::from_bytes(buf).expect("fixture PDF parses")
     }

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -1680,9 +1680,9 @@ fn execute_separation_operators(
 /// The returned advance is shared across all plates (the rasteriser is
 /// deterministic for a given font/text/state, so each plate's advance
 /// agrees) — we use the last computed value, matching the single-plate
-/// behaviour. If no plate is touched (all tints are `None` or render
-/// mode 3) the advance is computed from the font metrics so the text
-/// matrix still progresses correctly.
+/// behaviour. If no plate is touched (every plate's [`PaintAction`] is
+/// `Skip`, or render mode 3) the advance is computed from the font
+/// metrics so the text matrix still progresses correctly.
 #[allow(clippy::too_many_arguments)]
 fn render_text_to_plate(
     pixmaps: &mut [Pixmap],

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -50,6 +50,39 @@
 //! coverage on the press, not transparent compositing. Callers who need the
 //! transparent intent (e.g. a 50%-alpha spot text overlay) should evaluate it
 //! against the underlying content with [`super::page_renderer`] first.
+//!
+//! # Overprint
+//!
+//! The renderer implements the per-plate overprint model defined in
+//! ISO 32000-1 §11.7.4 ("Overprint Control"). The ExtGState entries
+//! `/OP` (stroke), `/op` (non-stroke), and `/OPM` (overprint mode) are
+//! parsed and applied to the graphics state.
+//!
+//! - **Default (`OP = false`):** for every plate, the spec rule "areas
+//!   of unspecified colorants are erased (painted with a tint value of
+//!   0.0)" applies. A DeviceCMYK fill knocks out underlying Cyan,
+//!   Magenta, Yellow, Black, *and* any spot inks within its shape; a
+//!   Separation `/Pantone-185` fill knocks out underlying process and
+//!   other-spot plates within its shape. This is the standard
+//!   per-plate prepress convention.
+//! - **`OP = true`:** plates outside the source's colorant set are left
+//!   untouched. Designers use this to overlay spot inks on process
+//!   backgrounds without knocking them out (the typical packaging /
+//!   label authoring workflow).
+//! - **`OPM = 1` (Adobe nonzero overprint):** when the source colour
+//!   space is DeviceCMYK and overprint is enabled, a component value of
+//!   exactly `0.0` is treated as "colorant not specified" — the
+//!   matching plate is left untouched. Per §11.7.4.3, OPM applies only
+//!   to DeviceCMYK sources; Separation and DeviceN content is
+//!   unaffected by OPM and routes through OP/op alone.
+//!
+//! Overprint state participates in `q`/`Q` save/restore via the existing
+//! graphics-state stack and propagates into Form XObjects per §8.10.1.
+//! The decision happens in `tint_for_ink`, which returns either
+//! `PaintAction::Paint(tint)` (write tint into the plate; 0.0 = knockout)
+//! or `PaintAction::Skip` (leave the plate untouched). Spot/DeviceN
+//! sources route to their named plates regardless of overprint, matching
+//! the inherent behavior of real separation devices.
 #![allow(
     clippy::field_reassign_with_default,
     clippy::ptr_arg,

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -630,9 +630,49 @@ fn load_fonts(doc: &PdfDocument, resources: &Object) -> HashMap<String, Arc<Font
     fonts
 }
 
-/// Compute the tint contribution to `target_ink` for the current colour
-/// state. Returns `None` if the current colour does not touch this
-/// plate; `Some(tint)` otherwise, with `tint` in 0.0..=1.0.
+/// Per-plate routing decision for a single paint operation, after applying
+/// the overprint rules of ISO 32000-1 §11.7.4.
+///
+/// - [`PaintAction::Paint`] writes the given tint into the plate. A tint
+///   of 0.0 is the spec-default "knockout" — the existing
+///   [`fill_separation`] / [`stroke_separation`] use opaque source-over,
+///   so writing 0.0 erases any underlying ink at the touched pixels.
+/// - [`PaintAction::Skip`] leaves the plate completely untouched. Used
+///   when (a) the source colour space doesn't reference this plate and
+///   overprint is enabled, or (b) the source is DeviceCMYK with OPM=1
+///   and the component is exactly 0.0 (the "Adobe nonzero overprint"
+///   rule, §11.7.4).
+enum PaintAction {
+    Paint(f32),
+    Skip,
+}
+
+/// Decide how the current paint operation contributes to `target_ink`,
+/// honoring ISO 32000-1 §11.7.4 (Overprint Control).
+///
+/// The decision tree:
+///
+/// ```text
+/// For each plate P, source colour space S with component vector c[]:
+///
+///   if S = Separation(/All):                              Paint(c[0])
+///   if S = Separation(/None) or empty components:         Skip
+///   if S = Separation(name) and name == P:                Paint(c[0])
+///   if S = Separation(name) and name != P:
+///         overprint? Skip : Paint(0.0)                    // §11.7.4 default knockout
+///
+///   if S = DeviceN(names) and P in names:                 Paint(c[index_of_P])
+///   if S = DeviceN(names) and P not in names:
+///         overprint? Skip : Paint(0.0)
+///
+///   if S = DeviceCMYK / IccCmyk:
+///         if P in {C, M, Y, K}:
+///             overprint && opm == 1 && tint == 0.0 ? Skip : Paint(tint)
+///         else:                                            // spot plate
+///             overprint? Skip : Paint(0.0)                 // §11.7.4 default knockout
+///
+///   if S = RGB/Gray/IccRgb/IccGray:                       Skip
+/// ```
 fn tint_for_ink(
     fill: bool,
     gs: &GraphicsState,
@@ -642,7 +682,7 @@ fn tint_for_ink(
     target_ink: &str,
     fill_components: &[f32],
     stroke_components: &[f32],
-) -> Option<f32> {
+) -> PaintAction {
     let space_name = if fill {
         &gs.fill_color_space
     } else {
@@ -653,10 +693,28 @@ fn tint_for_ink(
     } else {
         stroke_components
     };
+    let overprint = if fill {
+        gs.fill_overprint
+    } else {
+        gs.stroke_overprint
+    };
+    // §11.7.4.3: OPM applies only when the source is DeviceCMYK (or implicit
+    // conversion thereto). The match arms below check this where relevant.
+    let opm = gs.overprint_mode;
+
+    // Default action when the source colour space doesn't name the
+    // target plate: under OP=true, leave it alone; under OP=false (the
+    // spec default), erase it to 0.0 ("areas of unspecified colorants
+    // are erased" — §11.7.4).
+    let other_plate_action = if overprint {
+        PaintAction::Skip
+    } else {
+        PaintAction::Paint(0.0)
+    };
 
     let resolved = resolve_color_space(space_name, color_spaces, resources, doc);
     match resolved {
-        ResolvedSpace::Cmyk => {
+        ResolvedSpace::Cmyk | ResolvedSpace::IccCmyk => {
             let cmyk_state = if fill {
                 gs.fill_color_cmyk
             } else {
@@ -667,35 +725,47 @@ fn tint_for_ink(
             } else if components.len() >= 4 {
                 (components[0], components[1], components[2], components[3])
             } else {
-                return None;
+                return PaintAction::Skip;
             };
-            match target_ink {
-                "Cyan" => Some(c),
-                "Magenta" => Some(m),
-                "Yellow" => Some(y),
-                "Black" => Some(k),
-                _ => None,
+            let tint = match target_ink {
+                "Cyan" => c,
+                "Magenta" => m,
+                "Yellow" => y,
+                "Black" => k,
+                // Spot plate — not in DeviceCMYK's colorant set.
+                _ => return other_plate_action,
+            };
+            // §11.7.4 OPM=1 nonzero overprint: zero source components on
+            // DeviceCMYK are treated as "not specified" — leave the
+            // matching plate untouched. OPM=0 (default) paints zero,
+            // which erases (knocks out) the plate.
+            if overprint && opm == 1 && tint == 0.0 {
+                PaintAction::Skip
+            } else {
+                PaintAction::Paint(tint)
             }
         },
         ResolvedSpace::Rgb
         | ResolvedSpace::Gray
         | ResolvedSpace::IccRgb
         | ResolvedSpace::IccGray => {
-            // RGB / Gray content does not contribute to ink plates.
-            // Converting RGB → CMYK is intentionally not done: prepress
-            // workflows want artwork that was authored in process or
-            // spot colours, not synthesised process from RGB.
-            None
+            // §11.7.4: overprint is a separation-space concept. RGB / Gray
+            // sources do not route to ink plates at all. Converting them
+            // would require a tint transform and is intentionally not done.
+            PaintAction::Skip
         },
         ResolvedSpace::Separation(ink) => {
-            // §8.6.6.4: /All paints to every output separation; /None paints
-            // nothing. Treat the rest as a regular per-ink match.
-            if ink == "None" || components.is_empty() {
-                None
-            } else if ink == "All" || ink == target_ink {
-                Some(components[0])
+            // §8.6.6.4: /All paints to every plate; /None paints nothing.
+            if components.is_empty() || ink == "None" {
+                return PaintAction::Skip;
+            }
+            if ink == "All" {
+                return PaintAction::Paint(components[0]);
+            }
+            if ink == target_ink {
+                PaintAction::Paint(components[0])
             } else {
-                None
+                other_plate_action
             }
         },
         ResolvedSpace::DeviceN(names) => {
@@ -704,26 +774,12 @@ fn tint_for_ink(
                     continue;
                 }
                 if (n == "All" || n == target_ink) && i < components.len() {
-                    return Some(components[i]);
+                    return PaintAction::Paint(components[i]);
                 }
             }
-            None
+            other_plate_action
         },
-        ResolvedSpace::IccCmyk => {
-            // Heuristic: 4-component ICC space = CMYK. See module docs.
-            if components.len() >= 4 {
-                match target_ink {
-                    "Cyan" => Some(components[0]),
-                    "Magenta" => Some(components[1]),
-                    "Yellow" => Some(components[2]),
-                    "Black" => Some(components[3]),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        },
-        ResolvedSpace::Unknown => None,
+        ResolvedSpace::Unknown => PaintAction::Skip,
     }
 }
 
@@ -1088,7 +1144,7 @@ fn execute_separation_operators(
                     let transform = combine_transforms(base_transform, &gs.ctm);
                     let clip = clip_stack.last().and_then(|c| c.as_ref());
                     for (i, &ink) in target_inks.iter().enumerate() {
-                        if let Some(tint) = tint_for_ink(
+                        if let PaintAction::Paint(tint) = tint_for_ink(
                             false,
                             gs,
                             color_spaces,
@@ -1120,7 +1176,7 @@ fn execute_separation_operators(
                     let transform = combine_transforms(base_transform, &gs.ctm);
                     let clip = clip_stack.last().and_then(|c| c.as_ref());
                     for (i, &ink) in target_inks.iter().enumerate() {
-                        if let Some(tint) = tint_for_ink(
+                        if let PaintAction::Paint(tint) = tint_for_ink(
                             true,
                             gs,
                             color_spaces,
@@ -1159,7 +1215,7 @@ fn execute_separation_operators(
                     let transform = combine_transforms(base_transform, &gs.ctm);
                     let clip = clip_stack.last().and_then(|c| c.as_ref());
                     for (i, &ink) in target_inks.iter().enumerate() {
-                        if let Some(tint) = tint_for_ink(
+                        if let PaintAction::Paint(tint) = tint_for_ink(
                             true,
                             gs,
                             color_spaces,
@@ -1198,7 +1254,7 @@ fn execute_separation_operators(
                     let transform = combine_transforms(base_transform, &gs.ctm);
                     let clip = clip_stack.last().and_then(|c| c.as_ref());
                     for (i, &ink) in target_inks.iter().enumerate() {
-                        if let Some(tint) = tint_for_ink(
+                        if let PaintAction::Paint(tint) = tint_for_ink(
                             true,
                             gs,
                             color_spaces,
@@ -1217,7 +1273,7 @@ fn execute_separation_operators(
                                 clip,
                             );
                         }
-                        if let Some(tint) = tint_for_ink(
+                        if let PaintAction::Paint(tint) = tint_for_ink(
                             false,
                             gs,
                             color_spaces,
@@ -1249,7 +1305,7 @@ fn execute_separation_operators(
                     let transform = combine_transforms(base_transform, &gs.ctm);
                     let clip = clip_stack.last().and_then(|c| c.as_ref());
                     for (i, &ink) in target_inks.iter().enumerate() {
-                        if let Some(tint) = tint_for_ink(
+                        if let PaintAction::Paint(tint) = tint_for_ink(
                             true,
                             gs,
                             color_spaces,
@@ -1268,7 +1324,7 @@ fn execute_separation_operators(
                                 clip,
                             );
                         }
-                        if let Some(tint) = tint_for_ink(
+                        if let PaintAction::Paint(tint) = tint_for_ink(
                             false,
                             gs,
                             color_spaces,
@@ -1616,8 +1672,8 @@ fn render_text_to_plate(
             &cs.fill_components,
             &cs.stroke_components,
         ) {
-            Some(t) => t,
-            None => continue,
+            PaintAction::Paint(t) => t,
+            PaintAction::Skip => continue,
         };
 
         // Build a faked-grayscale GraphicsState so the rasteriser paints in

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -848,6 +848,9 @@ struct InheritedState {
     stroke_color_cmyk: Option<(f32, f32, f32, f32)>,
     fill_components: Vec<f32>,
     stroke_components: Vec<f32>,
+    fill_overprint: bool,
+    stroke_overprint: bool,
+    overprint_mode: u8,
 }
 
 /// Execute operators for separation plate rendering, dispatching paint
@@ -878,6 +881,14 @@ fn execute_separation_operators(
             gs.stroke_color_space = inh.stroke_color_space.clone();
             gs.fill_color_cmyk = inh.fill_color_cmyk;
             gs.stroke_color_cmyk = inh.stroke_color_cmyk;
+            // §8.10.1: inherit the caller's overprint state too. Without
+            // this, an outer `gs` setting OP=true would be silently
+            // dropped at the Form XObject boundary and the form's CMYK
+            // content would knock out underlying inks against the
+            // caller's intent.
+            gs.fill_overprint = inh.fill_overprint;
+            gs.stroke_overprint = inh.stroke_overprint;
+            gs.overprint_mode = inh.overprint_mode;
         } else {
             gs.fill_color_space = "DeviceGray".to_string();
             gs.stroke_color_space = "DeviceGray".to_string();
@@ -1597,6 +1608,9 @@ fn execute_separation_operators(
                                             stroke_color_cmyk: gs.stroke_color_cmyk,
                                             fill_components: cs.fill_components.clone(),
                                             stroke_components: cs.stroke_components.clone(),
+                                            fill_overprint: gs.fill_overprint,
+                                            stroke_overprint: gs.stroke_overprint,
+                                            overprint_mode: gs.overprint_mode,
                                         };
 
                                         let form_ops = parse_content_stream(&stream_data)?;

--- a/tests/test_separation_overprint.rs
+++ b/tests/test_separation_overprint.rs
@@ -464,6 +464,79 @@ fn cmyk_fill_with_op_true_preserves_unrelated_spot_plate() {
 }
 
 // ========================================================================
+// Form XObject inheritance (§8.10.1)
+// ========================================================================
+
+#[test]
+fn overprint_propagates_into_form_xobject() {
+    // §8.10.1: a Form XObject's initial graphics state is the calling
+    // context's graphics state. The caller sets OP=true + OPM=1, then
+    // invokes a form whose content is `0 0 0 1 k 40 40 50 50 re f`.
+    // Under the inherited OPM=1 nonzero rule, the zero M component is
+    // treated as "not specified" and the M plate is preserved. Without
+    // inheritance, OPM defaults back to 0 at the form boundary and the
+    // M plate gets knocked out — that failure is what this test catches.
+    let content = "0 1 0 0 k\n10 10 50 50 re f\n\
+                   q /GS1 gs /Fm Do Q\n";
+    let form_content = "0 0 0 1 k\n40 40 50 50 re f\n";
+    let form_obj = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+         /Resources << >> /Length {} >>\nstream\n{}\nendstream\nendobj\n",
+        form_content.len(),
+        form_content
+    );
+    let pdf = build_pdf(
+        content,
+        "/ExtGState << /GS1 << /OP true /op true /OPM 1 >> >> \
+         /XObject << /Fm 5 0 R >>",
+        &[&form_obj],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+    let k = plate(&plates, "Black");
+
+    assert!(
+        sample(m, OVERLAP_X, OVERLAP_Y) > 200,
+        "M preserved inside Form XObject under inherited OP=true + OPM=1 (got {})",
+        sample(m, OVERLAP_X, OVERLAP_Y)
+    );
+    assert!(sample(k, OVERLAP_X, OVERLAP_Y) > 200, "Black painted by form's CMYK fill");
+}
+
+#[test]
+fn overprint_caller_unaffected_by_inner_form_overprint_changes() {
+    // The form's OP changes must not leak back to the caller. Form
+    // content sets /GS1 gs (OP=true OPM=1), then the form ends. After
+    // the `Do`, the caller's gs is restored from the q/Q frame and OP
+    // is back to the original false. A subsequent caller fill must
+    // knock out per the default.
+    let content = "0 1 0 0 k\n10 10 50 50 re f\n\
+                   q /Fm Do Q\n\
+                   0 0 0 1 k\n40 40 50 50 re f\n";
+    // Form content sets OP=true / OPM=1 internally; this should NOT
+    // affect the outer scope after Do returns.
+    let form_content = "/GS1 gs\n";
+    let form_obj = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+         /Resources << /ExtGState << /GS1 << /OP true /op true /OPM 1 >> >> >> \
+         /Length {} >>\nstream\n{}\nendstream\nendobj\n",
+        form_content.len(),
+        form_content
+    );
+    let pdf = build_pdf(content, "/XObject << /Fm 5 0 R >>", &[&form_obj]);
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+
+    assert_eq!(
+        sample(m, OVERLAP_X, OVERLAP_Y),
+        0,
+        "Form's OP/OPM state must not leak past the q/Q frame"
+    );
+}
+
+// ========================================================================
 // Sanity: outside both shapes, plates are zero
 // ========================================================================
 

--- a/tests/test_separation_overprint.rs
+++ b/tests/test_separation_overprint.rs
@@ -1,0 +1,498 @@
+//! Spec-driven tests for ISO 32000-1 §11.7.4 (Overprint Control) in the
+//! separation-plate renderer.
+//!
+//! Spatial layout shared by every test:
+//!
+//! ```text
+//!   100x100 PDF page.
+//!     First  rectangle (the "background"): PDF (10, 10) (50x50)  → image rows 40-90, cols 10-60
+//!     Second rectangle (the "overlay")   : PDF (40, 40) (50x50)  → image rows 10-60, cols 40-90
+//!     Overlap region                     : PDF (40, 40)-(60, 60) → image rows 40-60, cols 40-60
+//!
+//!   Sample sites (image-space, top-left origin, +y down):
+//!     OVERLAP : (50, 50) — both rectangles paint here
+//!     FIRST   : (20, 80) — only the first rectangle paints
+//!     SECOND  : (80, 20) — only the second rectangle paints
+//!     OUTSIDE : ( 5,  5) — neither paints
+//! ```
+
+#![cfg(feature = "rendering")]
+
+use pdf_oxide::document::PdfDocument;
+use pdf_oxide::rendering::{render_separation, render_separations, SeparationPlate};
+
+const OVERLAP_X: u32 = 50;
+const OVERLAP_Y: u32 = 50;
+const FIRST_X: u32 = 20;
+const FIRST_Y: u32 = 80;
+const SECOND_X: u32 = 80;
+const SECOND_Y: u32 = 20;
+
+fn sample(plate: &SeparationPlate, x: u32, y: u32) -> u8 {
+    plate.data[(y * plate.width + x) as usize]
+}
+
+fn plate<'a>(plates: &'a [SeparationPlate], name: &str) -> &'a SeparationPlate {
+    plates
+        .iter()
+        .find(|p| p.ink_name == name)
+        .unwrap_or_else(|| panic!("missing plate {name:?}; have {:?}", names(plates)))
+}
+
+fn names(plates: &[SeparationPlate]) -> Vec<&str> {
+    plates.iter().map(|p| p.ink_name.as_str()).collect()
+}
+
+/// Build a single-page PDF given a content stream and an optional /Resources
+/// override fragment (e.g. ColorSpace + ExtGState declarations). Resources
+/// always include the entries the caller supplied; the page itself is 100x100.
+fn build_pdf(content: &str, resources_inner: &str, extra_objs: &[&str]) -> Vec<u8> {
+    let content_bytes = content.as_bytes();
+    let mut buf = Vec::new();
+    let mut offsets = Vec::new();
+
+    buf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    offsets.push(buf.len());
+    let page = format!(
+        "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+         /Contents 4 0 R /Resources << {} >> >>\nendobj\n",
+        resources_inner
+    );
+    buf.extend_from_slice(page.as_bytes());
+
+    offsets.push(buf.len());
+    let header = format!("4 0 obj\n<< /Length {} >>\nstream\n", content_bytes.len());
+    buf.extend_from_slice(header.as_bytes());
+    buf.extend_from_slice(content_bytes);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    for obj in extra_objs {
+        offsets.push(buf.len());
+        buf.extend_from_slice(obj.as_bytes());
+        if !obj.ends_with('\n') {
+            buf.push(b'\n');
+        }
+    }
+
+    let xref_offset = buf.len();
+    buf.extend_from_slice(b"xref\n");
+    buf.extend_from_slice(format!("0 {}\n", offsets.len() + 1).as_bytes());
+    buf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    buf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len() + 1,
+            xref_offset
+        )
+        .as_bytes(),
+    );
+    buf
+}
+
+// ========================================================================
+// DeviceCMYK + default overprint (OP=false, the §11.7.4 spec default)
+// ========================================================================
+
+#[test]
+fn cmyk_black_default_knocks_out_underlying_magenta() {
+    // §11.7.4: with OP=false, painting in DeviceCMYK over an area where
+    // Magenta was previously painted erases (sets to 0) the Magenta plate
+    // inside the new shape. The first fill paints Magenta = 1.0; the
+    // second fill is `0 0 0 1 k` → all four CMYK components specified
+    // (M = 0.0), so the M plate is knocked out in the overlap.
+    let pdf = build_pdf("0 1 0 0 k\n10 10 50 50 re f\n0 0 0 1 k\n40 40 50 50 re f\n", "", &[]);
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+    let k = plate(&plates, "Black");
+
+    assert_eq!(
+        sample(m, OVERLAP_X, OVERLAP_Y),
+        0,
+        "Magenta should be knocked out in overlap under OP=false default"
+    );
+    assert!(
+        sample(m, FIRST_X, FIRST_Y) > 200,
+        "Magenta preserved in first-only region (got {})",
+        sample(m, FIRST_X, FIRST_Y)
+    );
+    assert!(
+        sample(k, OVERLAP_X, OVERLAP_Y) > 200,
+        "Black painted in overlap (got {})",
+        sample(k, OVERLAP_X, OVERLAP_Y)
+    );
+}
+
+// ========================================================================
+// DeviceCMYK + OP=true (overprint enabled, OPM=0 default)
+// ========================================================================
+
+#[test]
+fn cmyk_black_with_op_true_opm0_still_knocks_out_underlying_magenta() {
+    // §11.7.4: OPM=0 means "each source colour component value replaces
+    // the value previously painted... no matter what the new value is."
+    // So even with OP=true, a 0.0 M component still knocks the M plate
+    // to zero. The OPM=1 nonzero rule is what protects zero components.
+    let pdf = build_pdf(
+        "0 1 0 0 k\n10 10 50 50 re f\n/GS1 gs 0 0 0 1 k\n40 40 50 50 re f\n",
+        "/ExtGState << /GS1 << /OP true /op true /OPM 0 >> >>",
+        &[],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+
+    assert_eq!(
+        sample(m, OVERLAP_X, OVERLAP_Y),
+        0,
+        "OPM=0 + OP=true: zero M component still knocks out M plate"
+    );
+}
+
+#[test]
+fn cmyk_black_with_op_true_opm1_preserves_underlying_magenta() {
+    // §11.7.4 (worked example, Example 4.18): under OP=true + OPM=1,
+    // `0 0 0 1 k` is equivalent to painting in a DeviceN[C, M, Black]
+    // space — zero components are treated as "not specified." So the
+    // Magenta plate is left untouched within the overlap.
+    let pdf = build_pdf(
+        "0 1 0 0 k\n10 10 50 50 re f\n/GS1 gs 0 0 0 1 k\n40 40 50 50 re f\n",
+        "/ExtGState << /GS1 << /OP true /op true /OPM 1 >> >>",
+        &[],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+    let k = plate(&plates, "Black");
+
+    assert!(
+        sample(m, OVERLAP_X, OVERLAP_Y) > 200,
+        "OPM=1: M preserved in overlap (got {})",
+        sample(m, OVERLAP_X, OVERLAP_Y)
+    );
+    assert!(
+        sample(k, OVERLAP_X, OVERLAP_Y) > 200,
+        "K painted in overlap (got {})",
+        sample(k, OVERLAP_X, OVERLAP_Y)
+    );
+}
+
+// ========================================================================
+// Separation / Spot ink against CMYK process background
+// ========================================================================
+
+fn pantone_185_cs_obj() -> &'static str {
+    "5 0 obj\n[/Separation /Pantone-185 /DeviceCMYK << \
+        /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] \
+        /C1 [0 0.85 0.45 0] /N 1 >>]\nendobj\n"
+}
+
+#[test]
+fn separation_spot_default_knocks_out_underlying_process_plates() {
+    // §11.7.4 default: painting in Separation /Pantone-185 over a
+    // Magenta background causes the M plate to be erased to 0 within
+    // the spot fill's shape ("areas of unspecified colorants are
+    // erased"). The Pantone-185 plate gets the spot fill.
+    let pdf = build_pdf(
+        "0 1 0 0 k\n10 10 50 50 re f\n/CS1 cs 1 scn\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >>",
+        &[pantone_185_cs_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+    let pantone = plate(&plates, "Pantone-185");
+
+    assert_eq!(
+        sample(m, OVERLAP_X, OVERLAP_Y),
+        0,
+        "M knocked out under Pantone fill (OP=false default)"
+    );
+    assert!(
+        sample(pantone, OVERLAP_X, OVERLAP_Y) > 200,
+        "Pantone painted in overlap (got {})",
+        sample(pantone, OVERLAP_X, OVERLAP_Y)
+    );
+    assert!(sample(m, FIRST_X, FIRST_Y) > 200, "M preserved outside Pantone shape");
+}
+
+#[test]
+fn separation_spot_with_op_true_preserves_underlying_process_plates() {
+    // §11.7.4 OP=true: anything previously painted in other colorants
+    // is left undisturbed. This is the "spot ink overprints process"
+    // case that designers explicitly enable for typical packaging art.
+    let pdf = build_pdf(
+        "0 1 0 0 k\n10 10 50 50 re f\n\
+         /GS1 gs /CS1 cs 1 scn\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >> \
+         /ExtGState << /GS1 << /OP true /op true >> >>",
+        &[pantone_185_cs_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+    let pantone = plate(&plates, "Pantone-185");
+
+    assert!(
+        sample(m, OVERLAP_X, OVERLAP_Y) > 200,
+        "M preserved under Pantone fill with OP=true (got {})",
+        sample(m, OVERLAP_X, OVERLAP_Y)
+    );
+    assert!(sample(pantone, OVERLAP_X, OVERLAP_Y) > 200, "Pantone painted");
+}
+
+#[test]
+fn opm_one_does_not_apply_to_separation_source() {
+    // §11.7.4.3: the OPM=1 "treat zero as not-specified" rule applies
+    // only to DeviceCMYK sources. A Separation/DeviceN source ignores
+    // OPM entirely — overprint vs knockout is governed by OP/op alone.
+    // Verify by: separation source with /OP true /OPM 1, with the
+    // *tint* set to 0.0 (which OPM=1 would treat as "skip" for DeviceCMYK).
+    // Under §11.7.4.3 the Pantone plate is still painted with 0.0
+    // (knockout-of-self, not skip).
+    let pdf = build_pdf(
+        "/CS1 cs 1 scn\n10 10 50 50 re f\n\
+         /GS1 gs /CS1 cs 0 scn\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >> \
+         /ExtGState << /GS1 << /OP true /op true /OPM 1 >> >>",
+        &[pantone_185_cs_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let pantone = plate(&plates, "Pantone-185");
+
+    // The second fill (tint 0.0) DOES touch the Pantone plate — OPM=1
+    // does not apply to Separation sources, so it paints 0.0 (knockout).
+    assert_eq!(
+        sample(pantone, OVERLAP_X, OVERLAP_Y),
+        0,
+        "OPM=1 does not skip on Separation source; tint 0.0 still knocks out"
+    );
+    assert!(
+        sample(pantone, FIRST_X, FIRST_Y) > 200,
+        "First fill at tint 1.0 preserved outside overlap"
+    );
+}
+
+// ========================================================================
+// /All and /None colorants (§8.6.6.4)
+// ========================================================================
+
+fn all_separation_cs_obj() -> &'static str {
+    "5 0 obj\n[/Separation /All /DeviceGray << \
+        /FunctionType 2 /Domain [0 1] /C0 [0] /C1 [1] /N 1 >>]\nendobj\n"
+}
+
+fn none_separation_cs_obj() -> &'static str {
+    "5 0 obj\n[/Separation /None /DeviceGray << \
+        /FunctionType 2 /Domain [0 1] /C0 [0] /C1 [1] /N 1 >>]\nendobj\n"
+}
+
+#[test]
+fn all_colorant_paints_every_plate_regardless_of_overprint() {
+    // §8.6.6.4: /All "refers collectively to all colorants available on
+    // an output device". Overprint setting is irrelevant.
+    let pdf = build_pdf(
+        "/CS1 cs 0.5 scn\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >>",
+        &[all_separation_cs_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+
+    // /All declares no specific ink name → only the process plates exist
+    // in the output. Each should carry tint 0.5.
+    for ink in ["Cyan", "Magenta", "Yellow", "Black"] {
+        let p = plate(&plates, ink);
+        let v = sample(p, OVERLAP_X, OVERLAP_Y);
+        assert!(v > 100 && v < 160, "/All should paint {ink} at tint 0.5 (got {v})",);
+    }
+}
+
+#[test]
+fn none_colorant_paints_nothing_and_does_not_knock_out() {
+    // §8.6.6.4: a /None Separation "has no effect on the current page."
+    // Underlying ink is preserved regardless of OP setting.
+    let pdf = build_pdf(
+        "0 1 0 0 k\n10 10 50 50 re f\n\
+         /CS1 cs 1 scn\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >>",
+        &[none_separation_cs_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+
+    assert!(sample(m, OVERLAP_X, OVERLAP_Y) > 200, "Magenta preserved under /None fill");
+}
+
+// ========================================================================
+// Save/restore isolation
+// ========================================================================
+
+#[test]
+fn save_restore_isolates_overprint_state() {
+    // q gs(OP=true) … Q must restore OP=false. Two fills, second outside
+    // the q…Q block — its OP must NOT inherit the OP=true from inside.
+    let pdf = build_pdf(
+        "0 1 0 0 k\n10 10 50 50 re f\n\
+         q /GS1 gs Q\n\
+         0 0 0 1 k\n40 40 50 50 re f\n",
+        "/ExtGState << /GS1 << /OP true /op true /OPM 1 >> >>",
+        &[],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+
+    // After Q, OP is back to default false → M knocks out.
+    assert_eq!(
+        sample(m, OVERLAP_X, OVERLAP_Y),
+        0,
+        "OP=true inside q…Q must not leak past Q (default knockout restored)"
+    );
+}
+
+// ========================================================================
+// Stroke vs fill overprint independence (§11.7.4 /OP vs /op)
+// ========================================================================
+
+#[test]
+fn fill_overprint_only_does_not_affect_stroke() {
+    // op=true (fill overprint) but OP defaults to false (stroke knockout).
+    // A subsequent stroke should still knock out underlying inks.
+    //
+    // Layout: full-width Magenta fill, then a stroked rectangle on top.
+    // The stroke uses CMYK with M=0 → if stroke knockout is honored, the
+    // pixels along the stroke path lose Magenta. If stroke overprint were
+    // incorrectly enabled, they would keep it.
+    let pdf = build_pdf(
+        // Fill the whole page with Magenta first.
+        "0 1 0 0 k\n0 0 100 100 re f\n\
+         /GS1 gs\n\
+         5 w 0 0 0 1 K\n\
+         40 40 50 50 re S\n",
+        "/ExtGState << /GS1 << /op true /OPM 0 >> >>",
+        &[],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+
+    // Sample directly on the stroke path. The rectangle's top edge in
+    // PDF coords is y=90 (image y=10). With line width 5, the stroke
+    // covers image y ∈ [7.5, 12.5]. Pick (60, 10).
+    let stroke_sample = sample(m, 60, 10);
+    assert_eq!(
+        stroke_sample, 0,
+        "stroke knockout still applies when only /op (fill) overprint set"
+    );
+
+    // And confirm the rectangle interior (not painted by either fill or
+    // stroke since we only stroked) keeps its background Magenta.
+    let interior_sample = sample(m, 60, 35);
+    assert!(
+        interior_sample > 200,
+        "rectangle interior keeps background M (no fill, no stroke here); got {}",
+        interior_sample
+    );
+}
+
+// ========================================================================
+// Plates outside any source space stay untouched
+// ========================================================================
+
+#[test]
+fn cmyk_fill_does_not_knock_out_unrelated_spot_plate_under_default() {
+    // The OP=false default knockout per §11.7.4 applies to colorants
+    // *of the source's process model that aren't specified*. For a
+    // DeviceCMYK source over a Pantone-185 background, the Pantone
+    // plate is NOT a colorant of the source's process model — it's a
+    // spot that exists on the output device. The default still erases
+    // it inside the painted shape per the spec's text: "the
+    // corresponding areas of unspecified colorants" — Pantone-185 is
+    // unspecified by the DeviceCMYK source.
+    //
+    // This pins what every prepress engine does: a CMYK black fill
+    // over a spot background DOES knock out the spot in the overlap.
+    let pdf = build_pdf(
+        "/CS1 cs 1 scn\n10 10 50 50 re f\n\
+         0 0 0 1 k\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >>",
+        &[pantone_185_cs_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let pantone = plate(&plates, "Pantone-185");
+
+    assert_eq!(
+        sample(pantone, OVERLAP_X, OVERLAP_Y),
+        0,
+        "CMYK source under default knocks out spot plate in overlap"
+    );
+}
+
+#[test]
+fn cmyk_fill_with_op_true_preserves_unrelated_spot_plate() {
+    // Same scenario with OP=true: spot plate preserved.
+    let pdf = build_pdf(
+        "/CS1 cs 1 scn\n10 10 50 50 re f\n\
+         /GS1 gs 0 0 0 1 k\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >> \
+         /ExtGState << /GS1 << /OP true /op true >> >>",
+        &[pantone_185_cs_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let pantone = plate(&plates, "Pantone-185");
+
+    assert!(
+        sample(pantone, OVERLAP_X, OVERLAP_Y) > 200,
+        "OP=true: spot plate preserved under CMYK overlap (got {})",
+        sample(pantone, OVERLAP_X, OVERLAP_Y)
+    );
+}
+
+// ========================================================================
+// Sanity: outside both shapes, plates are zero
+// ========================================================================
+
+#[test]
+fn outside_both_shapes_all_plates_are_zero() {
+    let pdf = build_pdf("0 1 0 0 k\n10 10 50 50 re f\n0 0 0 1 k\n40 40 50 50 re f\n", "", &[]);
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    for p in &plates {
+        assert_eq!(
+            sample(p, 5, 5),
+            0,
+            "plate {} should be zero outside any painted shape",
+            p.ink_name
+        );
+    }
+}
+
+// Suppress dead-code warnings on the SECOND_* constants if a future test
+// removes the only use; keeping them documented for the spatial layout.
+#[allow(dead_code)]
+fn _unused_pinned_layout() -> (u32, u32) {
+    (SECOND_X, SECOND_Y)
+}
+
+// Suppress dead-code warning for render_separation import if not exercised
+// in this file — it's part of the public API surface that may be used by
+// follow-up tests in this module.
+#[allow(dead_code)]
+fn _api_surface(doc: &PdfDocument) -> Option<SeparationPlate> {
+    render_separation(doc, 0, "Cyan", 72).ok()
+}

--- a/tests/test_separation_overprint.rs
+++ b/tests/test_separation_overprint.rs
@@ -188,6 +188,58 @@ fn cmyk_black_with_op_true_opm1_preserves_underlying_magenta() {
 }
 
 // ========================================================================
+// ICCBased(N=4) — OPM=1 nonzero-overprint scope per §11.7.4.3
+// ========================================================================
+
+/// ICCBased /N 4 colour-space object. The profile stream payload is
+/// empty (length 0); the resolver only consults /N to classify as
+/// IccCmyk per the renderer's documented 4-component heuristic.
+fn icc_cmyk_cs_obj() -> &'static str {
+    "5 0 obj\n[/ICCBased 6 0 R]\nendobj\n"
+}
+
+fn icc_cmyk_stream_obj() -> &'static str {
+    "6 0 obj\n<< /N 4 /Alternate /DeviceCMYK /Length 0 >>\nstream\n\nendstream\nendobj\n"
+}
+
+#[test]
+fn icc_cmyk_with_op_true_opm1_preserves_underlying_magenta() {
+    // §11.7.4.3 OPM scope: "applies only to painting operations that use
+    // the current color in the graphics state when the current color
+    // space is DeviceCMYK (or is implicitly converted to DeviceCMYK)."
+    // An ICCBased N=4 space classified as IccCmyk falls under the
+    // "implicitly converted to DeviceCMYK" clause for our renderer
+    // (per the module-level ICCBased heuristic). OPM=1 + OP=true on an
+    // IccCmyk source should still skip plates whose component is 0.0.
+    //
+    // Layout: paint M=1 background, then paint `0 0 0 1 scn` through
+    // /CS1 (an ICCBased N=4 space) under /GS1 (OP=true / OPM=1). The
+    // Magenta plate must be preserved in the overlap.
+    let pdf = build_pdf(
+        "0 1 0 0 k\n10 10 50 50 re f\n\
+         /GS1 gs /CS1 cs 0 0 0 1 scn\n40 40 50 50 re f\n",
+        "/ColorSpace << /CS1 5 0 R >> \
+         /ExtGState << /GS1 << /OP true /op true /OPM 1 >> >>",
+        &[icc_cmyk_cs_obj(), icc_cmyk_stream_obj()],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let m = plate(&plates, "Magenta");
+    let k = plate(&plates, "Black");
+
+    assert!(
+        sample(m, OVERLAP_X, OVERLAP_Y) > 200,
+        "OPM=1 on IccCmyk: M preserved in overlap (got {})",
+        sample(m, OVERLAP_X, OVERLAP_Y)
+    );
+    assert!(
+        sample(k, OVERLAP_X, OVERLAP_Y) > 200,
+        "K painted in overlap (got {})",
+        sample(k, OVERLAP_X, OVERLAP_Y)
+    );
+}
+
+// ========================================================================
 // Separation / Spot ink against CMYK process background
 // ========================================================================
 

--- a/tests/test_separation_rendering.rs
+++ b/tests/test_separation_rendering.rs
@@ -968,12 +968,12 @@ mod tests {
     // turns them into passing regression tests.
     // =====================================================================
 
-    /// §11.7.4.4 — Overprint mode. With OP=true and OPM=0 (default), painting
-    /// a Separation ink on top of CMYK content should *add* to the spot plate
-    /// while leaving the underlying CMYK plates unchanged. Without overprint
-    /// the spot paint knocks out the CMYK at those pixels.
+    /// §11.7.4 — Overprint. With OP=true painting a Separation ink on top of
+    /// CMYK content adds to the spot plate while leaving the underlying CMYK
+    /// plates unchanged. Without overprint the spot paint knocks out the CMYK
+    /// at those pixels (covered by the spec-default tests in
+    /// `tests/test_separation_overprint.rs`).
     #[test]
-    #[ignore = "spec gap: overprint (/OP, /op, /OPM) — §11.7 not yet implemented"]
     fn test_overprint_preserves_underlying_ink() {
         // K rect 50% under, Separation rect on top with OP=true via /GS1.
         // Spec: spot paint with overprint preserves underlying K plate.
@@ -996,10 +996,11 @@ mod tests {
         let doc = PdfDocument::from_bytes(pdf).unwrap();
         let plates = render_separations(&doc, 0, 144).unwrap();
 
-        // Sample center of the overlap region (where the spot rect sits on top of K).
+        // Sample center of the overlap. Page is 100x100pt at 144 DPI →
+        // image is 200x200, so PDF (50,50) lands at image (100,100).
         let black = plates.iter().find(|p| p.ink_name == "Black").unwrap();
         let bw = black.width as usize;
-        let center = black.data[(50 * bw) + 50];
+        let center = black.data[(100 * bw) + 100];
         assert!(
             (100..=140).contains(&center),
             "Black plate at overlap should retain ~50% tint under overprinted spot, got {}",
@@ -1008,7 +1009,10 @@ mod tests {
 
         let spot = plates.iter().find(|p| p.ink_name == "SpotInk").unwrap();
         let sw = spot.width as usize;
-        assert!(spot.data[(50 * sw) + 50] > 200, "SpotInk plate should show the overprinted ink");
+        assert!(
+            spot.data[(100 * sw) + 100] > 200,
+            "SpotInk plate should show the overprinted ink"
+        );
     }
 
     /// §9.3.6 — Text rendering mode 3 = "neither fill nor stroke (invisible)".


### PR DESCRIPTION
## Description

Implements PDF overprint per ISO 32000-1 §11.7.4 in the separation-plate renderer. The previous implementation silently treated every plate outside the source color space as "skip" — which matched OP=true behavior — meaning the spec-default knockout case ("areas of unspecified colorants are erased") was unreachable.

Concretely this surfaced two bugs prior to the change: a DeviceCMYK fill over a spot background did not knock out the spot plate inside the painted shape, and a Separation/Pantone fill over a process background did not knock out the process plates. After this change, both produce the spec-correct knockout under OP=false (default) and preserve under OP=true.

The §11.7.4.3 OPM=1 "Adobe nonzero overprint" scope is honored: the zero-component-skip rule applies *only* to DeviceCMYK sources; Separation and DeviceN sources route per-colorant regardless of OPM. 
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Tests
- [ ] CI/CD changes

## Related Issues

No tracking issue. The behavior gap was discovered while running the separation renderer on real Esko prepress artwork and is documented in the §11.7.4 spec citations on each commit.

## Changes Made

- **ExtGState parser** (`src/rendering/ext_gstate.rs`): reads `/OP`, `/op`, `/OPM`; honors the §11.7.4 / Table 128 rule that `/OP` without `/op` sets both; clamps `/OPM` values to `0` or `1`.
- **GraphicsState** (`src/content/graphics_state.rs`): new `fill_overprint`, `stroke_overprint`, `overprint_mode` fields with spec defaults `false / false / 0`. Participates in `q`/`Q` save/restore via the existing stack.
- **Per-plate routing** (`src/rendering/separation_renderer.rs`): `tint_for_ink` refactored from `Option<f32>` to a `PaintAction { Paint(f32), Skip }` enum. `Paint(0.0)` produces the spec-default knockout via `BlendMode::SourceOver` at alpha 255 (opaque replacement); `Skip` leaves the plate untouched. All 8 call sites (5 path-paint operators + 2 fill+stroke combos + text path) updated.
- **Form XObject inheritance** (§8.10.1): `InheritedState` extended with the three overprint fields so a form invoked via `Do` sees the caller's OP/OPM state.
- **Module rustdoc**: new `# Overprint` section describing the per-plate model, the §11.7.4.3 OPM scope, and `q`/`Q` participation.
- **15 spec-driven integration tests** in `tests/test_separation_overprint.rs` covering default knockout vs OP=true preservation for both DeviceCMYK and Separation sources, OPM=0 vs OPM=1, OPM=1 inapplicability to Separation, `/All` paints every plate, `/None` paints nothing, stroke/fill overprint independence, `q`/`Q` save-restore isolation, unrelated-spot knockout under default + preservation under OP=true, and Form XObject inheritance + isolation.
- **One previously-ignored test un-ignored**: `test_overprint_preserves_underlying_ink` in `tests/test_separation_rendering.rs` was documented as a spec gap and tagged `#[ignore]`. It is now active, with DPI-aware sample coordinates corrected (the 100×100 pt page at 144 DPI samples PDF (50,50) at image (100,100), not (50,50)).

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have run `cargo test --all-features`
- [ ] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

Test counts:
- 15 new integration tests in `tests/test_separation_overprint.rs` — all pass
- 1 previously-ignored test now active and passing
- 24/24 in `tests/test_separation_rendering.rs` (8 still `#[ignore]`'d as unrelated spec gaps)
- 5431/5431 lib tests pass
- `cargo doc --no-deps` clean

Clippy is unchecked because the repo's `clippy.toml` references the `clippy::manual_checked_ops` lint name which produces an `unknown lint: clippy::manual_checked_ops` warning under the installed toolchain — unrelated to this PR. Plain `cargo clippy --features rendering --lib --tests` reports no warnings on the changed files.

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

No Python surface change. Overprint is consumed transparently by `render_separations` and `render_separation`; the existing Python bindings expose the same separation plates with the spec-correct routing.

## Documentation

- [x] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md


## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)

N/A — the visible difference is on per-plate output, not composite render. Behavior is verified via the 15 spatial-assertion integration tests.

## Additional Notes

**Stand-alone PR.** This is one of four independent branches from a recent debugging session on Esko packaging artwork. The others fix the spec-default behavior of `get_page_inks` (nested-form spot ink discovery), an embedded CFF subset GID-mapping bug (badge text rendering as bare 'A' glyphs), and image XObject routing to ink plates. Each PR can be reviewed and merged in any order; the overprint work here is the foundation the image PR's `paint_image_to_plates` is designed against (image routing currently follows main's pre-overprint vector behavior and will gain the OP/OPM/§11.7.4.3 carve-out automatically once both branches land).

**Spec citations on every commit.** Each commit message references the ISO 32000-1 section it implements, and the source code has `§11.7.4` / `§11.7.4.3` / `§8.6.6.4` / `§8.10.1` comments at the relevant decision points.
