### PR TITLE
fix(text): preserve same-row span order when grouping splits a line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Same-row spans no longer reordered or split in plain-text output (#752)** — when a producer emits one logical line as several spans at the same Y in different reading-order groups whose boxes overlap by a fraction of a point, `to_plain_text` interleaved the overlapping group as if it were a vertical column (hoisting a fragment to the front) and forced a space between the overlapping fragments (splitting a word). A group whose spans share a Y row is now excluded from columnar detection, and the cross-group same-Y space special case is removed in favour of the standard `has_horizontal_gap` threshold the other converters already use — so overlapping fragments join. Fixes e.g. `ALPHA BETA GAMMA DELTA EPSILON` extracted as `A EPSILON ALPHA BETA GAMMA DELT`.
+
 ## [0.3.67] - 2026-06-20
 
 > Reading-order quality release for untagged scientific papers — manuscript-line-number rails lifted out of the body, dense two-column bodies kept apart at a measured gutter, comma-bearing statistic subscripts rejoined, repeated journal pagination footers suppressed, whole-page placed-PDF article bodies recovered, and single-column pages protected from false column detection.

--- a/src/pipeline/converters/plain_text.rs
+++ b/src/pipeline/converters/plain_text.rs
@@ -72,6 +72,23 @@ impl PlainTextConverter {
         table.render_text()
     }
 
+    /// Whether a run of spans occupies distinct vertical rows — a real table
+    /// column has one cell per row. A group whose spans share a Y row (e.g. a
+    /// name split into adjacent same-line fragments) is a broken-up line, not a
+    /// column; treating it as one makes the row-interleave hoist same-row spans
+    /// out of left-to-right order.
+    fn run_has_distinct_rows(spans: &[&OrderedTextSpan]) -> bool {
+        let mut ys: Vec<f32> = spans.iter().map(|s| s.span.bbox.y).collect();
+        ys.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
+        let tol = spans
+            .iter()
+            .map(|s| s.span.font_size)
+            .fold(0.0_f32, f32::max)
+            .max(1.0)
+            * 0.5;
+        ys.windows(2).all(|w| (w[1] - w[0]).abs() >= tol)
+    }
+
     /// Detect consecutive groups that form a columnar layout and reorder
     /// their spans row-by-row instead of column-by-column.
     ///
@@ -126,8 +143,12 @@ impl PlainTextConverter {
 
         while i < runs.len() {
             let base_count = runs[i].2;
-            // Need at least 2 rows per column (header + data) and at least 2 columns.
-            if base_count < 2 {
+            // Need at least 2 rows per column (header + data) and at least 2
+            // columns. A column must also occupy distinct Y rows (one cell per
+            // row); a group whose spans share a row is a split line, not a column.
+            if base_count < 2
+                || !Self::run_has_distinct_rows(&sorted[runs[i].1..runs[i].1 + runs[i].2])
+            {
                 i += 1;
                 continue;
             }
@@ -142,6 +163,13 @@ impl PlainTextConverter {
                 // Check that groups are horizontally separated.
                 let prev_spans = &sorted[runs[j - 1].1..runs[j - 1].1 + runs[j - 1].2];
                 let curr_spans = &sorted[runs[j].1..runs[j].1 + runs[j].2];
+
+                // A candidate column must occupy distinct Y rows (one cell per
+                // row). A group with two spans on the same row is a split line,
+                // not a column — interleaving it reorders same-row spans.
+                if !Self::run_has_distinct_rows(curr_spans) {
+                    break;
+                }
 
                 // Compute X range for each group.
                 let prev_min_x = prev_spans
@@ -466,17 +494,6 @@ impl PlainTextConverter {
                         let columnar_same_row_space = in_columnar
                             && !result.ends_with(' ')
                             && !span.span.text.starts_with(' ');
-                        // Cross-group same-Y: spans merged from different groups
-                        // at the same vertical position always need a space
-                        // (the large horizontal gap is expected for label+value pairs).
-                        let cross_group_same_y_space = same_y
-                            && !in_columnar
-                            && !result.ends_with(' ')
-                            && !span.span.text.starts_with(' ')
-                            && match (span.group_id, prev.group_id) {
-                                (Some(a), Some(b)) => a != b,
-                                _ => false,
-                            };
                         let needs_gap_space = !result.ends_with(' ')
                             && !span.span.text.starts_with(' ')
                             && super::has_horizontal_gap(&prev.span, &span.span);
@@ -489,11 +506,7 @@ impl PlainTextConverter {
                             && !span.span.text.starts_with(' ')
                             && y_diff > 2.0
                             && !super::has_horizontal_gap(&prev.span, &span.span);
-                        if columnar_same_row_space
-                            || cross_group_same_y_space
-                            || needs_gap_space
-                            || stacked_needs_space
-                        {
+                        if columnar_same_row_space || needs_gap_space || stacked_needs_space {
                             result.push(' ');
                         }
                     }
@@ -562,11 +575,19 @@ impl PlainTextConverter {
             let mut insertions: Vec<(usize, f32, String)> = Vec::new();
             for (orphan_y, group) in &orphan_lines {
                 let mut orphan_text = String::new();
+                let mut prev: Option<&OrderedTextSpan> = None;
                 for span in group {
-                    if !orphan_text.is_empty() {
-                        orphan_text.push(' ');
+                    // Space between same-line orphan fragments only when there
+                    // is a real horizontal gap. Overlapping fragments are one
+                    // continuous run the producer's kerning split across spans;
+                    // a space there would break a word.
+                    if let Some(p) = prev {
+                        if super::has_horizontal_gap(&p.span, &span.span) {
+                            orphan_text.push(' ');
+                        }
                     }
                     orphan_text.push_str(&span.span.text);
+                    prev = Some(span);
                 }
 
                 // Find the best insertion point: the last line_marker whose
@@ -1079,6 +1100,77 @@ mod tests {
     }
 
     #[test]
+    fn test_orphan_overlapping_fragments_no_spurious_space() {
+        // Same overlapping-fragment defect as the main converter path, but in
+        // the in-table orphan-recovery path: a value drawn as a Td-chain of
+        // runs lands inside a detected table region without matching any cell,
+        // so the spans become orphans. Adjacent orphan fragments whose boxes
+        // overlap are one continuous run the producer split; joining them with
+        // a space would break the word ("DELT" + "A" -> "DELT A").
+        let converter = PlainTextConverter::new();
+        let config = TextPipelineConfig::default();
+
+        // Table region x=50..250, y=100..300, with a cell that does NOT contain
+        // the fragment text, forcing the fragments to be treated as orphans.
+        let mut table = Table::new();
+        table.bbox = Some(Rect::new(50.0, 100.0, 200.0, 200.0));
+        table.col_count = 1;
+        let mut row = TableRow::new(false);
+        row.add_cell(TableCell::new("Label".to_string(), false));
+        table.add_row(row);
+
+        // "DELT" ends at x = 100 + 30 = 130; "A" starts at 129.5 (overlap),
+        // same Y (y=200), both inside the table region.
+        let mut frag1 = make_span_with_width("DELT", 100.0, 200.0, 30.0);
+        frag1.reading_order = 0;
+        let mut frag2 = make_span_with_width("A", 129.5, 200.0, 8.0);
+        frag2.reading_order = 1;
+
+        let result = converter
+            .convert_with_tables(&[frag1, frag2], &[table], &config)
+            .unwrap();
+
+        assert!(result.contains("DELTA"), "overlapping orphan fragments must join: {:?}", result,);
+        assert!(
+            !result.contains("DELT A"),
+            "no spurious space between overlapping orphan fragments: {:?}",
+            result,
+        );
+    }
+
+    #[test]
+    fn test_orphan_gapped_fragments_keep_space() {
+        // Counterpart to the overlap case: orphan fragments on the same line
+        // with a real horizontal gap are distinct tokens and must keep their
+        // space ("Field" + wide gap + "Value" -> "Field Value").
+        let converter = PlainTextConverter::new();
+        let config = TextPipelineConfig::default();
+
+        let mut table = Table::new();
+        table.bbox = Some(Rect::new(50.0, 100.0, 400.0, 200.0));
+        table.col_count = 1;
+        let mut row = TableRow::new(false);
+        row.add_cell(TableCell::new("Label".to_string(), false));
+        table.add_row(row);
+
+        // "Field" ends at x = 100 + 40 = 140; "Value" starts at 200 (60pt gap).
+        let mut frag1 = make_span_with_width("Field", 100.0, 200.0, 40.0);
+        frag1.reading_order = 0;
+        let mut frag2 = make_span_with_width("Value", 200.0, 200.0, 40.0);
+        frag2.reading_order = 1;
+
+        let result = converter
+            .convert_with_tables(&[frag1, frag2], &[table], &config)
+            .unwrap();
+
+        assert!(
+            result.contains("Field Value"),
+            "gapped orphan fragments must keep their space: {:?}",
+            result,
+        );
+    }
+
+    #[test]
     fn test_no_extra_space_when_overlapping_spans() {
         // Spans with overlapping/touching bboxes should NOT get an extra space.
         let converter = PlainTextConverter::new();
@@ -1093,6 +1185,81 @@ mod tests {
 
         let result = converter.convert(&[span1, span2], &config).unwrap();
         assert_eq!(result, "Hello World\n");
+    }
+
+    #[test]
+    fn test_split_line_not_misdetected_as_column() {
+        // Regression: one line of text is emitted as several spans in distinct
+        // reading-order groups, with adjacent spans overlapping by a fraction
+        // of a point. Here "ALPHA BETA GAMMA
+        // DELT" (group 0) is continued by "A EP" + "SILON" (group 1) on the SAME
+        // row. The columnar detector used to treat group 1 (two spans sharing a
+        // Y) as a vertical column and interleave it, hoisting "A EP" to the front
+        // ("A EP ALPHA ... DELT SILON"). A real column has one cell per row, so a
+        // group whose spans share a row must not be a column candidate.
+        let converter = PlainTextConverter::new();
+        let config = TextPipelineConfig::default();
+
+        let mut header = make_span_with_width("Header", 35.0, 634.0, 64.0);
+        header.reading_order = 0;
+        header.group_id = Some(0);
+        // wide span ending at x≈138
+        let mut name_a = make_span_with_width("ALPHA BETA GAMMA DELT", 35.0, 622.0, 103.0);
+        name_a.reading_order = 1;
+        name_a.group_id = Some(0);
+        let mut row_c = make_span_with_width("LabelC", 35.0, 606.0, 30.0);
+        row_c.reading_order = 2;
+        row_c.group_id = Some(0);
+        let mut row_d = make_span_with_width("LabelD", 35.0, 578.0, 51.0);
+        row_d.reading_order = 3;
+        row_d.group_id = Some(0);
+        // group 1: two fragments on the SAME row (y=622), overlapping group 0
+        let mut frag_a = make_span_with_width("A EP", 137.7, 622.0, 18.4);
+        frag_a.reading_order = 4;
+        frag_a.group_id = Some(1);
+        let mut frag_b = make_span_with_width("SILON", 155.5, 622.0, 15.1);
+        frag_b.reading_order = 5;
+        frag_b.group_id = Some(1);
+        let mut right_c = make_span_with_width("RightC", 167.0, 606.0, 66.0);
+        right_c.reading_order = 6;
+        right_c.group_id = Some(1);
+
+        let spans = vec![header, name_a, row_c, row_d, frag_a, frag_b, right_c];
+        let result = converter.convert(&spans, &config).unwrap();
+
+        // Reconstructed left-to-right, the fragments form one word: DELT + A EP +
+        // SILON = "DELTA EPSILON". Order preserved, no spurious mid-word space.
+        assert!(
+            result.contains("ALPHA BETA GAMMA DELTA EPSILON"),
+            "name should read in order with no spurious split: {:?}",
+            result,
+        );
+        assert!(
+            !result.contains("A EP ALPHA"),
+            "fragment must not be hoisted ahead of the line: {:?}",
+            result,
+        );
+    }
+
+    #[test]
+    fn test_overlapping_cross_group_spans_no_spurious_space() {
+        // Two same-row spans from different reading-order groups that OVERLAP
+        // horizontally are one continuous run the grouping split — they must not
+        // get the cross-group "label/value" space.
+        let converter = PlainTextConverter::new();
+        let config = TextPipelineConfig::default();
+
+        // "DELT" ends at x = 100 + 30 = 130; "A" starts at 129.5 (overlap).
+        let mut s1 = make_span_with_width("DELT", 100.0, 200.0, 30.0);
+        s1.reading_order = 0;
+        s1.group_id = Some(0);
+        let mut s2 = make_span_with_width("A", 129.5, 200.0, 8.0);
+        s2.reading_order = 1;
+        s2.group_id = Some(1);
+
+        let result = converter.convert(&[s1, s2], &config).unwrap();
+        assert!(result.contains("DELTA"), "overlapping fragments must join: {:?}", result);
+        assert!(!result.contains("DELT A"), "no spurious cross-group space: {:?}", result);
     }
 
     // ============================================================================


### PR DESCRIPTION
## Description

`to_plain_text` orders spans by reading-order group, then `reorder_columnar_groups`
interleaves side-by-side column groups row-by-row and `merge_same_y_across_groups`
joins same-Y spans from different groups onto one line. When a producer draws one
logical line as a `Td`-chain whose runs land in **different reading-order groups at the
same Y with boxes overlapping by ~0.5pt**, two failures compound:

1. the overlapping group (≥2 spans sharing a Y) is mistaken for a 2-row vertical column
   and interleaved, hoisting a fragment to the front of the line; and
2. the `cross_group_same_y_space` rule forces a space between the overlapping fragments,
   splitting a word.

Net: `ALPHA BETA GAMMA DELTA EPSILON` → `A EPSILON ALPHA BETA GAMMA DELT`. Every glyph is
present — a reading-order/spacing defect, not character corruption.

Text show operators position glyphs purely geometrically; a `Td` offset encodes no space
character (ISO 32000-1:2008 §9.4.3), so adjacency must be inferred from box geometry — and
overlapping boxes mean one continuous run, never a column boundary or a label/value gap.

### Approach

- `reorder_columnar_groups` — a column candidate must occupy distinct Y rows (one cell per
  row). New `run_has_distinct_rows` helper; a group whose spans share a Y is excluded from
  columnar detection at both the base-group and column-extension checks.
- render spacing — remove `cross_group_same_y_space`. It bypassed `has_horizontal_gap` to
  always space same-Y cross-group pairs; since #487 removed that helper's upper gap bound,
  genuine label/value gaps are already covered by `needs_gap_space`, so the branch was
  redundant and, on overlapping fragments, wrong. Plain-text now uses the same gap
  threshold as the Markdown/HTML converters.
- orphan recovery — same-line orphan fragments are spaced only on a real horizontal gap
  (`has_horizontal_gap`), mirroring the main render path.

Self-gating: clean columns (distinct Ys) and genuine label/value pairs (positive gap) are
unchanged; only the ambiguous overlap case is touched.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #752 · Complements #724 (inter-word spaces on tightly-typeset PDFs) and #487 (the
`has_horizontal_gap` upper-bound removal this builds on)

## Changes Made

- `src/pipeline/converters/plain_text.rs` — (1) new `run_has_distinct_rows` + guards in
  `reorder_columnar_groups` (base group and column-extension) so a same-Y group is not a
  column candidate; (2) remove the `cross_group_same_y_space` branch from the per-span
  spacing decision; (3) orphan-line builder spaces fragments only on a real
  `has_horizontal_gap`. Adds four in-module regression tests:
  `test_split_line_not_misdetected_as_column`,
  `test_overlapping_cross_group_spans_no_spurious_space`,
  `test_orphan_overlapping_fragments_no_spurious_space`,
  `test_orphan_gapped_fragments_keep_space`.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Testing

- [x] I have added tests that prove the fix (all fail on `main`, pass here; each pins a
      distinct hunk — columnar reorder, render spacing, orphan path).
- [x] All new and existing tests pass locally (`cargo test --lib` green; the columnar /
      two-column / converter-structure / extraction-API integration suites green).
- [ ] I have run `cargo test --all-features` (enables `fips`, mutually exclusive with the
      default `legacy-crypto` — `compile_error!`; CI doesn't run it either).
- [x] I have run `cargo clippy --all-targets -- -D warnings`
- [x] I have run `cargo fmt`

## Python Bindings (if applicable)

N/A — core Rust converter change, no binding API change; flows through to all bindings.

## Documentation

- [x] I have updated CHANGELOG.md
- [ ] Examples (not applicable)

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format

## Additional Notes

Regression tests build spans in code (synthetic, in-memory — no binary fixtures). The
issue's reproducer extracts `Header ALPHA BETA GAMMA DELTA EPSILON RIGHTVAL` as expected.

Tradeoff: removing `cross_group_same_y_space` makes the plain-text converter apply the same
`has_horizontal_gap` threshold as the Markdown/HTML converters — a cross-group same-Y pair
whose boxes touch or overlap (gap ≤ 0.15·font) no longer gets a forced space. This is the
consistent, geometry-based behavior and the safe default for the reported corruption.
