### PR TITLE
fix(color): don't abort OutputIntents scan on a broken entry; log damaged profiles (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## next-version
+
+### Fixed
+
+- **`/OutputIntents` parsing no longer aborts on the first broken entry, and logs damaged profiles (#712)** — `PdfDocument::output_intent_cmyk_profile` (the CMYK ICC fallback for `/DeviceCMYK` content, now load-bearing for the 0.3.61 press-accurate render path) returned `None` for the *entire* array if a single entry's object failed to load, hiding a valid CMYK `DestOutputProfile` declared later (ISO 32000-1:2008 §14.11.5). A failing entry is now skipped so the search continues — matching the resilient handling the spec already requires for missing references (§7.3.10) and the behaviour of the inner profile-stream load. Entries that fail to load, fail to decode, or are not a valid `N=4` ICC profile (§8.6.5.5) now emit a `log::warn!` naming the object instead of being dropped silently, so a declared-but-damaged press profile is diagnosable rather than mis-rendering through the §10.3.5 additive-clamp fallback with no trace. Thanks @mbeschastn0v.
+
 ## [0.3.62] - 2026-06-09
 
 > Best-in-class text, Markdown and HTML extraction: right-to-left (Arabic/Hebrew) and vertical-CJK (tategaki) reading order across every format, untagged multi-column reading order, table / list / heading / hyperlink structure fidelity, paragraph reflow and fenced code blocks, correct display of flattened form fields (incl. CJK/emoji), hyperlink-URI XSS hardening, and an OCR-augmented `auto` extraction mode that is a strict superset of native output on text, Markdown and HTML.
@@ -33,7 +39,6 @@ All notable changes to PDFOxide are documented here.
 
 - **Pre-commit hooks and pre-existing lint errors fixed (#677)** — Thanks **@norbusan**.
 - **Documentation for the page-oriented Python API (#678)** — Thanks **@SeanPedersen**.
-
 ## [0.3.61] - 2026-06-07
 
 > Press-accurate CMYK→RGB rendering via document `/OutputIntents` ICC profiles, vertical writing mode (WMode 1 / tategaki) support, RTL (Hebrew/Arabic) and Indic text-extraction fixes, separation-plate image rendering and ActualText extraction, path flattening (`PathContent::to_points`), Node.js quickstart and form-display fixes, macOS OCR detection, faster table-heavy extraction, and cross-OS + cross-language CI verification

--- a/src/document.rs
+++ b/src/document.rs
@@ -3734,7 +3734,19 @@ impl PdfDocument {
 
         for entry in intents_arr {
             let entry = match entry {
-                Object::Reference(r) => self.load_object(r).ok()?,
+                // A broken entry must not abort the whole search: skip it and
+                // keep looking (parity with the profile-stream load below).
+                // The prior `?` returned None for the entire array on the first
+                // unloadable entry, hiding a valid CMYK profile declared later
+                // (#712). Missing references are already Null per §7.3.10; this
+                // covers entries whose object exists but fails to parse.
+                Object::Reference(r) => match self.load_object(r) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        log::warn!("OutputIntents entry {r} could not be loaded ({e:?}); skipping");
+                        continue;
+                    },
+                },
                 other => other,
             };
             let entry_dict = match entry.as_dict() {
@@ -3745,10 +3757,21 @@ impl PdfDocument {
                 Some(p) => p.clone(),
                 None => continue,
             };
+            // Identifier for diagnostics; a DestOutputProfile is normally an
+            // indirect stream reference (streams cannot be inline dict values).
+            let profile_label = match &profile_obj {
+                Object::Reference(r) => format!("DestOutputProfile {r}"),
+                _ => "inline DestOutputProfile".to_string(),
+            };
             let profile_stream = match profile_obj {
-                Object::Reference(r) => match self.load_object(r) {
-                    Ok(o) => o,
-                    Err(_) => continue,
+                Object::Reference(r) => {
+                    match self.load_object(r) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            log::warn!("OutputIntent {profile_label} could not be loaded ({e:?}); skipping");
+                            continue;
+                        },
+                    }
                 },
                 other => other,
             };
@@ -3762,10 +3785,23 @@ impl PdfDocument {
             };
             let bytes = match profile_stream.decode_stream_data() {
                 Ok(b) => b,
-                Err(_) => continue,
+                Err(e) => {
+                    log::warn!(
+                        "OutputIntent {profile_label} stream failed to decode ({e:?}); skipping"
+                    );
+                    continue;
+                },
             };
-            if let Some(prof) = crate::color::IccProfile::parse(bytes, n) {
-                return Some(std::sync::Arc::new(prof));
+            // §8.6.5.5: N must match the profile's component count, enforced by
+            // IccProfile::parse. A declared-but-damaged press profile is dropped
+            // here; log it instead of silently falling back to §10.3.5.
+            match crate::color::IccProfile::parse(bytes, n) {
+                Some(prof) => return Some(std::sync::Arc::new(prof)),
+                None => {
+                    log::warn!(
+                        "OutputIntent {profile_label} is not a valid N=4 ICC profile; skipping"
+                    )
+                },
             }
         }
         None

--- a/tests/test_output_intent_resilience.rs
+++ b/tests/test_output_intent_resilience.rs
@@ -1,0 +1,206 @@
+//! Resilience of `PdfDocument::output_intent_cmyk_profile` to malformed
+//! `/OutputIntents` entries (issue #712).
+//!
+//! Per ISO 32000-1:2008 §14.11.5 the catalog `/OutputIntents` array advertises
+//! the target device's colour characteristics; `output_intent_cmyk_profile`
+//! returns the first CMYK (`N=4`) `DestOutputProfile` it can parse, used as the
+//! fallback ICC profile for plain `/DeviceCMYK` content. A single broken entry
+//! must not hide a valid profile declared later in the array.
+//!
+//! These tests build real PDFs and open them through `PdfDocument::from_bytes`
+//! (no mocking). They need neither the `rendering` nor `icc` feature — the
+//! accessor and `IccProfile::parse` are compiled unconditionally — so unlike
+//! `tests/test_render_output_intent.rs` (which renders pixels) they run under
+//! the default `cargo test`.
+
+use pdf_oxide::document::PdfDocument;
+
+/// Minimal valid CMYK ICC profile body: a 128-byte header with the `acsp`
+/// signature (offset 36) and a `CMYK` data-colour-space (offset 16). Accepted
+/// by `IccProfile::parse(_, 4)` without a CMM. Mirrors the helper in
+/// `tests/test_icc_cmyk_conversion.rs`.
+fn cmyk_icc_profile() -> Vec<u8> {
+    let mut v = vec![0u8; 128];
+    v[8..12].copy_from_slice(&0x0400_0000u32.to_be_bytes()); // version
+    v[12..16].copy_from_slice(b"prtr"); // device class
+    v[16..20].copy_from_slice(b"CMYK"); // data colour space (N=4)
+    v[20..24].copy_from_slice(b"Lab "); // PCS
+    v[36..40].copy_from_slice(b"acsp"); // profile-file signature
+    v
+}
+
+/// A 3-component (RGB) ICC profile body — `output_intent_cmyk_profile` must
+/// ignore it (only `N=4` entries are eligible, §8.6.5.5).
+fn rgb_icc_profile() -> Vec<u8> {
+    let mut v = cmyk_icc_profile();
+    v[16..20].copy_from_slice(b"RGB "); // data colour space (N=3)
+    v
+}
+
+/// Build a classic cross-reference-table PDF.
+///
+/// Objects 1–4 are a minimal catalog / page tree. `tail_objects` are appended
+/// verbatim as `"<num> 0 obj\n<body>\nendobj\n"` with real byte offsets.
+/// `bad_offsets` overrides specific objects' xref offsets with a bogus value to
+/// simulate a corrupt xref entry (the object then fails to load).
+fn build_pdf(
+    catalog_entries: &str,
+    tail_objects: &[(u32, Vec<u8>)],
+    bad_offsets: &[(u32, u64)],
+) -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut offsets: Vec<(u32, usize)> = Vec::new();
+    buf.extend_from_slice(b"%PDF-1.4\n");
+
+    offsets.push((1, buf.len()));
+    buf.extend_from_slice(
+        format!("1 0 obj\n<< /Type /Catalog /Pages 2 0 R {catalog_entries} >>\nendobj\n")
+            .as_bytes(),
+    );
+    offsets.push((2, buf.len()));
+    buf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    offsets.push((3, buf.len()));
+    buf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << >> >>\nendobj\n",
+    );
+    offsets.push((4, buf.len()));
+    buf.extend_from_slice(b"4 0 obj\n<< >>\nendobj\n");
+
+    for (num, body) in tail_objects {
+        offsets.push((*num, buf.len()));
+        buf.extend_from_slice(format!("{num} 0 obj\n").as_bytes());
+        buf.extend_from_slice(body);
+        buf.extend_from_slice(b"\nendobj\n");
+    }
+
+    for &(num, bad) in bad_offsets {
+        if let Some(entry) = offsets.iter_mut().find(|(n, _)| *n == num) {
+            entry.1 = bad as usize;
+        }
+    }
+
+    let size = offsets.iter().map(|(n, _)| *n).max().unwrap_or(4) + 1;
+    let xref_off = buf.len();
+    buf.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for n in 1..size {
+        let off = offsets
+            .iter()
+            .find(|(o, _)| *o == n)
+            .map(|(_, o)| *o)
+            .unwrap_or(0);
+        buf.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref_off}\n%%EOF\n")
+            .as_bytes(),
+    );
+    buf
+}
+
+/// An indirect ICC profile stream object `<< /N n /Length .. >> stream .. endstream`.
+fn icc_stream_obj(num: u32, n: u8, profile: &[u8]) -> (u32, Vec<u8>) {
+    let mut body = format!("<< /N {n} /Length {} >>\nstream\n", profile.len()).into_bytes();
+    body.extend_from_slice(profile);
+    body.extend_from_slice(b"\nendstream");
+    (num, body)
+}
+
+/// A good CMYK OutputIntent dictionary (inline) whose `DestOutputProfile`
+/// references object `icc_num`.
+fn good_cmyk_oi(icc_num: u32) -> String {
+    format!("<< /Type /OutputIntent /S /GTS_PDFX /OutputCondition (CMYK) /DestOutputProfile {icc_num} 0 R >>")
+}
+
+/// Regression for #712 (defect #1): a corrupt first entry whose object fails to
+/// load (here a corrupt xref offset → `load_object` returns `Err`) must be
+/// skipped, not abort the whole search — a valid CMYK profile later in the array
+/// is still returned. Fails before the fix (the `?` propagated `None`).
+#[test]
+fn corrupt_entry_does_not_abort_remaining_search() {
+    let catalog = format!("/OutputIntents [5 0 R {}]", good_cmyk_oi(6));
+    // Object 5 exists but its xref offset is corrupt (points past EOF) → Err.
+    let pdf = build_pdf(
+        &catalog,
+        &[
+            (5, b"<< /Type /OutputIntent >>".to_vec()),
+            icc_stream_obj(6, 4, &cmyk_icc_profile()),
+        ],
+        &[(5, 9_000_000)],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("open synthetic PDF");
+    assert!(
+        doc.output_intent_cmyk_profile().is_some(),
+        "a corrupt earlier entry must not hide the valid CMYK profile in entry 2 (#712)"
+    );
+}
+
+/// Defect #2 guard: an entry whose `DestOutputProfile` stream cannot be decoded
+/// is skipped (and now logged), and a later valid CMYK profile is returned.
+#[test]
+fn undecodable_profile_stream_entry_skipped_then_good() {
+    // /Filter /FlateDecode with non-flate bytes → decode_stream_data Err.
+    let bad_stream =
+        b"<< /N 4 /Filter /FlateDecode /Length 9 >>\nstream\nnot-flate\nendstream".to_vec();
+    let catalog = format!(
+        "/OutputIntents [<< /Type /OutputIntent /S /GTS_PDFX /DestOutputProfile 5 0 R >> {}]",
+        good_cmyk_oi(6)
+    );
+    let pdf =
+        build_pdf(&catalog, &[(5, bad_stream), icc_stream_obj(6, 4, &cmyk_icc_profile())], &[]);
+    let doc = PdfDocument::from_bytes(pdf).expect("open synthetic PDF");
+    assert!(
+        doc.output_intent_cmyk_profile().is_some(),
+        "an undecodable profile stream must be skipped, not abort the search (#712)"
+    );
+}
+
+/// Defect #2 guard: an entry whose stream decodes but is not a valid ICC profile
+/// is skipped (and now logged), and a later valid CMYK profile is returned.
+#[test]
+fn unparseable_icc_entry_skipped_then_good() {
+    let not_icc = b"this is not an ICC profile, definitely too short and wrong".to_vec();
+    let catalog = format!(
+        "/OutputIntents [<< /Type /OutputIntent /S /GTS_PDFX /DestOutputProfile 5 0 R >> {}]",
+        good_cmyk_oi(6)
+    );
+    let pdf = build_pdf(
+        &catalog,
+        &[
+            icc_stream_obj(5, 4, &not_icc),
+            icc_stream_obj(6, 4, &cmyk_icc_profile()),
+        ],
+        &[],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("open synthetic PDF");
+    assert!(
+        doc.output_intent_cmyk_profile().is_some(),
+        "an unparseable ICC entry must be skipped, not abort the search (#712)"
+    );
+}
+
+/// Happy path is unchanged: a single valid CMYK OutputIntent is returned.
+#[test]
+fn single_valid_cmyk_profile_is_found() {
+    let catalog = format!("/OutputIntents [{}]", good_cmyk_oi(5));
+    let pdf = build_pdf(&catalog, &[icc_stream_obj(5, 4, &cmyk_icc_profile())], &[]);
+    let doc = PdfDocument::from_bytes(pdf).expect("open synthetic PDF");
+    assert!(doc.output_intent_cmyk_profile().is_some());
+}
+
+/// No `/OutputIntents` at all → `None` (unchanged).
+#[test]
+fn no_output_intents_returns_none() {
+    let pdf = build_pdf("", &[], &[]);
+    let doc = PdfDocument::from_bytes(pdf).expect("open synthetic PDF");
+    assert!(doc.output_intent_cmyk_profile().is_none());
+}
+
+/// Only a non-CMYK (RGB, `N=3`) OutputIntent → `None` (CMYK filter, §8.6.5.5).
+#[test]
+fn rgb_only_output_intent_returns_none() {
+    let catalog =
+        "/OutputIntents [<< /Type /OutputIntent /S /GTS_PDFX /DestOutputProfile 5 0 R >>]";
+    let pdf = build_pdf(catalog, &[icc_stream_obj(5, 3, &rgb_icc_profile())], &[]);
+    let doc = PdfDocument::from_bytes(pdf).expect("open synthetic PDF");
+    assert!(doc.output_intent_cmyk_profile().is_none());
+}


### PR DESCRIPTION
## What

Makes `PdfDocument::output_intent_cmyk_profile` resilient to a broken `/OutputIntents` entry, and adds diagnostics for damaged profiles.

- **Defect #1 (the bug):** the per-entry load used `self.load_object(r).ok()?` — the `?` returned `None` from the *entire function* if one array entry failed to load, so `[<broken entry>, <valid CMYK profile>]` lost colour management entirely. It now skips the failing entry and keeps searching, matching the inner profile-stream load just below it.
- **Defect #2 (observability):** entries that fail to load, fail to decode, or are not a valid `N=4` ICC profile were dropped silently. They now emit a `log::warn!` naming the object, so a declared-but-damaged press profile is diagnosable instead of silently mis-rendering through the §10.3.5 additive-clamp fallback.

## Why

`output_intent_cmyk_profile` is the CMYK ICC fallback for `/DeviceCMYK` content and became load-bearing with the 0.3.61 press-accurate render path (#652). A prepress PDF that *declares* a CMYK OutputIntent but ships one bad entry would silently render with wrong plate values and no trace. Fixes #712.

## Spec alignment (ISO 32000-1:2008)

- §14.11.5 OutputIntents (the array being parsed).
- §7.3.10 — a missing reference is already treated as `null` (handled). This fix covers the remaining case: an entry whose object **exists but fails to parse**, applying the same "don't abort, keep going" resilience.
- §8.6.5.5 — `N` must match the profile's component count (already enforced by `IccProfile::parse`); a mismatch is now logged rather than silently skipped.

Scope boundary: the outer load of the whole `/OutputIntents` array object is left as-is — if the array object itself is unloadable there is nothing to iterate, so `None` is correct.

## Testing

New `tests/test_output_intent_resilience.rs` — real PDFs built and opened via `PdfDocument::from_bytes` (no mocks):

| Test | `/OutputIntents` | Expect |
|---|---|---|
| **Regression (defect #1)** | `[<entry whose object fails to load>, <valid CMYK>]` | `Some` (failed before this fix) |
| Undecodable profile stream, then good | `[<FlateDecode stream w/ non-flate body>, <valid CMYK>]` | `Some` |
| Unparseable ICC bytes, then good | `[<N=4 stream w/ non-ICC body>, <valid CMYK>]` | `Some` |
| Happy path | `[<valid CMYK>]` | `Some` |
| No OutputIntents | absent | `None` |
| RGB-only (`N=3`) | `[<sRGB>]` | `None` |

The suite runs under the **default** `cargo test` (the accessor needs neither the `rendering` nor `icc` feature), so the regression is actually guarded in CI — unlike the existing render-pixel `tests/test_render_output_intent.rs`, which stays green (39 passed, 3 pre-existing ignores).

Verification: `cargo test`, `cargo fmt --check`, `cargo clippy --lib --tests -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — all clean.

A note on the regression fixture: a *missing* reference is `Ok(Null)` per §7.3.10 (already skipped), so the broken entry is one whose object exists but fails to parse (corrupt xref offset) — confirmed to exercise the abort via a RED→GREEN transition.

## Type of Change

- [x] Bug fix (with added diagnostics; no behaviour change on the happy / no-profile paths)

## Checklist

- [x] Tests pass (new regression + existing suites)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy clean (`-D warnings`)
- [x] Docs updated (CHANGELOG `next-version` → `### Fixed`)
- [x] DCO sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
