### PR TITLE
docs: document new page-oriented Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,17 @@ The fastest PDF library for text extraction, image extraction, and markdown conv
 ```python
 from pdf_oxide import PdfDocument
 
-# path can be str or pathlib.Path; use with for scoped access
+with PdfDocument("paper.pdf") as doc:
+    print(len(doc))                          # number of pages
+    for page in doc:
+        text = page.text                     # lazy property
+        chars = page.chars                   # lazy property
+        md = page.markdown(detect_headings=True)
+
+# Direct page access by index
 doc = PdfDocument("paper.pdf")
-# or: with PdfDocument("paper.pdf") as doc: ...
-text = doc.extract_text(0)
-chars = doc.extract_chars(0)
-markdown = doc.to_markdown(0, detect_headings=True)
+page = doc[0]
+text = page.text
 ```
 
 ```bash
@@ -139,53 +144,56 @@ Benchmarked on 3,830 PDFs from three independent public test suites (veraPDF, Mo
 
 ## Python API
 
+### Page-oriented API
+
 ```python
 from pdf_oxide import PdfDocument
 
-# Path can be str or pathlib.Path; use "with PdfDocument(...) as doc" for context manager
-doc = PdfDocument("report.pdf")
-print(f"Pages: {doc.page_count()}")
-print(f"Version: {doc.version()}")
+with PdfDocument("report.pdf") as doc:
+    print(len(doc))          # page count
+    print(doc.version())
 
-# 1. Scoped extraction (v0.3.14)
-# Extract only from a specific area: (x, y, width, height)
+    # Iterate or index pages
+    for page in doc:
+        text   = page.text                      # str, lazy
+        chars  = page.chars                     # list[TextChar], lazy
+        words  = page.words                     # list[Word], lazy
+        lines  = page.lines                     # list[TextLine], lazy
+        tables = page.tables                    # list[Table], lazy
+        images = page.images                    # list[Image], lazy
+        md     = page.markdown(detect_headings=True)
+        html   = page.html()
+        print(f"Page {page.index}: {page.width:.0f}×{page.height:.0f} pts")
+
+    # Direct index access (supports negative indices)
+    first = doc[0]
+    last  = doc[-1]
+```
+
+### Scoped extraction
+
+```python
+# Extract from a region: (x, y, width, height) in PDF points
 header = doc.within(0, (0, 700, 612, 92)).extract_text()
+region = doc.within(0, (50, 400, 500, 200))
+region_words  = region.extract_words()
+region_images = region.extract_images()
+```
 
-# 2. Word-level extraction (v0.3.14)
-words = doc.extract_words(0)
-for w in words:
-    print(f"{w.text} at {w.bbox}")
-    # Access individual characters in the word
-    # print(w.chars[0].font_name)
+### Extraction profiles
 
-# Optional: override the adaptive word gap threshold (in PDF points)
-words = doc.extract_words(0, word_gap_threshold=2.5)
-
-# 3. Line-level extraction (v0.3.14)
-lines = doc.extract_text_lines(0)
-for line in lines:
-    print(f"Line: {line.text}")
-
-# Optional: override word and/or line gap thresholds (in PDF points)
-lines = doc.extract_text_lines(0, word_gap_threshold=2.5, line_gap_threshold=4.0)
-
-# Inspect the adaptive thresholds before overriding
-params = doc.page_layout_params(0)
-print(f"word gap: {params.word_gap_threshold:.1f}, line gap: {params.line_gap_threshold:.1f}")
-
-# Use a pre-tuned extraction profile for specific document types
+```python
 from pdf_oxide import ExtractionProfile
+
+# Pre-tuned profiles for different document types
 words = doc.extract_words(0, profile=ExtractionProfile.form())
 lines = doc.extract_text_lines(0, profile=ExtractionProfile.academic())
 
-# 4. Table extraction (v0.3.14)
-tables = doc.extract_tables(0)
-for table in tables:
-    print(f"Table with {table.row_count} rows")
-
-# 5. Traditional extraction
-text = doc.extract_text(0)
-chars = doc.extract_chars(0)
+# Override adaptive thresholds (in PDF points)
+words = doc.extract_words(0, word_gap_threshold=2.5)
+lines = doc.extract_text_lines(0, word_gap_threshold=2.5, line_gap_threshold=4.0)
+params = doc.page_layout_params(0)
+print(f"word gap: {params.word_gap_threshold:.1f}")
 ```
 
 ### Form Fields

--- a/python/README.md
+++ b/python/README.md
@@ -17,9 +17,11 @@ pip install pdf_oxide
 ```python
 from pdf_oxide import PdfDocument
 
-doc = PdfDocument("paper.pdf")
-text = doc.extract_text(0)
-markdown = doc.to_markdown(0, detect_headings=True)
+with PdfDocument("paper.pdf") as doc:
+    print(len(doc))                          # number of pages
+    for page in doc:
+        text = page.text                     # lazy property
+        md   = page.markdown(detect_headings=True)
 ```
 
 ## Why pdf_oxide?
@@ -66,19 +68,57 @@ from pdf_oxide import PdfDocument
 
 # Path can be str or pathlib.Path
 doc = PdfDocument("report.pdf")
-print(f"Pages: {doc.page_count()}")
+print(f"Pages: {len(doc)}")
 print(f"PDF version: {doc.version()}")
 
-# Or use as a context manager — closes automatically
+# Context manager — closes automatically
 with PdfDocument("report.pdf") as doc:
-    text = doc.extract_text(0)
+    for page in doc:
+        print(page.text)
 
 # From bytes or with a password
 doc = PdfDocument.from_bytes(pdf_bytes)
 doc = PdfDocument("encrypted.pdf", password="secret")
 ```
 
-### Text extraction
+### Page objects
+
+`PdfDocument` is a sequence of `Page` objects. Pages are cheap to create; all
+extraction is lazy and computed only when the property or method is accessed.
+
+```python
+with PdfDocument("report.pdf") as doc:
+    print(len(doc))                  # page count
+
+    # Iterate all pages
+    for page in doc:
+        print(f"Page {page.index}: {page.width:.0f}×{page.height:.0f} pts")
+        text   = page.text           # str
+        chars  = page.chars          # list[TextChar]
+        words  = page.words          # list[Word]
+        lines  = page.lines          # list[TextLine]
+        spans  = page.spans          # list[TextSpan]
+        tables = page.tables         # list[Table]
+        images = page.images         # list[Image]
+        annots = page.annotations    # list[Annotation]
+        paths  = page.paths          # list[Path]
+
+        md   = page.markdown(detect_headings=True)
+        html = page.html()
+        txt  = page.plain_text()
+
+        # Render to PNG/JPEG bytes
+        png_bytes = page.render(dpi=150, format="png")
+
+        # Search within this page
+        hits = page.search("revenue", case_insensitive=True)
+
+    # Index access (negative indices supported)
+    first = doc[0]
+    last  = doc[-1]
+```
+
+### Text extraction (document-level)
 
 ```python
 text = doc.extract_text(0)            # single page
@@ -104,7 +144,7 @@ words = doc.extract_words(0, word_gap_threshold=2.5)
 lines = doc.extract_text_lines(0, word_gap_threshold=2.5, line_gap_threshold=4.0)
 ```
 
-### Format conversion
+### Format conversion (document-level)
 
 ```python
 # Markdown with optional heading detection and form-field inclusion

--- a/python/README.md
+++ b/python/README.md
@@ -95,13 +95,13 @@ with PdfDocument("report.pdf") as doc:
         print(f"Page {page.index}: {page.width:.0f}×{page.height:.0f} pts")
         text   = page.text           # str
         chars  = page.chars          # list[TextChar]
-        words  = page.words          # list[Word]
+        words  = page.words          # list[PyWord]
         lines  = page.lines          # list[TextLine]
         spans  = page.spans          # list[TextSpan]
         tables = page.tables         # list[Table]
-        images = page.images         # list[Image]
-        annots = page.annotations    # list[Annotation]
-        paths  = page.paths          # list[Path]
+        images = page.images         # list[dict]
+        annots = page.annotations    # list[dict]
+        paths  = page.paths          # list[dict]
 
         md   = page.markdown(detect_headings=True)
         html = page.html()


### PR DESCRIPTION
Closes #371

## Summary

- Updated the **Quick Start** Python snippet in `README.md` and `python/README.md` to use the new page-oriented idiom (`len(doc)`, `for page in doc`, `page.text`, `page.markdown()`)
- Added a **"Page objects"** section in `python/README.md` documenting the full `Page` surface: lazy properties (`text`, `chars`, `words`, `lines`, `spans`, `tables`, `images`, `annotations`, `paths`) and methods (`markdown()`, `html()`, `plain_text()`, `render()`, `search()`)
- Restructured the **"Python API"** section in `README.md` with a "Page-oriented API" subsection
- Kept document-level methods (`extract_text(0)` etc.) documented as the lower-level alternative for backward compatibility

## Test plan

- [ ] Verify code snippets match the published PyPI wheel API
- [ ] Confirm all `page.*` properties and methods shown are present in `src/python.rs` (`PyDocPage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)