### PR TITLE
docs: fix Node.js PdfDocument open examples

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -16,9 +16,9 @@ npm install pdf-oxide
 ```
 
 ```javascript
-const { PdfDocument } = require("pdf-oxide");
+import { PdfDocument } from "pdf-oxide";
 
-const doc = new PdfDocument("paper.pdf");
+const doc = PdfDocument.open("paper.pdf");
 const text = doc.extractText(0);
 const markdown = doc.toMarkdown(0);
 doc.close();
@@ -29,7 +29,7 @@ TypeScript:
 ```typescript
 import { PdfDocument } from "pdf-oxide";
 
-const doc = new PdfDocument("paper.pdf");
+const doc = PdfDocument.open("paper.pdf");
 const text: string = doc.extractText(0);
 const markdown: string = doc.toMarkdown(0);
 doc.close();
@@ -82,9 +82,9 @@ Requires Node.js 18 or newer. No system dependencies. No Rust toolchain required
 ### Open a document
 
 ```javascript
-const { PdfDocument } = require("pdf-oxide");
+import { PdfDocument } from "pdf-oxide";
 
-const doc = new PdfDocument("report.pdf");
+const doc = PdfDocument.open("report.pdf");
 console.log(`Pages: ${doc.getPageCount()}`);
 
 const { major, minor } = doc.getVersion();
@@ -97,7 +97,7 @@ Use `using` for automatic cleanup (Node.js 22+):
 
 ```javascript
 {
-  using doc = new PdfDocument("report.pdf");
+  using doc = PdfDocument.open("report.pdf");
   const text = doc.extractText(0);
 } // doc.close() called automatically
 ```
@@ -117,7 +117,7 @@ const allHtml = doc.toHtmlAll();
 ### Iterate all pages
 
 ```javascript
-const doc = new PdfDocument("document.pdf");
+const doc = PdfDocument.open("document.pdf");
 const pageCount = doc.getPageCount();
 
 const pages = [];
@@ -132,7 +132,7 @@ doc.close();
 
 ```javascript
 async function extractAll(filePath) {
-  const doc = new PdfDocument(filePath);
+  const doc = PdfDocument.open(filePath);
   try {
     const pageCount = doc.getPageCount();
     const pages = [];


### PR DESCRIPTION
## Summary
- switch the Node.js README examples to ESM imports, matching the package type/module exports
- use PdfDocument.open(...) instead of constructing PdfDocument with a file path
- update the quick start, API tour, using, iteration, and async wrapper snippets consistently

Refs #648 and #650.

## Validation
- Checked js/README.md no longer contains require("pdf-oxide") or new PdfDocument(...)
- Checked examples against js/src/index.ts and js/index.d.ts, where PdfDocument.open(path) is the public file-open API
- git diff --check