### PR TITLE
feat: spot ink discovery deep

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -10619,6 +10619,169 @@ impl PdfDocument {
         Ok(ink_names)
     }
 
+    /// List ink / separation names declared on a page **including** those
+    /// declared inside Form XObjects reached through the page's content-stream
+    /// `Do` operators.
+    ///
+    /// Walks the page's content stream looking for `Do` operators that invoke
+    /// Form XObjects (§8.10), recurses into each form's `/Resources/ColorSpace`
+    /// dictionary, and accumulates `/Separation` and `/DeviceN` ink names from
+    /// every visited resource tree.
+    ///
+    /// **Cycle handling:** indirect XObject references are deduplicated by
+    /// `ObjectRef`; recursion depth is bounded at `MAX_RECURSION_DEPTH` (100).
+    /// A cycle below the depth bound is silently terminated; a tree deeper
+    /// than the bound returns [`Error::RecursionLimitExceeded`].
+    ///
+    /// **Out of scope:** tiling / shading patterns (§8.7) and annotation
+    /// appearance streams (§12.5.5) — both can declare their own colour
+    /// spaces but the separation renderer does not paint into them, so
+    /// surfacing their inks here would create plates that stay empty.
+    pub fn get_page_inks_deep(&self, page_index: usize) -> Result<Vec<String>> {
+        let resources = self.get_page_resources(page_index)?;
+        let content_data = self.get_page_content_data(page_index)?;
+        let operators = crate::content::parser::parse_content_stream(&content_data)?;
+
+        let mut ink_names: Vec<String> = Vec::new();
+        let mut visited: std::collections::HashSet<crate::object::ObjectRef> =
+            std::collections::HashSet::new();
+
+        self.collect_inks_from_resources(&resources, &mut ink_names)?;
+        self.walk_form_xobject_tree_for_inks(
+            &operators,
+            &resources,
+            &mut ink_names,
+            &mut visited,
+            0,
+        )?;
+
+        ink_names.sort();
+        ink_names.dedup();
+        Ok(ink_names)
+    }
+
+    /// Append inks declared in `resources./ColorSpace` (resolving indirect
+    /// references) to `out`. Internal helper for both
+    /// [`Self::get_page_inks_deep`] and the recursive form walker.
+    fn collect_inks_from_resources(&self, resources: &Object, out: &mut Vec<String>) -> Result<()> {
+        let res_dict = match resources.as_dict() {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+        let cs_obj = match res_dict.get("ColorSpace") {
+            Some(obj) => self.resolve_object(obj)?,
+            None => return Ok(()),
+        };
+        let cs_dict_raw = match cs_obj.as_dict() {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+
+        let mut resolved: std::collections::HashMap<String, Object> =
+            std::collections::HashMap::with_capacity(cs_dict_raw.len());
+        for (name, cs_def) in cs_dict_raw.iter() {
+            let v = match cs_def.as_reference() {
+                Some(r) => match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(_) => continue,
+                },
+                None => cs_def.clone(),
+            };
+            resolved.insert(name.clone(), v);
+        }
+        extract_inks_from_color_space_dict(&resolved, out);
+        Ok(())
+    }
+
+    /// Recursive walker: for every `Operator::Do { name }` in `operators` that
+    /// resolves to a Form XObject, scan that form's `/Resources/ColorSpace`
+    /// and recurse into the form's own content stream.
+    ///
+    /// `visited` is keyed on the XObject's `ObjectRef` (indirect references
+    /// only). Inline-stream forms cannot self-reference (no name to invoke);
+    /// the depth limit is the backstop for any other malformed shape.
+    fn walk_form_xobject_tree_for_inks(
+        &self,
+        operators: &[crate::content::operators::Operator],
+        parent_resources: &Object,
+        out: &mut Vec<String>,
+        visited: &mut std::collections::HashSet<crate::object::ObjectRef>,
+        depth: u32,
+    ) -> Result<()> {
+        if depth >= MAX_RECURSION_DEPTH {
+            return Err(Error::RecursionLimitExceeded(MAX_RECURSION_DEPTH));
+        }
+        let xobjects = match parent_resources.as_dict() {
+            Some(rd) => match rd.get("XObject") {
+                Some(o) => self.resolve_object(o)?,
+                None => return Ok(()),
+            },
+            None => return Ok(()),
+        };
+        let xobj_dict = match xobjects.as_dict() {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+
+        for op in operators {
+            let name = match op {
+                crate::content::operators::Operator::Do { name } => name,
+                _ => continue,
+            };
+            let xobj_entry = match xobj_dict.get(name) {
+                Some(o) => o,
+                None => continue,
+            };
+            let xobj_ref = xobj_entry.as_reference();
+            if let Some(r) = xobj_ref {
+                // Cycle through indirect refs: silent skip below depth bound.
+                if !visited.insert(r) {
+                    continue;
+                }
+            }
+            let xobj = match self.resolve_object(xobj_entry) {
+                Ok(o) => o,
+                Err(_) => continue,
+            };
+            let (form_dict, form_stream) = match xobj {
+                Object::Stream { ref dict, .. } => {
+                    if dict.get("Subtype").and_then(Object::as_name) != Some("Form") {
+                        continue;
+                    }
+                    let data = match xobj_ref {
+                        Some(r) => self.decode_stream_with_encryption(&xobj, r)?,
+                        None => xobj.decode_stream_data()?,
+                    };
+                    (dict.clone(), data)
+                },
+                _ => continue,
+            };
+
+            // §8.10.1: form may override resources or inherit the parent's.
+            let form_resources = match form_dict.get("Resources") {
+                Some(res) => self.resolve_object(res)?,
+                None => parent_resources.clone(),
+            };
+            self.collect_inks_from_resources(&form_resources, out)?;
+
+            // Recurse into the form's own content stream looking for nested
+            // `Do`. Malformed streams are tolerated — we want graceful
+            // degradation in a discovery API, not a hard error.
+            let form_ops = match crate::content::parser::parse_content_stream(&form_stream) {
+                Ok(ops) => ops,
+                Err(_) => continue,
+            };
+            self.walk_form_xobject_tree_for_inks(
+                &form_ops,
+                &form_resources,
+                out,
+                visited,
+                depth + 1,
+            )?;
+        }
+        Ok(())
+    }
+
     /// # Performance Note
     ///
     /// Character extraction is typically 30-50% faster than span extraction

--- a/src/document.rs
+++ b/src/document.rs
@@ -632,6 +632,53 @@ fn contains_objstm_marker(window: &[u8]) -> bool {
     false
 }
 
+/// Append ink names declared by `Separation` and `DeviceN` colour spaces
+/// in `cs_dict` to `out`. Reserved colorants `/All` and `/None` (§8.6.6.4)
+/// are skipped. Caller is responsible for deduping across multiple calls.
+///
+/// Used by both [`PdfDocument::get_page_inks`] and
+/// [`PdfDocument::get_page_inks_deep`] so the per-colorant rules live in
+/// exactly one place.
+fn extract_inks_from_color_space_dict(
+    cs_dict: &std::collections::HashMap<String, Object>,
+    out: &mut Vec<String>,
+) {
+    for cs_def in cs_dict.values() {
+        let arr = match cs_def.as_array() {
+            Some(a) => a,
+            None => continue,
+        };
+        if arr.len() < 2 {
+            continue;
+        }
+        let cs_type = match arr.first().and_then(Object::as_name) {
+            Some(n) => n,
+            None => continue,
+        };
+        match cs_type {
+            "Separation" => {
+                if let Some(ink) = arr.get(1).and_then(Object::as_name) {
+                    if ink != "All" && ink != "None" {
+                        out.push(ink.to_string());
+                    }
+                }
+            },
+            "DeviceN" => {
+                if let Some(Object::Array(inks)) = arr.get(1) {
+                    for ink_obj in inks {
+                        if let Some(ink) = ink_obj.as_name() {
+                            if ink != "All" && ink != "None" {
+                                out.push(ink.to_string());
+                            }
+                        }
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
 impl PdfDocument {
     /// Open a PDF document from in-memory bytes.
     ///
@@ -10548,9 +10595,12 @@ impl PdfDocument {
             None => return Ok(Vec::new()),
         };
 
-        let mut ink_names = Vec::new();
-        for (_name, cs_def) in cs_dict.iter() {
-            let cs_arr_obj = if let Some(r) = cs_def.as_reference() {
+        // Resolve any indirect references so the extractor sees inline
+        // arrays. Mirrors the pre-existing per-entry resolve loop.
+        let mut resolved: std::collections::HashMap<String, Object> =
+            std::collections::HashMap::with_capacity(cs_dict.len());
+        for (name, cs_def) in cs_dict.iter() {
+            let v = if let Some(r) = cs_def.as_reference() {
                 match self.load_object(r) {
                     Ok(o) => o,
                     Err(_) => continue,
@@ -10558,39 +10608,11 @@ impl PdfDocument {
             } else {
                 cs_def.clone()
             };
-
-            if let Some(arr) = cs_arr_obj.as_array() {
-                if arr.len() >= 2 {
-                    if let Some(Object::Name(cs_type)) = arr.first() {
-                        match cs_type.as_str() {
-                            "Separation" => {
-                                // [/Separation /InkName /AlternateCS /TintTransform]
-                                // §8.6.6.4: /All and /None are reserved colorant names
-                                // (paint to all / paint to none) and never name a plate.
-                                if let Some(Object::Name(ink)) = arr.get(1) {
-                                    if ink != "All" && ink != "None" {
-                                        ink_names.push(ink.clone());
-                                    }
-                                }
-                            },
-                            "DeviceN" => {
-                                // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
-                                if let Some(Object::Array(inks)) = arr.get(1) {
-                                    for ink_obj in inks {
-                                        if let Object::Name(ink) = ink_obj {
-                                            if ink != "All" && ink != "None" {
-                                                ink_names.push(ink.clone());
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            _ => {},
-                        }
-                    }
-                }
-            }
+            resolved.insert(name.clone(), v);
         }
+
+        let mut ink_names = Vec::new();
+        extract_inks_from_color_space_dict(&resolved, &mut ink_names);
 
         ink_names.sort();
         ink_names.dedup();
@@ -21873,5 +21895,80 @@ mod tests {
         let paths = doc.extract_paths(0).unwrap();
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0].layer, None);
+    }
+}
+
+#[cfg(test)]
+mod ink_dict_extractor_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn name(s: &str) -> Object {
+        Object::Name(s.to_string())
+    }
+
+    fn separation_cs(ink: &str) -> Object {
+        Object::Array(vec![name("Separation"), name(ink), name("DeviceCMYK"), Object::Null])
+    }
+
+    fn device_n_cs(inks: &[&str]) -> Object {
+        Object::Array(vec![
+            name("DeviceN"),
+            Object::Array(inks.iter().map(|s| name(s)).collect()),
+            name("DeviceCMYK"),
+            Object::Null,
+        ])
+    }
+
+    #[test]
+    fn extracts_separation_ink_name() {
+        let mut cs_dict = HashMap::new();
+        cs_dict.insert("CS0".to_string(), separation_cs("Pantone-185"));
+        let mut out = Vec::new();
+        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        assert_eq!(out, vec!["Pantone-185".to_string()]);
+    }
+
+    #[test]
+    fn extracts_devicen_ink_names_in_declared_order() {
+        let mut cs_dict = HashMap::new();
+        cs_dict.insert(
+            "CS0".to_string(),
+            device_n_cs(&["Cyan", "Magenta", "SpotGold"]),
+        );
+        let mut out = Vec::new();
+        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        assert_eq!(
+            out,
+            vec!["Cyan".to_string(), "Magenta".to_string(), "SpotGold".to_string()]
+        );
+    }
+
+    #[test]
+    fn skips_all_and_none_colorants() {
+        // §8.6.6.4: /All and /None are reserved; never plate names.
+        let mut cs_dict = HashMap::new();
+        cs_dict.insert("CS0".to_string(), separation_cs("All"));
+        cs_dict.insert("CS1".to_string(), separation_cs("None"));
+        cs_dict.insert(
+            "CS2".to_string(),
+            device_n_cs(&["All", "Spot1", "None"]),
+        );
+        let mut out = Vec::new();
+        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        assert_eq!(out, vec!["Spot1".to_string()]);
+    }
+
+    #[test]
+    fn ignores_non_separation_color_spaces() {
+        let mut cs_dict = HashMap::new();
+        cs_dict.insert(
+            "CS0".to_string(),
+            Object::Array(vec![name("ICCBased"), Object::Null]),
+        );
+        cs_dict.insert("CS1".to_string(), name("DeviceCMYK"));
+        let mut out = Vec::new();
+        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        assert!(out.is_empty());
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -10667,7 +10667,7 @@ impl PdfDocument {
     /// spaces but the separation renderer does not paint into them, so
     /// surfacing their inks here would create plates that stay empty.
     pub fn get_page_inks_deep(&self, page_index: usize) -> Result<Vec<String>> {
-        let resources = self.get_page_resources(page_index)?;
+        let resources = self.page_resources_for_inks(page_index)?;
         let content_data = self.get_page_content_data(page_index)?;
         let operators = crate::content::parser::parse_content_stream(&content_data)?;
 
@@ -10689,6 +10689,36 @@ impl PdfDocument {
         Ok(ink_names)
     }
 
+    /// Resolve the page's `/Resources` entry, following an indirect
+    /// reference if present. Mirrors the same pattern used by
+    /// [`Self::get_page_inks`]. Internal helper that does not depend on
+    /// the `rendering`-feature-gated [`Self::get_page_resources`].
+    fn page_resources_for_inks(&self, page_index: usize) -> Result<Object> {
+        let page = self.get_page(page_index)?;
+        let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
+            offset: 0,
+            reason: "Page is not a dictionary".to_string(),
+        })?;
+        let resources = match page_dict.get("Resources") {
+            Some(r) => match r.as_reference() {
+                Some(rr) => self.load_object(rr)?,
+                None => r.clone(),
+            },
+            None => Object::Dictionary(std::collections::HashMap::new()),
+        };
+        Ok(resources)
+    }
+
+    /// Dereference `obj` if it is an indirect reference; otherwise clone.
+    /// Internal helper that mirrors the rendering-gated
+    /// [`Self::resolve_object`] without taking the gate.
+    fn deref_object_for_inks(&self, obj: &Object) -> Result<Object> {
+        match obj.as_reference() {
+            Some(r) => self.load_object(r),
+            None => Ok(obj.clone()),
+        }
+    }
+
     /// Append inks declared in `resources./ColorSpace` (resolving indirect
     /// references) to `out`. Internal helper for both
     /// [`Self::get_page_inks_deep`] and the recursive form walker.
@@ -10698,7 +10728,7 @@ impl PdfDocument {
             None => return Ok(()),
         };
         let cs_obj = match res_dict.get("ColorSpace") {
-            Some(obj) => self.resolve_object(obj)?,
+            Some(obj) => self.deref_object_for_inks(obj)?,
             None => return Ok(()),
         };
         let cs_dict_raw = match cs_obj.as_dict() {
@@ -10742,7 +10772,7 @@ impl PdfDocument {
         }
         let xobjects = match parent_resources.as_dict() {
             Some(rd) => match rd.get("XObject") {
-                Some(o) => self.resolve_object(o)?,
+                Some(o) => self.deref_object_for_inks(o)?,
                 None => return Ok(()),
             },
             None => return Ok(()),
@@ -10768,7 +10798,7 @@ impl PdfDocument {
                     continue;
                 }
             }
-            let xobj = match self.resolve_object(xobj_entry) {
+            let xobj = match self.deref_object_for_inks(xobj_entry) {
                 Ok(o) => o,
                 Err(_) => continue,
             };
@@ -10788,7 +10818,7 @@ impl PdfDocument {
 
             // §8.10.1: form may override resources or inherit the parent's.
             let form_resources = match form_dict.get("Resources") {
-                Some(res) => self.resolve_object(res)?,
+                Some(res) => self.deref_object_for_inks(res)?,
                 None => parent_resources.clone(),
             };
             self.collect_inks_from_resources(&form_resources, out)?;
@@ -12779,7 +12809,7 @@ impl PdfDocument {
                 return Ok(arc);
             }
         }
-        let resolved = self.resolve_object(font_obj)?;
+        let resolved = self.deref_object_for_inks(font_obj)?;
         let info = crate::fonts::FontInfo::from_dict(&resolved, self)?;
         let arc = Arc::new(info);
         if let Some(font_ref) = font_obj.as_reference() {

--- a/src/document.rs
+++ b/src/document.rs
@@ -636,13 +636,26 @@ fn contains_objstm_marker(window: &[u8]) -> bool {
 /// in `cs_dict` to `out`. Reserved colorants `/All` and `/None` (§8.6.6.4)
 /// are skipped. Caller is responsible for deduping across multiple calls.
 ///
+/// When `doc` is `Some`, indirect references inside each colour-space array
+/// (e.g. a DeviceN whose names list is `4 0 R` rather than inline) are
+/// resolved. Tools that hand-build inline arrays and don't need indirection
+/// resolution can pass `None`.
+///
 /// Used by both [`PdfDocument::get_page_inks`] and
 /// [`PdfDocument::get_page_inks_deep`] so the per-colorant rules live in
 /// exactly one place.
 fn extract_inks_from_color_space_dict(
     cs_dict: &std::collections::HashMap<String, Object>,
+    doc: Option<&PdfDocument>,
     out: &mut Vec<String>,
 ) {
+    let deref = |obj: &Object| -> Object {
+        match (obj.as_reference(), doc) {
+            (Some(r), Some(d)) => d.load_object(r).unwrap_or_else(|_| obj.clone()),
+            _ => obj.clone(),
+        }
+    };
+
     for cs_def in cs_dict.values() {
         let arr = match cs_def.as_array() {
             Some(a) => a,
@@ -657,14 +670,28 @@ fn extract_inks_from_color_space_dict(
         };
         match cs_type {
             "Separation" => {
-                if let Some(ink) = arr.get(1).and_then(Object::as_name) {
+                // §8.6.6.2: [/Separation /InkName /AlternateCS /TintTransform].
+                // The name slot is usually inline but resolve indirects for safety.
+                let name_obj = match arr.get(1) {
+                    Some(o) => deref(o),
+                    None => continue,
+                };
+                if let Some(ink) = name_obj.as_name() {
                     if ink != "All" && ink != "None" {
                         out.push(ink.to_string());
                     }
                 }
             },
             "DeviceN" => {
-                if let Some(Object::Array(inks)) = arr.get(1) {
+                // §8.6.6.3: [/DeviceN <names-array> /AlternateCS /TintTransform <attrs>].
+                // The names array is commonly emitted as an indirect reference
+                // when the same colorant set is shared across multiple DeviceN
+                // spaces; resolve before unpacking the names.
+                let names_obj = match arr.get(1) {
+                    Some(o) => deref(o),
+                    None => continue,
+                };
+                if let Some(inks) = names_obj.as_array() {
                     for ink_obj in inks {
                         if let Some(ink) = ink_obj.as_name() {
                             if ink != "All" && ink != "None" {
@@ -10612,7 +10639,7 @@ impl PdfDocument {
         }
 
         let mut ink_names = Vec::new();
-        extract_inks_from_color_space_dict(&resolved, &mut ink_names);
+        extract_inks_from_color_space_dict(&resolved, Some(self), &mut ink_names);
 
         ink_names.sort();
         ink_names.dedup();
@@ -10689,7 +10716,7 @@ impl PdfDocument {
             };
             resolved.insert(name.clone(), v);
         }
-        extract_inks_from_color_space_dict(&resolved, out);
+        extract_inks_from_color_space_dict(&resolved, Some(self), out);
         Ok(())
     }
 
@@ -22088,7 +22115,7 @@ mod ink_dict_extractor_tests {
         let mut cs_dict = HashMap::new();
         cs_dict.insert("CS0".to_string(), separation_cs("Pantone-185"));
         let mut out = Vec::new();
-        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        extract_inks_from_color_space_dict(&cs_dict, None, &mut out);
         assert_eq!(out, vec!["Pantone-185".to_string()]);
     }
 
@@ -22100,7 +22127,7 @@ mod ink_dict_extractor_tests {
             device_n_cs(&["Cyan", "Magenta", "SpotGold"]),
         );
         let mut out = Vec::new();
-        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        extract_inks_from_color_space_dict(&cs_dict, None, &mut out);
         assert_eq!(
             out,
             vec!["Cyan".to_string(), "Magenta".to_string(), "SpotGold".to_string()]
@@ -22118,7 +22145,7 @@ mod ink_dict_extractor_tests {
             device_n_cs(&["All", "Spot1", "None"]),
         );
         let mut out = Vec::new();
-        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        extract_inks_from_color_space_dict(&cs_dict, None, &mut out);
         assert_eq!(out, vec!["Spot1".to_string()]);
     }
 
@@ -22131,7 +22158,7 @@ mod ink_dict_extractor_tests {
         );
         cs_dict.insert("CS1".to_string(), name("DeviceCMYK"));
         let mut out = Vec::new();
-        extract_inks_from_color_space_dict(&cs_dict, &mut out);
+        extract_inks_from_color_space_dict(&cs_dict, None, &mut out);
         assert!(out.is_empty());
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -10580,9 +10580,11 @@ impl PdfDocument {
     /// declared inside a Form XObject's local `/Resources /ColorSpace`
     /// dictionary will not be enumerated — even though the renderer and
     /// extractor will still honor them at use time. Callers populating a
-    /// UI picker from this list may miss XObject-local inks; if that
-    /// matters, walk the page's XObject resources separately or
-    /// enumerate inks from the content stream operators.
+    /// UI picker from this list may miss XObject-local inks.
+    ///
+    /// For the full walk that follows `Do` operators into Form XObject
+    /// resources, use [`Self::get_page_inks_deep`] — that is what the
+    /// separation renderer uses to allocate plates.
     pub fn get_page_inks(&self, page_index: usize) -> Result<Vec<String>> {
         let page = self.get_page(page_index)?;
         let page_dict = page.as_dict().ok_or_else(|| Error::ParseError {
@@ -22098,7 +22100,12 @@ mod ink_dict_extractor_tests {
     }
 
     fn separation_cs(ink: &str) -> Object {
-        Object::Array(vec![name("Separation"), name(ink), name("DeviceCMYK"), Object::Null])
+        Object::Array(vec![
+            name("Separation"),
+            name(ink),
+            name("DeviceCMYK"),
+            Object::Null,
+        ])
     }
 
     fn device_n_cs(inks: &[&str]) -> Object {
@@ -22122,15 +22129,16 @@ mod ink_dict_extractor_tests {
     #[test]
     fn extracts_devicen_ink_names_in_declared_order() {
         let mut cs_dict = HashMap::new();
-        cs_dict.insert(
-            "CS0".to_string(),
-            device_n_cs(&["Cyan", "Magenta", "SpotGold"]),
-        );
+        cs_dict.insert("CS0".to_string(), device_n_cs(&["Cyan", "Magenta", "SpotGold"]));
         let mut out = Vec::new();
         extract_inks_from_color_space_dict(&cs_dict, None, &mut out);
         assert_eq!(
             out,
-            vec!["Cyan".to_string(), "Magenta".to_string(), "SpotGold".to_string()]
+            vec![
+                "Cyan".to_string(),
+                "Magenta".to_string(),
+                "SpotGold".to_string()
+            ]
         );
     }
 
@@ -22140,10 +22148,7 @@ mod ink_dict_extractor_tests {
         let mut cs_dict = HashMap::new();
         cs_dict.insert("CS0".to_string(), separation_cs("All"));
         cs_dict.insert("CS1".to_string(), separation_cs("None"));
-        cs_dict.insert(
-            "CS2".to_string(),
-            device_n_cs(&["All", "Spot1", "None"]),
-        );
+        cs_dict.insert("CS2".to_string(), device_n_cs(&["All", "Spot1", "None"]));
         let mut out = Vec::new();
         extract_inks_from_color_space_dict(&cs_dict, None, &mut out);
         assert_eq!(out, vec!["Spot1".to_string()]);
@@ -22152,10 +22157,7 @@ mod ink_dict_extractor_tests {
     #[test]
     fn ignores_non_separation_color_spaces() {
         let mut cs_dict = HashMap::new();
-        cs_dict.insert(
-            "CS0".to_string(),
-            Object::Array(vec![name("ICCBased"), Object::Null]),
-        );
+        cs_dict.insert("CS0".to_string(), Object::Array(vec![name("ICCBased"), Object::Null]));
         cs_dict.insert("CS1".to_string(), name("DeviceCMYK"));
         let mut out = Vec::new();
         extract_inks_from_color_space_dict(&cs_dict, None, &mut out);

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -2877,16 +2877,31 @@ impl<'doc> TextExtractor<'doc> {
         if let Some(cs_array) = self.resolve_color_space(name) {
             if cs_array.len() >= 2 {
                 if let Some(cs_type) = cs_array[0].as_name() {
+                    // §8.6.6.2 / §8.6.6.3: the colorant slot (Separation's
+                    // ink-name, DeviceN's names array) can be an indirect
+                    // reference. Some subsetters share the names list across
+                    // multiple DeviceN spaces, emitting
+                    // `[/DeviceN 4 0 R /DeviceCMYK <attrs>]` where `4 0 R`
+                    // points to the actual names list. Resolve before
+                    // pattern-matching.
+                    let deref = |obj: &Object| -> Object {
+                        match (obj.as_reference(), self.document) {
+                            (Some(r), Some(d)) => d.load_object(r).unwrap_or_else(|_| obj.clone()),
+                            _ => obj.clone(),
+                        }
+                    };
                     match cs_type {
                         "Separation" => {
                             // [/Separation /InkName /AlternateCS /TintTransform]
-                            if let Some(ink_name) = cs_array[1].as_name() {
+                            let name_obj = deref(&cs_array[1]);
+                            if let Some(ink_name) = name_obj.as_name() {
                                 return self.excluded_inks.contains(ink_name);
                             }
                         },
                         "DeviceN" => {
-                            // [/DeviceN [/Ink1 /Ink2 ...] /AlternateCS /TintTransform]
-                            if let Some(ink_names) = cs_array[1].as_array() {
+                            // [/DeviceN <names-array> /AlternateCS /TintTransform <attrs>]
+                            let names_obj = deref(&cs_array[1]);
+                            if let Some(ink_names) = names_obj.as_array() {
                                 return ink_names.iter().any(|obj| {
                                     obj.as_name()
                                         .map(|n| self.excluded_inks.contains(n))

--- a/src/python.rs
+++ b/src/python.rs
@@ -221,9 +221,9 @@ impl PyPdfDocument {
     ///     inks = doc.get_page_inks_deep(0)
     ///     # ['Cut', 'PANTONE 186 C', 'yellow fluorescent']
     fn get_page_inks_deep(&mut self, page: usize) -> PyResult<Vec<String>> {
-        self.inner.get_page_inks_deep(page).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to get page inks (deep): {}", e))
-        })
+        self.inner
+            .get_page_inks_deep(page)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page inks (deep): {}", e)))
     }
 
     /// Enumerate existing PDF signatures. Returns a list of

--- a/src/python.rs
+++ b/src/python.rs
@@ -197,6 +197,35 @@ impl PyPdfDocument {
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to get page inks: {}", e)))
     }
 
+    /// List ink / separation names declared on a page, INCLUDING those
+    /// declared inside Form XObjects reached through the page's content
+    /// stream `Do` operators.
+    ///
+    /// Unlike :py:meth:`get_page_inks`, which only walks the page's own
+    /// ``/Resources/ColorSpace`` dictionary, this method recurses into
+    /// each invoked Form XObject and accumulates ink names from every
+    /// visited resource tree. This is the method the separation renderer
+    /// uses internally to allocate plates, so its result matches the
+    /// plate list returned by :py:meth:`render_separations`.
+    ///
+    /// Args:
+    ///     page (int): Page index (0-based)
+    ///
+    /// Returns:
+    ///     list[str]: Ink names from Separation/DeviceN color spaces in
+    ///         the page resources and every nested Form XObject reached
+    ///         via Do operators. Recursion is bounded; cycles are
+    ///         deduplicated by object reference.
+    ///
+    /// Example:
+    ///     inks = doc.get_page_inks_deep(0)
+    ///     # ['Cut', 'PANTONE 186 C', 'yellow fluorescent']
+    fn get_page_inks_deep(&mut self, page: usize) -> PyResult<Vec<String>> {
+        self.inner.get_page_inks_deep(page).map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to get page inks (deep): {}", e))
+        })
+    }
+
     /// Enumerate existing PDF signatures. Returns a list of
     /// `Signature` objects — empty list when the document has no
     /// AcroForm or no signed signature fields.

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -27,7 +27,11 @@
 //! - **Raster image XObjects** (`Do` with `Subtype /Image`), including
 //!   DeviceN / Separation-encoded TIFFs and CMYK photographs. The
 //!   sample data is dropped. Vector artwork inside Form XObjects is
-//!   recursed into and rendered normally.
+//!   recursed into and rendered normally; spot / DeviceN ink
+//!   *declarations* in nested Form XObject `/Resources` are also
+//!   surfaced as plates via
+//!   [`crate::document::PdfDocument::get_page_inks_deep`] even when the
+//!   form's local content stream doesn't paint them.
 //! - **Shading patterns** (`sh` operator) — gradients used as fills.
 //! - **Tiling and shading patterns** invoked via `scn` / `SCN` with a
 //!   `/Pattern` colour space.

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -251,12 +251,13 @@ fn render_plates_for_inks(
 
 /// Collect all ink names present on a page.
 ///
-/// CMYK is always returned regardless of whether the page actually
-/// uses CMYK content — emitting four extra all-zero plates is much
-/// cheaper than the recursive operator walk that would be required to
-/// detect CMYK content nested inside Form XObjects (the previous
-/// shallow scan missed those, RED #1). Unused CMYK plates are filtered
-/// out by the short-circuit in [`render_separations`].
+/// CMYK is always returned regardless of whether the page actually uses
+/// CMYK content; unused process plates are filtered out by the per-plate
+/// short-circuit in [`render_separations`].
+///
+/// Spot inks come from [`PdfDocument::get_page_inks_deep`], which walks
+/// the page's content stream into nested Form XObjects (§8.10) so spots
+/// declared in form-local resources are discovered.
 fn collect_page_inks(doc: &PdfDocument, page_num: usize) -> Result<Vec<String>> {
     let mut inks = vec![
         "Cyan".to_string(),
@@ -265,7 +266,7 @@ fn collect_page_inks(doc: &PdfDocument, page_num: usize) -> Result<Vec<String>> 
         "Black".to_string(),
     ];
 
-    let spot_inks = doc.get_page_inks(page_num)?;
+    let spot_inks = doc.get_page_inks_deep(page_num)?;
     for ink in spot_inks {
         if !inks.contains(&ink) {
             inks.push(ink);

--- a/tests/test_ocg_ink_filtering.rs
+++ b/tests/test_ocg_ink_filtering.rs
@@ -1058,3 +1058,141 @@ fn test_filtering_unrelated_layer_produces_identical_output() {
         text_normal, text_filtered
     );
 }
+
+// ============================================================================
+// Bug 4: DeviceN names array as indirect reference is not resolved during
+// ink-filter classification — mirrors a real-world shape
+// `/CS6 [/DeviceN 4 0 R /DeviceCMYK <attrs>]` where the names list is a
+// separate indirect object shared across multiple colour spaces.
+// ============================================================================
+
+/// Build a PDF where a Form XObject paints text in a DeviceN colour space
+/// whose names array is an **indirect reference** to another object,
+/// matching the banana-label `/CS6 [/DeviceN 4 0 R …]` shape.
+///
+/// Page content :  BT (BEFORE) Tj ET  /Fm0 Do  BT (AFTER) Tj ET
+/// Form content :  /CS1 cs 1 0 0 0 scn BT (NESTED_SPOT_TEXT) Tj ET
+/// Form resources : /CS1 → 7 0 R
+/// Obj 7 : [/DeviceN 8 0 R /DeviceCMYK 9 0 R]   ← names slot is INDIRECT
+/// Obj 8 : [/Cyan /Magenta /Yellow /SpotRed]    ← the names list
+fn build_pdf_with_indirect_devicen_names_in_form() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    let mut offsets: Vec<usize> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Obj 1: Catalog
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+    // Obj 2: Pages
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+    // Obj 3: Page
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\n\
+           /Contents 4 0 R\n\
+           /Resources << /Font << /F1 6 0 R >> /XObject << /Fm0 5 0 R >> >> >>\nendobj\n\n",
+    );
+
+    // Obj 4: Page content
+    let page_content =
+        b"BT /F1 12 Tf 50 700 Td (BEFORE) Tj ET /Fm0 Do BT /F1 12 Tf 50 600 Td (AFTER) Tj ET";
+    offsets.push(pdf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    pdf.extend_from_slice(hdr.as_bytes());
+    pdf.extend_from_slice(page_content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 5: Form XObject — selects /CS1 (DeviceN), sets all 4 components,
+    // then paints (NESTED_SPOT_TEXT). Because /CS1's names array includes
+    // /SpotRed, exclude_inks={SpotRed} must suppress this text.
+    let form_stream = b"/CS1 cs 1 0 0 0 scn BT /F1 12 Tf 50 650 Td (NESTED_SPOT_TEXT) Tj ET";
+    offsets.push(pdf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]\n\
+            /Resources << /Font << /F1 6 0 R >>\n\
+            /ColorSpace << /CS1 7 0 R >> >>\n\
+            /Length {} >>\nstream\n",
+        form_stream.len()
+    );
+    pdf.extend_from_slice(form_hdr.as_bytes());
+    pdf.extend_from_slice(form_stream);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    // Obj 6: Font
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+           /Encoding /WinAnsiEncoding >>\nendobj\n\n",
+    );
+
+    // Obj 7: DeviceN colour space. Names slot is INDIRECT (8 0 R).
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"7 0 obj\n[/DeviceN 8 0 R /DeviceCMYK 9 0 R]\nendobj\n\n");
+
+    // Obj 8: the actual names array.
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(b"8 0 obj\n[/Cyan /Magenta /Yellow /SpotRed]\nendobj\n\n");
+
+    // Obj 9: identity-like Type 4 tint transform (output = input on all four
+    // process channels; just needs to be present so the colour space parses).
+    let tint_fn = b"{ 0 0 0 0 }";
+    offsets.push(pdf.len());
+    let fn_hdr = format!(
+        "9 0 obj\n<< /FunctionType 4 /Domain [0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0]\n\
+         /Range [0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0] /Length {} >>\nstream\n",
+        tint_fn.len()
+    );
+    pdf.extend_from_slice(fn_hdr.as_bytes());
+    pdf.extend_from_slice(tint_fn);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+    let xref_offset = pdf.len();
+    let n_obj = offsets.len() + 1;
+    let mut xref = format!("xref\n0 {}\n", n_obj);
+    xref.push_str("0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{:010} 00000 n \n", off));
+    }
+    pdf.extend_from_slice(xref.as_bytes());
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {n_obj} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n")
+            .as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn test_ink_filter_resolves_indirect_devicen_names_in_nested_form() {
+    let pdf_bytes = build_pdf_with_indirect_devicen_names_in_form();
+    let doc = PdfDocument::from_bytes(pdf_bytes).expect("parse PDF");
+
+    let excluded_inks = HashSet::from(["SpotRed".to_string()]);
+    let text = doc
+        .extract_text_filtered(0, HashSet::new(), excluded_inks)
+        .expect("filtered extract");
+
+    // The DeviceN colour space's names array is an indirect reference. The
+    // extractor's is_excluded_ink_color_space must resolve it before
+    // checking colorant names; otherwise NESTED_SPOT_TEXT slips through.
+    assert!(
+        !text.contains("NESTED_SPOT_TEXT"),
+        "NESTED_SPOT_TEXT should be suppressed — SpotRed is one of the DeviceN \
+         colorants (via indirect names array). Got: {:?}",
+        text
+    );
+
+    // Page-level text outside the DeviceN colour space must still be visible.
+    assert!(
+        text.contains("BEFORE"),
+        "BEFORE should be visible (DeviceGray, before form invocation). Got: {:?}",
+        text
+    );
+    assert!(
+        text.contains("AFTER"),
+        "AFTER should be visible (DeviceGray, after form returns). Got: {:?}",
+        text
+    );
+}

--- a/tests/test_spot_ink_discovery.rs
+++ b/tests/test_spot_ink_discovery.rs
@@ -234,11 +234,7 @@ fn deep_terminates_on_form_cycle() {
     let doc = PdfDocument::from_bytes(build_pdf_with_cyclic_forms()).expect("parse");
     let deep = doc.get_page_inks_deep(0).expect("deep");
     let count = deep.iter().filter(|s| s.as_str() == "CycleSpot").count();
-    assert_eq!(
-        count, 1,
-        "CycleSpot must appear exactly once after dedupe; got {:?}",
-        deep
-    );
+    assert_eq!(count, 1, "CycleSpot must appear exactly once after dedupe; got {:?}", deep);
 }
 
 /// Two sibling forms whose /Resources/ColorSpace each point at the SAME
@@ -300,11 +296,7 @@ fn deep_dedupes_spot_declared_in_multiple_forms() {
     let doc = PdfDocument::from_bytes(build_pdf_with_shared_spot_in_two_forms()).expect("parse");
     let deep = doc.get_page_inks_deep(0).expect("deep");
     let count = deep.iter().filter(|s| s.as_str() == "SharedSpot").count();
-    assert_eq!(
-        count, 1,
-        "SharedSpot must dedupe across forms; got {:?}",
-        deep
-    );
+    assert_eq!(count, 1, "SharedSpot must dedupe across forms; got {:?}", deep);
 }
 
 #[test]
@@ -354,9 +346,7 @@ fn build_pdf_with_devicen_indirect_names() -> Vec<u8> {
     buf.extend_from_slice(b"5 0 obj\n[/DeviceN 6 0 R /DeviceCMYK 7 0 R]\nendobj\n");
     offsets.push(buf.len());
     // Indirect names list with a #20-escaped multi-word ink name.
-    buf.extend_from_slice(
-        b"6 0 obj\n[/Cyan /Magenta /Yellow /yellow#20fluorescent]\nendobj\n",
-    );
+    buf.extend_from_slice(b"6 0 obj\n[/Cyan /Magenta /Yellow /yellow#20fluorescent]\nendobj\n");
     offsets.push(buf.len());
     buf.extend_from_slice(
         b"7 0 obj\n<< /FunctionType 2 /Domain [0 1 0 1 0 1 0 1] /N 1 \

--- a/tests/test_spot_ink_discovery.rs
+++ b/tests/test_spot_ink_discovery.rs
@@ -94,3 +94,214 @@ fn deep_finds_spot_declared_in_nested_form() {
         deep
     );
 }
+
+#[test]
+fn deep_finds_declared_but_unused_spot() {
+    // The form declares /Separation /SpotRed in its /Resources/ColorSpace
+    // but its content stream never paints with it (form_content is empty
+    // in the fixture). Discovery surfaces declared-not-used inks.
+    let doc = PdfDocument::from_bytes(build_pdf_with_spot_in_nested_form()).expect("parse");
+    let deep = doc.get_page_inks_deep(0).expect("deep");
+    assert!(
+        deep.contains(&"SpotRed".to_string()),
+        "declared-but-unused spot must be discovered; got {:?}",
+        deep
+    );
+}
+
+/// Two-level nesting: Page → FormA → FormB, where only FormB declares the spot.
+fn build_pdf_with_spot_two_levels_deep() -> Vec<u8> {
+    let page_content = b"/FmA Do\n";
+    let form_a_content = b"/FmB Do\n";
+    let form_b_content = b"";
+
+    let mut buf = Vec::new();
+    let mut offsets = Vec::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+           /Contents 4 0 R \
+           /Resources << /XObject << /FmA 5 0 R >> >> >>\nendobj\n",
+    );
+    offsets.push(buf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    buf.extend_from_slice(hdr.as_bytes());
+    buf.extend_from_slice(page_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    let fma_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+            /Resources << /XObject << /FmB 6 0 R >> >> \
+            /Length {} >>\nstream\n",
+        form_a_content.len()
+    );
+    buf.extend_from_slice(fma_hdr.as_bytes());
+    buf.extend_from_slice(form_a_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    let fmb_hdr = format!(
+        "6 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+            /Resources << /ColorSpace << /CS1 7 0 R >> >> \
+            /Length {} >>\nstream\n",
+        form_b_content.len()
+    );
+    buf.extend_from_slice(fmb_hdr.as_bytes());
+    buf.extend_from_slice(form_b_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"7 0 obj\n[/Separation /DeepSpot /DeviceCMYK 8 0 R]\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"8 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0 0] /C1 [1 0 0 0] >>\nendobj\n",
+    );
+    finalize_pdf(buf, offsets)
+}
+
+#[test]
+fn deep_finds_spot_two_levels_deep() {
+    let doc = PdfDocument::from_bytes(build_pdf_with_spot_two_levels_deep()).expect("parse");
+    let deep = doc.get_page_inks_deep(0).expect("deep");
+    assert!(
+        deep.contains(&"DeepSpot".to_string()),
+        "two-level nested form spot must surface; got {:?}",
+        deep
+    );
+}
+
+/// Cycle: FmA invokes FmB which invokes FmA back. The walker's visited-set
+/// must terminate the recursion without an error and without unbounded growth.
+fn build_pdf_with_cyclic_forms() -> Vec<u8> {
+    let page_content = b"/FmA Do\n";
+    let form_a_content = b"/FmB Do\n";
+    let form_b_content = b"/FmA Do\n"; // cycle back
+
+    let mut buf = Vec::new();
+    let mut offsets = Vec::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+           /Contents 4 0 R \
+           /Resources << /XObject << /FmA 5 0 R /FmB 6 0 R >> \
+                       /ColorSpace << /CS1 7 0 R >> >> >>\nendobj\n",
+    );
+    offsets.push(buf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    buf.extend_from_slice(hdr.as_bytes());
+    buf.extend_from_slice(page_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    let fma_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+            /Resources << /XObject << /FmB 6 0 R >> >> \
+            /Length {} >>\nstream\n",
+        form_a_content.len()
+    );
+    buf.extend_from_slice(fma_hdr.as_bytes());
+    buf.extend_from_slice(form_a_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    let fmb_hdr = format!(
+        "6 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+            /Resources << /XObject << /FmA 5 0 R >> >> \
+            /Length {} >>\nstream\n",
+        form_b_content.len()
+    );
+    buf.extend_from_slice(fmb_hdr.as_bytes());
+    buf.extend_from_slice(form_b_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"7 0 obj\n[/Separation /CycleSpot /DeviceCMYK 8 0 R]\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"8 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0 0] /C1 [1 0 0 0] >>\nendobj\n",
+    );
+    finalize_pdf(buf, offsets)
+}
+
+#[test]
+fn deep_terminates_on_form_cycle() {
+    let doc = PdfDocument::from_bytes(build_pdf_with_cyclic_forms()).expect("parse");
+    let deep = doc.get_page_inks_deep(0).expect("deep");
+    let count = deep.iter().filter(|s| s.as_str() == "CycleSpot").count();
+    assert_eq!(
+        count, 1,
+        "CycleSpot must appear exactly once after dedupe; got {:?}",
+        deep
+    );
+}
+
+/// Two sibling forms whose /Resources/ColorSpace each point at the SAME
+/// `/Separation /SharedSpot` object — dedupe must collapse them.
+fn build_pdf_with_shared_spot_in_two_forms() -> Vec<u8> {
+    let page_content = b"/FmA Do\n/FmB Do\n";
+    let form_a_content = b"";
+    let form_b_content = b"";
+
+    let mut buf = Vec::new();
+    let mut offsets = Vec::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+           /Contents 4 0 R \
+           /Resources << /XObject << /FmA 5 0 R /FmB 6 0 R >> >> >>\nendobj\n",
+    );
+    offsets.push(buf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    buf.extend_from_slice(hdr.as_bytes());
+    buf.extend_from_slice(page_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    let fma_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+            /Resources << /ColorSpace << /CSa 7 0 R >> >> \
+            /Length {} >>\nstream\n",
+        form_a_content.len()
+    );
+    buf.extend_from_slice(fma_hdr.as_bytes());
+    buf.extend_from_slice(form_a_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    let fmb_hdr = format!(
+        "6 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+            /Resources << /ColorSpace << /CSb 7 0 R >> >> \
+            /Length {} >>\nstream\n",
+        form_b_content.len()
+    );
+    buf.extend_from_slice(fmb_hdr.as_bytes());
+    buf.extend_from_slice(form_b_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"7 0 obj\n[/Separation /SharedSpot /DeviceCMYK 8 0 R]\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"8 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0 0] /C1 [1 0 0 0] >>\nendobj\n",
+    );
+    finalize_pdf(buf, offsets)
+}
+
+#[test]
+fn deep_dedupes_spot_declared_in_multiple_forms() {
+    let doc = PdfDocument::from_bytes(build_pdf_with_shared_spot_in_two_forms()).expect("parse");
+    let deep = doc.get_page_inks_deep(0).expect("deep");
+    let count = deep.iter().filter(|s| s.as_str() == "SharedSpot").count();
+    assert_eq!(
+        count, 1,
+        "SharedSpot must dedupe across forms; got {:?}",
+        deep
+    );
+}

--- a/tests/test_spot_ink_discovery.rs
+++ b/tests/test_spot_ink_discovery.rs
@@ -1,0 +1,96 @@
+//! Spec-driven tests for deep spot-ink discovery through nested Form
+//! XObject resources (ISO 32000-1 §8.6.6.2 Separation, §8.6.6.3 DeviceN,
+//! §8.10 Form XObjects).
+//!
+//! Fixture builders mirror the pattern in `tests/test_separation_overprint.rs`:
+//! hand-rolled PDF byte buffers with explicit object numbers and explicit xref.
+
+#![cfg(feature = "rendering")]
+
+use pdf_oxide::document::PdfDocument;
+
+/// Build a single-page PDF whose page-level /Resources/ColorSpace is empty
+/// and whose content stream invokes one Form XObject. The Form XObject's
+/// /Resources/ColorSpace declares a /Separation /SpotRed space.
+fn build_pdf_with_spot_in_nested_form() -> Vec<u8> {
+    let page_content = b"/Fm0 Do\n";
+    let form_content = b"";
+
+    let mut buf = Vec::new();
+    let mut offsets = Vec::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+           /Contents 4 0 R \
+           /Resources << /XObject << /Fm0 5 0 R >> >> >>\nendobj\n",
+    );
+    offsets.push(buf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    buf.extend_from_slice(hdr.as_bytes());
+    buf.extend_from_slice(page_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    let form_hdr = format!(
+        "5 0 obj\n<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] \
+            /Resources << /ColorSpace << /CS1 6 0 R >> >> \
+            /Length {} >>\nstream\n",
+        form_content.len()
+    );
+    buf.extend_from_slice(form_hdr.as_bytes());
+    buf.extend_from_slice(form_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"6 0 obj\n[/Separation /SpotRed /DeviceCMYK 7 0 R]\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"7 0 obj\n<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0 0] /C1 [0 1 0 0] >>\nendobj\n",
+    );
+
+    finalize_pdf(buf, offsets)
+}
+
+fn finalize_pdf(mut buf: Vec<u8>, offsets: Vec<usize>) -> Vec<u8> {
+    let xref_offset = buf.len();
+    buf.extend_from_slice(b"xref\n");
+    buf.extend_from_slice(format!("0 {}\n", offsets.len() + 1).as_bytes());
+    buf.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    buf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len() + 1,
+            xref_offset
+        )
+        .as_bytes(),
+    );
+    buf
+}
+
+#[test]
+fn deep_finds_spot_declared_in_nested_form() {
+    let doc = PdfDocument::from_bytes(build_pdf_with_spot_in_nested_form()).expect("parse");
+
+    // Shallow API: misses the nested declaration (documented contract).
+    let shallow = doc.get_page_inks(0).expect("shallow");
+    assert!(
+        !shallow.contains(&"SpotRed".to_string()),
+        "shallow get_page_inks must NOT find XObject-local inks; got {:?}",
+        shallow
+    );
+
+    // Deep API: finds it.
+    let deep = doc.get_page_inks_deep(0).expect("deep");
+    assert!(
+        deep.contains(&"SpotRed".to_string()),
+        "deep walk must surface SpotRed declared in nested form; got {:?}",
+        deep
+    );
+}

--- a/tests/test_spot_ink_discovery.rs
+++ b/tests/test_spot_ink_discovery.rs
@@ -8,6 +8,7 @@
 #![cfg(feature = "rendering")]
 
 use pdf_oxide::document::PdfDocument;
+use pdf_oxide::rendering::render_separations;
 
 /// Build a single-page PDF whose page-level /Resources/ColorSpace is empty
 /// and whose content stream invokes one Form XObject. The Form XObject's
@@ -303,5 +304,81 @@ fn deep_dedupes_spot_declared_in_multiple_forms() {
         count, 1,
         "SharedSpot must dedupe across forms; got {:?}",
         deep
+    );
+}
+
+#[test]
+fn render_separations_allocates_plate_for_nested_form_spot() {
+    // The bug that motivated this whole plan: a spot ink declared only
+    // inside a Form XObject must show up as a plate from render_separations.
+    let doc = PdfDocument::from_bytes(build_pdf_with_spot_in_nested_form()).expect("parse");
+    let plates = render_separations(&doc, 0, 72).expect("render");
+    let plate_names: Vec<&str> = plates.iter().map(|p| p.ink_name.as_str()).collect();
+    assert!(
+        plate_names.contains(&"SpotRed"),
+        "render_separations must allocate a plate for nested-form spot; got {:?}",
+        plate_names
+    );
+}
+
+/// DeviceN colour space whose names array is an **indirect reference**:
+///   /CS1 → [/DeviceN 4 0 R /DeviceCMYK <<attrs>>]
+///   4 0 obj [/Cyan /Magenta /Yellow /yellow#20fluorescent] endobj
+///
+/// This is a common emission pattern for DeviceN spaces with many inks
+/// — the names list is shared as a separate indirect object. The
+/// extractor must resolve `4 0 R` before pulling ink names out.
+fn build_pdf_with_devicen_indirect_names() -> Vec<u8> {
+    let page_content = b"";
+
+    let mut buf = Vec::new();
+    let mut offsets = Vec::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+           /Contents 4 0 R \
+           /Resources << /ColorSpace << /CS1 5 0 R >> >> >>\nendobj\n",
+    );
+    offsets.push(buf.len());
+    let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", page_content.len());
+    buf.extend_from_slice(hdr.as_bytes());
+    buf.extend_from_slice(page_content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    offsets.push(buf.len());
+    // CS1 → DeviceN with the names list as an indirect ref (6 0 R).
+    buf.extend_from_slice(b"5 0 obj\n[/DeviceN 6 0 R /DeviceCMYK 7 0 R]\nendobj\n");
+    offsets.push(buf.len());
+    // Indirect names list with a #20-escaped multi-word ink name.
+    buf.extend_from_slice(
+        b"6 0 obj\n[/Cyan /Magenta /Yellow /yellow#20fluorescent]\nendobj\n",
+    );
+    offsets.push(buf.len());
+    buf.extend_from_slice(
+        b"7 0 obj\n<< /FunctionType 2 /Domain [0 1 0 1 0 1 0 1] /N 1 \
+            /C0 [0 0 0 0] /C1 [0 0 0 1] >>\nendobj\n",
+    );
+    finalize_pdf(buf, offsets)
+}
+
+#[test]
+fn deep_resolves_indirect_devicen_names_array() {
+    let doc = PdfDocument::from_bytes(build_pdf_with_devicen_indirect_names()).expect("parse");
+    let deep = doc.get_page_inks_deep(0).expect("deep");
+    assert!(
+        deep.contains(&"yellow fluorescent".to_string()),
+        "deep walk must resolve indirect /DeviceN names arrays and decode #20 escapes; got {:?}",
+        deep
+    );
+    // Same content is reachable from the shallow scan too — page-level CS.
+    let shallow = doc.get_page_inks(0).expect("shallow");
+    assert!(
+        shallow.contains(&"yellow fluorescent".to_string()),
+        "shallow get_page_inks must also resolve indirect names arrays; got {:?}",
+        shallow
     );
 }


### PR DESCRIPTION
## Description

Closes two related discovery / filtering gaps in the spot-ink pipeline, both surfaced by packaging artwork that emits `[/DeviceN <indirect-names-ref> /DeviceCMYK <attrs>]` colour spaces with the names list shared across multiple spaces via indirect reference.

**The discovery gap:** `PdfDocument::get_page_inks` only walks the page's own `/Resources/ColorSpace`. Spot inks declared only inside a Form XObject's local resources were never enumerated, so `render_separations` allocated no plate for them and the artwork on those inks was silently dropped. The renderer returned 5 plates on the motivating fixture instead of the 6 Acrobat's Output Preview enumerated.

**The indirect-reference gap:** both `get_page_inks` (on the discovery side) and `is_excluded_ink_color_space` (on the text-extraction filter side) only matched inline arrays for the DeviceN names slot and inline names for the Separation ink-name slot.  subsetters routinely emit `[/DeviceN 4 0 R /DeviceCMYK <attrs>]` where `4 0 R` is the actual names list shared across colour spaces — the matchers returned `None` and silently treated those spaces as having no spot colorants.

The fix has three parts:

1. New `PdfDocument::get_page_inks_deep(page_index)` walks the page's content stream into Form XObjects via `Do`, accumulating `/Separation` and `/DeviceN` ink names from every visited resource tree. Recursion is bounded by `MAX_RECURSION_DEPTH` (100); cycles are deduplicated by `ObjectRef`. The shallow `get_page_inks` keeps its documented page-scope contract — the regression test at `tests/test_ocg_ink_filtering.rs::test_get_page_inks_returns_separation_names` still pins that behavior.

2. `extract_inks_from_color_space_dict` in `document.rs` resolves indirect references inside `/Separation` and `/DeviceN` array slots. This also benefits the shallow `get_page_inks` path.

3. `is_excluded_ink_color_space` in `src/extractors/text.rs` applies the same indirect-reference resolution before checking colorant names. Without this, `extract_text_filtered(exclude_inks=…)` silently ignored the user's exclusion for nested-form text painted with indirect-DeviceN colour spaces — even when the user had correctly used `get_page_inks_deep` to discover the ink name.



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Tests
- [ ] CI/CD changes

## Related Issues

No tracking issue. Behavior gaps discovered while running `render_separations` and `extract_text_filtered` against a realistic prepress PDF; the spec references on each commit are §8.6.6.2 (Separation), §8.6.6.3 (DeviceN), and §8.10 (Form XObjects).

Fixes #

## Changes Made

- **`src/document.rs`** — extracted module-scope helper `extract_inks_from_color_space_dict` so both the shallow and deep paths share one place for the `/All` / `/None` filter logic (§8.6.6.4). Added `Option<&PdfDocument>` parameter so the helper resolves indirect children of DeviceN names arrays and Separation ink-name slots; both production call sites pass `Some(self)`.
- **`src/document.rs`** — added `pub fn get_page_inks_deep(&self, page_index: usize) -> Result<Vec<String>>` plus two private helpers: `collect_inks_from_resources` (single dict scan) and `walk_form_xobject_tree_for_inks` (recursive walker with `HashSet<ObjectRef>` visited set + `MAX_RECURSION_DEPTH` cap). The shallow `get_page_inks` rustdoc now cross-references the deep variant.
- **`src/rendering/separation_renderer.rs`** — `collect_page_inks` switched to `get_page_inks_deep`. Module-level rustdoc updated to mention deep ink discovery through nested forms.
- **`src/extractors/text.rs`** — `is_excluded_ink_color_space` now resolves indirect references in the second-element slot of `Separation` and `DeviceN` colour-space arrays. Comment cross-references the parallel `document.rs` fix and §8.6.6.2 / §8.6.6.3 for the spec rationale.
- **`src/python.rs`** — added `PdfDocument.get_page_inks_deep(page)` Python binding mirroring the existing `get_page_inks` shape and docstring.
- **`tests/test_spot_ink_discovery.rs`** (new) — 7 integration tests covering nested-form discovery, two-level Page → FormA → FormB nesting, cyclic Form references terminating without error, dedup across sibling forms, declared-but-unused spots, indirect `/DeviceN` names-array resolution (including `#20`-escaped multi-word names), and `render_separations` allocating a plate for a nested-form spot.
- **`tests/test_ocg_ink_filtering.rs`** — added `test_ink_filter_resolves_indirect_devicen_names_in_nested_form` ("Bug 4" in the file's existing numbered-bug structure). The fixture mirrors the banana-label `[/DeviceN 4 0 R /DeviceCMYK <attrs>]` shape inside a Form XObject; without the extractor fix the test fails with `NESTED_SPOT_TEXT` slipping through the `exclude_inks` filter.
- **`src/document.rs`** — 4 unit tests in a new `ink_dict_extractor_tests` module covering `/Separation` extraction, `/DeviceN` per-component extraction in declared order, `/All` and `/None` skip, and non-Separation/DeviceN colour spaces ignored.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have run `cargo test --all-features`
- [ ] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

Test counts on this branch:
- 4 new unit tests in `src/document.rs::ink_dict_extractor_tests` — pass
- 7 new integration tests in `tests/test_spot_ink_discovery.rs` — pass
- 1 new integration test in `tests/test_ocg_ink_filtering.rs::test_ink_filter_resolves_indirect_devicen_names_in_nested_form` — pass (verified failing before the extractor fix)
- 14/14 in `tests/test_ocg_ink_filtering.rs` total (13 pre-existing + 1 new), including the regression-pinning shallow-API test `test_get_page_inks_returns_separation_names` — pass
- 23/23 in `tests/test_separation_rendering.rs` (9 still `#[ignore]`'d as unrelated spec gaps) — pass
- 5431/5431 lib tests pass
- `cargo doc --no-deps` clean

Clippy is unchecked because the repo's `clippy.toml` references the lint name `clippy::manual_checked_ops` which produces an `unknown lint` warning under the installed toolchain — unrelated to this PR. Plain `cargo clippy --features rendering --lib --tests` reports no warnings on the changed files.


## Python Bindings (if applicable)

- [x] Python bindings updated (if needed)
- [ ] Python tests pass
- [x] Python code formatted with `ruff format`
- [x] Python code linted with `ruff check`

Added `PdfDocument.get_page_inks_deep(page)` binding mirroring the existing `get_page_inks` shape. The existing shallow method is unchanged. The extractor fix is consumed transparently by the existing `extract_text(exclude_inks=…)` / `extract_chars(exclude_inks=…)` Python surface — no binding changes needed. No Python test was added since the binding is a thin pass-through to the Rust method that has its own coverage; happy to add one if you want it pinned at the binding layer.

## Documentation

- [x] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

- Rustdoc on `get_page_inks` cross-references `get_page_inks_deep` for the renderer use case.
- Rustdoc on `get_page_inks_deep` documents recursion bounds, cycle handling, and out-of-scope items (patterns, annotation appearance streams).
- Module-level rustdoc in `src/rendering/separation_renderer.rs` mentions deep ink discovery through nested forms.
- Python docstring on `get_page_inks_deep` mirrors the Rust description with a banana-label example.
- Inline comment on the extractor fix explains the §8.6.6.2 / §8.6.6.3 rationale and cross-references the parallel `document.rs` fix.

CHANGELOG.md is not touched — entries appear to be added at release time by the maintainer.

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)

N/A — the visible difference is in (a) the plate list returned by `render_separations` and (b) which spans `extract_text_filtered` suppresses. No pixel-level rendering changes.

## Additional Notes

**Stand-alone PR.** This is one of four independent branches from a recent debugging session on packaging artwork. The others address overprint per §11.7.4 (already submitted), an embedded CFF subset GID-mapping bug (badge text rendering as bare 'A' glyphs), and raster image XObject routing to ink plates. Each PR can be reviewed and merged in any order.

**Two parallel indirect-reference fixes intentionally bundled.** The renderer-side and extractor-side checks for the DeviceN names slot are separate code paths (`document.rs::extract_inks_from_color_space_dict` and `extractors/text.rs::is_excluded_ink_color_space`). Both had the same inline-only matching bug; both are fixed here. Splitting would mean shipping a "discovery surfaces the ink, then filtering silently ignores it" intermediate state, which would be confusing for anyone trying to use the deep walker for an `exclude_inks` UI. Happy to split into two PRs if you'd prefer.

**Scope decisions** (documented in commit messages and `get_page_inks_deep` rustdoc):
- **Tiling/shading patterns (§8.7) and annotation appearance streams (§12.5.5) are out of scope.** Both can declare their own colour spaces, but the separation renderer doesn't paint patterns or annotations, so surfacing their inks would create perpetually empty plates. Bundle each with adding the corresponding paint support.
- **No per-document ink cache.** `get_page_inks_deep` runs once per `render_separations` invocation and the per-page cost is bounded by the XObject reach × content-stream parsing — dwarfed by the actual pixel-painting cost. Easy to add a `LazyLock<HashMap<usize, Vec<String>>>` if profiling later shows it as a batch-workflow bottleneck.
- **Inline-stream Form XObjects** rely on the depth limit alone for cycle detection (no `ObjectRef` to deduplicate). They cannot self-reference (no name to invoke), so the only cycle path goes through indirect references where the visited set catches it; depth is the catch-all.

Branch is 9 commits; each commit's message documents its intent with §-references.