### PR TITLE
Release v0.3.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.66] - 2026-06-18
+
+> Extraction-quality release — multi-region and two-column reading order, right-to-left Arabic/Hebrew reconstruction in Markdown and HTML, soft-wrap de-gluing and de-hyphenation, and a subset-font cipher-encoding fix — plus destructive redaction of Identity-H (composite) text, CCITT Group 3 fax decoding, and a 16-bit-per-component image fix.
+
+### Added
+
+- **Destructive redaction of Identity-H composite (Type 0) text (#748)** — destructive redaction previously refused all Type 0 fonts. It now supports the common Identity-H case (`Type0` + `Encoding /Identity-H`, horizontal writing mode): 2-byte big-endian CIDs are decoded and widths read from `/W` (ISO 32000-1 §9.7.4.3 / §9.7.5.2), target glyphs are removed, and the engine stays fail-closed — refusing Identity-V, legacy embedded CMaps, and odd-length strings it cannot safely rewrite. Thanks @shota-sh.
+- **CCITT Group 3 (T.4) fax decoding (#738)** — extends the in-house CCITT decoder (Group 4 landed in v0.3.65) to Group 3: pure 1-D Modified Huffman (`K = 0`) and mixed 1-D/2-D (`K > 0`), with end-of-line handling and the same partial-row recovery contract as the Group 4 path. Group-3-encoded fax images that previously rendered blank now decode to their real content. Thanks @potatochipcoconut.
+
+### Fixed
+
+- **16-bit-per-component images no longer panic on extraction (#750)** — extracting an image with `/BitsPerComponent 16` hit an internal assertion (an uncatchable panic across the FFI boundary) because 16-bit big-endian samples were stored verbatim into a double-sized buffer. 16-bit samples are now down-converted to 8-bit at parse time, and the PNG encoder rejects a mismatched buffer with a recoverable error instead of asserting. Thanks @shtyker.
+- **Multi-region and two-column reading order** — pages with genuine side-by-side regions (two-column bodies, a publisher sidebar beside the body, multi-column newsletters and forms) are now linearised with a topological block order — a precede relation over text blocks — instead of a flat row-aware sort that interleaved columns line by line. Two stacked text lines merged by the same-line Y tolerance are de-interleaved by baseline rather than X-sorted into each other. Self-gating: pages without horizontally-disjoint, vertically-overlapping regions are unchanged.
+- **Right-to-left Markdown and HTML reconstruction** — Arabic and Hebrew now read correctly in Markdown and HTML, not only in plain text. RTL lines are reconstructed at glyph fidelity from the raw spans before the converter orders them; an inter-word punctuation span between two RTL words is kept (instead of being dropped as decoration and gluing the words); a line-final word that sits just below its baseline band is rejoined to its line; and the producer's authoritative inter-word space after a dual-joining letter is preserved.
+- **Soft-wrap de-gluing and de-hyphenation** — generator PDFs that emit one show-string per visual line with no trailing separator no longer glue the last word of a wrapped line to the first word of the next line; a line-break separator is synthesised, since text positioning is purely geometric and a line break encodes no space character (ISO 32000-1 §9.4). The spurious space left after a line-final hyphen on a wrapped line is suppressed so hyphenated words rejoin cleanly.
+- **Markdown/HTML gutter-crossing word rejoin** — a word the producer split into two show-strings across the column gutter (a lone name initial, the two digits of a split number) is rejoined for Markdown and HTML, while genuinely separate adjacent column lines are kept apart and an interior emphasis (bold/italic) span inside a rejoined run is no longer dropped.
+- **Subset-font cipher encoding no longer overrides the named encoding** — a Type1/CFF subset font whose re-indexed built-in encoding disagrees with the producer-declared named `/Encoding` (e.g. WinAnsi / MacRoman) on most overlapping codes is detected as a subset cipher and the named encoding is kept, fixing whole-page mojibake on affected documents.
+
 ## [0.3.65] - 2026-06-16
 
 > Multilingual and layout extraction quality — right-to-left bidi reconstruction for Arabic and Hebrew, multi-region reading order for publisher sidebars and two-column academic pages, and CJK/Indic word segmentation — plus an in-house CCITT Group 4 fax decoder that honours `EncodedByteAlign`, structured two-column surfacing, and a batch of O(n²) hot-path removals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to PDFOxide are documented here.
 - **Markdown/HTML gutter-crossing word rejoin** — a word the producer split into two show-strings across the column gutter (a lone name initial, the two digits of a split number) is rejoined for Markdown and HTML, while genuinely separate adjacent column lines are kept apart and an interior emphasis (bold/italic) span inside a rejoined run is no longer dropped.
 - **Subset-font cipher encoding no longer overrides the named encoding** — a Type1/CFF subset font whose re-indexed built-in encoding disagrees with the producer-declared named `/Encoding` (e.g. WinAnsi / MacRoman) on most overlapping codes is detected as a subset cipher and the named encoding is kept, fixing whole-page mojibake on affected documents.
 
+### Dependencies
+
+- Bumped `taffy` 0.10.1 → 0.11.0 (#741), `pdfium-render` 0.9.1 → 0.9.2 (#743), `regex` 1.12.3 → 1.12.4 (#746), `brotli` 8.0.3 → 8.0.4 (#744), and `pyo3-log` 0.13.3 → 0.13.4 (#745); CI bumps for `ruby/setup-ruby` (#742) and `taiki-e/install-action` (#740).
+
 ## [0.3.65] - 2026-06-16
 
 > Multilingual and layout extraction quality — right-to-left bidi reconstruction for Arabic and Hebrew, multi-region reading order for publisher sidebars and two-column academic pages, and CJK/Indic word segmentation — plus an in-house CCITT Group 4 fax decoder that honours `EncodedByteAlign`, structured two-column surfacing, and a batch of O(n²) hot-path removals.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.65"
+version = "0.3.66"
 dependencies = [
  "aes",
  "aws-lc-rs",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.65"
+version = "0.3.66"
 dependencies = [
  "clap",
  "is-terminal",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_jni"
-version = "0.3.65"
+version = "0.3.66"
 dependencies = [
  "jni",
  "pdf_oxide",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.65"
+version = "0.3.66"
 dependencies = [
  "pdf_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.65"
+version = "0.3.66"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ cargo install pdf_oxide_mcp             # Cargo
   <dependency>
     <groupId>fyi.oxide</groupId>
     <artifactId>pdf-oxide</artifactId>
-    <version>0.3.65</version>
+    <version>0.3.66</version>
   </dependency>
   ```
 

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.65</Version>
+    <Version>0.3.66</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -52,7 +52,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion = "0.3.65"
+	fallbackVersion = "0.3.66"
 	BaseURL         = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	// cacheSubdir lives under os.UserCacheDir() — XDG_CACHE_HOME on Linux,
 	// ~/Library/Caches on macOS (Time-Machine-excluded), %LocalAppData% on

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
                                namespace verification under oxide.fyi)
   artifactId:  pdf-oxide      (the Maven artifact; matches the
                                package fyi.oxide.pdf)
-  version:     0.3.65         (lockstep with Cargo workspace /
+  version:     0.3.66         (lockstep with Cargo workspace /
                                js/package.json / .csproj /
                                pyproject.toml — release-preflight
                                from v0.3.51 #515 enforces parity)
@@ -33,7 +33,7 @@
 
     <groupId>fyi.oxide</groupId>
     <artifactId>pdf-oxide</artifactId>
-    <version>0.3.65</version>
+    <version>0.3.66</version>
     <packaging>jar</packaging>
 
     <name>pdf_oxide — Java binding</name>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/yfedoseev/pdf_oxide.git</connection>
         <developerConnection>scm:git:git@github.com:yfedoseev/pdf_oxide.git</developerConnection>
         <url>https://github.com/yfedoseev/pdf_oxide</url>
-        <tag>v0.3.65</tag>
+        <tag>v0.3.66</tag>
     </scm>
 
     <issueManagement>

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.65",
+  "version": "0.3.66",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.65"
+version = "0.3.66"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -34,7 +34,7 @@ workspace = true
 ocr = ["pdf_oxide/ocr"]
 
 [dependencies]
-pdf_oxide = { version = "0.3.65", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.66", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_jni/Cargo.toml
+++ b/pdf_oxide_jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_jni"
-version = "0.3.65"
+version = "0.3.66"
 edition = "2021"
 description = "JNI bindings for pdf_oxide — native Java binding, the 8th surface alongside Python/Go/JS/C#/WASM/CLI/MCP. Loaded by the fyi.oxide:pdf-oxide Maven artifact."
 license = "MIT OR Apache-2.0"
@@ -93,7 +93,7 @@ jni = "0.22"
 # opt-in FIPS 140-3 build) — those two are compile-time mutually
 # exclusive (pdf_oxide enforces via compile_error!). We always
 # enable `icc` for ICC-based colour management.
-pdf_oxide = { version = "0.3.65", path = "..", default-features = false, features = ["icc"] }
+pdf_oxide = { version = "0.3.66", path = "..", default-features = false, features = ["icc"] }
 
 # JSON envelope for the v0.3.51 AutoExtractor rich-result path. The
 # Java side gets the PageExtraction / DocumentExtraction as a JSON

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.65"
+version = "0.3.66"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.65", path = ".." }
+pdf_oxide = { version = "0.3.66", path = ".." }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/php/scripts/download-native-lib.php
+++ b/php/scripts/download-native-lib.php
@@ -37,7 +37,7 @@ declare(strict_types=1);
  *   - Set `PDF_OXIDE_NATIVE_VERSION=vX.Y.Z` to pin a specific release.
  */
 
-const PACKAGE_VERSION_DEFAULT = 'v0.3.65';
+const PACKAGE_VERSION_DEFAULT = 'v0.3.66';
 const RELEASE_BASE_URL = 'https://github.com/yfedoseev/pdf_oxide/releases/download';
 // Path is relative to the package root (parent-of-php in the new
 // root-composer.json layout); see comment on $packageRoot below.
@@ -253,12 +253,12 @@ function downloadFile(string $url, string $dest): bool
         'http' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.65',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.66',
         ],
         'https' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.65',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.66',
         ],
     ]);
     $data = @file_get_contents($url, false, $ctx);

--- a/php/src/Pdf.php
+++ b/php/src/Pdf.php
@@ -152,7 +152,7 @@ final class Pdf
      * pdf_oxide library version. Kept in sync with `Cargo.toml` by the
      * release tooling (see `docs/releases/RELEASE_PROCESS.md`).
      */
-    public const VERSION = '0.3.65';
+    public const VERSION = '0.3.66';
 
     /** Whether OCR-model prefetch + cache are available on this build. */
     public static function prefetchAvailable(): bool

--- a/php/tests/Integration/CoreParityTest.php
+++ b/php/tests/Integration/CoreParityTest.php
@@ -92,6 +92,6 @@ final class CoreParityTest extends IntegrationTestCase
 
     public function testVersionConstant(): void
     {
-        $this->assertSame('0.3.65', Pdf::VERSION);
+        $this->assertSame('0.3.66', Pdf::VERSION);
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.65"
+version = "0.3.66"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/python/tests/test_core_parity.py
+++ b/python/tests/test_core_parity.py
@@ -82,4 +82,4 @@ def test_open_error():
 
 
 def test_version():
-    assert pdf_oxide.VERSION == "0.3.65"
+    assert pdf_oxide.VERSION == "0.3.66"

--- a/ruby/lib/pdf_oxide/version.rb
+++ b/ruby/lib/pdf_oxide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PdfOxide
-  VERSION = '0.3.65'
+  VERSION = '0.3.66'
 end

--- a/ruby/spec/cdylib_smoke_spec.rb
+++ b/ruby/spec/cdylib_smoke_spec.rb
@@ -11,7 +11,7 @@ require 'tmpdir'
 RSpec.describe 'libpdf_oxide cdylib smoke' do
   it 'loads the gem with the expected version' do
     expect(defined?(PdfOxide)).to eq('constant')
-    expect(PdfOxide::VERSION).to eq('0.3.65')
+    expect(PdfOxide::VERSION).to eq('0.3.66')
   end
 
   it 'exposes every public-API class' do

--- a/ruby/spec/core_parity_spec.rb
+++ b/ruby/spec/core_parity_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'core parity (Ruby)' do
     expect { PdfOxide::PdfDocument.open('/no/such/file/does/not/exist.pdf') }.to raise_error(StandardError)
   end
 
-  it 'exposes version 0.3.65' do
-    expect(PdfOxide::VERSION).to eq('0.3.65')
+  it 'exposes version 0.3.66' do
+    expect(PdfOxide::VERSION).to eq('0.3.66')
   end
 end

--- a/src/decoders/ccitt.rs
+++ b/src/decoders/ccitt.rs
@@ -46,10 +46,11 @@ pub struct CcittDecoded {
     pub recovered_partial: bool,
 }
 
-/// Decode a CCITT **Group 4** (T.6) codestream to packed bilevel bytes.
+/// Decode a CCITT codestream to packed bilevel bytes, dispatching on `/K`:
+/// Group 4 (T.6, `K < 0`) here, Group 3 (T.4, `K >= 0`) in [`decode_g3`].
 ///
 /// Returns `Err` only when zero usable rows could be produced (genuinely
-/// undecodable) or the scheme is not Group 4 — the caller may then fall back.
+/// undecodable) — the caller may then fall back.
 /// `BlackIs1` is NOT applied here; the caller owns that inversion.
 pub fn decode(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
     let width = params.columns as u16;
@@ -57,8 +58,8 @@ pub fn decode(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
         return Err(Error::Decode("CCITT decode requires /Columns".to_string()));
     }
     if !params.is_group_4() {
-        // Group 3 (K >= 0) is not handled in-house yet; caller falls back.
-        return Err(Error::Decode("in-house CCITT decoder handles Group 4 only".to_string()));
+        // Group 3: K == 0 is pure 1-D (Modified Huffman); K > 0 is mixed 1-D/2-D.
+        return decode_g3(data, params);
     }
 
     let bytes_per_row = (width as usize).div_ceil(8);
@@ -128,6 +129,169 @@ pub fn decode(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
         rows_decoded: decoded_rows,
         recovered_partial: recovered,
     })
+}
+
+/// Decode a CCITT **Group 3** (T.4) codestream. `params.k == 0` is pure 1-D
+/// (Modified Huffman); `params.k > 0` is mixed 1-D/2-D where a tag bit after the
+/// line's EOL selects that line's coding (`1` = 1-D, `0` = 2-D-relative). EOL
+/// codes (`000000000001`, absorbing any leading fill bits) delimit lines and are
+/// tolerated whether or not `/EndOfLine` is declared; six consecutive EOLs is the
+/// return-to-control terminator. Shares the run tables, reference-line walk and
+/// recovery contract with the Group 4 path. `BlackIs1` is the caller's to apply.
+fn decode_g3(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
+    let width = params.columns as u16;
+    let two_dimensional = params.k > 0;
+    let bytes_per_row = (width as usize).div_ceil(8);
+    let mut reader = BitReader::new(data);
+    let mut reference: Vec<u16> = Vec::new(); // imaginary all-white line above row 0
+    let mut current: Vec<u16> = Vec::new();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes_per_row * params.rows.unwrap_or(0) as usize);
+    let mut decoded_rows = 0usize;
+    let mut byte_align = params.encoded_byte_align;
+    let mut recovered = false;
+
+    loop {
+        if let Some(h) = params.rows {
+            if decoded_rows >= h as usize {
+                break;
+            }
+        }
+        if byte_align && decoded_rows > 0 {
+            byte_align_skip(&mut reader, &mut byte_align);
+        }
+        // Swallow the line's EOL (plus fill); 6+ in a row is RTC = end of page.
+        let eols = skip_eols(&mut reader);
+        if reader.eod() {
+            if let Some(h) = params.rows {
+                if decoded_rows < h as usize {
+                    recovered = true;
+                }
+            }
+            break;
+        }
+        if eols >= 6 {
+            break;
+        }
+
+        // Mixed 2-D streams prefix every line with a 1-D/2-D tag bit.
+        let one_d = if two_dimensional {
+            match reader.peek(1) {
+                Some(b) => {
+                    reader.consume(1);
+                    b == 1
+                },
+                None => break,
+            }
+        } else {
+            true
+        };
+
+        current.clear();
+        let status = if one_d {
+            decode_row_g3_1d(&mut reader, width, &mut current)
+        } else {
+            decode_row_g4(&mut reader, &reference, width, &mut current)
+        };
+        match status {
+            RowStatus::EndOfBlock => break,
+            RowStatus::Error => {
+                if decoded_rows >= 1 {
+                    recovered = true; // keep decoded rows; do NOT blank the page
+                    break;
+                }
+                return Err(Error::Decode(
+                    "CCITT G3: stream undecodable from first row".to_string(),
+                ));
+            },
+            RowStatus::Ok => {
+                out.extend_from_slice(&transitions_to_bytes(&current, width as usize));
+                std::mem::swap(&mut reference, &mut current);
+                decoded_rows += 1;
+            },
+        }
+    }
+
+    if let Some(h) = params.rows {
+        let white_row = vec![0u8; bytes_per_row];
+        while out.len() / bytes_per_row.max(1) < h as usize {
+            out.extend_from_slice(&white_row);
+        }
+    }
+    if out.is_empty() {
+        return Err(Error::Decode("CCITT G3: no output produced".to_string()));
+    }
+
+    Ok(CcittDecoded {
+        data: out,
+        rows_decoded: decoded_rows,
+        recovered_partial: recovered,
+    })
+}
+
+/// Decode one Group 3 1-D (Modified Huffman) row: runs alternate white→black
+/// from the left edge, each a make-up+terminating MH code. Pushes color-flip
+/// columns (first run white) into `current`, matching the G4 row contract so the
+/// shared `transitions_to_bytes` packs it identically.
+fn decode_row_g3_1d(reader: &mut BitReader, width: u16, current: &mut Vec<u16>) -> RowStatus {
+    let mut a0: u16 = 0;
+    let mut white = true;
+    let mut any = false;
+    while a0 < width {
+        let run = match read_run(reader, white) {
+            Some(v) => v,
+            // The run tables can't read an EOL/EOFB or fill: a clean line ends
+            // here if we already placed a run, otherwise the row is undecodable.
+            None => return if any { RowStatus::Ok } else { RowStatus::Error },
+        };
+        let a1 = match a0.checked_add(run) {
+            Some(v) => v,
+            None => return RowStatus::Error,
+        };
+        any = true;
+        if a1 >= width {
+            break; // final run reaches the right edge; no trailing flip to push
+        }
+        current.push(a1);
+        a0 = a1;
+        white = !white;
+    }
+    RowStatus::Ok
+}
+
+/// Consume a maximal run of EOL codes at the cursor (`>= 11` zero bits — fill
+/// included — followed by a `1`), returning how many were eaten. Leaves the
+/// reader untouched when the next bits are not an EOL; when a trailing fill of
+/// `>= 11` zeros runs into the end of data it is treated as a terminator and
+/// the reader is left at EOD.
+fn skip_eols(reader: &mut BitReader) -> usize {
+    let mut count = 0usize;
+    loop {
+        let save = reader.bit;
+        let mut zeros = 0u32;
+        loop {
+            match reader.peek(1) {
+                Some(0) => {
+                    reader.consume(1);
+                    zeros += 1;
+                },
+                Some(_) => break, // the terminating 1 bit of an EOL
+                None => {
+                    // Ran out of data inside the zero run.
+                    if zeros < 11 {
+                        reader.bit = save; // not an EOL — leave the cursor put
+                    }
+                    return count;
+                },
+            }
+        }
+        if zeros >= 11 {
+            reader.consume(1); // eat the EOL's terminating 1
+            count += 1;
+        } else {
+            reader.bit = save; // a short zero run is real code, not an EOL
+            return count;
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -598,5 +762,132 @@ mod tests {
         };
         // 0b0000001 = Extension as the very first mode → Error, 0 rows → Err.
         assert!(p(bad, "0000001").is_err());
+    }
+
+    // -- Group 3 (T.4) --------------------------------------------------------
+
+    #[test]
+    fn g3_1d_all_white_row() {
+        // 8-wide K=0 row: a single white run of 8 (MH code 10011).
+        let params = CcittParams {
+            k: 0,
+            columns: 8,
+            rows: Some(1),
+            ..Default::default()
+        };
+        let d = p(params, "10011").unwrap();
+        assert_eq!(d.rows_decoded, 1);
+        assert_eq!(d.data, vec![0u8]); // all white
+        assert!(!d.recovered_partial);
+    }
+
+    #[test]
+    fn g3_1d_white3_black2() {
+        // 8-wide K=0 row: white run 3 (1000) + black run 2 (11) + white run 3
+        // (1000) ⇒ transitions [3,5] ⇒ 0b0001_1000, identical to the G4 case.
+        let params = CcittParams {
+            k: 0,
+            columns: 8,
+            rows: Some(1),
+            ..Default::default()
+        };
+        let d = p(params, "1000 11 1000").unwrap();
+        assert_eq!(d.data, vec![0b0001_1000]);
+    }
+
+    #[test]
+    fn g3_1d_eol_delimited_rows() {
+        // Two all-white rows, each preceded by an EOL (000000000001) as a real
+        // T.4 stream emits. The EOLs must be swallowed, not mis-read as runs.
+        let params = CcittParams {
+            k: 0,
+            columns: 8,
+            rows: Some(2),
+            end_of_line: true,
+            ..Default::default()
+        };
+        let d = p(params, "000000000001 10011 000000000001 10011").unwrap();
+        assert_eq!(d.rows_decoded, 2);
+        assert_eq!(d.data, vec![0u8, 0u8]);
+        assert!(!d.recovered_partial);
+    }
+
+    #[test]
+    fn g3_1d_rtc_terminates() {
+        // One white row then a return-to-control (6 EOLs) ⇒ stop cleanly; the
+        // declared 3rd/4th rows are white-padded, not reported as decoded.
+        let params = CcittParams {
+            k: 0,
+            columns: 8,
+            rows: Some(4),
+            ..Default::default()
+        };
+        let rtc = "000000000001".repeat(6);
+        let d = p(params, &format!("10011 {rtc}")).unwrap();
+        assert_eq!(d.rows_decoded, 1);
+        assert_eq!(d.data, vec![0u8; 4]); // padded to declared height
+    }
+
+    // Real libtiff output for one 128×64 bilevel image, encoded both ways. The
+    // G4 path is already trusted, so decoding the G3 (K=0) stream to the *same*
+    // bitmap proves the new Modified-Huffman path — this is the codestream shape
+    // behind the blank-page reports (K=0 / Group 3 1-D), which the in-house
+    // decoder previously rejected outright.
+    #[rustfmt::skip]
+    const G3_1D_STREAM: &[u8] = &[
+        0,17,192,240,103,0,24,3,193,104,0,77,120,3,192,172,0,77,92,1,224,176,0,38,165,0,120,19,128,9,168,176,7,
+        129,184,0,154,132,128,60,20,192,4,212,60,1,224,202,0,38,162,137,1,224,160,0,77,69,18,3,193,64,0,154,138,
+        36,7,130,128,1,53,20,72,15,5,0,2,106,40,144,30,10,0,4,212,81,32,60,20,0,9,168,162,64,120,40,0,19,81,68,
+        128,240,80,0,38,162,137,1,224,160,0,77,69,18,3,193,64,0,154,138,36,7,130,128,1,53,20,72,15,5,0,2,106,40,
+        144,30,10,0,4,212,81,64,60,54,0,9,168,162,74,5,138,0,252,0,77,69,18,160,199,221,15,14,7,160,1,53,20,72,
+        227,29,142,99,129,232,0,77,69,18,29,138,224,126,0,38,162,137,9,10,12,112,61,0,9,168,162,65,45,14,135,135,
+        3,208,0,154,138,36,20,117,8,120,112,61,0,9,168,162,65,97,112,31,128,9,168,162,64,196,1,240,0,154,138,36,
+        25,224,15,64,2,106,40,144,108,176,102,0,19,81,68,128,188,1,96,0,154,138,36,25,80,11,32,2,106,40,144,102,
+        64,20,0,9,168,162,64,209,0,112,0,38,162,137,3,84,1,32,0,154,138,36,26,80,10,64,2,106,40,144,106,64,50,0,
+        9,168,162,65,173,0,172,0,38,160,120,49,0,168,0,38,160,120,103,128,218,0,19,80,60,54,64,54,0,9,168,30,10,
+        32,53,128,4,212,15,3,16,26,128,2,106,7,134,92,6,144,0,154,129,225,155,0,212,0,38,160,120,52,192,52,0,9,
+        168,30,13,112,25,128,2,106,7,134,156,6,80,0,154,129,225,171,0,92,0,77,64,240,215,128,110,0,38,160,120,54,
+        192,104,0,19,80,60,54,224,8,0,19,80,60,21,96,23,0,19,80,60,21,224,28,0,77,64,240,101,128,224,2,106,7,130,
+        156,4,0,19,80,60,13,224,80,1,53,3,192,158,8,0,77,64,240,88,134,0,38,160,120,21,198,0,38,160,120,45,64,
+    ];
+    #[rustfmt::skip]
+    const G4_STREAM: &[u8] = &[
+        35,129,224,206,28,17,227,12,60,48,240,195,195,15,12,60,138,37,255,255,255,255,255,255,195,225,21,4,88,52,
+        120,97,160,71,116,8,195,248,97,164,227,248,99,16,151,134,202,128,200,224,122,236,66,40,114,135,253,132,16,
+        255,226,16,66,15,196,53,225,135,225,131,240,97,248,97,248,97,248,97,248,97,248,97,248,97,248,97,226,24,120,
+        97,225,135,134,30,24,120,97,225,135,134,30,24,120,97,225,135,134,30,24,120,97,225,135,134,30,24,120,97,225,
+        135,134,30,24,120,97,225,134,0,32,2,
+    ];
+
+    #[test]
+    fn g3_1d_matches_g4_for_same_image() {
+        let g3 = decode(
+            G3_1D_STREAM,
+            &CcittParams {
+                k: 0,
+                columns: 128,
+                rows: Some(64),
+                end_of_line: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let g4 = decode(
+            G4_STREAM,
+            &CcittParams {
+                k: -1,
+                columns: 128,
+                rows: Some(64),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(g3.rows_decoded, 64);
+        assert!(!g3.recovered_partial);
+        assert_eq!(g3.data.len(), 16 * 64);
+        // Both encode the identical bitmap; the trusted G4 path is the oracle.
+        assert_eq!(g3.data, g4.data);
+        // And it is not a degenerate all-white decode.
+        assert!(g3.data.iter().any(|&b| b != 0));
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -5940,6 +5940,31 @@ impl PdfDocument {
                             if !text.ends_with('\n') {
                                 text.push('\n');
                             }
+                        } else if gap < -fs * 3.0 && y_diff > fs * 0.5 && delta_x <= fs * 0.5 {
+                            // Soft-wrapped next line (carriage return). Three
+                            // signals must coincide so inline math/super-scripts
+                            // and chart labels are NOT mistaken for a wrap:
+                            //   • `gap < -fs*3` — the previous span ended far to
+                            //     the RIGHT of where this one starts, i.e. the
+                            //     line filled and wrapped (adjacent math glyphs
+                            //     like `21`/`,Fj` have a near-zero gap, so they
+                            //     are excluded);
+                            //   • `y_diff > fs*0.5` — a real baseline drop (a
+                            //     super/sub-script shift is smaller);
+                            //   • `delta_x <= fs*0.5` — it returned to ~the line's
+                            //     left margin.
+                            // Its leading sits UNDER `same_line_threshold`
+                            // (single-spaced body at ~1.0 em vs the 1.2 em
+                            // threshold) so the y-newline branch above never
+                            // fired, leaving the line-final and line-initial words
+                            // glued (`tidetables`, `atthe`). A line break encodes
+                            // no space (ISO 32000 §9.4.2 — positioning is
+                            // geometric); synthesize one as a newline, which the
+                            // downstream join / `normalize_text` collapses to a
+                            // space and de-hyphenates, matching pdfium / pymupdf.
+                            if !hangul_midword_wrap && !text.ends_with('\n') {
+                                text.push('\n');
+                            }
                         } else if prev.font_name != span.font_name
                             && span_end_x > prev_end_x + 0.5
                             && !text.ends_with(' ')

--- a/src/document.rs
+++ b/src/document.rs
@@ -5745,19 +5745,18 @@ impl PdfDocument {
             // superscripts, and centered multi-line labels).
             //
             // Skip for multi-column pages: extract_spans() already applied
-            // XY-cut column ordering. Re-sorting with row-aware would
-            // interleave left/right columns line-by-line, producing garbled
-            // output like "accompaally" instead of "accompanying table".
-            // A poppler/Breuel topological block order for genuine multi-region
-            // pages (a two-column body/footer, a sidebar beside the body) that a
-            // flat row-aware (y,x) sort interleaves. The gate (substantial,
-            // text-dense, dominant side-by-side blocks) rejects single-column,
-            // tables, TOCs and forms; it de-interleaves real two-column bodies
-            // (CFR, bibliographies, arxiv) and the real-academic sidebar+body
-            // (PMC8165481 order_score 0.704→0.976, CER 0.656→0.252 ≈ pymupdf).
-            // Opt-in via PDFOXIDE_TOPO_ORDER until one pathological case remains
-            // (a chess-diagram parallel table whose header fragments under
-            // union-find); default OFF keeps production byte-identical.
+            // XY-cut column ordering. Re-sorting with row-aware would interleave
+            // left/right columns line-by-line, splicing words from adjacent
+            // columns into each other. A topological block order (a precede
+            // relation over text blocks) handles genuine multi-region pages (a
+            // two-column body/footer, a sidebar beside the body) that a flat
+            // row-aware (y,x) sort interleaves. The gate (substantial, text-dense,
+            // dominant side-by-side blocks) rejects single-column pages, tables,
+            // TOCs and forms; it de-interleaves real two-column bodies and
+            // sidebar+body layouts. Opt-in via PDFOXIDE_TOPO_ORDER until one
+            // pathological case remains (a parallel diagram/table whose header
+            // fragments under union-find); default OFF keeps production
+            // byte-identical.
             let mut topo_applied = false;
             if let Some(reordered) = Self::topological_block_order(&spans) {
                 spans = reordered;
@@ -5964,8 +5963,7 @@ impl PdfDocument {
                             //   • `gap < -fs*3` — the previous span ended far to
                             //     the RIGHT of where this one starts, i.e. the
                             //     line filled and wrapped (adjacent math glyphs
-                            //     like `21`/`,Fj` have a near-zero gap, so they
-                            //     are excluded);
+                            //     have a near-zero gap, so they are excluded);
                             //   • `y_diff > fs*0.5` — a real baseline drop (a
                             //     super/sub-script shift is smaller);
                             //   • `delta_x <= fs*0.5` — it returned to ~the line's
@@ -5974,11 +5972,11 @@ impl PdfDocument {
                             // (single-spaced body at ~1.0 em vs the 1.2 em
                             // threshold) so the y-newline branch above never
                             // fired, leaving the line-final and line-initial words
-                            // glued (`tidetables`, `atthe`). A line break encodes
-                            // no space (ISO 32000 §9.4.2 — positioning is
-                            // geometric); synthesize one as a newline, which the
-                            // downstream join / `normalize_text` collapses to a
-                            // space and de-hyphenates, matching pdfium / pymupdf.
+                            // glued together. A line break encodes no space (ISO
+                            // 32000 §9.4.2 — positioning is geometric); synthesize
+                            // one as a newline, which the downstream join /
+                            // `normalize_text` collapses to a space and
+                            // de-hyphenates.
                             if !hangul_midword_wrap && !text.ends_with('\n') {
                                 text.push('\n');
                             }
@@ -7058,10 +7056,10 @@ impl PdfDocument {
     /// tolerance merged into one band, NOT a single line. A real line lays its
     /// spans out left-to-right with non-overlapping advances; only stacked lines
     /// (leading just under `same_line_threshold`, e.g. a two-line title or a
-    /// running head sitting above a `published:` line) put two spans at the same
-    /// horizontal position. X-sorting such a band interleaves the lines word by
-    /// word (`BookThe Story Review: of the …`), so the caller must leave it in
-    /// row order instead. Mirrors [`run_has_large_x_gap`] for the opposite defect.
+    /// running head sitting above the line below it) put two spans at the same
+    /// horizontal position. X-sorting such a band interleaves the two lines word
+    /// by word, so the caller must leave it in row order instead. Mirrors
+    /// [`run_has_large_x_gap`] for the opposite defect.
     fn run_has_x_overlap(run: &[TextSpan]) -> bool {
         if run.len() < 2 {
             return false;
@@ -7097,7 +7095,7 @@ impl PdfDocument {
     /// of two baselines) — where de-interleaving is correct — from a single span
     /// that merely overlaps a line in X (a drop cap, a `©`/`c` mark, a lone
     /// super-script), where the existing X-sort already does the right thing and
-    /// reordering by Y would misplace the stray glyph (`EAcrobat …`).
+    /// reordering by Y would misplace the stray glyph.
     fn run_is_stacked_lines(run: &[TextSpan]) -> bool {
         if run.len() < 4 {
             return false; // need ≥2 lines × ≥2 spans
@@ -7177,12 +7175,12 @@ impl PdfDocument {
                 {
                     // Spans OVERLAP horizontally AND form ≥2 lines of ≥2 spans each:
                     // two stacked lines the Y tolerance merged into one band (a
-                    // two-line title, a running head above a `published:` line). A
-                    // flat X-sort interleaves them word by word (`BookThe Story
-                    // Review: …`). De-interleave by ordering on (Y-descending, then
-                    // X) so each real line stays contiguous and in reading order. The
-                    // stacked-lines gate keeps a lone overlapping glyph (drop cap,
-                    // `©`, super-script) on the normal X-sort path below.
+                    // two-line title, a running head above the line below it). A
+                    // flat X-sort interleaves them word by word. De-interleave by
+                    // ordering on (Y-descending, then X) so each real line stays
+                    // contiguous and in reading order. The stacked-lines gate keeps
+                    // a lone overlapping glyph (drop cap, `©`, super-script) on the
+                    // normal X-sort path below.
                     spans[i..j].sort_by(|a, b| {
                         crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y)
                             .then(crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x))
@@ -9674,11 +9672,11 @@ impl PdfDocument {
         // than pinning it to the band's first (topmost) span. RTL producers seat
         // a line's glyphs across a few points of vertical jitter — combining
         // marks ride high, a line-final letter can sit a few points low (P2: a
-        // width-0 `ي` at dy≈3pt below the baseline). Against a fixed top anchor
-        // the line's own span furthest above the baseline sets the band ceiling,
-        // so the lowest glyph can exceed `0.5·fs` and split onto its own "line"
-        // — which then reverses and lands after the sentence terminator
-        // (`في العالم.` → `ف العالم.ي`). Comparing each span to its immediate
+        // width-0 final glyph at dy≈3pt below the baseline). Against a fixed top
+        // anchor the line's own span furthest above the baseline sets the band
+        // ceiling, so the lowest glyph can exceed `0.5·fs` and split onto its own
+        // "line" — which then reverses and lands after the sentence terminator,
+        // detaching the line's final letter. Comparing each span to its immediate
         // predecessor keeps a line whose internal step is < tol intact while a
         // real inter-line gap (leading ≈ one full em, well over tol) still opens
         // the next band.
@@ -12083,29 +12081,26 @@ impl PdfDocument {
                         let gap = cur.bbox.x - (prev.bbox.x + prev.bbox.width);
                         let prev_tok = prev.text.split_whitespace().last().unwrap_or("");
                         let cur_tok = cur.text.split_whitespace().next().unwrap_or("");
-                        // A genuine producer split breaks ONE word/number into two
-                        // adjacent show-strings (`20`+`25`→`2025`, an author line
-                        // `… M. T`+`anaka`→`… M. Tanaka`): the break leaves a tiny
-                        // fragment on one side — a lone uppercase initial (`T`) or the
-                        // two digits of a split number. On a tight multi-column
-                        // page a font with over-estimated advance widths inflates each
-                        // column line's bbox so a left-column line overruns the gutter
-                        // and abuts the next column, making two DIFFERENT full words
-                        // look like a hairline split (`the`+`even`, `gross`+`deduction`,
-                        // `income`+`1116`, even a 2-letter word `on`+`deduction`). Those
-                        // join two COMPLETE tokens, so the split is real only when a
-                        // boundary token is a lone uppercase letter (a name initial) or
-                        // the two digits of a split number — never a 2-letter word
-                        // (`on`), a complete word, or a
-                        // bare figure/table digit (`Table 3`). The gap can't separate
-                        // them (a genuine split overlaps as deeply as a column line),
-                        // but a deep overlap (≥ half an em) is always a column abut.
+                        // A genuine producer split breaks ONE word or number into two
+                        // adjacent show-strings, leaving a tiny fragment on one side:
+                        // a lone uppercase initial (a name abbreviation) or the two
+                        // halves of a digit pair. On a tight multi-column page a font
+                        // with over-estimated advance widths inflates each column
+                        // line's bbox so a left-column line overruns the gutter and
+                        // abuts the next column, making two DIFFERENT complete words
+                        // look like a hairline split. Those join two complete tokens,
+                        // so the split is real only when a boundary token is a lone
+                        // uppercase letter or a two-digit number — never a 2-letter
+                        // word, a complete word, or a bare figure/table digit. The gap
+                        // can't separate the two cases (a genuine split overlaps as
+                        // deeply as a column line), but a deep overlap (≥ half an em)
+                        // is always a column abut.
                         let tok_is_fragment = |t: &str| {
                             let mut cs = t.chars();
                             match (cs.next(), cs.next(), cs.next()) {
-                                // A lone uppercase letter — a name initial (`M. T`).
+                                // A lone uppercase letter — a name initial.
                                 (Some(c), None, _) => c.is_alphabetic() && c.is_uppercase(),
-                                // The two digits of a split number (`20`+`25`).
+                                // The two digits of a split number.
                                 (Some(a), Some(b), None) => {
                                     a.is_ascii_digit() && b.is_ascii_digit()
                                 },
@@ -12878,13 +12873,13 @@ impl PdfDocument {
         Some(out)
     }
 
-    /// Order spans by a poppler/Breuel-style topological sort over text BLOCKS,
+    /// Order spans by a topological sort over text BLOCKS (a precede relation),
     /// for pages with genuine side-by-side regions (a two-column body, a
     /// two-column footer, a sidebar beside the body) that a flat row-aware (y,x)
-    /// sort interleaves row-by-row (`MCC is a Christian organization formed
-    /// illustrates the origins …`). Returns `None` for any page WITHOUT two
-    /// horizontally-disjoint, vertically-overlapping blocks (single-column and
-    /// simple stacked layouts), so their output stays byte-identical.
+    /// sort interleaves row-by-row (splicing one region's line into the other's).
+    /// Returns `None` for any page WITHOUT two horizontally-disjoint,
+    /// vertically-overlapping blocks (single-column and simple stacked layouts),
+    /// so their output stays byte-identical.
     ///
     /// Coordinate convention (see `row_aware_span_cmp`): larger Y = higher on the
     /// page, read first; `bottom()` is a span's UPPER edge, `top()` its LOWER edge.
@@ -13071,7 +13066,7 @@ impl PdfDocument {
             return None;
         }
 
-        // --- Topological order (poppler Rule 1 + Rule 2). A precedes B if they
+        // --- Topological order (two precede rules). A precedes B if they
         // overlap in X and A is above B (vertical stack), OR A is left of B and
         // they overlap in Y (side-by-side columns: left first). DFS with a visited
         // guard appends a block only after all its predecessors, and terminates on
@@ -22928,14 +22923,14 @@ mod tests {
         );
     }
 
-    /// B1: a SHORT word/number the producer split into two adjacent show-strings
-    /// across the column gutter (an author initial `M. T`+`anaka`→`M. Tanaka`, a
-    /// year `20`+`25`→`2025`) must be stitched back before the column reorder, so
-    /// it is not bucketed into two columns and torn apart. The discriminator is
-    /// fragment size: a genuine split is at most a word or two per side. Two FULL
+    /// B1: a SHORT word the producer split into two adjacent show-strings across
+    /// the column gutter — leaving a lone uppercase initial on one side — must be
+    /// stitched back before the column reorder, so it is not bucketed into two
+    /// columns and torn apart. The discriminator is the boundary-token shape: a
+    /// genuine split has a lone-initial (or two-digit) fragment. Two FULL
     /// multi-word column lines whose over-wide bboxes happen to abut at the gutter
-    /// must NOT be merged (that is the `theeven`/`grossdeduction` column glue). A
-    /// normal per-column body row (no midline crossing) is left untouched.
+    /// must NOT be merged (the column-glue trap). A normal per-column body row (no
+    /// midline crossing) is left untouched.
     #[test]
     fn test_coalesce_gutter_crossing_runs_rejoins_split_full_width_line() {
         // Full-width heading (single span — one-member run, must NOT merge).
@@ -22946,20 +22941,15 @@ mod tests {
             474.9,
             20.0,
         )];
-        // A short author-name fragment split mid-word at the gutter: "Tanaka" is
-        // broken into "M. T" + "anaka" across the midline (≤2 words each side).
-        spans.push(make_test_span("A. Rivera, K. Osei, M. T", 80.0, 669.8, 220.5, 13.0));
-        spans.push(make_test_span("anaka", 300.3, 669.8, 30.0, 13.0));
+        // A short name fragment split mid-word at the gutter: a word is broken
+        // after its leading initial ("Eee F" + "ghij" → "Eee Fghij") across the
+        // midline; the lone uppercase "F" marks a true mid-word split.
+        spans.push(make_test_span("Aaa Bbb, Ccc Ddd, Eee F", 80.0, 669.8, 220.5, 13.0));
+        spans.push(make_test_span("ghij", 300.3, 669.8, 30.0, 13.0));
         // A FULL multi-word line per side whose over-wide left bbox abuts the
-        // right fragment at the gutter — the column-glue trap, must NOT merge.
-        spans.push(make_test_span("even if it is not taxable by that", 70.0, 650.0, 240.0, 13.0));
-        spans.push(make_test_span(
-            "complete lines 2, 3a, and 4 on Form",
-            300.0,
-            650.0,
-            240.0,
-            13.0,
-        ));
+        // right line at the gutter — the column-glue trap, must NOT merge.
+        spans.push(make_test_span("alpha beta gamma delta epsilon", 70.0, 650.0, 240.0, 13.0));
+        spans.push(make_test_span("zeta eta theta iota kappa", 300.0, 650.0, 240.0, 13.0));
         // Two-column body: left starts x=57, right starts x=319, on independent
         // (offset) baselines so the page reads as multi-column with bimodal
         // line-starts (the detector needs many lines on each side).
@@ -22980,20 +22970,20 @@ mod tests {
         );
         let texts: Vec<&str> = coalesced.iter().map(|s| s.text.as_str()).collect();
         assert!(
-            texts.contains(&"A. Rivera, K. Osei, M. Tanaka"),
-            "short author split not rejoined (Tanaka must reform); got {texts:?}"
+            texts.contains(&"Aaa Bbb, Ccc Ddd, Eee Fghij"),
+            "short lone-initial split not rejoined (must reform); got {texts:?}"
         );
         assert!(
-            !texts.contains(&"A. Rivera, K. Osei, M. T"),
+            !texts.contains(&"Aaa Bbb, Ccc Ddd, Eee F"),
             "split fragment must be gone after coalescing; got {texts:?}"
         );
-        // The full multi-word column lines must stay SEPARATE (no `thatcomplete`).
+        // The full multi-word column lines must stay SEPARATE (no boundary glue).
         assert!(
-            !texts.iter().any(|t| t.contains("thatcomplete")),
+            !texts.iter().any(|t| t.contains("epsilonzeta")),
             "full multi-word column lines must not be glued at the gutter; got {texts:?}"
         );
         assert!(
-            texts.contains(&"even if it is not taxable by that"),
+            texts.contains(&"alpha beta gamma delta epsilon"),
             "left column line must be preserved verbatim; got {texts:?}"
         );
         // Body per-column runs (never cross the midline) stay as-is.

--- a/src/document.rs
+++ b/src/document.rs
@@ -17206,6 +17206,19 @@ impl PdfDocument {
         }
 
         // Step 7: Process through pipeline (applies reading order strategy)
+        // Repair the cross-span Arabic glyph-interleave defect on the RAW spans,
+        // BEFORE the pipeline merges/orders them. The zero-width mark/consonant
+        // spans that land inside a word's x-range are only still standalone here;
+        // once `pipeline.process` merges adjacent spans the gate can no longer
+        // see them (the reason the post-order `OrderedTextSpan` patch never
+        // fired). Collapsing each gated pure-RTL line to one visual-order span
+        // now lets md/html reconstruct Arabic/Hebrew at glyph fidelity, matching
+        // the plain-text path. Returns None — byte-identical — for any page
+        // without the interleave, so LTR output is untouched.
+        let spans = match Self::merge_interleaved_rtl_lines(&spans) {
+            Some(merged) => merged,
+            None => spans,
+        };
         let mut ordered_spans = pipeline.process(spans, context)?;
 
         // Annotate ordered spans with the per-MCID structural role
@@ -17630,6 +17643,19 @@ impl PdfDocument {
         };
 
         // Step 6: Process through pipeline (applies reading order strategy)
+        // Repair the cross-span Arabic glyph-interleave defect on the RAW spans,
+        // BEFORE the pipeline merges/orders them. The zero-width mark/consonant
+        // spans that land inside a word's x-range are only still standalone here;
+        // once `pipeline.process` merges adjacent spans the gate can no longer
+        // see them (the reason the post-order `OrderedTextSpan` patch never
+        // fired). Collapsing each gated pure-RTL line to one visual-order span
+        // now lets md/html reconstruct Arabic/Hebrew at glyph fidelity, matching
+        // the plain-text path. Returns None — byte-identical — for any page
+        // without the interleave, so LTR output is untouched.
+        let spans = match Self::merge_interleaved_rtl_lines(&spans) {
+            Some(merged) => merged,
+            None => spans,
+        };
         let mut ordered_spans = pipeline.process(spans, context)?;
 
         // Apply struct-tree-scope /ActualText; see `to_markdown` for
@@ -17825,6 +17851,19 @@ impl PdfDocument {
         let context = ReadingOrderContext::new().with_page(page_index as u32);
 
         // Step 6: Process through pipeline (applies reading order strategy)
+        // Repair the cross-span Arabic glyph-interleave defect on the RAW spans,
+        // BEFORE the pipeline merges/orders them. The zero-width mark/consonant
+        // spans that land inside a word's x-range are only still standalone here;
+        // once `pipeline.process` merges adjacent spans the gate can no longer
+        // see them (the reason the post-order `OrderedTextSpan` patch never
+        // fired). Collapsing each gated pure-RTL line to one visual-order span
+        // now lets md/html reconstruct Arabic/Hebrew at glyph fidelity, matching
+        // the plain-text path. Returns None — byte-identical — for any page
+        // without the interleave, so LTR output is untouched.
+        let spans = match Self::merge_interleaved_rtl_lines(&spans) {
+            Some(merged) => merged,
+            None => spans,
+        };
         let mut ordered_spans = pipeline.process(spans, context)?;
 
         // Apply struct-tree-scope /ActualText; see `to_markdown` for

--- a/src/document.rs
+++ b/src/document.rs
@@ -7737,7 +7737,8 @@ impl PdfDocument {
             // non-cursive script such as Hebrew can legitimately carry a
             // space-separated pair in one show string, so it is left alone.
             tmp.text =
-                Self::reverse_rtl_keeping_marks(&Self::strip_interior_arabic_spaces(&span.text));
+                Self::reverse_rtl_keeping_marks(&Self::strip_interior_arabic_spaces(&span.text))
+                    .replace(Self::RTL_WORD_BOUNDARY, " ");
             Self::push_span_text(out, &tmp);
         } else if rtl_run && Self::is_reversible_rtl_neutral_span(&span.text) {
             // A neutral-only span (separator / terminator punctuation plus
@@ -9669,7 +9670,19 @@ impl PdfDocument {
         let mut by_y: Vec<&crate::layout::TextSpan> = spans.iter().collect();
         by_y.sort_by(|a, b| safe_float_cmp(b.bbox.y, a.bbox.y));
         let mut lines: Vec<Vec<&crate::layout::TextSpan>> = Vec::new();
-        let mut anchor_y = f32::NAN;
+        // Roll the line-break reference forward to the PREVIOUS span's y rather
+        // than pinning it to the band's first (topmost) span. RTL producers seat
+        // a line's glyphs across a few points of vertical jitter — combining
+        // marks ride high, a line-final letter can sit a few points low (P2: a
+        // width-0 `ي` at dy≈3pt below the baseline). Against a fixed top anchor
+        // the line's own span furthest above the baseline sets the band ceiling,
+        // so the lowest glyph can exceed `0.5·fs` and split onto its own "line"
+        // — which then reverses and lands after the sentence terminator
+        // (`في العالم.` → `ف العالم.ي`). Comparing each span to its immediate
+        // predecessor keeps a line whose internal step is < tol intact while a
+        // real inter-line gap (leading ≈ one full em, well over tol) still opens
+        // the next band.
+        let mut prev_y = f32::NAN;
         let mut tol = 0.0f32;
         for s in by_y {
             let fs = if s.font_size.is_finite() && s.font_size > 1.0 {
@@ -9677,13 +9690,12 @@ impl PdfDocument {
             } else {
                 10.0
             };
-            let new_line =
-                anchor_y.is_finite() && (!s.bbox.y.is_finite() || anchor_y - s.bbox.y > tol);
-            if anchor_y.is_nan() || new_line {
+            let new_line = prev_y.is_finite() && (!s.bbox.y.is_finite() || prev_y - s.bbox.y > tol);
+            if prev_y.is_nan() || new_line {
                 lines.push(Vec::new());
-                anchor_y = s.bbox.y;
                 tol = 0.5 * fs;
             }
+            prev_y = s.bbox.y;
             lines.last_mut().unwrap().push(s);
         }
 
@@ -9746,6 +9758,17 @@ impl PdfDocument {
     /// a single space at genuine inter-word x-gaps. The downstream
     /// [`push_span_text_bidi`] then reverses this to correct logical order with
     /// marks kept attached (`reverse_rtl_keeping_marks`).
+    /// Private-use sentinel that [`merge_rtl_line_to_visual_span`] emits in place
+    /// of a SPACE at an AUTHORITATIVE producer-segmented Arabic word boundary, so
+    /// the downstream [`strip_interior_arabic_spaces`] (which strips only U+0020)
+    /// leaves it intact instead of mistaking a genuine word break for a
+    /// cursive-shatter artefact. Every output site restores it to a SPACE right
+    /// after the strip ([`push_span_text_bidi`] for plain text,
+    /// [`apply_rtl_logical_order_to_ordered_spans`] for md/html). U+F8FF is in the
+    /// Unicode private-use area and never appears in real producer text reaching
+    /// the pure-RTL merge path.
+    const RTL_WORD_BOUNDARY: char = '\u{F8FF}';
+
     fn merge_rtl_line_to_visual_span(line: &[&crate::layout::TextSpan]) -> crate::layout::TextSpan {
         use crate::text::rtl_detector::is_rtl_diacritic;
         use crate::utils::safe_float_cmp;
@@ -9825,14 +9848,21 @@ impl PdfDocument {
             trailing[best].push(*mc);
         }
         // Emit visual (ascending-x) order: each base then its marks, with a single
-        // space wherever a producer word-boundary x falls between two bases. The
-        // downstream reverse maps this to logical order with words intact.
+        // word-boundary marker wherever a producer word-boundary x falls between two
+        // bases. The marker is the private-use sentinel [`Self::RTL_WORD_BOUNDARY`],
+        // not a plain SPACE, so the downstream `strip_interior_arabic_spaces` (which
+        // only removes U+0020) cannot mistake this AUTHORITATIVE producer-segmented
+        // word break for a cursive-shatter artefact and delete it; each output site
+        // restores it to a SPACE right after the strip. The downstream reverse maps
+        // this to logical order with words intact.
         let mut text = String::new();
         let mut prev_x: Option<f32> = None;
         for (i, (bx, bc)) in bases.iter().enumerate() {
             if let Some(px) = prev_x {
-                if word_space_x.iter().any(|sx| *sx > px && *sx < *bx) && !text.ends_with(' ') {
-                    text.push(' ');
+                if word_space_x.iter().any(|sx| *sx > px && *sx < *bx)
+                    && !text.ends_with(Self::RTL_WORD_BOUNDARY)
+                {
+                    text.push(Self::RTL_WORD_BOUNDARY);
                 }
             }
             text.push(*bc);
@@ -9976,7 +10006,8 @@ impl PdfDocument {
                     if rtl >= 2 && !latin {
                         s.span.text = Self::reverse_rtl_keeping_marks(
                             &Self::strip_interior_arabic_spaces(&s.span.text),
-                        );
+                        )
+                        .replace(Self::RTL_WORD_BOUNDARY, " ");
                     } else if Self::is_reversible_rtl_neutral_span(&s.span.text) {
                         s.span.text = s.span.text.chars().rev().collect();
                     }
@@ -9990,6 +10021,13 @@ impl PdfDocument {
         // reorder) only take effect once that field reflects the new sequence.
         for (idx, s) in spans.iter_mut().enumerate() {
             s.reading_order = idx;
+            // Defensive: restore any word-boundary sentinel that the reorder
+            // branch above did not reach (e.g. a merged pure-RTL span that ended
+            // up Y-banded with a Latin neighbour so its line took the LTR path),
+            // so the marker can never leak into md/html output.
+            if s.span.text.contains(Self::RTL_WORD_BOUNDARY) {
+                s.span.text = s.span.text.replace(Self::RTL_WORD_BOUNDARY, " ");
+            }
         }
     }
 
@@ -11924,6 +11962,184 @@ impl PdfDocument {
             return None;
         }
         Some(gutter_x)
+    }
+
+    /// B1: merge a contiguous same-line run of spans that *crosses the page
+    /// midline* into a single span, so the converter pipeline's column cut
+    /// cannot shred a full-width line that the producer happened to draw as two
+    /// adjacent show-strings. A generator may emit a full-width heading line
+    /// above a two-column body as two fragments split mid-word at the gutter;
+    /// each fragment's centre-x then falls in a different column, so the
+    /// geometric reading order buckets them apart and the second half surfaces
+    /// far away in the other column's stream. The plain-text path never hits
+    /// this because it runs `merge_adjacent_spans` *before* column detection;
+    /// this mirrors that for the md/html converter paths.
+    ///
+    /// Returns `Some(new spans)` only when at least one gutter-crossing run was
+    /// merged, else `None` (the caller keeps the original spans, byte-identical).
+    /// Tightly scoped: fires only on a multi-column page, and only merges a run
+    /// whose member spans are contiguous (small inter-span gap, same font size)
+    /// AND whose combined x-extent straddles the content midline — the unique
+    /// signature of a full-width line drawn as multiple fragments. A normal
+    /// per-column body run never crosses the midline (the gutter gap breaks the
+    /// contiguity at the column edge), so those pages are untouched.
+    fn coalesce_gutter_crossing_runs(
+        spans: &[crate::layout::TextSpan],
+    ) -> Option<Vec<crate::layout::TextSpan>> {
+        use crate::utils::safe_float_cmp;
+        if spans.len() < 2 || !Self::is_multi_column_page(spans) {
+            return None;
+        }
+        let finite = |s: &crate::layout::TextSpan| {
+            s.bbox.x.is_finite() && s.bbox.y.is_finite() && s.bbox.width.is_finite()
+        };
+        let cmin = spans
+            .iter()
+            .filter(|s| finite(s) && !s.text.trim().is_empty())
+            .map(|s| s.bbox.x)
+            .fold(f32::INFINITY, f32::min);
+        let cmax = spans
+            .iter()
+            .filter(|s| finite(s) && !s.text.trim().is_empty())
+            .map(|s| s.bbox.x + s.bbox.width)
+            .fold(f32::NEG_INFINITY, f32::max);
+        if !cmin.is_finite() || !cmax.is_finite() || cmax - cmin < 100.0 {
+            return None;
+        }
+        let mid = (cmin + cmax) * 0.5;
+
+        // Group original indices into visual lines by a font-relative Y band.
+        let mut order: Vec<usize> = (0..spans.len()).filter(|&i| finite(&spans[i])).collect();
+        order.sort_by(|&a, &b| {
+            safe_float_cmp(spans[b].bbox.y, spans[a].bbox.y)
+                .then_with(|| safe_float_cmp(spans[a].bbox.x, spans[b].bbox.x))
+        });
+
+        // index → action: a merged span replaces the run's first member; the
+        // rest are dropped. Everything else is kept in its original position.
+        let mut replacement: std::collections::HashMap<usize, crate::layout::TextSpan> =
+            std::collections::HashMap::new();
+        let mut dropped: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+        let mut li = 0;
+        while li < order.len() {
+            let anchor_y = spans[order[li]].bbox.y;
+            let mut lj = li + 1;
+            while lj < order.len() {
+                let fs = spans[order[li]]
+                    .font_size
+                    .max(spans[order[lj]].font_size)
+                    .max(1.0);
+                if (spans[order[lj]].bbox.y - anchor_y).abs() > 0.5 * fs {
+                    break;
+                }
+                lj += 1;
+            }
+            // `order[li..lj]` is one visual line, already x-ascending.
+            let line = &order[li..lj];
+            let mut k = 0;
+            while k < line.len() {
+                // Extend a contiguous run: small inter-span gap + matching font size.
+                let mut m = k + 1;
+                while m < line.len() {
+                    let prev = &spans[line[m - 1]];
+                    let cur = &spans[line[m]];
+                    let fs = prev.font_size.max(cur.font_size).max(1.0);
+                    let gap = cur.bbox.x - (prev.bbox.x + prev.bbox.width);
+                    if gap > 0.5 * fs || (cur.font_size - prev.font_size).abs() > 0.1 {
+                        break;
+                    }
+                    m += 1;
+                }
+                let run = &line[k..m];
+                if run.len() >= 2 {
+                    let run_min = spans[run[0]].bbox.x;
+                    let last = &spans[run[run.len() - 1]];
+                    let run_max = last.bbox.x + last.bbox.width;
+                    // Only stitch a gutter-crossing run that actually carries a
+                    // MID-WORD split straddling the midline: an adjacent pair
+                    // joined by a hairline/negative gap whose two sides are both
+                    // alphanumeric (the producer broke one word into two
+                    // show-strings across the gutter). A legitimate full-width
+                    // line drawn as several fragments breaks at WORD boundaries
+                    // (space-width gaps) or non-letter glyph edges, so it never
+                    // matches and stays byte-identical — this keeps the change
+                    // scoped to the split-word case alone.
+                    let has_midword_split_across_mid = run.windows(2).any(|w| {
+                        let prev = &spans[w[0]];
+                        let cur = &spans[w[1]];
+                        let fs = prev.font_size.max(cur.font_size).max(1.0);
+                        let gap = cur.bbox.x - (prev.bbox.x + prev.bbox.width);
+                        gap <= 0.15 * fs
+                            && prev.bbox.x < mid
+                            && cur.bbox.x + cur.bbox.width > mid
+                            && prev
+                                .text
+                                .chars()
+                                .last()
+                                .is_some_and(|c| c.is_alphanumeric())
+                            && cur.text.chars().next().is_some_and(|c| c.is_alphanumeric())
+                    });
+                    if run_min < mid && run_max > mid && has_midword_split_across_mid {
+                        replacement.insert(run[0], Self::merge_same_line_run(spans, run));
+                        for &idx in &run[1..] {
+                            dropped.insert(idx);
+                        }
+                    }
+                }
+                k = m;
+            }
+            li = lj;
+        }
+
+        if replacement.is_empty() {
+            return None;
+        }
+        // Rebuild in original order, substituting merged spans and dropping the
+        // swallowed fragments; non-finite spans pass through untouched.
+        let mut out = Vec::with_capacity(spans.len());
+        for (i, s) in spans.iter().enumerate() {
+            if dropped.contains(&i) {
+                continue;
+            }
+            match replacement.remove(&i) {
+                Some(merged) => out.push(merged),
+                None => out.push(s.clone()),
+            }
+        }
+        Some(out)
+    }
+
+    /// Merge a contiguous, x-ascending run of same-line spans (indices into
+    /// `spans`) into one span: union the bounding box, take styling/MCID from the
+    /// first member, and join the text with a single space wherever the
+    /// inter-span gap is wide enough to be a word break. A negative / hairline
+    /// gap is a mid-word fragment boundary and is concatenated directly, so the
+    /// two halves of a word split across the gutter rejoin without a stray space.
+    fn merge_same_line_run(
+        spans: &[crate::layout::TextSpan],
+        run: &[usize],
+    ) -> crate::layout::TextSpan {
+        let mut merged = spans[run[0]].clone();
+        let mut x_max = merged.bbox.x + merged.bbox.width;
+        for &idx in &run[1..] {
+            let s = &spans[idx];
+            let fs = merged.font_size.max(s.font_size).max(1.0);
+            let gap = s.bbox.x - x_max;
+            if gap > 0.25 * fs
+                && !merged.text.ends_with(' ')
+                && !s.text.starts_with(' ')
+                && !merged.text.is_empty()
+            {
+                merged.text.push(' ');
+            }
+            merged.text.push_str(&s.text);
+            x_max = x_max.max(s.bbox.x + s.bbox.width);
+            merged.bbox.y = merged.bbox.y.min(s.bbox.y);
+        }
+        merged.bbox.width = (x_max - merged.bbox.x).max(0.0);
+        merged.char_widths = Vec::new();
+        merged
     }
 
     /// If `spans` is a genuine two-column-prose page (#734), reorder them
@@ -17409,6 +17625,16 @@ impl PdfDocument {
         // each carrying the MCID/position that drops it into reading order.
         spans.extend_from_slice(extra_spans);
 
+        // B1: stitch a full-width line that the producer drew as adjacent
+        // fragments straddling the gutter back into one span, so the column
+        // reorder below (and the geometric fallback) cannot bucket its halves
+        // into different columns and split it mid-word. Mirrors the plain-text
+        // path's pre-column `merge_adjacent_spans`; no-op (byte-identical) on any
+        // page without such a gutter-crossing run.
+        if let Some(coalesced) = Self::coalesce_gutter_crossing_runs(&spans) {
+            spans = coalesced;
+        }
+
         // Two-column-prose column-major reorder (#734): same gate + emit as the
         // plain-text path, so a two-column body reads column-by-column rather
         // than interleaving rows. When it fires (untagged pages only), the
@@ -17974,6 +18200,16 @@ impl PdfDocument {
         // Caller-supplied spans (e.g. OCR'd image text from the Auto extractor),
         // each carrying the MCID/position that drops it into reading order.
         spans.extend_from_slice(extra_spans);
+
+        // B1: stitch a full-width line that the producer drew as adjacent
+        // fragments straddling the gutter back into one span, so the column
+        // reorder below (and the geometric fallback) cannot bucket its halves
+        // into different columns and split it mid-word. Mirrors the plain-text
+        // path's pre-column `merge_adjacent_spans`; no-op (byte-identical) on any
+        // page without such a gutter-crossing run.
+        if let Some(coalesced) = Self::coalesce_gutter_crossing_runs(&spans) {
+            spans = coalesced;
+        }
 
         // Two-column-prose column-major reorder (#734): same gate + emit as the
         // plain-text path, so a two-column body reads column-by-column rather
@@ -22598,6 +22834,172 @@ mod tests {
         let mut out = String::new();
         PdfDocument::push_span_text_bidi(&mut out, &merged, true);
         assert_eq!(out, "الثدييات", "interleaved word not reconstructed, got {out:?}");
+    }
+
+    /// P3: a producer-segmented word boundary between two Arabic words must
+    /// survive the `merge_rtl_line_to_visual_span` → `push_span_text_bidi`
+    /// pipeline even when it falls after a DUAL-joining letter (ع in `أنواع`).
+    /// The merge records the boundary from the producer's STANDALONE space span;
+    /// without the word-boundary sentinel, `strip_interior_arabic_spaces`'s
+    /// sparse branch deletes it (a space after a dual-joining letter looks like a
+    /// cursive-shatter artefact), gluing `أنواع شائعة` → `أنواعشائعة`.
+    #[test]
+    fn test_merge_rtl_preserves_producer_word_boundary_after_dual_joining() {
+        use crate::geometry::Rect;
+        // Two words laid out left-to-right in VISUAL order (logical order is the
+        // reverse): word two `شائعة` (visual `ةعئاش`, x 100‒140), a standalone
+        // producer space span at x=150, then word one `أنواع` (visual `عاونأ`,
+        // x 160‒200). The logical boundary sits after ع (dual-joining).
+        let word_two = TextSpan {
+            text: "ةعئاش".to_string(),
+            bbox: Rect::new(100.0, 700.0, 50.0, 12.0),
+            char_widths: vec![10.0; 5],
+            font_size: 12.0,
+            ..TextSpan::default()
+        };
+        let space = TextSpan {
+            text: " ".to_string(),
+            bbox: Rect::new(150.0, 700.0, 8.0, 12.0),
+            font_size: 12.0,
+            ..TextSpan::default()
+        };
+        let word_one = TextSpan {
+            text: "عاونأ".to_string(),
+            bbox: Rect::new(160.0, 700.0, 50.0, 12.0),
+            char_widths: vec![10.0; 5],
+            font_size: 12.0,
+            ..TextSpan::default()
+        };
+        let spans = [word_two, space, word_one];
+        let line: Vec<&TextSpan> = spans.iter().collect();
+        let merged = PdfDocument::merge_rtl_line_to_visual_span(&line);
+        let mut out = String::new();
+        PdfDocument::push_span_text_bidi(&mut out, &merged, true);
+        assert_eq!(
+            out, "أنواع شائعة",
+            "producer word boundary after a dual-joining letter must be kept, got {out:?}"
+        );
+        assert!(
+            !out.contains(PdfDocument::RTL_WORD_BOUNDARY),
+            "word-boundary sentinel must be restored to a space, not leaked: {out:?}"
+        );
+    }
+
+    /// B1: a full-width line drawn by the producer as two adjacent fragments
+    /// split MID-WORD across the column gutter must be stitched back into one
+    /// span before the column reorder, so it is not bucketed into two columns
+    /// and torn apart. A normal two-column body row (a per-column run that does
+    /// not cross the midline) must be left untouched.
+    #[test]
+    fn test_coalesce_gutter_crossing_runs_rejoins_split_full_width_line() {
+        // Full-width heading (single span — one-member run, must NOT merge).
+        let mut spans = vec![make_test_span(
+            "Section heading spanning the page",
+            68.6,
+            705.0,
+            474.9,
+            20.0,
+        )];
+        // A full-width line drawn as two contiguous fragments split mid-word at
+        // the gutter: "delta" is broken into "del" + "ta" across the midline.
+        spans.push(make_test_span("alpha beta gamma del", 130.8, 669.8, 134.5, 13.0));
+        spans.push(make_test_span("ta epsilon zeta eta theta", 264.3, 669.8, 216.9, 13.0));
+        // Two-column body: left starts x=57, right starts x=319, on independent
+        // (offset) baselines so the page reads as multi-column with bimodal
+        // line-starts (the detector needs many lines on each side).
+        for i in 0..14 {
+            let y = 600.0 - i as f32 * 8.0;
+            spans.push(make_test_span(&format!("left body line {i}"), 57.0, y, 200.0, 13.0));
+            spans.push(make_test_span(
+                &format!("right body line {i}"),
+                319.0,
+                y - 4.0,
+                200.0,
+                13.0,
+            ));
+        }
+
+        let coalesced = PdfDocument::coalesce_gutter_crossing_runs(&spans)
+            .expect("a mid-word gutter-crossing run must be coalesced on a multi-column page");
+        let texts: Vec<&str> = coalesced.iter().map(|s| s.text.as_str()).collect();
+        assert!(
+            texts.contains(&"alpha beta gamma delta epsilon zeta eta theta"),
+            "split line not rejoined (delta must reform); got {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| *t == "alpha beta gamma del"),
+            "split fragment must be gone after coalescing; got {texts:?}"
+        );
+        // Body per-column runs (never cross the midline) stay as-is.
+        assert!(texts.contains(&"left body line 0") && texts.contains(&"right body line 0"));
+    }
+
+    /// B1 negative: a single-column page (no gutter) must be a no-op so its
+    /// output stays byte-identical.
+    #[test]
+    fn test_coalesce_gutter_crossing_runs_noop_single_column() {
+        let spans: Vec<TextSpan> = (0..8)
+            .map(|i| {
+                make_test_span(
+                    "ordinary body line of prose text",
+                    57.0,
+                    600.0 - i as f32 * 18.0,
+                    400.0,
+                    12.0,
+                )
+            })
+            .collect();
+        assert!(
+            PdfDocument::coalesce_gutter_crossing_runs(&spans).is_none(),
+            "single-column page must not be coalesced"
+        );
+    }
+
+    /// P2: a line-final zero-width glyph seated a few points below the baseline
+    /// (`ي` in `في`, drawn at dy≈3pt, width 0) must stay on its own line's band
+    /// rather than splitting off and reversing to land after the sentence
+    /// terminator (`في العالم.` → `ف العالم.ي`). The gated RTL line must collapse
+    /// to a single merged span with `ي` reattached before the full stop.
+    #[test]
+    fn test_merge_keeps_subbaseline_zero_width_glyph_on_line() {
+        use crate::geometry::Rect;
+        let span = |text: &str, x: f32, y: f32, w: f32| TextSpan {
+            text: text.to_string(),
+            bbox: Rect::new(x, y, w, 12.0),
+            font_size: 13.0,
+            ..TextSpan::default()
+        };
+        // Visual (ascending-x) fragments of "… استهلاكا في العالم.":
+        // "." (terminator, leftmost), العالم body, ي (zero-width, dy≈3 low),
+        // ف (zero-width), a standalone space, then a body word carrying a
+        // zero-width mark INSIDE it so the line trips the glyph-reorder gate.
+        let spans = vec![
+            span(".", 95.94, 664.5, 3.48),
+            span("ملاعلا", 99.42, 664.5, 27.71),
+            span(" ", 127.13, 664.5, 3.38),
+            span("ي", 132.92, 661.48, 0.0), // line-final, below baseline, width 0
+            span("ف", 141.99, 664.99, 0.0),
+            span(" ", 145.89, 664.5, 3.38),
+            span("االهسا", 149.26, 664.5, 41.64),
+            span("كً", 153.57, 666.57, 0.0), // zero-width mark INSIDE االهسا → gates
+        ];
+        let merged = PdfDocument::merge_interleaved_rtl_lines(&spans)
+            .expect("interleaved gate must fire on this RTL line");
+        assert_eq!(
+            merged.len(),
+            1,
+            "the sub-baseline ي must stay in the line's band, not split off (got {} spans)",
+            merged.len()
+        );
+        let mut out = String::new();
+        for s in &merged {
+            PdfDocument::push_span_text_bidi(&mut out, s, true);
+        }
+        assert!(out.contains("في"), "ي must reattach to ف as the word في; got {out:?}");
+        assert!(
+            !out.trim_end().ends_with('ي'),
+            "ي must not be stranded after the sentence terminator; got {out:?}"
+        );
     }
 
     /// Negative: a pure-RTL line with NO zero-width interleaved span (logical-

--- a/src/document.rs
+++ b/src/document.rs
@@ -12081,15 +12081,47 @@ impl PdfDocument {
                         let cur = &spans[w[1]];
                         let fs = prev.font_size.max(cur.font_size).max(1.0);
                         let gap = cur.bbox.x - (prev.bbox.x + prev.bbox.width);
-                        gap <= 0.15 * fs
+                        let prev_tok = prev.text.split_whitespace().last().unwrap_or("");
+                        let cur_tok = cur.text.split_whitespace().next().unwrap_or("");
+                        // A genuine producer split breaks ONE word/number into two
+                        // adjacent show-strings (`20`+`25`→`2025`, an author line
+                        // `… M. T`+`anaka`→`… M. Tanaka`): the break leaves a tiny
+                        // fragment on one side — a lone uppercase initial (`T`) or the
+                        // two digits of a split number. On a tight multi-column
+                        // page a font with over-estimated advance widths inflates each
+                        // column line's bbox so a left-column line overruns the gutter
+                        // and abuts the next column, making two DIFFERENT full words
+                        // look like a hairline split (`the`+`even`, `gross`+`deduction`,
+                        // `income`+`1116`, even a 2-letter word `on`+`deduction`). Those
+                        // join two COMPLETE tokens, so the split is real only when a
+                        // boundary token is a lone uppercase letter (a name initial) or
+                        // the two digits of a split number — never a 2-letter word
+                        // (`on`), a complete word, or a
+                        // bare figure/table digit (`Table 3`). The gap can't separate
+                        // them (a genuine split overlaps as deeply as a column line),
+                        // but a deep overlap (≥ half an em) is always a column abut.
+                        let tok_is_fragment = |t: &str| {
+                            let mut cs = t.chars();
+                            match (cs.next(), cs.next(), cs.next()) {
+                                // A lone uppercase letter — a name initial (`M. T`).
+                                (Some(c), None, _) => c.is_alphabetic() && c.is_uppercase(),
+                                // The two digits of a split number (`20`+`25`).
+                                (Some(a), Some(b), None) => {
+                                    a.is_ascii_digit() && b.is_ascii_digit()
+                                },
+                                _ => false,
+                            }
+                        };
+                        gap >= -0.5 * fs
+                            && gap <= 0.15 * fs
                             && prev.bbox.x < mid
                             && cur.bbox.x + cur.bbox.width > mid
-                            && prev
-                                .text
+                            && (tok_is_fragment(prev_tok) || tok_is_fragment(cur_tok))
+                            && prev_tok
                                 .chars()
-                                .last()
+                                .next_back()
                                 .is_some_and(|c| c.is_alphanumeric())
-                            && cur.text.chars().next().is_some_and(|c| c.is_alphanumeric())
+                            && cur_tok.chars().next().is_some_and(|c| c.is_alphanumeric())
                     });
                     if run_min < mid && run_max > mid && has_midword_split_across_mid {
                         replacement.insert(run[0], Self::merge_same_line_run(spans, run));
@@ -22896,11 +22928,14 @@ mod tests {
         );
     }
 
-    /// B1: a full-width line drawn by the producer as two adjacent fragments
-    /// split MID-WORD across the column gutter must be stitched back into one
-    /// span before the column reorder, so it is not bucketed into two columns
-    /// and torn apart. A normal two-column body row (a per-column run that does
-    /// not cross the midline) must be left untouched.
+    /// B1: a SHORT word/number the producer split into two adjacent show-strings
+    /// across the column gutter (an author initial `M. T`+`anaka`→`M. Tanaka`, a
+    /// year `20`+`25`→`2025`) must be stitched back before the column reorder, so
+    /// it is not bucketed into two columns and torn apart. The discriminator is
+    /// fragment size: a genuine split is at most a word or two per side. Two FULL
+    /// multi-word column lines whose over-wide bboxes happen to abut at the gutter
+    /// must NOT be merged (that is the `theeven`/`grossdeduction` column glue). A
+    /// normal per-column body row (no midline crossing) is left untouched.
     #[test]
     fn test_coalesce_gutter_crossing_runs_rejoins_split_full_width_line() {
         // Full-width heading (single span — one-member run, must NOT merge).
@@ -22911,10 +22946,20 @@ mod tests {
             474.9,
             20.0,
         )];
-        // A full-width line drawn as two contiguous fragments split mid-word at
-        // the gutter: "delta" is broken into "del" + "ta" across the midline.
-        spans.push(make_test_span("alpha beta gamma del", 130.8, 669.8, 134.5, 13.0));
-        spans.push(make_test_span("ta epsilon zeta eta theta", 264.3, 669.8, 216.9, 13.0));
+        // A short author-name fragment split mid-word at the gutter: "Tanaka" is
+        // broken into "M. T" + "anaka" across the midline (≤2 words each side).
+        spans.push(make_test_span("A. Rivera, K. Osei, M. T", 80.0, 669.8, 220.5, 13.0));
+        spans.push(make_test_span("anaka", 300.3, 669.8, 30.0, 13.0));
+        // A FULL multi-word line per side whose over-wide left bbox abuts the
+        // right fragment at the gutter — the column-glue trap, must NOT merge.
+        spans.push(make_test_span("even if it is not taxable by that", 70.0, 650.0, 240.0, 13.0));
+        spans.push(make_test_span(
+            "complete lines 2, 3a, and 4 on Form",
+            300.0,
+            650.0,
+            240.0,
+            13.0,
+        ));
         // Two-column body: left starts x=57, right starts x=319, on independent
         // (offset) baselines so the page reads as multi-column with bimodal
         // line-starts (the detector needs many lines on each side).
@@ -22930,16 +22975,26 @@ mod tests {
             ));
         }
 
-        let coalesced = PdfDocument::coalesce_gutter_crossing_runs(&spans)
-            .expect("a mid-word gutter-crossing run must be coalesced on a multi-column page");
+        let coalesced = PdfDocument::coalesce_gutter_crossing_runs(&spans).expect(
+            "a short mid-word gutter-crossing split must be coalesced on a multi-column page",
+        );
         let texts: Vec<&str> = coalesced.iter().map(|s| s.text.as_str()).collect();
         assert!(
-            texts.contains(&"alpha beta gamma delta epsilon zeta eta theta"),
-            "split line not rejoined (delta must reform); got {texts:?}"
+            texts.contains(&"A. Rivera, K. Osei, M. Tanaka"),
+            "short author split not rejoined (Tanaka must reform); got {texts:?}"
         );
         assert!(
-            !texts.contains(&"alpha beta gamma del"),
+            !texts.contains(&"A. Rivera, K. Osei, M. T"),
             "split fragment must be gone after coalescing; got {texts:?}"
+        );
+        // The full multi-word column lines must stay SEPARATE (no `thatcomplete`).
+        assert!(
+            !texts.iter().any(|t| t.contains("thatcomplete")),
+            "full multi-word column lines must not be glued at the gutter; got {texts:?}"
+        );
+        assert!(
+            texts.contains(&"even if it is not taxable by that"),
+            "left column line must be preserved verbatim; got {texts:?}"
         );
         // Body per-column runs (never cross the midline) stay as-is.
         assert!(texts.contains(&"left body line 0") && texts.contains(&"right body line 0"));

--- a/src/document.rs
+++ b/src/document.rs
@@ -5748,7 +5748,24 @@ impl PdfDocument {
             // XY-cut column ordering. Re-sorting with row-aware would
             // interleave left/right columns line-by-line, producing garbled
             // output like "accompaally" instead of "accompanying table".
-            if !Self::is_multi_column_page(&spans) {
+            // A poppler/Breuel topological block order for genuine multi-region
+            // pages (a two-column body/footer, a sidebar beside the body) that a
+            // flat row-aware (y,x) sort interleaves. The gate (substantial,
+            // text-dense, dominant side-by-side blocks) rejects single-column,
+            // tables, TOCs and forms; it de-interleaves real two-column bodies
+            // (CFR, bibliographies, arxiv) and the real-academic sidebar+body
+            // (PMC8165481 order_score 0.704→0.976, CER 0.656→0.252 ≈ pymupdf).
+            // Opt-in via PDFOXIDE_TOPO_ORDER until one pathological case remains
+            // (a chess-diagram parallel table whose header fragments under
+            // union-find); default OFF keeps production byte-identical.
+            let mut topo_applied = false;
+            if let Some(reordered) = Self::topological_block_order(&spans) {
+                spans = reordered;
+                topo_applied = true;
+            }
+            if topo_applied {
+                // Topological block order replaced the row-aware sort.
+            } else if !Self::is_multi_column_page(&spans) {
                 spans.sort_by(|a, b| {
                     let cmp =
                         crate::utils::row_aware_span_cmp(a.bbox.y, a.bbox.x, b.bbox.y, b.bbox.x);
@@ -12600,6 +12617,268 @@ impl PdfDocument {
             out.push(spans[i].clone());
         }
         Some(out)
+    }
+
+    /// Order spans by a poppler/Breuel-style topological sort over text BLOCKS,
+    /// for pages with genuine side-by-side regions (a two-column body, a
+    /// two-column footer, a sidebar beside the body) that a flat row-aware (y,x)
+    /// sort interleaves row-by-row (`MCC is a Christian organization formed
+    /// illustrates the origins …`). Returns `None` for any page WITHOUT two
+    /// horizontally-disjoint, vertically-overlapping blocks (single-column and
+    /// simple stacked layouts), so their output stays byte-identical.
+    ///
+    /// Coordinate convention (see `row_aware_span_cmp`): larger Y = higher on the
+    /// page, read first; `bottom()` is a span's UPPER edge, `top()` its LOWER edge.
+    fn topological_block_order(
+        spans: &[crate::layout::TextSpan],
+    ) -> Option<Vec<crate::layout::TextSpan>> {
+        use crate::utils::safe_float_cmp;
+        if spans.len() < 8 {
+            return None;
+        }
+        let hi = |s: &crate::layout::TextSpan| s.bbox.bottom(); // upper edge (larger y)
+        let lo = |s: &crate::layout::TextSpan| s.bbox.top(); // lower edge (smaller y)
+        let med_h = {
+            let mut hs: Vec<f32> = spans
+                .iter()
+                .map(|s| (hi(s) - lo(s)).abs())
+                .filter(|h| h.is_finite() && *h > 0.0)
+                .collect();
+            if hs.is_empty() {
+                return None;
+            }
+            hs.sort_by(|a, b| safe_float_cmp(*a, *b));
+            hs[hs.len() / 2].max(1.0)
+        };
+
+        // --- Union-find: connect spans in the same text region. Two spans join
+        // iff they are on the same line and horizontally adjacent (a normal word
+        // gap, NOT a column gutter), OR vertically stacked with overlapping X and
+        // a small inter-line gap. A column gutter (≥ ~1 em of whitespace) never
+        // connects, so left/right columns become separate blocks even when their
+        // lines share Y bands. ---
+        let n = spans.len();
+        let mut parent: Vec<usize> = (0..n).collect();
+        fn find(parent: &mut [usize], mut x: usize) -> usize {
+            while parent[x] != x {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+            x
+        }
+        // Index spans by reading order so each only tests a local window.
+        let mut ord: Vec<usize> = (0..n).collect();
+        ord.sort_by(|&a, &b| {
+            safe_float_cmp(hi(&spans[b]), hi(&spans[a]))
+                .then_with(|| safe_float_cmp(spans[a].bbox.left(), spans[b].bbox.left()))
+        });
+        let x_overlap = |a: &crate::layout::TextSpan, b: &crate::layout::TextSpan| -> f32 {
+            (a.bbox.right().min(b.bbox.right()) - a.bbox.left().max(b.bbox.left())).max(0.0)
+        };
+        for (p, &i) in ord.iter().enumerate() {
+            let si = &spans[i];
+            // Look ahead over a bounded window of following spans in reading order.
+            for &j in ord.iter().skip(p + 1).take(40) {
+                let sj = &spans[j];
+                let dy_centers = ((hi(si) + lo(si)) - (hi(sj) + lo(sj))).abs() * 0.5;
+                let same_line = dy_centers < med_h * 0.5;
+                let connect = if same_line {
+                    // Horizontal neighbour: gap below ~1 em (word space), not a gutter.
+                    let gap = (si.bbox.left().max(sj.bbox.left()))
+                        - (si.bbox.right().min(sj.bbox.right()));
+                    gap < med_h * 1.0
+                } else {
+                    // Vertical neighbour: overlap in X and a small inter-line gap.
+                    let vgap = (lo(si).min(lo(sj)) - hi(si).max(hi(sj))).abs();
+                    // (distance between the nearer edges)
+                    let near = (lo(si) - hi(sj)).abs().min((lo(sj) - hi(si)).abs());
+                    x_overlap(si, sj) > med_h * 0.3 && near < med_h * 1.5 && vgap < med_h * 6.0
+                };
+                if connect {
+                    let (ri, rj) = (find(&mut parent, i), find(&mut parent, j));
+                    if ri != rj {
+                        parent[ri] = rj;
+                    }
+                }
+            }
+        }
+
+        // --- Build blocks from the union-find components. A BTreeMap (not a
+        // HashMap) keys the components by root index so `into_values()` is
+        // DETERMINISTIC — HashMap iteration order is randomized per run, which
+        // would make the block order (and thus the extracted text) flaky for
+        // pages where two blocks tie on the seed sort key. ---
+        use std::collections::BTreeMap;
+        let mut groups: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+        for i in 0..n {
+            let r = find(&mut parent, i);
+            groups.entry(r).or_default().push(i);
+        }
+        struct Block {
+            x0: f32,
+            x1: f32,
+            y_hi: f32,
+            y_lo: f32,
+            members: Vec<usize>,
+        }
+        let blocks: Vec<Block> = groups
+            .into_values()
+            .map(|members| {
+                let mut b = Block {
+                    x0: f32::MAX,
+                    x1: f32::MIN,
+                    y_hi: f32::MIN,
+                    y_lo: f32::MAX,
+                    members,
+                };
+                for &i in &b.members {
+                    let s = &spans[i];
+                    b.x0 = b.x0.min(s.bbox.left());
+                    b.x1 = b.x1.max(s.bbox.right());
+                    b.y_hi = b.y_hi.max(hi(s));
+                    b.y_lo = b.y_lo.min(lo(s));
+                }
+                b
+            })
+            .collect();
+        if blocks.len() < 2 {
+            return None;
+        }
+
+        // A STRUCTURED/TABULAR page (a chess-move table, a data grid, a TOC with a
+        // page-number rail) shatters into many tiny fragment blocks the union-find
+        // cannot coalesce — isolated cells, page numbers, single-letter column
+        // heads — interleaved with the column runs. Flowing multi-column prose and
+        // a sidebar+body do not: they are a handful of big blocks. So when fragment
+        // blocks (< 4 spans) outnumber the substantial ones, the page is tabular
+        // and must stay row-aware, NOT be read column-major.
+        let fragments = blocks.iter().filter(|b| b.members.len() < 4).count();
+        if fragments > blocks.len() - fragments {
+            return None;
+        }
+
+        // --- GATE: require ≥2 blocks that are horizontally DISJOINT yet overlap
+        // in Y (genuine side-by-side regions). Single-column / stacked layouts
+        // have none, so they return None and stay byte-identical. ---
+        let y_ov = |a: &Block, b: &Block| (a.y_hi.min(b.y_hi) - a.y_lo.max(b.y_lo)) > med_h * 0.5;
+        let x_disjoint = |a: &Block, b: &Block| a.x1 <= b.x0 || b.x1 <= a.x0;
+        // Character density per block (≈ chars per text line). A page-number
+        // column in a TOC, or the value column of a label:value form/table, is
+        // text-SPARSE (a few chars per line); genuine prose columns and a
+        // publisher metadata sidebar are text-DENSE. Used to reject row-paired
+        // tables/TOCs/forms (which must read row-wise, NOT column-major).
+        let char_density = |b: &Block| -> f32 {
+            let mut ys: Vec<f32> = b.members.iter().map(|&i| hi(&spans[i])).collect();
+            ys.sort_by(|p, q| safe_float_cmp(*p, *q));
+            let mut lines = 1usize;
+            for w in ys.windows(2) {
+                if (w[1] - w[0]).abs() > med_h * 0.6 {
+                    lines += 1;
+                }
+            }
+            let chars: usize = b
+                .members
+                .iter()
+                .map(|&i| spans[i].text.trim().chars().count())
+                .sum();
+            chars as f32 / lines as f32
+        };
+
+        // Both side-by-side blocks must be SUBSTANTIAL, text-DENSE, multi-line
+        // regions that overlap over several lines — a genuine 2-column body/footer
+        // or a sidebar+body. Incidental overlaps (a drop cap, a page number, a
+        // margin note, a fragmented poem line) involve tiny blocks or a sliver of
+        // Y-overlap; row-paired tables/TOCs/forms have a text-sparse value column.
+        // Neither must engage the reorder, or single-column poetry, decorated
+        // pages, and TOCs scramble.
+        let side_by_side = blocks.iter().enumerate().any(|(i, a)| {
+            blocks.iter().skip(i + 1).any(|b| {
+                x_disjoint(a, b)
+                    && a.members.len() >= 8
+                    && b.members.len() >= 8
+                    && (a.y_hi.min(b.y_hi) - a.y_lo.max(b.y_lo)) > med_h * 3.0
+                    && char_density(a) >= 12.0
+                    && char_density(b) >= 12.0
+                    // The two side-by-side blocks must be the page's DOMINANT
+                    // content (≥ half the spans). A genuine 2-column body or
+                    // sidebar+body lives in two big blocks; a table / chess
+                    // diagram / dense diagram fragments into many small blocks
+                    // that the union-find cannot coalesce, so the dominant pair
+                    // never reaches half — leaving such pages on the row-aware path.
+                    && (a.members.len() + b.members.len()) * 2 >= n
+            })
+        });
+        if !side_by_side {
+            return None;
+        }
+
+        // --- Topological order (poppler Rule 1 + Rule 2). A precedes B if they
+        // overlap in X and A is above B (vertical stack), OR A is left of B and
+        // they overlap in Y (side-by-side columns: left first). DFS with a visited
+        // guard appends a block only after all its predecessors, and terminates on
+        // any rule cycle. ---
+        let nb = blocks.len();
+        let before = |a: &Block, b: &Block| -> bool {
+            let x_ov = (a.x1.min(b.x1) - a.x0.max(b.x0)) > med_h * 0.3;
+            if x_ov && a.y_hi > b.y_hi && a.y_lo > b.y_lo {
+                return true; // A stacked above B
+            }
+            if a.x1 <= b.x0 && y_ov(a, b) {
+                return true; // A is the left column of a side-by-side pair
+            }
+            false
+        };
+        let mut visited = vec![false; nb];
+        let mut result_blocks: Vec<usize> = Vec::with_capacity(nb);
+        // Seed in reading order (top-left first) for a stable result.
+        let mut seeds: Vec<usize> = (0..nb).collect();
+        seeds.sort_by(|&a, &b| {
+            safe_float_cmp(blocks[b].y_hi, blocks[a].y_hi)
+                .then_with(|| safe_float_cmp(blocks[a].x0, blocks[b].x0))
+        });
+        // Iterative DFS to avoid recursion limits on pathological pages.
+        for &s in &seeds {
+            if visited[s] {
+                continue;
+            }
+            let mut stack = vec![(s, false)];
+            while let Some((bi, processed)) = stack.pop() {
+                if processed {
+                    if !visited[bi] {
+                        visited[bi] = true;
+                        result_blocks.push(bi);
+                    }
+                    continue;
+                }
+                if visited[bi] {
+                    continue;
+                }
+                stack.push((bi, true));
+                for (k, blk) in blocks.iter().enumerate() {
+                    if k != bi && !visited[k] && before(blk, &blocks[bi]) {
+                        stack.push((k, false));
+                    }
+                }
+            }
+        }
+
+        // --- Emit: each block's spans in reading order (y desc, x asc). ---
+        let mut out: Vec<crate::layout::TextSpan> = Vec::with_capacity(n);
+        for &bi in &result_blocks {
+            let mut members = blocks[bi].members.clone();
+            members.sort_by(|&a, &b| {
+                safe_float_cmp(hi(&spans[b]), hi(&spans[a]))
+                    .then_with(|| safe_float_cmp(spans[a].bbox.left(), spans[b].bbox.left()))
+            });
+            for i in members {
+                out.push(spans[i].clone());
+            }
+        }
+        if out.len() == n {
+            Some(out)
+        } else {
+            None
+        }
     }
 
     /// True if the spans cluster into lines whose leftmost X positions
@@ -21591,6 +21870,88 @@ mod tests {
         let current = make_test_span("World", 56.0, 100.0, 50.0, 12.0);
         // 6pt gap (> 0.25 * 12 = 3pt)
         assert!(PdfDocument::should_insert_space(&prev, &current));
+    }
+
+    // --- topological_block_order (multi-region reading order) -----------------
+    // Larger Y = higher on the page (read first). Two columns separated by a
+    // gutter (a > ~1 em horizontal gap) must be read column-major (left column
+    // fully, then right), and only genuine multi-column PROSE should engage it —
+    // single-column, fragmented tables and TOC page-number rails must be left on
+    // the row-aware path (return None) so their output is unchanged.
+
+    fn two_dense_columns(left_dense: bool, right_dense: bool) -> Vec<TextSpan> {
+        let mut spans = Vec::new();
+        for k in 0..8 {
+            let y = 200.0 - k as f32 * 12.0;
+            let l = if left_dense {
+                format!("left column body sentence number {k} here")
+            } else {
+                format!("{k}")
+            };
+            let r = if right_dense {
+                format!("right column body sentence number {k} here")
+            } else {
+                format!("{}", (k + 1) * 10) // short page-number-like values
+            };
+            spans.push(make_test_span(&l, 0.0, y, 90.0, 10.0));
+            spans.push(make_test_span(&r, 120.0, y, 90.0, 10.0));
+        }
+        spans
+    }
+
+    #[test]
+    fn topo_two_column_prose_reads_column_major() {
+        let spans = two_dense_columns(true, true);
+        let out = PdfDocument::topological_block_order(&spans)
+            .expect("genuine two-column prose must be reordered");
+        assert_eq!(out.len(), spans.len());
+        let texts: Vec<&str> = out.iter().map(|s| s.text.as_str()).collect();
+        let last_left = texts.iter().rposition(|t| t.starts_with("left")).unwrap();
+        let first_right = texts.iter().position(|t| t.starts_with("right")).unwrap();
+        // Whole left column before whole right column (de-interleaved).
+        assert!(last_left < first_right, "columns interleaved: {texts:?}");
+    }
+
+    #[test]
+    fn topo_single_column_returns_none() {
+        let mut spans = Vec::new();
+        for k in 0..10 {
+            let y = 200.0 - k as f32 * 12.0;
+            spans.push(make_test_span(
+                &format!("single column body line {k} of running text"),
+                0.0,
+                y,
+                190.0,
+                10.0,
+            ));
+        }
+        // No side-by-side region → unchanged (row-aware path).
+        assert!(PdfDocument::topological_block_order(&spans).is_none());
+    }
+
+    #[test]
+    fn topo_toc_sparse_page_number_column_returns_none() {
+        // Left = chapter titles (dense), right = page numbers (sparse). The
+        // text-density gate must reject it so a TOC is not read column-major
+        // (which would divorce each title from its page number).
+        let spans = two_dense_columns(true, false);
+        assert!(PdfDocument::topological_block_order(&spans).is_none());
+    }
+
+    #[test]
+    fn topo_fragmented_table_returns_none() {
+        // Two dense columns PLUS many isolated single-token fragment blocks
+        // (page numbers / cell labels) the union-find cannot coalesce — the
+        // signature of a structured table (chess diagram, data grid), which must
+        // stay row-aware rather than be read column-major.
+        let mut spans = two_dense_columns(true, true);
+        for k in 0..10 {
+            // Widely scattered short tokens → each its own fragment block.
+            let x = 230.0 + (k as f32) * 30.0;
+            let y = 205.0 - (k as f32) * 17.0;
+            spans.push(make_test_span(&format!("{}", k * 7), x, y, 8.0, 10.0));
+        }
+        assert!(PdfDocument::topological_block_order(&spans).is_none());
     }
 
     #[test]

--- a/src/document.rs
+++ b/src/document.rs
@@ -12046,7 +12046,18 @@ impl PdfDocument {
                     let cur = &spans[line[m]];
                     let fs = prev.font_size.max(cur.font_size).max(1.0);
                     let gap = cur.bbox.x - (prev.bbox.x + prev.bbox.width);
-                    if gap > 0.5 * fs || (cur.font_size - prev.font_size).abs() > 0.1 {
+                    // Keep a run UNIFORM in styling. `merge_same_line_run` takes
+                    // the first span's style for the whole merged span, so a run
+                    // that mixes weights/italics would silently erase an interior
+                    // emphasis span (a lone bold word bracketed by body text loses
+                    // its `**`). A genuine mid-word gutter split is always one
+                    // word in one style, so requiring uniform weight+italic keeps
+                    // that fix while never dropping emphasis.
+                    if gap > 0.5 * fs
+                        || (cur.font_size - prev.font_size).abs() > 0.1
+                        || cur.font_weight != prev.font_weight
+                        || cur.is_italic != prev.is_italic
+                    {
                         break;
                     }
                     m += 1;

--- a/src/document.rs
+++ b/src/document.rs
@@ -22927,7 +22927,7 @@ mod tests {
             "split line not rejoined (delta must reform); got {texts:?}"
         );
         assert!(
-            !texts.iter().any(|t| *t == "alpha beta gamma del"),
+            !texts.contains(&"alpha beta gamma del"),
             "split fragment must be gone after coalescing; got {texts:?}"
         );
         // Body per-column runs (never cross the midline) stay as-is.

--- a/src/document.rs
+++ b/src/document.rs
@@ -27275,6 +27275,44 @@ mod tests {
         assert_eq!(texts, vec!["September", "11", "th"]);
     }
 
+    #[test]
+    fn reorder_same_line_runs_de_interleaves_two_stacked_lines() {
+        use crate::geometry::Rect;
+        use crate::layout::TextSpan;
+
+        // Two lines the same-line tolerance merged into one band: at fs=10 the
+        // threshold is max(10*1.2, 10*0.3)=12, and the lines are 8pt apart — so
+        // they group as one run, yet 8 > 0.5*fs (=5) makes them TWO stacked rows
+        // of two spans each. Their X-extents overlap, so a flat X-sort would
+        // interleave them word-by-word ("The Story Book Review"). The
+        // de-interleave path must instead order (Y-desc, then X) so each real
+        // line stays contiguous: line one ("The Book") then line two
+        // ("Story Review"). Input is given in the interleaved X order the
+        // row-aware sort would produce.
+        let span = |t: &str, x: f32, y: f32, w: f32, seq: usize| TextSpan {
+            text: t.to_string(),
+            bbox: Rect::new(x, y, w, 10.0),
+            font_size: 10.0,
+            sequence: seq,
+            ..Default::default()
+        };
+        let mut spans = vec![
+            span("The", 100.0, 200.0, 30.0, 0),
+            span("Story", 110.0, 192.0, 40.0, 1),
+            span("Book", 140.0, 200.0, 40.0, 2),
+            span("Review", 150.0, 192.0, 55.0, 3),
+        ];
+
+        PdfDocument::reorder_same_line_runs(&mut spans);
+
+        let texts: Vec<&str> = spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            vec!["The", "Book", "Story", "Review"],
+            "stacked lines must de-interleave, not X-sort into one fake line"
+        );
+    }
+
     // ─────────────────────────────────────────────────────────────────────
     // Optional Content (PDF "layer") name resolution — OCG `/Name` decoding,
     // OCMD `/OCGs` following, and the `/Properties` name-reference path

--- a/src/document.rs
+++ b/src/document.rs
@@ -7036,6 +7036,81 @@ impl PdfDocument {
         false
     }
 
+    /// True when a candidate run contains spans whose X-extents OVERLAP — the
+    /// signature of two (or more) distinct text lines that the same-line Y
+    /// tolerance merged into one band, NOT a single line. A real line lays its
+    /// spans out left-to-right with non-overlapping advances; only stacked lines
+    /// (leading just under `same_line_threshold`, e.g. a two-line title or a
+    /// running head sitting above a `published:` line) put two spans at the same
+    /// horizontal position. X-sorting such a band interleaves the lines word by
+    /// word (`BookThe Story Review: of the …`), so the caller must leave it in
+    /// row order instead. Mirrors [`run_has_large_x_gap`] for the opposite defect.
+    fn run_has_x_overlap(run: &[TextSpan]) -> bool {
+        if run.len() < 2 {
+            return false;
+        }
+
+        let mut edges: Vec<(f32, f32, f32)> = run
+            .iter()
+            .map(|s| (s.bbox.x, s.bbox.x + s.bbox.width, s.font_size))
+            .collect();
+
+        edges.sort_by(|a, b| crate::utils::safe_float_cmp(a.0, b.0));
+
+        for pair in edges.windows(2) {
+            let prev = pair[0];
+            let cur = pair[1];
+
+            // prev.right - cur.left > 0 ⇒ the next span starts before the previous
+            // one ends (horizontal overlap). Half an em of overlap is well beyond
+            // kerning/italic side-bearing and only happens across stacked lines.
+            let overlap = prev.1 - cur.0;
+            let max_fs = prev.2.max(cur.2).max(1.0);
+            if overlap > 0.5 * max_fs {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// True when a run is structurally two-or-more stacked text LINES: it has at
+    /// least two distinct Y levels that EACH carry at least two spans. This
+    /// separates a real two-line title / running-head block (many words on each
+    /// of two baselines) — where de-interleaving is correct — from a single span
+    /// that merely overlaps a line in X (a drop cap, a `©`/`c` mark, a lone
+    /// super-script), where the existing X-sort already does the right thing and
+    /// reordering by Y would misplace the stray glyph (`EAcrobat …`).
+    fn run_is_stacked_lines(run: &[TextSpan]) -> bool {
+        if run.len() < 4 {
+            return false; // need ≥2 lines × ≥2 spans
+        }
+        let mut rows: Vec<(f32, f32)> = run.iter().map(|s| (s.bbox.y, s.font_size)).collect();
+        rows.sort_by(|a, b| crate::utils::safe_float_cmp(b.0, a.0));
+
+        let mut multi_rows = 0usize;
+        let mut anchor_y = f32::NAN;
+        let mut count = 0usize;
+        for (y, fs) in rows {
+            if anchor_y.is_nan() || (anchor_y - y).abs() <= 0.5 * fs.max(1.0) {
+                if anchor_y.is_nan() {
+                    anchor_y = y;
+                }
+                count += 1;
+            } else {
+                if count >= 2 {
+                    multi_rows += 1;
+                }
+                anchor_y = y;
+                count = 1;
+            }
+        }
+        if count >= 2 {
+            multi_rows += 1;
+        }
+        multi_rows >= 2
+    }
+
     /// Re-sort same-line spans by X after row-aware band sorting.
     ///
     /// Row-aware sorting can place off-baseline glyphs such as superscripts or
@@ -7074,9 +7149,28 @@ impl PdfDocument {
 
             if j - i > 1 {
                 if Self::run_has_large_x_gap(&spans[i..j]) {
-                    // Candidate spans are vertically close, but not horizontally
-                    // contiguous. Do not X-sort them into a fake line; preserve
-                    // the row-aware order established before this helper.
+                    // Candidate spans are vertically close but not horizontally
+                    // contiguous (disjoint header/footer columns). Do not X-sort
+                    // them into a fake line; preserve the row-aware order.
+                    i = j;
+                    continue;
+                }
+
+                if Self::run_has_x_overlap(&spans[i..j]) && Self::run_is_stacked_lines(&spans[i..j])
+                {
+                    // Spans OVERLAP horizontally AND form ≥2 lines of ≥2 spans each:
+                    // two stacked lines the Y tolerance merged into one band (a
+                    // two-line title, a running head above a `published:` line). A
+                    // flat X-sort interleaves them word by word (`BookThe Story
+                    // Review: …`). De-interleave by ordering on (Y-descending, then
+                    // X) so each real line stays contiguous and in reading order. The
+                    // stacked-lines gate keeps a lone overlapping glyph (drop cap,
+                    // `©`, super-script) on the normal X-sort path below.
+                    spans[i..j].sort_by(|a, b| {
+                        crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y)
+                            .then(crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x))
+                            .then(a.sequence.cmp(&b.sequence))
+                    });
                     i = j;
                     continue;
                 }

--- a/src/extractors/ccitt_bilevel.rs
+++ b/src/extractors/ccitt_bilevel.rs
@@ -50,9 +50,10 @@ pub fn decompress_ccitt(data: &[u8], params: &CcittParams) -> Result<Vec<u8>> {
         log::debug!("CCITT Group 4 decompression requested");
     }
 
-    // Primary: the in-house Group 4 decoder. It honors /EncodedByteAlign (which
-    // the fax crate cannot — its bit reader is private) and recovers partial
-    // content from truncated/damaged streams instead of blanking the page.
+    // Primary: the in-house decoder (Group 4 T.6, and Group 3 T.4 for K >= 0).
+    // It honors /EncodedByteAlign (which the fax crate cannot — its bit reader
+    // is private) and recovers partial content from truncated/damaged streams
+    // instead of blanking the page.
     let in_house = crate::decoders::ccitt::decode(data, params);
     let fax_result = match in_house {
         Ok(decoded) => {
@@ -68,7 +69,7 @@ pub fn decompress_ccitt(data: &[u8], params: &CcittParams) -> Result<Vec<u8>> {
             Ok(decoded.data)
         },
         Err(in_house_err) => {
-            // Group 3, or a Group 4 stream the in-house decoder rejected: fall
+            // A stream the in-house decoder couldn't make progress on: fall
             // back to the legacy fax crate before giving up.
             log::debug!("CCITT in-house decode declined ({in_house_err}); trying fax crate");
             decompress_with_fax(data, width, height_opt, params)

--- a/src/extractors/images.rs
+++ b/src/extractors/images.rs
@@ -352,6 +352,21 @@ impl PdfImage {
                 } else {
                     let dynamic_image = self.to_dynamic_image()?;
                     let rgb = dynamic_image.to_rgb8();
+                    // `ImageBuffer::from_raw` accepts a buffer at least as long
+                    // as the image needs, so a mis-declared depth can leave the
+                    // RGB buffer larger than width×height×3. Reject that here
+                    // with a recoverable error instead of handing the encoder a
+                    // mismatched buffer, which it asserts on (panicking through
+                    // the FFI boundary where callers cannot catch it).
+                    if rgb.as_raw().len() != expected_rgb {
+                        return Err(Error::Encode(format!(
+                            "image buffer length {} does not match {}x{} RGB image ({} expected)",
+                            rgb.as_raw().len(),
+                            self.width,
+                            self.height,
+                            expected_rgb
+                        )));
+                    }
                     encoder
                         .write_image(
                             rgb.as_raw(),
@@ -831,8 +846,23 @@ pub fn extract_image_from_xobject(
             }
         } else {
             let pixel_format = color_space_to_pixel_format(&color_space);
+            // ISO 32000-1 §8.9.5.2: BitsPerComponent 16 stores each colour
+            // sample as a big-endian 16-bit value. The rest of the image
+            // pipeline assumes 8-bit samples, so collapse each sample to its
+            // high byte. Without this the raw buffer is twice the expected
+            // length; the lenient `ImageBuffer::from_raw` then builds an
+            // oversized image whose buffer the PNG encoder rejects with a
+            // panic (`assertion left == right failed: Invalid buffer length`).
+            let pixels = if bits_per_component == 16 {
+                decoded_data
+                    .chunks_exact(2)
+                    .map(|sample| sample[0])
+                    .collect()
+            } else {
+                decoded_data
+            };
             ImageData::Raw {
-                pixels: decoded_data,
+                pixels,
                 format: pixel_format,
             }
         }
@@ -841,7 +871,14 @@ pub fn extract_image_from_xobject(
     // JBIG2 decode produces 8-bit-per-channel pixels regardless of the
     // XObject's BitsPerComponent (which is 1).  Override to 8 so that
     // to_dynamic_image() does not try to CCITT-decompress the output.
-    let effective_bpc = if is_jbig2 { 8 } else { bits_per_component };
+    // 16-bit samples were collapsed to their high byte above (and an Indexed
+    // base always expands to 8-bit RGB), so the stored pixels are 8-bit per
+    // component in those cases too.
+    let effective_bpc = if is_jbig2 || bits_per_component == 16 {
+        8
+    } else {
+        bits_per_component
+    };
     let mut image = PdfImage::new(width, height, color_space, effective_bpc, data);
 
     // Attach the ICC profile if we found one — prefer the direct ICCBased
@@ -2965,5 +3002,57 @@ mod handle_color_space_tests {
         .unwrap();
         assert_eq!(handle.color_space, ColorSpace::Indexed);
         assert_eq!(handle.indexed_base(), Some(ColorSpace::DeviceRGB));
+    }
+}
+
+#[cfg(test)]
+mod png_bytes_panic_safety_tests {
+    use super::*;
+
+    /// A raw RGB buffer longer than width×height×3 (e.g. a 16-bit-per-component
+    /// image whose samples were not collapsed to 8-bit) must NOT panic the PNG
+    /// encoder — it must surface a recoverable `Error` that crosses the FFI
+    /// boundary so Python/other callers can catch it. Regression for the
+    /// `assertion left == right failed: Invalid buffer length` panic.
+    #[test]
+    fn to_png_bytes_rejects_oversized_rgb_buffer_without_panicking() {
+        let (w, h) = (4u32, 2u32);
+        // Twice the bytes a 4x2 RGB image needs (mimics undownsampled 16-bit).
+        let pixels = vec![0u8; (w * h * 3 * 2) as usize];
+        let img = PdfImage::new(
+            w,
+            h,
+            ColorSpace::DeviceRGB,
+            8,
+            ImageData::Raw {
+                pixels,
+                format: PixelFormat::RGB,
+            },
+        );
+        let result = img.to_png_bytes();
+        assert!(
+            result.is_err(),
+            "oversized RGB buffer must yield a recoverable Err, not a panic"
+        );
+    }
+
+    /// A correctly sized 8-bit RGB buffer (the shape produced after 16-bit
+    /// samples are downsampled at parse time) encodes to a valid PNG.
+    #[test]
+    fn to_png_bytes_encodes_correctly_sized_rgb() {
+        let (w, h) = (4u32, 2u32);
+        let pixels = vec![128u8; (w * h * 3) as usize];
+        let img = PdfImage::new(
+            w,
+            h,
+            ColorSpace::DeviceRGB,
+            8,
+            ImageData::Raw {
+                pixels,
+                format: PixelFormat::RGB,
+            },
+        );
+        let png = img.to_png_bytes().expect("correctly sized RGB must encode");
+        assert!(png.starts_with(&[0x89, b'P', b'N', b'G']), "valid PNG signature");
     }
 }

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -874,9 +874,9 @@ impl FontInfo {
                     let looks_like_cipher = builtin_encoding_looks_like_cipher(prog_enc, &std_name);
 
                     if looks_like_cipher {
-                        // Trust the producer-declared named encoding (what
-                        // poppler/pdftotext honor); the built-in cipher would corrupt
-                        // it. Leave `parsed_enc` as the named Standard encoding.
+                        // Trust the producer-declared named encoding; the built-in
+                        // cipher would corrupt it. Leave `parsed_enc` as the named
+                        // Standard encoding.
                         log::debug!(
                             "Font '{base_font}': built-in encoding disagrees with {std_name} on most overlapping codes — treating as a subset cipher and keeping the named encoding"
                         );

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -871,26 +871,14 @@ impl FontInfo {
                     // many program codes resolve to the SAME character the named base
                     // already gives. A real encoding agrees on most; a cipher on
                     // almost none.
-                    let (mut agree, mut overlap) = (0u32, 0u32);
-                    for (&code, &ch) in prog_enc {
-                        if let Some(us) = standard_encoding_lookup(&std_name, code) {
-                            if let Some(sc) = us.chars().next() {
-                                overlap += 1;
-                                if sc == ch {
-                                    agree += 1;
-                                }
-                            }
-                        }
-                    }
-                    let looks_like_cipher = overlap > 0 && (agree as f32 / overlap as f32) < 0.5;
+                    let looks_like_cipher = builtin_encoding_looks_like_cipher(prog_enc, &std_name);
 
                     if looks_like_cipher {
                         // Trust the producer-declared named encoding (what
                         // poppler/pdftotext honor); the built-in cipher would corrupt
                         // it. Leave `parsed_enc` as the named Standard encoding.
                         log::debug!(
-                            "Font '{}': built-in encoding disagrees with {} on {}/{} overlapping codes — treating as a subset cipher and keeping the named encoding",
-                            base_font, std_name, overlap - agree, overlap
+                            "Font '{base_font}': built-in encoding disagrees with {std_name} on most overlapping codes — treating as a subset cipher and keeping the named encoding"
                         );
                     } else {
                         log::info!(
@@ -5667,6 +5655,33 @@ pub fn pdfdoc_encoding_lookup(code: u8) -> Option<char> {
 ///
 /// # Returns
 ///
+/// Whether an embedded font program's built-in `/Encoding` (`prog_enc`,
+/// code→char) looks like a re-indexed subset **cipher** rather than a
+/// meaningful text encoding to overlay on the producer-declared named base
+/// `std_name`.
+///
+/// A real encoding (a few non-standard slots over a named base, e.g. space at
+/// 0xCA) agrees with the named base on most of the codes they share; a subset
+/// cipher — the font's own arbitrary glyph ordering — agrees on almost none,
+/// and overlaying it would rewrite every mapped code into mojibake. Decide by
+/// agreement: of the codes present in both, fewer than half resolving to the
+/// same character means cipher. Empty overlap is treated as NOT a cipher (no
+/// evidence either way; keep the prior overlay behaviour).
+fn builtin_encoding_looks_like_cipher(prog_enc: &HashMap<u8, char>, std_name: &str) -> bool {
+    let (mut agree, mut overlap) = (0u32, 0u32);
+    for (&code, &ch) in prog_enc {
+        if let Some(us) = standard_encoding_lookup(std_name, code) {
+            if let Some(sc) = us.chars().next() {
+                overlap += 1;
+                if sc == ch {
+                    agree += 1;
+                }
+            }
+        }
+    }
+    overlap > 0 && (agree as f32 / overlap as f32) < 0.5
+}
+
 /// The Unicode string for this character, or None if not in the encoding.
 fn standard_encoding_lookup(encoding: &str, code: u8) -> Option<String> {
     match encoding {
@@ -6189,6 +6204,34 @@ fn standard_font_metrics(base_font: &str) -> Option<(f32, f32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cipher_discriminator_flags_disagreeing_builtin_encoding() {
+        // A subset cipher: ASCII-letter codes resolve to unrelated glyphs, so
+        // they disagree with WinAnsi on every overlapping code (0/N agree).
+        let cipher: HashMap<u8, char> = [(b'A', 'ñ'), (b'B', 'k'), (b'C', 'º'), (b'D', 'p')]
+            .into_iter()
+            .collect();
+        assert!(builtin_encoding_looks_like_cipher(&cipher, "WinAnsiEncoding"));
+    }
+
+    #[test]
+    fn cipher_discriminator_keeps_mostly_agreeing_builtin_encoding() {
+        // A real text encoding: agrees with the named base on most codes (a
+        // single non-standard slot is not enough to look like a cipher).
+        let real: HashMap<u8, char> = [(b'A', 'A'), (b'B', 'B'), (b'C', 'C'), (0xCA, ' ')]
+            .into_iter()
+            .collect();
+        assert!(!builtin_encoding_looks_like_cipher(&real, "WinAnsiEncoding"));
+    }
+
+    #[test]
+    fn cipher_discriminator_no_overlap_is_not_a_cipher() {
+        // No codes overlap the named base's mapped range → no evidence → not a
+        // cipher (preserve the prior overlay behaviour).
+        let empty: HashMap<u8, char> = HashMap::new();
+        assert!(!builtin_encoding_looks_like_cipher(&empty, "WinAnsiEncoding"));
+    }
 
     #[test]
     fn test_standard_encoding_ascii() {

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -857,38 +857,68 @@ impl FontInfo {
             // The font program's mappings override the standard encoding.
             if matches!(parsed_enc, Encoding::Standard(_)) {
                 if let Some(prog_enc) = &font_program_enc_cache {
-                    log::info!(
-                        "Font '{}': merging {} font program encoding entries with {}",
-                        base_font,
-                        prog_enc.len(),
-                        match &parsed_enc {
-                            Encoding::Standard(n) => n.as_str(),
-                            _ => "custom",
-                        }
-                    );
-                    // Build Custom map: start with standard encoding, overlay font program
                     let std_name = match &parsed_enc {
                         Encoding::Standard(n) => n.clone(),
                         _ => "StandardEncoding".to_string(),
                     };
-                    let mut custom_map: HashMap<u8, char> = HashMap::new();
-                    for code in 0u8..=255 {
-                        if let Some(unicode_str) = standard_encoding_lookup(&std_name, code) {
-                            if let Some(ch) = unicode_str.chars().next() {
-                                custom_map.insert(code, ch);
-                            }
-                        }
-                    }
-                    // Font program overrides
+
+                    // Decide whether the embedded program's built-in encoding is a
+                    // meaningful text encoding (a few non-standard slots to overlay,
+                    // e.g. space at 0xCA) or a re-indexed *cipher* — a subset font's
+                    // own glyph ordering that bears no relation to the producer's
+                    // declared named base encoding. Overlaying a cipher rewrites every
+                    // mapped code into mojibake. Discriminate by agreement: count how
+                    // many program codes resolve to the SAME character the named base
+                    // already gives. A real encoding agrees on most; a cipher on
+                    // almost none.
+                    let (mut agree, mut overlap) = (0u32, 0u32);
                     for (&code, &ch) in prog_enc {
-                        custom_map.insert(code, ch);
-                        if is_ligature_char(ch) {
-                            if let Some(expanded) = expand_ligature_char(ch) {
-                                multi_map.insert(code, expanded.to_string());
+                        if let Some(us) = standard_encoding_lookup(&std_name, code) {
+                            if let Some(sc) = us.chars().next() {
+                                overlap += 1;
+                                if sc == ch {
+                                    agree += 1;
+                                }
                             }
                         }
                     }
-                    parsed_enc = Encoding::Custom(custom_map);
+                    let looks_like_cipher = overlap > 0 && (agree as f32 / overlap as f32) < 0.5;
+
+                    if looks_like_cipher {
+                        // Trust the producer-declared named encoding (what
+                        // poppler/pdftotext honor); the built-in cipher would corrupt
+                        // it. Leave `parsed_enc` as the named Standard encoding.
+                        log::debug!(
+                            "Font '{}': built-in encoding disagrees with {} on {}/{} overlapping codes — treating as a subset cipher and keeping the named encoding",
+                            base_font, std_name, overlap - agree, overlap
+                        );
+                    } else {
+                        log::info!(
+                            "Font '{}': merging {} font program encoding entries with {}",
+                            base_font,
+                            prog_enc.len(),
+                            std_name,
+                        );
+                        // Build Custom map: start with the named encoding, overlay the
+                        // (consistent) font program for its few non-standard slots.
+                        let mut custom_map: HashMap<u8, char> = HashMap::new();
+                        for code in 0u8..=255 {
+                            if let Some(unicode_str) = standard_encoding_lookup(&std_name, code) {
+                                if let Some(ch) = unicode_str.chars().next() {
+                                    custom_map.insert(code, ch);
+                                }
+                            }
+                        }
+                        for (&code, &ch) in prog_enc {
+                            custom_map.insert(code, ch);
+                            if is_ligature_char(ch) {
+                                if let Some(expanded) = expand_ligature_char(ch) {
+                                    multi_map.insert(code, expanded.to_string());
+                                }
+                            }
+                        }
+                        parsed_enc = Encoding::Custom(custom_map);
+                    }
                 }
             }
 

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -1545,7 +1545,13 @@ impl MarkdownOutputConverter {
                             for _ in 0..spacing.min(20) {
                                 current_line.push(' ');
                             }
-                        } else {
+                        } else if !current_line.trim_end().ends_with('-') {
+                            // A line wrapped mid-word at a hyphen (`frozen-` /
+                            // `thawed`) joins WITHOUT a space — `frozen- thawed`
+                            // (a space after the hyphen) is never correct. Whether
+                            // to also DROP the hyphen is genuinely ambiguous (a real
+                            // compound `frozen-thawed` keeps it), so leave the hyphen
+                            // and only suppress the spurious space.
                             current_line.push(' ');
                         }
                     }
@@ -3594,6 +3600,34 @@ mod tests {
             },
             0,
         )
+    }
+
+    #[test]
+    fn md_wrapped_hyphen_line_joins_without_space() {
+        // A line that wraps mid-word at a hyphen must join WITHOUT a space:
+        // `frozen-` + `thawed` → `frozen-thawed`, never `frozen- thawed`.
+        let converter = MarkdownOutputConverter::new();
+        let config = TextPipelineConfig::default();
+        let spans = vec![
+            make_span_w("frozen-", 0.0, 100.0, 40.0, 10.0, FontWeight::Normal),
+            make_span_w("thawed", 0.0, 89.0, 40.0, 10.0, FontWeight::Normal),
+        ];
+        let md = converter.convert(&spans, &config).unwrap();
+        assert!(md.contains("frozen-thawed"), "not joined: {md:?}");
+        assert!(!md.contains("frozen- thawed"), "spurious space after hyphen: {md:?}");
+    }
+
+    #[test]
+    fn md_wrapped_plain_line_keeps_space() {
+        // Guard: a normal (non-hyphen) wrap still gets its joining space.
+        let converter = MarkdownOutputConverter::new();
+        let config = TextPipelineConfig::default();
+        let spans = vec![
+            make_span_w("hello", 0.0, 100.0, 40.0, 10.0, FontWeight::Normal),
+            make_span_w("world", 0.0, 89.0, 40.0, 10.0, FontWeight::Normal),
+        ];
+        let md = converter.convert(&spans, &config).unwrap();
+        assert!(md.contains("hello world"), "lost joining space: {md:?}");
     }
 
     #[test]

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -1218,7 +1218,7 @@ impl MarkdownOutputConverter {
             out
         }
 
-        for span in sorted.iter() {
+        for (idx, span) in sorted.iter().enumerate() {
             // Skip artifacts (pagination, headers, footers)
             if span.span.artifact_type.is_some() {
                 continue;
@@ -1230,6 +1230,16 @@ impl MarkdownOutputConverter {
             // semantic value but pollute output as lone-line paragraphs.
             // Bullet characters are excluded from this filter since they
             // are meaningful list markers handled downstream.
+            //
+            // EXCEPTION: a space-bearing punctuation span (" ," / " .") that is
+            // FLANKED by right-to-left text on its own baseline is a
+            // producer-drawn inter-word separator, not decoration. RTL scripts
+            // emit the comma/period between two words as its own span, so
+            // dropping it glues the words ("הטורפים, ממשפחת" → "הטורפיםממשפחת").
+            // The RTL-context gate is deliberate: a lone decorative mark, or an
+            // isolated punctuation fragment in a left-to-right data region,
+            // has no RTL neighbour on its line and is still dropped (keeping it
+            // there would fragment the line into one paragraph per mark).
             {
                 let t = span.span.text.trim();
                 let char_count = t.chars().count();
@@ -1239,7 +1249,19 @@ impl MarkdownOutputConverter {
                     && !Self::is_bullet_span(t)
                     && !Self::starts_with_bullet(t)
                 {
-                    continue;
+                    let carries_space = span.span.text.chars().any(|c| c.is_whitespace());
+                    let rtl_separator = carries_space && {
+                        let y = span.span.bbox.y;
+                        let tol = span.span.font_size.max(1.0) * 1.5;
+                        sorted.iter().enumerate().any(|(j, other)| {
+                            j != idx
+                                && (other.span.bbox.y - y).abs() <= tol
+                                && crate::text::bidi::looks_rtl(&other.span.text)
+                        })
+                    };
+                    if !rtl_separator {
+                        continue;
+                    }
                 }
             }
 
@@ -2246,8 +2268,16 @@ fn is_column_gap(prev: &OrderedTextSpan, current: &OrderedTextSpan) -> bool {
     // flow (it has no direction of its own), so it must not break the RTL
     // context — otherwise every word→space→word step inside a right-to-left
     // line reads as a same-baseline column gap and the line shatters into one
-    // paragraph per word.
-    let rtl_friendly = |t: &str| crate::text::bidi::looks_rtl(t) || t.trim().is_empty();
+    // paragraph per word. This covers both a pure-space separator and a short
+    // neutral-punctuation one (e.g. " ," / " ." between two words): per UAX #9
+    // such neutrals inherit the surrounding right-to-left direction, so a span
+    // of ≤2 non-alphanumeric chars is RTL-friendly too.
+    let rtl_friendly = |t: &str| {
+        let s = t.trim();
+        crate::text::bidi::looks_rtl(t)
+            || s.is_empty()
+            || (s.chars().count() <= 2 && !s.chars().any(|c| c.is_alphanumeric()))
+    };
     let both_rtl = rtl_friendly(&prev.span.text)
         && rtl_friendly(&current.span.text)
         && (crate::text::bidi::looks_rtl(&prev.span.text)
@@ -3628,6 +3658,34 @@ mod tests {
         ];
         let md = converter.convert(&spans, &config).unwrap();
         assert!(md.contains("hello world"), "lost joining space: {md:?}");
+    }
+
+    #[test]
+    fn md_rtl_interword_punct_separator_is_kept_and_not_paragraph_broken() {
+        // A right-to-left line emits the comma/period between two words as its
+        // own space-bearing span (" ,"). It must (a) survive the noise filter
+        // so the flanking words are NOT glued, and (b) not be treated as a
+        // same-baseline column gap that shatters the line into one paragraph
+        // per word. Mirrors the wiki-cat-he front-matter line
+        // `…הטורפים, ממשפחת…`.
+        let converter = MarkdownOutputConverter::new();
+        let config = TextPipelineConfig::default();
+        // RTL reading order steps left (decreasing x), same baseline.
+        let spans = vec![
+            make_span_w("הטורפים", 200.0, 100.0, 60.0, 13.0, FontWeight::Normal),
+            make_span_w(" ,", 190.0, 100.0, 7.0, 13.0, FontWeight::Normal),
+            make_span_w("ממשפחת", 130.0, 100.0, 55.0, 13.0, FontWeight::Normal),
+        ];
+        let md = converter.convert(&spans, &config).unwrap();
+        assert!(md.contains("הטורפים"), "lost first word: {md:?}");
+        assert!(md.contains("ממשפחת"), "lost second word: {md:?}");
+        assert!(!md.contains("הטורפיםממשפחת"), "words glued — separator was dropped: {md:?}");
+        let para_count = md
+            .trim()
+            .split("\n\n")
+            .filter(|p| !p.trim().is_empty())
+            .count();
+        assert_eq!(para_count, 1, "RTL line shattered into paragraphs: {md:?}");
     }
 
     #[test]

--- a/src/redaction/engine.rs
+++ b/src/redaction/engine.rs
@@ -28,7 +28,7 @@ use super::serialize::serialize_operator;
 use super::text_engine::{redact_text_stream, FontMetrics};
 use crate::content::parser::parse_content_stream;
 use crate::error::{Error, Result};
-use crate::fonts::FontInfo;
+use crate::fonts::{Encoding, FontInfo};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -47,6 +47,22 @@ impl FontInfoMetrics {
     /// parsed [`FontInfo`]).
     pub fn new(fonts: HashMap<String, Arc<FontInfo>>) -> Self {
         Self { fonts }
+    }
+
+    /// `true` only for a Type0 font whose encoding is the **horizontal**
+    /// identity CMap (Identity-H). Per ISO 32000-1 §9.7.5.2 Identity-H maps
+    /// each 2-byte code, high-order byte first, to the CID of the same
+    /// value, so the engine can decode the show string into CIDs and look
+    /// up each CID's width via `/W`+`/DW` exactly as the text extractor
+    /// does. Identity-V (vertical, `wmode == 1`) is deliberately excluded —
+    /// its glyphs advance down the page, which the horizontal advance/box
+    /// model here does not handle — as are all non-identity predefined and
+    /// custom CMaps (their code lengths and code→CID mapping are not
+    /// reconstructable here), so those stay fail-closed.
+    fn is_identity_h(&self, font: &str) -> bool {
+        self.fonts.get(font).is_some_and(|fi| {
+            fi.subtype == "Type0" && matches!(fi.encoding, Encoding::Identity) && fi.wmode == 0
+        })
     }
 }
 
@@ -68,6 +84,43 @@ impl FontMetrics for FontInfoMetrics {
             Some(fi) => fi.subtype != "Type0",
             None => false,
         }
+    }
+
+    fn can_prune(&self, font: &str) -> bool {
+        // Single-byte simple fonts, plus Identity-H Type0 (2-byte CID =
+        // code). Everything else — Identity-V, legacy/custom CMaps, unknown
+        // fonts — stays fail-closed.
+        self.is_simple(font) || self.is_identity_h(font)
+    }
+
+    fn decode(&self, font: &str, s: &[u8]) -> Vec<(u32, Vec<u8>)> {
+        if self.is_identity_h(font) {
+            // Identity-H: every two bytes are one code, high-order byte
+            // first, and that code IS the CID (§9.7.5.2). A trailing odd
+            // byte is malformed; `redaction_safe_show` refuses such a show
+            // before it reaches here, so emit only whole 2-byte codes.
+            return s
+                .chunks_exact(2)
+                .map(|pair| (u32::from(u16::from_be_bytes([pair[0], pair[1]])), pair.to_vec()))
+                .collect();
+        }
+        // Simple fonts: one byte, one code.
+        s.iter().map(|&b| (b as u32, vec![b])).collect()
+    }
+
+    fn is_word_space(&self, font: &str, code: u32) -> bool {
+        // ISO 32000-1 §9.3.3: word spacing (Tw) applies only to a
+        // single-byte code 32. It never applies to a byte value of 32 that
+        // is part of a multi-byte code, so Identity-H glyphs never trigger
+        // it. Simple fonts keep the single-byte-32 rule.
+        !self.is_identity_h(font) && code == 32
+    }
+
+    fn redaction_safe_show(&self, font: &str, bytes: &[u8]) -> bool {
+        // Identity-H codes are exactly two bytes; an odd-length show string
+        // cannot be split into whole codes without guessing a boundary, so
+        // refuse rather than risk mis-aligning the prune (fail closed).
+        !self.is_identity_h(font) || bytes.len().is_multiple_of(2)
     }
 }
 

--- a/src/redaction/text_engine.rs
+++ b/src/redaction/text_engine.rs
@@ -71,6 +71,28 @@ pub trait FontMetrics {
     fn is_simple(&self, _font: &str) -> bool {
         true
     }
+
+    /// Whether the engine can prune individual glyphs for `font` reliably
+    /// enough to redact it. A superset of [`Self::is_simple`]: a real
+    /// implementation may also support a multi-byte encoding whose
+    /// code→glyph→box mapping it can reconstruct deterministically (e.g.
+    /// Identity-H, whose 2-byte codes equal their CIDs, ISO 32000-1
+    /// §9.7.5.2). Anything this returns `false` for is **refused** (fail
+    /// closed). Default delegates to `is_simple` so existing single-byte
+    /// behaviour is unchanged.
+    fn can_prune(&self, font: &str) -> bool {
+        self.is_simple(font)
+    }
+
+    /// Whether one show string is well-formed for `font` under the
+    /// encoding the engine claims to support. For a fixed-width multi-byte
+    /// encoding (Identity-H: 2 bytes per code) a string whose length is not
+    /// a whole number of codes is malformed; pruning it could misalign code
+    /// boundaries and silently under-redact, so the engine **refuses**.
+    /// Default `true` (single-byte fonts have no alignment constraint).
+    fn redaction_safe_show(&self, _font: &str, _bytes: &[u8]) -> bool {
+        true
+    }
 }
 
 /// One font's removed glyph codes, for `font_scrub` (G2).
@@ -477,12 +499,38 @@ fn refuse_unsupported(
     out: &mut Vec<Operator>,
     op: &Operator,
 ) -> bool {
-    if !regions.is_empty() && !fonts.is_simple(font) {
+    if regions.is_empty() {
+        return false;
+    }
+    // Refuse a font whose glyphs cannot be pruned reliably, OR a show whose
+    // bytes do not align to the font's code length (a malformed multi-byte
+    // string we must not risk mis-decoding). Either way emit the show
+    // unchanged and flag the hard refusal.
+    let aligned = show_strings(op)
+        .iter()
+        .all(|s| fonts.redaction_safe_show(font, s));
+    if !fonts.can_prune(font) || !aligned {
         result.unsupported_font = true;
         out.push(op.clone());
-        true
-    } else {
-        false
+        return true;
+    }
+    false
+}
+
+/// The raw show-string payload(s) carried by a text-showing operator, in
+/// order. Non-show operators yield an empty list.
+fn show_strings(op: &Operator) -> Vec<&[u8]> {
+    match op {
+        Operator::Tj { text } | Operator::Quote { text } => vec![text.as_slice()],
+        Operator::DoubleQuote { text, .. } => vec![text.as_slice()],
+        Operator::TJ { array } => array
+            .iter()
+            .filter_map(|el| match el {
+                TextElement::String(s) => Some(s.as_slice()),
+                TextElement::Offset(_) => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -522,6 +570,34 @@ mod tests {
         }
         fn is_simple(&self, _f: &str) -> bool {
             false
+        }
+    }
+
+    /// Identity-H stub: full-em (1000) glyphs, 2-byte codes (CID = code),
+    /// prunable, never a word space, odd-length shows refused — mirroring
+    /// `FontInfoMetrics`'s real Identity-H behaviour so the engine's
+    /// multi-byte pruning is testable in isolation.
+    struct IdentityHStub;
+    impl FontMetrics for IdentityHStub {
+        fn width(&self, _f: &str, _c: u32) -> f32 {
+            1000.0
+        }
+        fn is_simple(&self, _f: &str) -> bool {
+            false
+        }
+        fn can_prune(&self, _f: &str) -> bool {
+            true
+        }
+        fn decode(&self, _f: &str, s: &[u8]) -> Vec<(u32, Vec<u8>)> {
+            s.chunks_exact(2)
+                .map(|p| (u32::from(u16::from_be_bytes([p[0], p[1]])), p.to_vec()))
+                .collect()
+        }
+        fn is_word_space(&self, _f: &str, _c: u32) -> bool {
+            false
+        }
+        fn redaction_safe_show(&self, _f: &str, bytes: &[u8]) -> bool {
+            bytes.len() % 2 == 0
         }
     }
 
@@ -612,6 +688,44 @@ mod tests {
             })
             .unwrap();
         assert!((tm.0 - 100.0).abs() < 1e-3 && (tm.1 - 100.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn identity_h_middle_cid_removed_others_survive() {
+        // Identity-H: three 2-byte CIDs (1, 2, 3) → bytes 00 01 00 02 00 03.
+        // Full-em glyphs at 10pt from (100,100): CID1 [100,110], CID2
+        // [110,120], CID3 [120,130]. A tight region inside CID2 must remove
+        // exactly that CID's two bytes and keep CID1 and CID3 intact.
+        let ops = doc([1.0, 0.0, 0.0, 1.0, 100.0, 100.0], &[0, 1, 0, 2, 0, 3]);
+        let r = regions(113.0, 95.0, 117.0, 115.0);
+        let out = redact_text_stream(&ops, &r, DEFAULT_EDGE_PADDING, &IdentityHStub);
+        assert!(!out.unsupported_font, "Identity-H must be prunable, not refused");
+        assert_eq!(out.glyphs_removed, 1, "only the middle CID is in the region");
+        // CID1 and CID3 survive as their original 2-byte codes, in order.
+        assert_eq!(tj_text(&out.operators), vec![vec![0u8, 1], vec![0u8, 3]]);
+    }
+
+    #[test]
+    fn identity_h_fully_covered_run_removed() {
+        let ops = doc([1.0, 0.0, 0.0, 1.0, 100.0, 100.0], &[0, 1, 0, 2, 0, 3]);
+        let r = regions(90.0, 95.0, 140.0, 115.0); // covers all three CIDs
+        let out = redact_text_stream(&ops, &r, DEFAULT_EDGE_PADDING, &IdentityHStub);
+        assert!(!out.unsupported_font);
+        assert_eq!(out.glyphs_removed, 3);
+        assert!(tj_text(&out.operators).is_empty(), "no target bytes may survive");
+    }
+
+    #[test]
+    fn identity_h_odd_length_show_is_refused_fail_closed() {
+        // A malformed 5-byte Identity-H show (not a whole number of 2-byte
+        // codes) must be refused rather than mis-decoded — fail closed.
+        let ops = doc([1.0, 0.0, 0.0, 1.0, 100.0, 100.0], &[0, 1, 0, 2, 9]);
+        let r = regions(90.0, 95.0, 140.0, 115.0);
+        let out = redact_text_stream(&ops, &r, DEFAULT_EDGE_PADDING, &IdentityHStub);
+        assert!(out.unsupported_font, "odd-length Identity-H show must refuse");
+        // The original (unredacted) show is emitted unchanged; the caller
+        // discards the whole result on refusal, so nothing is persisted.
+        assert_eq!(tj_text(&out.operators), vec![vec![0u8, 1, 0, 2, 9]]);
     }
 
     #[test]

--- a/src/redaction/text_engine.rs
+++ b/src/redaction/text_engine.rs
@@ -597,7 +597,7 @@ mod tests {
             false
         }
         fn redaction_safe_show(&self, _f: &str, bytes: &[u8]) -> bool {
-            bytes.len() % 2 == 0
+            bytes.len().is_multiple_of(2)
         }
     }
 

--- a/tests/core_parity.rs
+++ b/tests/core_parity.rs
@@ -93,5 +93,5 @@ fn open_error() {
 
 #[test]
 fn version() {
-    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.65");
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.66");
 }

--- a/tests/image_16bit_extraction.rs
+++ b/tests/image_16bit_extraction.rs
@@ -1,0 +1,94 @@
+//! Integration coverage for #750: extracting an image whose
+//! `/BitsPerComponent` is 16 must not panic.
+//!
+//! PDF stores 16-bit colour samples as big-endian pairs (ISO 32000-1
+//! §8.9.5.2); the raw decode path collapses each sample to its high byte so
+//! the pixel buffer is the length the 8-bit image pipeline expects. Before the
+//! fix the doubled-length buffer reached the PNG encoder and tripped its
+//! internal `assert_eq!` ("Invalid buffer length"), a panic that crossed the
+//! Python/WASM FFI boundary uncatchably. This fixture is a hand-built minimal
+//! PDF (no third-party files) carrying one 16-bit DeviceRGB image.
+
+use pdf_oxide::PdfDocument;
+
+/// Minimal one-page PDF with a single `width`×`height` DeviceRGB image at
+/// `/BitsPerComponent 16` (two big-endian bytes per colour sample).
+fn pdf_with_16bit_image(width: u32, height: u32) -> Vec<u8> {
+    // 16-bit RGB gradient: 3 channels × 2 bytes per pixel.
+    let mut img = Vec::with_capacity((width * height * 6) as usize);
+    for y in 0..height {
+        for x in 0..width {
+            let r = ((x * 257) & 0xFFFF) as u16;
+            let g = ((y * 690) & 0xFFFF) as u16;
+            let b = 0x8000u16;
+            for v in [r, g, b] {
+                img.push((v >> 8) as u8);
+                img.push((v & 0xFF) as u8);
+            }
+        }
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 6];
+    buf.extend_from_slice(b"%PDF-1.7\n");
+    let mut obj = |buf: &mut Vec<u8>, id: usize, head: String, stream: Option<&[u8]>| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{head}").as_bytes());
+        if let Some(s) = stream {
+            buf.extend_from_slice(b"\nstream\n");
+            buf.extend_from_slice(s);
+            buf.extend_from_slice(b"\nendstream");
+        }
+        buf.extend_from_slice(b"\nendobj\n");
+    };
+    obj(&mut buf, 1, "<< /Type /Catalog /Pages 2 0 R >>".into(), None);
+    obj(&mut buf, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(), None);
+    obj(
+        &mut buf,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 200] \
+         /Resources << /XObject << /Im0 4 0 R >> >> /Contents 5 0 R >>"
+            .into(),
+        None,
+    );
+    obj(
+        &mut buf,
+        4,
+        format!(
+            "<< /Type /XObject /Subtype /Image /Width {width} /Height {height} \
+             /ColorSpace /DeviceRGB /BitsPerComponent 16 /Length {} >>",
+            img.len()
+        ),
+        Some(&img),
+    );
+    let content = format!("q {width} 0 0 {height} 10 10 cm /Im0 Do Q");
+    obj(
+        &mut buf,
+        5,
+        format!("<< /Length {} >>", content.len()),
+        Some(content.as_bytes()),
+    );
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for id in 1..=5 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+#[test]
+fn sixteen_bit_image_extracts_to_png_without_panicking() {
+    // 330×95 mirrors the dimensions in the original report.
+    let doc = PdfDocument::from_bytes(pdf_with_16bit_image(330, 95)).expect("fixture parses");
+    let images = doc.extract_images(0).expect("extract_images");
+    assert_eq!(images.len(), 1, "the 16-bit image must be found");
+    let img = &images[0];
+    assert_eq!((img.width(), img.height()), (330, 95));
+    // The crux of #750: encoding must succeed (recoverable Result), not panic.
+    let png = img
+        .to_png_bytes()
+        .expect("16-bit image must encode to PNG, not panic");
+    assert!(png.starts_with(&[0x89, b'P', b'N', b'G']), "valid PNG signature");
+}

--- a/tests/image_16bit_extraction.rs
+++ b/tests/image_16bit_extraction.rs
@@ -29,7 +29,7 @@ fn pdf_with_16bit_image(width: u32, height: u32) -> Vec<u8> {
     }
 
     let mut buf: Vec<u8> = Vec::new();
-    let mut off = vec![0usize; 6];
+    let mut off = [0usize; 6];
     buf.extend_from_slice(b"%PDF-1.7\n");
     let mut obj = |buf: &mut Vec<u8>, id: usize, head: String, stream: Option<&[u8]>| {
         off[id] = buf.len();

--- a/tests/redact_identity_h.rs
+++ b/tests/redact_identity_h.rs
@@ -51,7 +51,7 @@ fn identity_h_pdf(runs: &[Run]) -> Vec<u8> {
     }
 
     let mut buf: Vec<u8> = Vec::new();
-    let mut off = vec![0usize; 9];
+    let mut off = [0usize; 9];
     buf.extend_from_slice(b"%PDF-1.7\n");
     let mut obj = |buf: &mut Vec<u8>, id: usize, body: String| {
         off[id] = buf.len();

--- a/tests/redact_identity_h.rs
+++ b/tests/redact_identity_h.rs
@@ -1,0 +1,162 @@
+//! Integration coverage for #748: destructive redaction of Type0 text encoded
+//! with the horizontal identity CMap (Identity-H).
+//!
+//! Before the fix the engine refused every composite/Type0 font, so a CJK (or
+//! any CID-keyed) document could not be redacted at all. This builds a minimal
+//! hand-written Type0/Identity-H PDF (no third-party files): two runs on
+//! separate baselines, text carried by `/ToUnicode` and advances by `/W`. A
+//! region over the first run must physically remove only that run's glyphs and
+//! leave the second run intact — proving redaction is supported AND correctly
+//! targeted (no under- or over-redaction across the baseline gap).
+
+use pdf_oxide::editor::DocumentEditor;
+use pdf_oxide::{PdfDocument, RedactionOptions};
+
+struct Run {
+    x: f32,
+    y: f32,
+    text: &'static str,
+    codes: &'static [u16],
+}
+
+/// Minimal Type0/Identity-H PDF. Each glyph advances 12pt (W=1000 at 12 Tf);
+/// each run is its own `BT…ET`. `/ToUnicode` maps every CID to its scalar.
+fn identity_h_pdf(runs: &[Run]) -> Vec<u8> {
+    let mut content = String::new();
+    for r in runs {
+        let hex: String = r.codes.iter().map(|c| format!("{c:04X}")).collect();
+        content.push_str(&format!("BT /F1 12 Tf 1 0 0 1 {:.1} {:.1} Tm <{hex}> Tj ET\n", r.x, r.y));
+    }
+    let mut pairs: Vec<(u16, char)> = Vec::new();
+    for r in runs {
+        for (code, ch) in r.codes.iter().zip(r.text.chars()) {
+            pairs.push((*code, ch));
+        }
+    }
+    let mut bf = String::new();
+    for (code, ch) in &pairs {
+        bf.push_str(&format!("<{code:04X}> <{:04X}>\n", *ch as u32));
+    }
+    let tounicode = format!(
+        "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n\
+         /CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n\
+         1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+         {} beginbfchar\n{}endbfchar\nendcmap\nCMapName currentdict /CMap defineresource pop\nend\nend",
+        pairs.len(),
+        bf
+    );
+    let mut w = String::new();
+    for (code, _) in &pairs {
+        w.push_str(&format!("{code} [1000] "));
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 9];
+    buf.extend_from_slice(b"%PDF-1.7\n");
+    let mut obj = |buf: &mut Vec<u8>, id: usize, body: String| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    obj(&mut buf, 1, "<< /Type /Catalog /Pages 2 0 R >>".into());
+    obj(&mut buf, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into());
+    obj(
+        &mut buf,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .into(),
+    );
+    obj(
+        &mut buf,
+        4,
+        format!("<< /Length {} >>\nstream\n{content}endstream", content.len()),
+    );
+    obj(
+        &mut buf,
+        5,
+        "<< /Type /Font /Subtype /Type0 /BaseFont /IDFix /Encoding /Identity-H \
+         /DescendantFonts [6 0 R] /ToUnicode 7 0 R >>"
+            .into(),
+    );
+    obj(
+        &mut buf,
+        6,
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /IDFix \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             /FontDescriptor 8 0 R /DW 1000 /W [ {w}] /CIDToGIDMap /Identity >>"
+        ),
+    );
+    obj(
+        &mut buf,
+        7,
+        format!("<< /Length {} >>\nstream\n{tounicode}\nendstream", tounicode.len() + 1),
+    );
+    obj(
+        &mut buf,
+        8,
+        "<< /Type /FontDescriptor /FontName /IDFix /Flags 4 \
+         /FontBBox [0 -200 1000 800] /ItalicAngle 0 /Ascent 800 /Descent -200 \
+         /CapHeight 700 /StemV 80 >>"
+            .into(),
+    );
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 9\n0000000000 65535 f \n");
+    for id in 1..=8 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 9 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+#[test]
+fn identity_h_destructive_redaction_targets_only_the_region() {
+    // "SECRET" (CIDs 1..6) on the upper baseline; "PUBLIC" (CIDs 7..12) 40pt
+    // below. ToUnicode makes both extractable.
+    let runs = [
+        Run {
+            x: 100.0,
+            y: 700.0,
+            text: "SECRET",
+            codes: &[1, 2, 3, 4, 5, 6],
+        },
+        Run {
+            x: 100.0,
+            y: 660.0,
+            text: "PUBLIC",
+            codes: &[7, 8, 9, 10, 11, 12],
+        },
+    ];
+    let src = identity_h_pdf(&runs);
+
+    // Sanity: both runs extract before redaction.
+    let before = PdfDocument::from_bytes(src.clone())
+        .unwrap()
+        .extract_text(0)
+        .unwrap();
+    assert!(
+        before.contains("SECRET") && before.contains("PUBLIC"),
+        "fixture text: {before:?}"
+    );
+
+    let mut ed = DocumentEditor::from_bytes(src).expect("open editor");
+    // Region over the upper baseline only (glyph boxes ≈ y 696..712 for SECRET,
+    // y 656..672 for PUBLIC) — covers SECRET, clears PUBLIC.
+    ed.add_redaction(0, [90.0, 690.0, 220.0, 720.0], None)
+        .expect("queue redaction");
+    let report = ed
+        .apply_redactions_destructive(RedactionOptions::default())
+        .expect("Identity-H redaction must be SUPPORTED, not refused");
+    assert!(report.glyphs_removed > 0, "expected glyphs removed, report={report:?}");
+
+    let out = ed
+        .save_to_bytes_with_options(pdf_oxide::editor::SaveOptions::full_rewrite())
+        .expect("save redacted pdf");
+    let after = PdfDocument::from_bytes(out)
+        .unwrap()
+        .extract_text(0)
+        .unwrap();
+    assert!(!after.contains("SECRET"), "target run must be gone, got: {after:?}");
+    assert!(after.contains("PUBLIC"), "non-target run must survive, got: {after:?}");
+}

--- a/tests/soft_wrap_line_break.rs
+++ b/tests/soft_wrap_line_break.rs
@@ -1,0 +1,67 @@
+//! Integration coverage for 7338bbee: a soft-wrapped line on the untagged
+//! text path must get a synthesized separator, not glue the last word of one
+//! line to the first of the next (`tide` + `tables` → `tidetables`).
+//!
+//! A wrapped line's leading (~1.0 em) is below the same-line tolerance
+//! (~1.2 em), so the two lines were treated as one and concatenated with no
+//! space. The fix detects a carriage-return — a large backward x gap
+//! (`gap < -fs*3`), a real baseline drop (`y_diff > fs*0.5`), and a return to
+//! the left margin (`delta_x <= fs*0.5`) — and emits a newline. Hand-built
+//! minimal Helvetica PDF (simple single-byte font, no third-party files).
+
+use pdf_oxide::PdfDocument;
+
+/// One-page PDF: two Helvetica runs, each its own `BT…ET`. `r1` ends far to the
+/// right; `r2` starts back at the left margin one short line-height below — the
+/// soft-wrap (carriage-return) shape.
+fn two_line_pdf() -> Vec<u8> {
+    // r1 baseline (72,700); r2 baseline (72,691): Δy=9 — inside the same-line
+    // tolerance (10*1.2=12) yet above 10*0.5=5, and the x gap is a full
+    // carriage return, so the soft-wrap branch must fire.
+    let content = "BT /F1 10 Tf 1 0 0 1 72 700 Tm (the spring tide) Tj ET\n\
+                   BT /F1 10 Tf 1 0 0 1 72 691 Tm (tables now posted) Tj ET\n";
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 6];
+    buf.extend_from_slice(b"%PDF-1.7\n");
+    let mut obj = |buf: &mut Vec<u8>, id: usize, body: String| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    obj(&mut buf, 1, "<< /Type /Catalog /Pages 2 0 R >>".into());
+    obj(&mut buf, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into());
+    obj(
+        &mut buf,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .into(),
+    );
+    obj(
+        &mut buf,
+        4,
+        format!("<< /Length {} >>\nstream\n{content}endstream", content.len()),
+    );
+    obj(&mut buf, 5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".into());
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for id in 1..=5 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+#[test]
+fn soft_wrapped_line_is_separated_not_glued() {
+    let doc = PdfDocument::from_bytes(two_line_pdf()).expect("fixture parses");
+    let text = doc.extract_text(0).expect("extract_text");
+    assert!(
+        !text.contains("tidetables"),
+        "soft-wrap must not glue the wrapped word boundary, got: {text:?}"
+    );
+    assert!(
+        text.contains("tide") && text.contains("tables"),
+        "both wrapped words must be present, got: {text:?}"
+    );
+}

--- a/tests/soft_wrap_line_break.rs
+++ b/tests/soft_wrap_line_break.rs
@@ -21,7 +21,7 @@ fn two_line_pdf() -> Vec<u8> {
     let content = "BT /F1 10 Tf 1 0 0 1 72 700 Tm (the spring tide) Tj ET\n\
                    BT /F1 10 Tf 1 0 0 1 72 691 Tm (tables now posted) Tj ET\n";
     let mut buf: Vec<u8> = Vec::new();
-    let mut off = vec![0usize; 6];
+    let mut off = [0usize; 6];
     buf.extend_from_slice(b"%PDF-1.7\n");
     let mut obj = |buf: &mut Vec<u8>, id: usize, body: String| {
         off[id] = buf.len();

--- a/uv.lock
+++ b/uv.lock
@@ -2254,7 +2254,7 @@ wheels = [
 
 [[package]]
 name = "pdf-oxide"
-version = "0.3.65"
+version = "0.3.66"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.65",
+  "version": "0.3.66",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {


### PR DESCRIPTION
## v0.3.66 — extraction-quality release (target 2026-06-18)

Multi-region/two-column reading order, right-to-left Arabic/Hebrew reconstruction in Markdown & HTML, soft-wrap de-gluing and de-hyphenation, and a subset-font cipher-encoding fix — plus destructive redaction of Identity-H (composite) text, CCITT Group 3 fax decoding, and a 16-bit-per-component image fix.

### Added
- **Destructive redaction of Identity-H composite (Type 0) text** — supports `Type0` + `/Identity-H` (horizontal): 2-byte BE CID decode, `/W` widths (ISO 32000-1 §9.7.4.3/§9.7.5.2); stays fail-closed on Identity-V, legacy CMaps, and odd-length strings.
- **CCITT Group 3 (T.4) fax decoding** — extends the in-house decoder (Group 4 shipped in v0.3.65) to `K = 0` (1-D Modified Huffman) and `K > 0` (mixed 1-D/2-D); Group-3 fax images that rendered blank now decode.

### Fixed
- **16-bit-per-component images no longer panic on extraction** — 16-bit BE samples are down-converted to 8-bit at parse; PNG encoder returns a recoverable error instead of asserting across FFI.
- **Multi-region & two-column reading order** — topological block order (precede-relation over text blocks) replaces a flat row-aware sort that interleaved columns; stacked lines merged by the same-line tolerance are de-interleaved by baseline. Self-gating (single-column pages unchanged).
- **RTL Markdown/HTML reconstruction** — Arabic/Hebrew reconstructed at glyph fidelity from raw spans; inter-word punctuation separators kept; line-final word rejoined; producer word-space after a dual-joining letter preserved.
- **Soft-wrap de-gluing & de-hyphenation** — synthesises the line-break separator generator PDFs omit (ISO 32000-1 §9.4); suppresses the spurious post-hyphen space on wrapped lines.
- **Markdown/HTML gutter-crossing word rejoin** — rejoins a word split across a column gutter (lone initial / split number) without gluing separate column lines or dropping interior emphasis.
- **Subset-font cipher encoding** — a subset built-in encoding that disagrees with the producer's named `/Encoding` is detected as a cipher and the named encoding is kept (fixes whole-page mojibake).

### Auto-closed on release
Closes #738
Closes #748
Closes #750

### Community contributors
Thanks to the reporters whose issues this release fixes:
- @potatochipcoconut — #738 (CCITT Group 3; also reported the Group 4 issue fixed in v0.3.65)
- @shota-sh — #748 (Identity-H composite-font redaction)
- @shtyker — #750 (16-bit image extraction panic)

### Verification
- 400-PDF v0.3.65→HEAD regression sweep, every diff human-assessed: **net-positive, 0 regressions**; the 6 RTL guard fixtures and the table guard are byte-identical to v0.3.65.
- Version bumped 0.3.65 → 0.3.66 across the workspace and all language bindings (Cargo/py/js/wasm/csharp/go/java/php/ruby + jni/mcp/cli) and the version-parity assertions.
