### PR TITLE
fix(extractor): recover dropped inter-word spaces on tightly-typeset PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Dropped inter-word spaces on tightly-typeset PDFs** — text drawn one glyph per `Tj` with incremental `Td` offsets and **no space glyph** (inter-word gaps are just slightly larger `Td` moves, ~0.3–0.8 × the glyph advance — common in résumé generators) was concatenated: `"JOHN DOE"` → `"JOHNDOE"`, `"Master of Science"` → `"MasterofScience"`. The characters were correct; only the word boundaries were lost, which breaks search/indexing (`"science"` can't be matched inside `"masterofscience"`). PyMuPDF and poppler `pdftotext` both infer these spaces, so oxide was the outlier against its own calibration reference. Two root causes, both fixed: (1) `FontInfo::get_space_glyph_width` returned a CID (Type0) font's `/DW` *default* width (often ≥ 0.5 em) as the "space advance" when code `0x20` has no explicit `/W` entry — the norm for Identity-H subsets, where the space glyph is rarely at `0x20` — inflating the geometric word-gap threshold above real word gaps; it now falls back to the 0.25 em typographic default unless `0x20` carries an explicit `/W` width (preserving the #656 Arabic-subset fallback). (2) the intra-word kerning guard in `should_insert_space` suppressed lowercase→lowercase boundaries up to 2.4 × the geometric threshold (≈ 0.33 em for Helvetica) — far wider than any real inter-letter kerning — swallowing genuine tight word gaps; the ceiling is lowered to 1.5 × (≈ 0.2 em), which still clears worst-case ~0.19 em intra-word kerning while admitting 0.2-em-and-wider word gaps, the same ~0.18–0.2 em word-break point PyMuPDF / poppler use. Measured on a 138-document PyMuPDF/poppler parity set, mean word-token Jaccard 0.7777 → 0.7850 with no broad regression.
+
 ## [0.3.62] - 2026-06-09
 
 > Best-in-class text, Markdown and HTML extraction: right-to-left (Arabic/Hebrew) and vertical-CJK (tategaki) reading order across every format, untagged multi-column reading order, table / list / heading / hyperlink structure fidelity, paragraph reflow and fenced code blocks, correct display of flattened form fields (incl. CJK/emoji), hyperlink-URI XSS hardening, and an OCR-augmented `auto` extraction mode that is a strict superset of native output on text, Markdown and HTML.

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -1338,12 +1338,23 @@ fn should_insert_space(
     // the cluster but no explicit TJ offset crossed the threshold).
     // See the sibling guard in `process_tj_array_tiebreaker` for the
     // upstream space-as-span insertion path.
-    // 1.2 × full space-glyph advance. Any gap below that, between two
-    // alphabetic runs, is far more likely to be inter-letter kerning
-    // emitted by LaTeX or a Word-style exporter than a real word
-    // boundary. Real producer word gaps either match the space-glyph
-    // width plus the producer's word-spacing pad, or sit next to
-    // non-letter characters that fall through this guard.
+    //
+    // Ceiling = 1.5 × `geometric_threshold` (= 0.75 × space-glyph width,
+    // ≈ 0.2 em for a typical 0.25-em space). Inter-letter kerning is a
+    // property of font size — realistic microtype / Word letter-spacing
+    // is a few percent of the em and sits just above the 0.5-space-width
+    // threshold, never far beyond it. The previous 2.4× ceiling
+    // (≈ 1.2 × a full space-glyph advance, ≈ 0.33 em for Helvetica) was
+    // far wider than any real kerning and swallowed genuine *tight* word
+    // gaps between lowercase words — the dominant cause of
+    // "MasterofScience" / "Resultsdriven" gluing on resume-style PDFs
+    // that position words via small Td offsets. 1.5× still clears
+    // worst-case ~0.19-em intra-word kerning (including the ~0.15-em
+    // LaTeX/microtype letter-spacing case) while letting a
+    // 0.2-em-and-wider word gap through to the consensus path — the same
+    // ~0.18-0.2-em word-break point PyMuPDF / poppler use. Gaps in the
+    // overlap zone (wide letter-tracking in titles, ~0.28 em) are not
+    // separable from real word gaps by magnitude alone and fall through.
     //
     // Only fires when the font is available so the threshold is
     // computed from the font's own space-glyph advance — the no-font
@@ -1351,7 +1362,7 @@ fn should_insert_space(
     // conservative value that already separates real word gaps from
     // kerning at the consensus level.
     let kerning_guard_threshold = if fonts.contains_key(font_name) {
-        Some(geometric_threshold * 2.4)
+        Some(geometric_threshold * 1.5)
     } else {
         None
     };
@@ -1367,7 +1378,7 @@ fn should_insert_space(
                 // path, avoiding word-gluing like "APPENDIXA" or "OLIVERA.".
                 if pc.is_lowercase() && nc.is_lowercase() {
                     log::debug!(
-                        "intra-word kerning guard: suppressing space between '{pc}' and '{nc}' (gap={gap_pt:.2}pt < {thr:.2}pt, threshold = 1.2× space-glyph width)"
+                        "intra-word kerning guard: suppressing space between '{pc}' and '{nc}' (gap={gap_pt:.2}pt < {thr:.2}pt, threshold = 0.75× space-glyph width)"
                     );
                     return SpaceDecision::no_space(SpaceSource::NoSpace, 0.9);
                 }

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -3272,19 +3272,37 @@ impl FontInfo {
     ///
     /// # Returns
     ///
-    /// The width of the space character (code 0x20) in 1000ths of em,
-    /// or the font's default width if the space glyph is not defined.
+    /// The width of the space character (code 0x20) in 1000ths of em. When no
+    /// real space glyph is defined — a simple font with a near-zero 0x20, or a
+    /// CID font with no explicit /W entry for 0x20 — returns the 0.25 em (250)
+    /// typographic default rather than the font's (often much wider) /DW.
     pub fn get_space_glyph_width(&self) -> f32 {
+        // CID-keyed (Type0) fonts almost never place the space glyph at code
+        // 0x20 under Identity-H, so `get_glyph_width(0x20)` falls through to the
+        // font's *default* width (/DW) — commonly 0.5 em or wider. That default
+        // is NOT a space advance. Callers derive their geometric word-gap
+        // threshold from this width (threshold = space_width × ratio); feeding
+        // the inflated /DW in makes the threshold so large that tightly typeset
+        // word gaps — words positioned with incremental Td offsets and no space
+        // glyph — fall below it and glue together ("Master of Science" ->
+        // "MasterofScience"). PyMuPDF / poppler infer those spaces; oxide was
+        // the outlier. Trust code 0x20 only when it is an explicit /W entry;
+        // otherwise fall back to the 0.25 em typographic default.
+        if self.subtype == "Type0" {
+            return match self.cid_widths.as_ref().and_then(|w| w.get(&0x20)) {
+                Some(&w) if w >= 50.0 => w,
+                _ => 250.0,
+            };
+        }
         // Space character is always code 0x20 (32) in PDF.
         let w = self.get_glyph_width(0x20);
-        // Many CID-keyed subset fonts (notably shaped Arabic from Chrome /
+        // Many simple subset fonts (notably shaped Arabic from Chrome /
         // browser print) omit a glyph for code 0x20 entirely, so this returns
-        // ~0. Callers derive their geometric word-gap threshold from this
-        // width (threshold = space_width × ratio); a zero width collapses the
-        // threshold to 0, so *every* inter-glyph kerning gap is read as a word
-        // boundary and cursive Arabic words shatter into single letters (#656).
-        // Fall back to a typographic default of 0.25 em (250 font units) — the
-        // same value `should_insert_space` uses when the font is absent.
+        // ~0. A zero width collapses the threshold to 0, so *every* inter-glyph
+        // kerning gap is read as a word boundary and cursive Arabic words
+        // shatter into single letters. Fall back to a typographic
+        // default of 0.25 em (250 font units) — the same value
+        // `should_insert_space` uses when the font is absent.
         if w < 50.0 {
             250.0
         } else {

--- a/tests/test_word_spacing_segmentation.rs
+++ b/tests/test_word_spacing_segmentation.rs
@@ -1,0 +1,239 @@
+//! Regression test: inter-word spaces on tightly-spaced PDFs.
+//!
+//! Some producers (notably resume generators) draw text one glyph per `Tj`
+//! with incremental `Td` moves and emit NO space glyph — inter-word gaps are
+//! just slightly larger `Td` offsets (0.3–0.8 × glyph advance). oxide used to
+//! concatenate words in this case ("JOHN DOE" -> "JOHNDOE",
+//! "Master of Science" -> "MasterofScience") while PyMuPDF and poppler
+//! `pdftotext` both infer the spaces correctly, so oxide was the outlier
+//! against its own calibration reference.
+//!
+//! Two root causes, both fixed:
+//!   1. `FontInfo::get_space_glyph_width` returned a CID font's /DW default
+//!      width (often 0.5 em) as the "space advance", inflating the word-gap
+//!      threshold so tight gaps fell below it.
+//!   2. The intra-word kerning guard in `should_insert_space` suppressed
+//!      lowercase→lowercase boundaries up to 2.4 × the (already inflated)
+//!      threshold — far wider than any real kerning — swallowing genuine
+//!      tight word gaps.
+//!
+//! These fixtures are 100 % synthetic (no PII). The canonical subset BaseFont
+//! tag (`AAAAAA+`) keeps the font document-local so unrelated font-cache
+//! behaviour cannot interfere.
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::PdfDocument;
+
+const LINES: &[&[&str]] = &[
+    &["JOHN", "DOE", "Boston", "MA"],
+    &["Master", "of", "Science", "in", "Information", "Systems"],
+    &[
+        "Results",
+        "driven",
+        "engineer",
+        "with",
+        "expertise",
+        "in",
+        "data",
+    ],
+];
+
+/// Build a Type0/CIDFontType2 PDF that draws `LINES` one glyph per `Tj`, with a
+/// per-glyph advance equal to the declared width (so intra-word gap == 0) and
+/// an inter-word `Td` gap of `word_gap_factor × advance` (no space glyph).
+///
+/// `space_w`: when `Some(w)`, declare an explicit `/W` width for code 0x20 — the
+/// "embedded font that carries a real space-glyph width" case (real resumes).
+/// When `None`, the font has no space entry and oxide must not mistake /DW for
+/// the space advance — the non-embedded fixture case.
+fn build(word_gap_factor: f32, space_w: Option<u32>) -> Vec<u8> {
+    let size = 24.0f32;
+    let dw_units = 500u32;
+
+    // Unique glyphs in first-seen order; arbitrary CIDs from `cid_base` below.
+    let mut chars: Vec<char> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for ln in LINES {
+        for w in *ln {
+            for ch in w.chars() {
+                if seen.insert(ch) {
+                    chars.push(ch);
+                }
+            }
+        }
+    }
+    // Reserve CID 32 (= code 0x20) for the declared space glyph in the
+    // `space_w.is_some()` variant so no real word glyph collides with it
+    // (the space's declared width would otherwise mismatch the Td advance and
+    // open a spurious intra-word gap). The non-embedded variant has no /W, so
+    // base 3 is safe.
+    let cid_base: u32 = if space_w.is_some() { 33 } else { 3 };
+    let cid: std::collections::HashMap<char, u32> = chars
+        .iter()
+        .enumerate()
+        .map(|(i, &c)| (c, i as u32 + cid_base))
+        .collect();
+
+    let adv = dw_units as f32 / 1000.0 * size; // == declared width => 0 intra-word gap
+    let word_gap = word_gap_factor * adv;
+
+    let mut content = String::new();
+    let mut y = 760.0f32;
+    for ln in LINES {
+        content.push_str(&format!("BT\n/F1 {size} Tf\n1 0 0 1 40 {y:.2} Tm\n"));
+        for (wi, word) in ln.iter().enumerate() {
+            for ch in word.chars() {
+                content.push_str(&format!("<{:04X}> Tj\n{adv:.3} 0 Td\n", cid[&ch]));
+            }
+            if wi != ln.len() - 1 {
+                content.push_str(&format!("{word_gap:.3} 0 Td\n")); // inter-word gap, NO space glyph
+            }
+        }
+        content.push_str("ET\n");
+        y -= size * 1.6;
+    }
+    let content_b = content.into_bytes();
+
+    let bf: String = chars
+        .iter()
+        .map(|&ch| format!("<{:04X}> <{:04X}>", cid[&ch], ch as u32))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let cmap = format!(
+        "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n\
+         /CIDSystemInfo <</Registry (Adobe) /Ordering (UCS) /Supplement 0>> def\n\
+         /CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n\
+         1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+         {} beginbfchar\n{bf}\nendbfchar\nendcmap\nend\nend",
+        chars.len()
+    );
+    let cmap_b = cmap.into_bytes();
+
+    let w_entry = match space_w {
+        Some(w) => format!(" /W [32 [{w}]]"),
+        None => String::new(),
+    };
+
+    let basefont = "AAAAAA+Hv";
+    let objs: Vec<String> = vec![
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_string(),
+        format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content_b.len(),
+            String::from_utf8_lossy(&content_b)
+        ),
+        format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /{basefont} /Encoding /Identity-H \
+             /DescendantFonts [6 0 R] /ToUnicode 8 0 R >>"
+        ),
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /{basefont} \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             /FontDescriptor 7 0 R /DW {dw_units}{w_entry} /CIDToGIDMap /Identity >>"
+        ),
+        format!(
+            "<< /Type /FontDescriptor /FontName /{basefont} /Flags 4 \
+             /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 800 /Descent -200 \
+             /CapHeight 700 /StemV 80 /MissingWidth {dw_units} >>"
+        ),
+        format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            cmap_b.len(),
+            String::from_utf8_lossy(&cmap_b)
+        ),
+    ];
+
+    let mut out: Vec<u8> = b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n".to_vec();
+    let mut offsets = Vec::with_capacity(objs.len());
+    for (i, body) in objs.iter().enumerate() {
+        offsets.push(out.len());
+        out.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", i + 1).as_bytes());
+    }
+    let xref_pos = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n0000000000 65535 f \n", objs.len() + 1).as_bytes());
+    for off in &offsets {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF",
+            objs.len() + 1
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+fn extract(pdf: &[u8]) -> String {
+    let doc = PdfDocument::from_bytes(pdf.to_vec()).expect("parse pdf");
+    let opts = ConversionOptions::default();
+    let pages = doc.page_count().expect("page count");
+    (0..pages)
+        .map(|i| doc.to_plain_text(i, &opts).expect("to_plain_text"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Non-embedded font (no space glyph, only /DW): a 0.4–0.6 × advance gap is a
+/// real word break that must be recovered, matching PyMuPDF / pdftotext.
+#[test]
+fn tight_word_gaps_no_space_glyph_are_spaced() {
+    for factor in [0.4_f32, 0.6] {
+        let text = extract(&build(factor, None));
+        assert!(
+            text.contains("JOHN DOE"),
+            "gap factor {factor}: expected 'JOHN DOE', got: {text:?}"
+        );
+        assert!(
+            text.contains("Boston MA"),
+            "gap factor {factor}: expected 'Boston MA', got: {text:?}"
+        );
+        assert!(
+            text.contains("Master of Science in Information Systems"),
+            "gap factor {factor}: expected 'Master of Science in Information Systems', got: {text:?}"
+        );
+        // Lowercase→lowercase word boundaries are the regression-prone case.
+        assert!(
+            text.contains("Results driven engineer with expertise in data"),
+            "gap factor {factor}: lowercase word boundaries must be spaced, got: {text:?}"
+        );
+    }
+}
+
+/// Embedded font that DOES declare a space-glyph width (/W 32 [277] ≈ 0.277 em)
+/// yet still positions words via Td gaps (the real-resume case). The fix must
+/// cover this path too. A 0.6 × advance gap (≈ 0.3 em) is comfortably above
+/// intra-word kerning and must be recovered.
+///
+/// Note: a 0.4 × advance gap (≈ 0.2 em) against a 0.277-em space is only
+/// ~0.72 × the space width — that sits in the zone where a real word gap is
+/// not separable from aggressive letter-spacing by magnitude alone (see the
+/// guard comment in `should_insert_space`), so it is intentionally not
+/// asserted here.
+#[test]
+fn tight_word_gaps_with_declared_space_width_are_spaced() {
+    let factor = 0.6_f32;
+    let text = extract(&build(factor, Some(277)));
+    assert!(
+        text.contains("JOHN DOE")
+            && text.contains("Master of Science in Information Systems")
+            && text.contains("Results driven engineer with expertise in data"),
+        "declared-space gap factor {factor}: words must be spaced, got: {text:?}"
+    );
+}
+
+/// Lower bound: a 0.2 × advance gap is genuinely too small to be a word break
+/// (PyMuPDF / pdftotext also keep it glued). Guard against the fix over-firing
+/// and shattering tight intra-line text into spurious words.
+#[test]
+fn sub_threshold_gaps_stay_glued() {
+    let text = extract(&build(0.2, None));
+    assert!(
+        text.contains("JOHNDOE"),
+        "0.2x gap must NOT be treated as a word break, got: {text:?}"
+    );
+}


### PR DESCRIPTION
## Description

`to_plain_text` dropped inter-word spaces on PDFs that draw text one glyph per `Tj` with incremental `Td` offsets and **no space glyph** — inter-word gaps are just slightly larger `Td` moves (~0.3–0.8 × the glyph advance), which is how many résumé generators typeset. Words came out glued: `"Master of Science"` → `"MasterofScience"`, `"Results driven engineer"` → `"Resultsdrivenengineer"`. The characters were correct; only the word boundaries were lost, which breaks search/indexing (you can't match `science` inside `masterofscience`). PyMuPDF and poppler `pdftotext` both infer these spaces, so oxide was the outlier against its own calibration reference.

Two root causes:

1. **`FontInfo::get_space_glyph_width`** returned a CID (Type0) font's `/DW` *default* width (often ≥ 0.5 em) as the "space advance" when code `0x20` has no explicit `/W` entry — the norm for Identity-H subsets, where the space glyph is rarely at `0x20`. The geometric word-gap threshold is derived from this width, so the inflated `/DW` pushed it above real word gaps. `/DW` is a glyph-displacement default (ISO 32000-1 §9.7.4.3), not a space width; it now falls back to the 0.25 em typographic default unless `0x20` carries an explicit `/W` width (preserving the Arabic no-space-glyph fallback).
2. **The intra-word kerning guard** in `should_insert_space` suppressed lowercase→lowercase boundaries up to 2.4 × the geometric threshold (≈ 0.33 em for Helvetica) — far wider than any real inter-letter kerning — swallowing genuine tight word gaps. The ceiling is lowered to 1.5 × (≈ 0.2 em), which still clears worst-case ~0.19 em intra-word kerning while admitting 0.2-em-and-wider word gaps — the same ~0.18–0.2 em word-break point PyMuPDF / poppler use. Word-boundary determination is reader latitude (§9.10), so this matches the reference tools rather than the spec.

Before → after on the hand-built test PDF (0.4 × advance inter-word gaps, no space glyph), matching PyMuPDF / poppler `pdftotext`:

```
before : "JOHNDOEBostonMA / MasterofScienceinInformationSystems / Resultsdrivenengineerwithexpertiseindata"
after  : "JOHN DOE Boston MA / Master of Science in Information Systems / Results driven engineer with expertise in data"
```

Measured on a 138-document PyMuPDF/poppler parity set, mean word-token Jaccard 0.7777 → 0.7850 with no broad regression (the one slightly-down doc has wide letter-tracking in a title, ~0.28 em, which isn't separable from a real word gap by magnitude alone).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Related Issues

Fixes #724

## Changes Made

- `src/fonts/font_dict.rs` — `get_space_glyph_width` no longer treats a Type0 font's `/DW` default width as the space advance; falls back to 0.25 em unless `0x20` has an explicit `/W` entry.
- `src/extractors/text.rs` — intra-word kerning-guard ceiling lowered from 2.4× to 1.5× the geometric threshold.
- `tests/test_word_spacing_segmentation.rs` — in-code regression tests (hand-built Type0/CIDFontType2 PDFs from raw operators) covering the no-space-glyph (`/DW`) path, the declared-`/W` path, and the sub-threshold lower bound (which must stay glued).
- `CHANGELOG.md` — `[Unreleased]` entry.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally (`cargo test --lib` 5516 + `cargo test --tests` 7883)
- [ ] I have run `cargo test --all-features` (ran with default features; `ml`/`ocr` features need extra system deps locally — CI covers these)
- [x] I have run `cargo clippy --all-targets -- -D warnings`
- [x] I have run `cargo fmt`

## Python Bindings (if applicable)

N/A — core Rust extraction fix, no binding API changes; the behaviour flows through to all bindings automatically.

## Documentation

- [x] I have updated the documentation (CHANGELOG.md `[Unreleased]`)
- [ ] I have added/updated examples (not applicable)
- [x] I have updated CHANGELOG.md

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format

## Additional Notes

Test PDFs are hand-built in-code from raw operators (per the repo's no-binary-fixtures convention) — the synthetic content is fully fabricated, no PII.
