### PR TITLE
fix(python): drop leaked Py<Self> receiver params from generated .pyi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Fixed Python type stubs leaking the pyo3 `Py<Self>` receiver as a positional parameter** — methods implemented in Rust with a by-value receiver (`fn page(slf_handle: Py<Self>, …)` — the idiom pyo3 uses to hand a method an owned handle to its own instance) were emitted by the rylai stub generator with that receiver re-exposed *alongside* the injected `self`.
+
 ## [0.3.63] - 2026-06-09
 
 > CJK extraction-quality fixes — vertical-CJK (tategaki) reading order no longer mis-fires on horizontal Japanese text, CJK glyphs no longer surface as Kangxi-radical codepoints, and Korean number spacing is preserved — plus recovery of dropped inter-word spaces on tightly-typeset PDFs, and routine dependency updates.

--- a/rylai.toml
+++ b/rylai.toml
@@ -1,4 +1,12 @@
-format = ["uvx ruff format", "uvx ruff check --select I --fix"]
+# `format` commands run (in order) on the generated .pyi, with the file path
+# appended as the final argument. fix_self_handle_stub.py runs first to strip
+# leaked pyo3 `Py<Self>` receiver params that rylai re-emits as positional
+# parameters (see the script's docstring); ruff then re-formats the result.
+format = [
+    "python3 scripts/fix_self_handle_stub.py",
+    "uvx ruff format",
+    "uvx ruff check --select I --fix",
+]
 
 # `python_version` intentionally left at rylai's default so the emitted
 # stub uses PEP-585 / PEP-604 syntax directly (`tuple[int, ...]`,

--- a/scripts/fix_self_handle_stub.py
+++ b/scripts/fix_self_handle_stub.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Strip leaked PyO3 ``Py<Self>`` receiver params from a rylai-generated stub.
+
+rylai emits an implicit ``self`` for every ``#[pymethods]`` method, but it does
+*not* recognise a receiver taken by value as the first parameter (e.g.
+``fn page(slf_handle: Py<Self>, ...)`` or ``fn __iter__(slf: Py<Self>, ...)``).
+Those receivers are how pyo3 hands a method an owned handle to its own
+instance; pyo3 treats them as the receiver at runtime, but rylai re-emits them
+as an *extra positional parameter* alongside the injected ``self``. The stub
+then reads e.g. ``def page(self, slf_handle: DocumentBuilder, width, height)``,
+so ``builder.page(w, h)`` (correct at runtime) trips mypy's ``call-arg`` /
+``arg-type`` checks (issue: python-typing).
+
+For ordinary methods we fix this in Rust with ``#[pyo3(signature = (...))]``,
+which rylai honours. pyo3 *forbids* ``signature`` on magic methods
+(``__iter__``, ``__getitem__``, ...), so those receivers still leak. This
+post-processor — wired into rylai's ``format`` hook in ``rylai.toml`` so it runs
+on every generation, CI included — removes them.
+
+It deletes any parameter literally named ``slf`` or ``slf_handle``. Those are
+Rust receiver-binding names and never a legitimate Python parameter, so the
+transform is safe and also auto-covers any future ``Py<Self>`` method whose
+signature attribute is missing or disallowed.
+
+Usage (rylai appends the generated path):
+    fix_self_handle_stub.py <path-to-.pyi>
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+
+
+# Parameter names pyo3 code uses to bind an owned `Py<Self>` receiver. These are
+# never valid Python parameter names, so removing them on sight is safe.
+RECEIVER_NAMES = frozenset({"slf", "slf_handle"})
+
+
+def _line_starts(src: str) -> list[int]:
+    """Absolute char offset at which each (1-based) line begins."""
+    offsets = [0]
+    for line in src.splitlines(keepends=True):
+        offsets.append(offsets[-1] + len(line))
+    return offsets
+
+
+def fix(src: str) -> str:
+    tree = ast.parse(src)
+    starts = _line_starts(src)
+
+    def off(lineno: int, col: int) -> int:
+        return starts[lineno - 1] + col
+
+    # Collect (start, end) char spans to delete, then apply right-to-left so
+    # earlier offsets stay valid.
+    cuts: list[tuple[int, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        params = node.args.args  # positional-or-keyword params, in order
+        for i, arg in enumerate(params):
+            if arg.arg not in RECEIVER_NAMES:
+                continue
+            ann = arg.annotation
+            arg_start = off(arg.lineno, arg.col_offset)
+            if i + 1 < len(params):
+                # Not last: swallow this arg and the following ", ".
+                nxt = params[i + 1]
+                cuts.append((arg_start, off(nxt.lineno, nxt.col_offset)))
+            elif i > 0:
+                # Last arg: swallow the preceding ", " plus this arg, ending at
+                # the annotation (or the name if somehow unannotated).
+                prev = params[i - 1]
+                prev_end = (
+                    off(prev.annotation.end_lineno, prev.annotation.end_col_offset)
+                    if prev.annotation is not None
+                    else off(prev.lineno, prev.col_offset + len(prev.arg))
+                )
+                end = (
+                    off(ann.end_lineno, ann.end_col_offset)
+                    if ann is not None
+                    else off(arg.lineno, arg.col_offset + len(arg.arg))
+                )
+                cuts.append((prev_end, end))
+            else:
+                # Sole parameter: just remove the arg itself.
+                end = (
+                    off(ann.end_lineno, ann.end_col_offset)
+                    if ann is not None
+                    else off(arg.lineno, arg.col_offset + len(arg.arg))
+                )
+                cuts.append((arg_start, end))
+
+    for start, end in sorted(cuts, reverse=True):
+        src = src[:start] + src[end:]
+    return src
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <path-to-.pyi>", file=sys.stderr)
+        return 2
+    path = sys.argv[1]
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    fixed = fix(src)
+    if fixed != src:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(fixed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python.rs
+++ b/src/python.rs
@@ -430,6 +430,7 @@ impl PyPdfDocument {
     }
 
     /// Focus extraction on a region.
+    #[pyo3(signature = (page, bbox))]
     fn within(slf: Py<Self>, page: usize, bbox: (f32, f32, f32, f32)) -> PyResult<PyPdfPageRegion> {
         Ok(PyPdfPageRegion {
             doc: slf,
@@ -5695,6 +5696,7 @@ impl PyDocumentBuilder {
 
     /// Start a new A4 page and return a `FluentPageBuilder`. Call
     /// `.done()` on the returned builder to commit the page.
+    #[pyo3(signature = ())]
     fn a4_page(slf_handle: Py<Self>) -> PyFluentPageBuilder {
         PyFluentPageBuilder {
             parent: slf_handle,
@@ -5709,6 +5711,7 @@ impl PyDocumentBuilder {
         }
     }
 
+    #[pyo3(signature = ())]
     fn letter_page(slf_handle: Py<Self>) -> PyFluentPageBuilder {
         PyFluentPageBuilder {
             parent: slf_handle,
@@ -5725,6 +5728,7 @@ impl PyDocumentBuilder {
 
     /// Start a new page with custom dimensions in PDF points
     /// (72 pt = 1 inch). Use for non-standard paper sizes.
+    #[pyo3(signature = (width, height))]
     fn page(slf_handle: Py<Self>, width: f32, height: f32) -> PyFluentPageBuilder {
         PyFluentPageBuilder {
             parent: slf_handle,


### PR DESCRIPTION
## Description

rylai injects an implicit `self` for every #[pymethods] method but does not recognise a by-value receiver (`fn page(slf_handle: Py<Self>, ...)`), so it re-emits the receiver as an extra positional parameter. The stub then read e.g. `def page(self, slf_handle: DocumentBuilder, width, height)`, making `builder.page(w, h)` (correct at runtime) trip mypy's call-arg / arg-type checks and forcing downstream `# type: ignore`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes


## Changes Made

Fix in two parts:
- Add #[pyo3(signature = (...))] to the affected ordinary methods (page, a4_page, letter_page, within). rylai honours the signature attribute, which never lists the receiver, so the leak disappears.
- pyo3 forbids `signature` on magic methods, so __iter__/__getitem__ still leak. Add scripts/fix_self_handle_stub.py, wired into rylai's `format` hook in rylai.toml, to strip any param named slf/slf_handle from the generated stub. It runs on every generation (CI included) and uses ast for docstring-safe, offset-based removal.

## Testing

Verified: regenerated stub has no receiver leaks; mypy --strict and basedpyright report 0 errors on the affected call sites; runtime behaviour and stub symbol parity unchanged.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests pass locally
- [X] I have run `cargo test --all-features`
- [X] I have run `cargo clippy -- -D warnings`
- [X] I have run `cargo fmt`

## Python Bindings (if applicable)

- [ ] Python bindings updated (if needed)
- [ ] Python tests pass
- [ ] Python code formatted with `ruff format`
- [ ] Python code linted with `ruff check`

## Documentation

- [ ] I have updated the documentation (README, docs/, code comments)
- [ ] I have added/updated examples (if applicable)
- [ ] I have updated CHANGELOG.md

## Checklist

- [X] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

