### PR TITLE
Release v0.3.70 — kerning word-rejoin, font-relative line cells, resolved font names, content-stream order

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,6 +21,15 @@ ignore = [
     # pyo3-log supports 0.29 (review 2026-09-10).
     "RUSTSEC-2026-0176",
     "RUSTSEC-2026-0177",
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml < 0.41 — quadratic-time
+    # duplicate-attribute check and unbounded NsReader namespace allocation, both
+    # denial-of-service only (no memory-safety/RCE). Fixed in quick-xml 0.41.0,
+    # which is already our direct dependency; the only affected instance is
+    # quick-xml 0.40.1 pulled transitively by office_oxide 0.1.2 (Office-document
+    # conversion), which is the latest 0.1.x and cannot move to 0.41 until
+    # office_oxide releases against it. Drop these when it does (review 2026-09-30).
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 # Treat unmaintained crates as warnings (not errors)

--- a/.github/workflows/ci-fips.yml
+++ b/.github/workflows/ci-fips.yml
@@ -266,13 +266,13 @@ jobs:
           - label: linux aarch64
             runs-on: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
-          - label: macOS x86_64
-            runs-on: macos-latest
-            target: x86_64-apple-darwin
-          # macOS arm64 FIPS wheel deferred (mirrors release-fips.yml): aws-lc-fips
-          # links its arm64 dylib against the runner's build SDK (macOS 26) and
-          # ignores the deployment target, so delocate rejects any portable wheel
-          # tag. FIPS is predominantly Linux/x86_64; tracked as a follow-up.
+          # macOS FIPS wheels (x86_64 and arm64) deferred (mirrors release-fips.yml):
+          # aws-lc-fips links its dylib against the runner's build SDK and ignores
+          # MACOSX_DEPLOYMENT_TARGET. macos-latest is now arm64 macOS 26; the
+          # x86_64 wheel is cross-compiled there and hits the same 26.0 dylib
+          # floor, which delocate rejects against a portable tag (it only built
+          # before because macos-latest used to be Intel). FIPS is predominantly
+          # Linux/x86_64; tracked as a follow-up.
           - label: windows x86_64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -78,7 +78,7 @@ jobs:
           java-version: '17'
 
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08 # 13.4
+        uses: DeLaGuardo/setup-clojure@f556541eb28a9303896cee0679ba9f60b898300f # 13.5
         with:
           cli: latest
           clj-kondo: latest

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo build --release --lib --features ocr,rendering,signatures,barcodes,tsa-client,system-fonts
 
       - name: Set up Dart
-        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.0
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.0
         with:
           sdk: ${{ matrix.sdk }}
 

--- a/.github/workflows/julia.yml
+++ b/.github/workflows/julia.yml
@@ -60,7 +60,7 @@ jobs:
         run: cargo build --release --lib --features ocr,rendering,signatures,barcodes,tsa-client,system-fonts
 
       - name: Set up Julia
-        uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2
+        uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v2
         with:
           version: '1'
 

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -61,7 +61,7 @@ jobs:
         run: cargo build --release --lib --features ocr,rendering,signatures,barcodes,tsa-client,system-fonts
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: 'release'
           # Pull prebuilt Linux binaries from Posit Public Package Manager.

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -146,15 +146,15 @@ jobs:
             runs-on: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: pdf_oxide_fips-python-linux-aarch64
-          - label: macOS x86_64
-            runs-on: macos-latest
-            target: x86_64-apple-darwin
-            artifact: pdf_oxide_fips-python-macos-x86_64
-          # macOS arm64 FIPS wheel deferred: aws-lc-fips links its dylib against
-          # the runner's build SDK (now macOS 26) and ignores the deployment
-          # target, so the bundled dylib's minimum keeps rising with the runner
-          # image and delocate rejects any portable wheel tag. FIPS deployments
-          # are predominantly Linux/x86_64, so this is tracked as a follow-up.
+          # macOS FIPS wheels (both x86_64 and arm64) are deferred: aws-lc-fips
+          # links its dylib against the runner's build SDK and ignores
+          # MACOSX_DEPLOYMENT_TARGET, so the bundled dylib's minimum OS keeps
+          # rising with the runner image and delocate rejects any portable wheel
+          # tag. macos-latest is now arm64 macOS 26, and the x86_64 wheel is
+          # cross-compiled on that same runner, so it hits the identical 26.0
+          # floor (it only built before because macos-latest used to be Intel).
+          # FIPS deployments are predominantly Linux/x86_64; macOS is tracked as
+          # a follow-up (needs a native Intel runner or an aws-lc-fips fix).
           - label: windows x86_64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2134,7 +2134,7 @@ jobs:
           java-version: '17'
 
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@52716660ff0e592e21f16f47743ee9e996cb96be # 13.4
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08 # 13.4
         with:
           cli: latest
 
@@ -2201,7 +2201,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Dart
-        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.0
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.0
 
       - name: pub get
         working-directory: dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2148,7 +2148,7 @@ jobs:
           java-version: '17'
 
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08 # 13.4
+        uses: DeLaGuardo/setup-clojure@f556541eb28a9303896cee0679ba9f60b898300f # 13.5
         with:
           cli: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2122,7 +2122,12 @@ jobs:
           # so base64-encode the armored key here (only if not already encoded).
         run: |
           case "$PGP_SECRET" in
-            *"BEGIN PGP"*) PGP_SECRET="$(printf '%s' "$PGP_SECRET" | base64 -w0)" ;;
+            *"BEGIN PGP"*)
+              PGP_SECRET="$(printf '%s' "$PGP_SECRET" | base64 -w0)"
+              # The re-encoded value is a new string the runner hasn't been told
+              # to redact; register it so it can never surface in logs.
+              echo "::add-mask::$PGP_SECRET"
+              ;;
           esac
           export PGP_SECRET
           sbt ci-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2116,7 +2116,16 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           PGP_SECRET: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-        run: sbt ci-release
+          # The Java job feeds this same secret to setup-java's gpg-private-key,
+          # which wants ASCII-armored text, so the secret is stored armored.
+          # sbt-ci-release instead base64-decodes PGP_SECRET before importing,
+          # so base64-encode the armored key here (only if not already encoded).
+        run: |
+          case "$PGP_SECRET" in
+            *"BEGIN PGP"*) PGP_SECRET="$(printf '%s' "$PGP_SECRET" | base64 -w0)" ;;
+          esac
+          export PGP_SECRET
+          sbt ci-release
 
   # Clojure facade → Clojars via clojure/build.clj (tools.build + deps-deploy).
   publish-clojure:

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -64,7 +64,7 @@ jobs:
         run: cargo build --release --lib --features ocr,rendering,signatures,barcodes,tsa-client,system-fonts
 
       - name: Set up Zig (pinned — pre-1.0 API drift)
-        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.70] - 2026-07-02
+
+> Extraction-fidelity release — kerning-split words rejoined in plain text, table/form line cells split consistently regardless of word width, resolved `/BaseFont` names on the span/word APIs, and content-stream order exposed on extracted spans and words.
+
+### Added
+
+- **Content-stream order exposed on extracted spans and words (#779)** — `extract_words` and `extract_text_lines` now carry the originating span's `sequence` (the content-stream emission order), also exposed on Python's `PyTextSpan`/`PyWord`. This lets consumers tell genuinely-consecutive draw calls apart from spatially-close-but-stream-distant ones (e.g. table cells vs. overlays), independent of the final reading order. Thanks @ankursri494 for the request.
+
+### Fixed
+
+- **A word split by a spurious space when its glyph runs overlap slightly (#791)** — a single word drawn as two adjacent same-font runs whose glyphs overlap by a fraction of a point (ordinary tight kerning, e.g. `(PLANAL)` then `(TINA)` positioned just inside `PLANAL`'s right edge) was extracted as `PLANAL TINA`. The plain-text assembler now recognises this case — a negative inter-run gap, same font/weight/style, word characters on both sides, real (varying) per-glyph metrics, and *not* a lowercase→uppercase word boundary — and joins the runs with no inserted space, reconstructing `PLANALTINA`, matching pdftotext / PyMuPDF / lopdf on the same file. The spans are left unmerged, so page layout, reading order, and table detection are unaffected. Thanks @schelip for the report and minimal repro.
+- **`extract_text --format lines` merged table/form cells across column gaps inconsistently (#792)** — a flat 50 pt column-gap threshold made cell splitting depend on how wide each row's words happened to be, so a header row of short values (`CEP`/`Cidade`/`UF`) split into one line per cell while the value row directly below it (`73751-452`/`PLANALTINA`/`GO`, wider words, same gutters) merged into a single line. The threshold in line clustering is now font-relative (`(font_size × 3).max(30 pt)`), so rows sharing the same columns split the same way. Thanks @schelip for the report.
+- **Span-derived APIs reported unresolved (alias) font names (#780, part 1)** — `extract_spans`, `extract_words`, and `extract_text_lines` reported the page's `/Resources/Font` alias (e.g. `F1`) rather than the resolved `/BaseFont` (e.g. `Helvetica`, `CIDFont+F1`). They now resolve to the base font, matching `extract_chars` and pdfminer.six / pdfplumber. (The second part of #780 — per-glyph coordinate drift on CID/Type0 fonts in `extract_words` — is tracked for a follow-up release.) Thanks @ankursri494 for the report.
+- **Cased and caseless non-Latin prose no longer mis-detected as spatial tables** — the no-rulings table detector's prose-paragraph guard now recognises sentence boundaries in cased non-Latin scripts and treats the Bengali/Devanagari danda (`।`, `॥`) as a sentence terminator, so complex-script running prose that happens to align into columns is not extracted as a table grid.
+
+_Thanks to @schelip (#791, #792) and @ankursri494 (#779, #780) for reporting the issues that drove this release._
+
 ## [0.3.69] - 2026-06-27
 
 > Language-bindings release — idiomatic bindings for **C++, Swift, Kotlin, Dart, R, Julia, Zig, Scala, Clojure, Objective-C, and Elixir**, each over the stable C ABI, with per-language CI, package-registry publishing, cross-language regression examples, and single-source version management.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to PDFOxide are documented here.
 
 ### Added
 
-- **Content-stream order exposed on extracted spans and words (#779)** — `extract_words` and `extract_text_lines` now carry the originating span's `sequence` (the content-stream emission order), also exposed on Python's `PyTextSpan`/`PyWord`. This lets consumers tell genuinely-consecutive draw calls apart from spatially-close-but-stream-distant ones (e.g. table cells vs. overlays), independent of the final reading order. Thanks @ankursri494 for the request.
+- **Content-stream order exposed on extracted spans and words (#779)** — `extract_words` and `extract_text_lines` now carry the originating span's `sequence` (the content-stream emission order). It is surfaced idiomatically on the word/span types of every language binding — Python, Node.js and WASM, Go, the JVM (Java/Kotlin/Scala/Clojure), C#, Ruby, PHP, C and C++, Objective-C, Swift, Dart, R, Julia, Zig, and Elixir — via the new C-ABI accessor `pdf_oxide_word_get_sequence`. This lets consumers tell genuinely-consecutive draw calls apart from spatially-close-but-stream-distant ones (e.g. table cells vs. overlays), independent of the final reading order. Thanks @ankursri494 for the request.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2818,7 +2818,7 @@ dependencies = [
  "fast-float2",
  "libc",
  "log",
- "quick-xml",
+ "quick-xml 0.40.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.69"
+version = "0.3.70"
 dependencies = [
  "aes",
  "aws-lc-rs",
@@ -3070,7 +3070,7 @@ dependencies = [
  "pyo3-log",
  "qcms",
  "qrcode",
- "quick-xml",
+ "quick-xml 0.41.0",
  "rayon",
  "regex",
  "rsa",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.69"
+version = "0.3.70"
 dependencies = [
  "clap",
  "is-terminal",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_jni"
-version = "0.3.69"
+version = "0.3.70"
 dependencies = [
  "jni",
  "pdf_oxide",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.69"
+version = "0.3.70"
 dependencies = [
  "pdf_oxide",
  "serde_json",
@@ -3651,6 +3651,15 @@ checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5086,9 +5095,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anymap2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "aes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +43,20 @@ dependencies = [
  "cipher",
  "cpubits",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -200,9 +224,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -350,23 +374,24 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.14"
+version = "0.13.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+checksum = "6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
  "regex",
 ]
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -376,14 +401,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -632,9 +658,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1019,6 +1045,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1686,6 +1721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,9 +1759,9 @@ checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
 name = "glam"
-version = "0.33.1"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
 name = "glob"
@@ -1859,9 +1903,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -2056,9 +2100,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -2070,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2155,9 +2199,9 @@ checksum = "0b0b36cbb4e6704f12f5b5d7b01dac593982c6550859ebd5a66fb15c9ea27fd5"
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2218,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "lcms2-sys"
-version = "4.0.6"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2604b23848ca80b2add60f0fb2270fd980e622c25029b6597fa01cfd5f8d5f"
+checksum = "264db0b78119c5a37d78bb41fb355daab29b3b29430b53cd92e3da51f0ab06cc"
 dependencies = [
  "cc",
  "dunce",
@@ -2567,7 +2611,7 @@ dependencies = [
  "glam 0.30.10",
  "glam 0.31.1",
  "glam 0.32.1",
- "glam 0.33.1",
+ "glam 0.33.2",
  "matrixmultiply",
  "num-complex",
  "num-rational",
@@ -3319,11 +3363,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279a91971a1d8eb1260a30938eae3be9cb67b472dffecb222fbbbe2fd2dc1453"
+checksum = "63d440a804ec8d6fafbb6b84471e013286658d373248927692ab3366686220ca"
 dependencies = [
  "aes",
+ "aes-gcm",
  "cbc",
  "der 0.8.0",
  "pbkdf2",
@@ -3406,6 +3451,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4065,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -4649,9 +4705,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4669,9 +4725,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5033,6 +5089,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5157,9 +5223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5170,9 +5236,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5180,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5190,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5203,18 +5269,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
+checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
 dependencies = [
  "async-trait",
  "cast",
@@ -5234,9 +5300,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
+checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5245,15 +5311,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
+checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5589,9 +5655,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.69"
+version = "0.3.70"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85
@@ -251,7 +251,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # XML parsing (for XMP metadata)
-quick-xml = "0.40"
+quick-xml = "0.41"
 
 # Python bindings (optional)
 # Using latest version to support Python 3.14+

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Established bindings:
 - **Go** — `go get github.com/yfedoseev/pdf_oxide/go` — see [go/README.md](go/README.md)
 - **JavaScript / TypeScript (Node.js)** — `npm install pdf-oxide` — see [js/README.md](js/README.md)
 - **C# / .NET** — `dotnet add package PdfOxide` — see [csharp/README.md](csharp/README.md)
-- **Java (JDK 11+)** — Maven coords `fyi.oxide:pdf-oxide:0.3.69` — see [java/README.md](java/README.md)
+- **Java (JDK 11+)** — Maven coords `fyi.oxide:pdf-oxide:0.3.70` — see [java/README.md](java/README.md)
 - **Ruby** — `gem install pdf_oxide` — see [ruby/README.md](ruby/README.md)
 - **PHP** — `composer require oxide/pdf-oxide` — see [php/README.md](php/README.md)
 
@@ -298,7 +298,7 @@ New in v0.3.69 (all over the stable C ABI):
 
 - **C++** (header-only, CMake / Conan) — see [cpp/README.md](cpp/README.md)
 - **Swift** (SwiftPM) — see [swift/README.md](swift/README.md)
-- **Kotlin** (`fyi.oxide:pdf-oxide-kotlin:0.3.69`) — see [kotlin/README.md](kotlin/README.md)
+- **Kotlin** (`fyi.oxide:pdf-oxide-kotlin:0.3.70`) — see [kotlin/README.md](kotlin/README.md)
 - **Scala** (`fyi.oxide %% pdf-oxide-scala`) — see [scala/README.md](scala/README.md)
 - **Clojure** (`fyi.oxide/pdf-oxide-clojure` on Clojars) — see [clojure/README.md](clojure/README.md)
 - **Dart / Flutter** (`dart pub add pdf_oxide`) — see [dart/README.md](dart/README.md)
@@ -306,20 +306,20 @@ New in v0.3.69 (all over the stable C ABI):
 - **Julia** (`Pkg.add("PdfOxide")`) — see [julia/README.md](julia/README.md)
 - **Zig** (`build.zig.zon`) — see [zig/README.md](zig/README.md)
 - **Objective-C** (CocoaPods) — see [objc/README.md](objc/README.md)
-- **Elixir** (`{:pdf_oxide, "~> 0.3.69"}` on Hex) — see [elixir/README.md](elixir/README.md)
+- **Elixir** (`{:pdf_oxide, "~> 0.3.70"}` on Hex) — see [elixir/README.md](elixir/README.md)
 
 ```xml
 <!-- Java (Maven) -->
 <dependency>
   <groupId>fyi.oxide</groupId>
   <artifactId>pdf-oxide</artifactId>
-  <version>0.3.69</version>
+  <version>0.3.70</version>
 </dependency>
 ```
 
 ```gradle
 // Kotlin (Gradle, Kotlin DSL)
-implementation("fyi.oxide:pdf-oxide-kotlin:0.3.69")
+implementation("fyi.oxide:pdf-oxide-kotlin:0.3.70")
 ```
 
 Every binding shares the same Rust core, so a bug fix in one lands in all of them — everything you read in this README applies, just with each language's native naming conventions. Publishing details for each registry are in [docs/RELEASING-bindings.md](docs/RELEASING-bindings.md).

--- a/clojure/deps.edn
+++ b/clojure/deps.edn
@@ -4,7 +4,7 @@
 ;; Java NativeLoader resolves the JNI cdylib via the `fyi.oxide.pdf.lib.path`
 ;; system property (pointed at the freshly built libpdf_oxide_jni below).
 {:paths ["src"]
- :deps {fyi.oxide/pdf-oxide {:mvn/version "0.3.69"}}
+ :deps {fyi.oxide/pdf-oxide {:mvn/version "0.3.70"}}
  :aliases
  {:test
   {:extra-paths ["test"]

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(pdf_oxide_cpp VERSION 0.3.69 LANGUAGES CXX)
+project(pdf_oxide_cpp VERSION 0.3.70 LANGUAGES CXX)
 
 # Idiomatic C++17 RAII bindings over the pdf_oxide C ABI (header-only wrapper).
 #

--- a/cpp/include/pdf_oxide/pdf_oxide.hpp
+++ b/cpp/include/pdf_oxide/pdf_oxide.hpp
@@ -91,6 +91,10 @@ struct Word {
     std::string font_name;
     float font_size;
     bool bold;
+    /// Content-stream emission order of the word's originating span. Words drawn
+    /// consecutively share adjacent sequence values, distinguishing consecutive
+    /// draws from merely-spatially-close ones, independent of reading order.
+    std::int64_t sequence;
 };
 
 /// A single extracted text line.
@@ -449,6 +453,7 @@ class Document {
                                         code, "Document::extract_words");
                 w.font_size = pdf_oxide_word_get_font_size(list, i, &code);
                 w.bold = pdf_oxide_word_is_bold(list, i, &code);
+                w.sequence = pdf_oxide_word_get_sequence(list, i, &code);
                 out.push_back(std::move(w));
             }
         } catch (...) {
@@ -1566,6 +1571,7 @@ class Document {
                     pdf_oxide_word_get_font_name(list, i, &code), code, op);
                 w.font_size = pdf_oxide_word_get_font_size(list, i, &code);
                 w.bold = pdf_oxide_word_is_bold(list, i, &code);
+                w.sequence = pdf_oxide_word_get_sequence(list, i, &code);
                 out.push_back(std::move(w));
             }
         } catch (...) {

--- a/cpp/tests/test_api_coverage.cpp
+++ b/cpp/tests/test_api_coverage.cpp
@@ -88,6 +88,8 @@ int main() {
             (void)words[0].font_name;
             (void)words[0].font_size;
             (void)words[0].bold;
+            // content-stream emission order of the originating span
+            CHECK(words[0].sequence >= 0);
         }
 
         auto chars = doc.extract_chars(0); // extract_chars

--- a/csharp/PdfOxide/Core/PdfDocument.cs
+++ b/csharp/PdfOxide/Core/PdfDocument.cs
@@ -868,7 +868,7 @@ namespace PdfOxide.Core
         }
 
         /// <summary>Extracts words from a page. Returns handle-based results (use NativeMethods directly for now).</summary>
-        public (string Text, float X, float Y, float W, float H)[] ExtractWords(int pageIndex)
+        public (string Text, float X, float Y, float W, float H, long Sequence)[] ExtractWords(int pageIndex)
         {
             _lock.EnterReadLock();
             try
@@ -876,17 +876,18 @@ namespace PdfOxide.Core
                 ThrowIfDisposed();
                 var handle = NativeMethods.pdf_document_extract_words(_handle.Ptr, pageIndex, out var errorCode);
                 ExceptionMapper.ThrowIfError(errorCode);
-                if (handle == IntPtr.Zero) return Array.Empty<(string, float, float, float, float)>();
+                if (handle == IntPtr.Zero) return Array.Empty<(string, float, float, float, float, long)>();
                 try
                 {
                     var count = NativeMethods.pdf_oxide_word_count(handle);
-                    var results = new (string, float, float, float, float)[count];
+                    var results = new (string, float, float, float, float, long)[count];
                     for (int i = 0; i < count; i++)
                     {
                         var textPtr = NativeMethods.pdf_oxide_word_get_text(handle, i, out _);
                         var text = StringMarshaler.PtrToStringAndFree(textPtr);
                         NativeMethods.pdf_oxide_word_get_bbox(handle, i, out var x, out var y, out var w, out var h, out _);
-                        results[i] = (text, x, y, w, h);
+                        var sequence = NativeMethods.pdf_oxide_word_get_sequence(handle, i, out _);
+                        results[i] = (text, x, y, w, h, sequence);
                     }
                     return results;
                 }
@@ -1176,7 +1177,7 @@ namespace PdfOxide.Core
         }
 
         /// <summary>Extracts words from a rectangular region.</summary>
-        public (string Text, float X, float Y, float W, float H)[] ExtractWordsInRect(int pageIndex, float x, float y, float width, float height)
+        public (string Text, float X, float Y, float W, float H, long Sequence)[] ExtractWordsInRect(int pageIndex, float x, float y, float width, float height)
         {
             _lock.EnterReadLock();
             try
@@ -1184,17 +1185,18 @@ namespace PdfOxide.Core
                 ThrowIfDisposed();
                 var handle = NativeMethods.pdf_document_extract_words_in_rect(_handle.Ptr, pageIndex, x, y, width, height, out var errorCode);
                 ExceptionMapper.ThrowIfError(errorCode);
-                if (handle == IntPtr.Zero) return Array.Empty<(string, float, float, float, float)>();
+                if (handle == IntPtr.Zero) return Array.Empty<(string, float, float, float, float, long)>();
                 try
                 {
                     var count = NativeMethods.pdf_oxide_word_count(handle);
-                    var results = new (string, float, float, float, float)[count];
+                    var results = new (string, float, float, float, float, long)[count];
                     for (int i = 0; i < count; i++)
                     {
                         var textPtr = NativeMethods.pdf_oxide_word_get_text(handle, i, out _);
                         var text = StringMarshaler.PtrToStringAndFree(textPtr);
                         NativeMethods.pdf_oxide_word_get_bbox(handle, i, out var wx, out var wy, out var ww, out var wh, out _);
-                        results[i] = (text, wx, wy, ww, wh);
+                        var sequence = NativeMethods.pdf_oxide_word_get_sequence(handle, i, out _);
+                        results[i] = (text, wx, wy, ww, wh, sequence);
                     }
                     return results;
                 }
@@ -1925,7 +1927,7 @@ namespace PdfOxide.Core
             Task.Run(() => _doc.ToPlainText(Index), ct);
 
         /// <summary>Extracts words with bounding boxes.</summary>
-        public (string Text, float X, float Y, float W, float H)[] ExtractWords() =>
+        public (string Text, float X, float Y, float W, float H, long Sequence)[] ExtractWords() =>
             _doc.ExtractWords(Index);
 
         /// <summary>Extracts text lines with bounding boxes.</summary>

--- a/csharp/PdfOxide/Internal/NativeMethods.cs
+++ b/csharp/PdfOxide/Internal/NativeMethods.cs
@@ -5678,6 +5678,10 @@ namespace PdfOxide.Internal
 
         [LibraryImport(LibName, StringMarshalling = StringMarshalling.Utf8)]
         [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+        public static partial long pdf_oxide_word_get_sequence(IntPtr words, int index, out int errorCode);
+
+        [LibraryImport(LibName, StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
         public static partial void pdf_oxide_word_list_free(IntPtr handle);
 
         [LibraryImport(LibName, StringMarshalling = StringMarshalling.Utf8)]

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.69</Version>
+    <Version>0.3.70</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/dart/lib/pdf_oxide.dart
+++ b/dart/lib/pdf_oxide.dart
@@ -70,6 +70,8 @@ typedef _ListF32C = Float Function(Pointer<Void>, Int32, Pointer<Int32>);
 typedef _ListF32D = double Function(Pointer<Void>, int, Pointer<Int32>);
 typedef _ListI32C = Int32 Function(Pointer<Void>, Int32, Pointer<Int32>);
 typedef _ListI32D = int Function(Pointer<Void>, int, Pointer<Int32>);
+typedef _ListI64C = Int64 Function(Pointer<Void>, Int32, Pointer<Int32>);
+typedef _ListI64D = int Function(Pointer<Void>, int, Pointer<Int32>);
 typedef _ListU32C = Uint32 Function(Pointer<Void>, Int32, Pointer<Int32>);
 typedef _ListU32D = int Function(Pointer<Void>, int, Pointer<Int32>);
 typedef _ListBoolC = Bool Function(Pointer<Void>, Int32, Pointer<Int32>);
@@ -552,6 +554,8 @@ class _Native {
             'pdf_oxide_word_get_font_size'),
         wordIsBold = lib
             .lookupFunction<_ListBoolC, _ListBoolD>('pdf_oxide_word_is_bold'),
+        wordGetSequence = lib.lookupFunction<_ListI64C, _ListI64D>(
+            'pdf_oxide_word_get_sequence'),
         wordListFree = lib
             .lookupFunction<_ListFreeC, _ListFreeD>('pdf_oxide_word_list_free'),
         // text lines
@@ -1387,6 +1391,7 @@ class _Native {
   final _ListStrD wordGetFontName;
   final _ListF32D wordGetFontSize;
   final _ListBoolD wordIsBold;
+  final _ListI64D wordGetSequence;
   final _ListFreeD wordListFree;
   // text lines
   final _ExtractD extractLines;
@@ -2189,12 +2194,21 @@ class Char {
 
 /// A single extracted word.
 class Word {
-  const Word(this.text, this.bbox, this.fontName, this.fontSize, this.bold);
+  const Word(this.text, this.bbox, this.fontName, this.fontSize, this.bold,
+      this.sequence);
   final String text;
   final Bbox bbox;
   final String fontName;
   final double fontSize;
   final bool bold;
+
+  /// Content-stream emission order of this word's originating span.
+  ///
+  /// Words drawn consecutively in the page's content stream have adjacent
+  /// sequence values, which distinguishes genuinely consecutive draws from
+  /// words that merely happen to be spatially close. Independent of reading
+  /// order.
+  final int sequence;
 }
 
 /// A single extracted line of text.
@@ -2653,7 +2667,9 @@ class PdfDocument implements Finalizable {
         if (code.value != 0) throw PdfOxideError(code.value, 'extractWords');
         final bold = _n.wordIsBold(list, i, code);
         if (code.value != 0) throw PdfOxideError(code.value, 'extractWords');
-        out.add(Word(text, bbox, fontName, fontSize, bold));
+        final sequence = _n.wordGetSequence(list, i, code);
+        if (code.value != 0) throw PdfOxideError(code.value, 'extractWords');
+        out.add(Word(text, bbox, fontName, fontSize, bold, sequence));
       }
       return out;
     } finally {
@@ -3536,7 +3552,11 @@ class PdfDocument implements Finalizable {
         if (code.value != 0) {
           throw PdfOxideError(code.value, 'extractWordsInRect');
         }
-        out.add(Word(text, bbox, fontName, fontSize, bold));
+        final sequence = _n.wordGetSequence(list, i, code);
+        if (code.value != 0) {
+          throw PdfOxideError(code.value, 'extractWordsInRect');
+        }
+        out.add(Word(text, bbox, fontName, fontSize, bold, sequence));
       }
       return out;
     } finally {

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_oxide
 description: Idiomatic Dart/Flutter bindings for pdf_oxide — fast PDF text, Markdown and HTML extraction via dart:ffi over the C ABI.
-version: 0.3.69
+version: 0.3.70
 repository: https://github.com/yfedoseev/pdf_oxide
 homepage: https://github.com/yfedoseev/pdf_oxide
 issue_tracker: https://github.com/yfedoseev/pdf_oxide/issues

--- a/dart/test/api_coverage_test.dart
+++ b/dart/test/api_coverage_test.dart
@@ -79,6 +79,7 @@ void main() {
       expect(words, isNotEmpty);
       expect(words[0].text, isNotEmpty);
       expect(words[0].bbox, isA<Bbox>());
+      expect(words[0].sequence, isA<int>());
     });
     test('extractChars', () => expect(doc.extractChars(0), isNotEmpty));
     test('extractTextLines', () => expect(doc.extractTextLines(0), isNotEmpty));

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,16 @@ ignore = [
     # support. Re-audit 2026-09-10.
     "RUSTSEC-2026-0176",
     "RUSTSEC-2026-0177",
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195 — quick-xml < 0.41: quadratic-time
+    # duplicate-attribute check and unbounded `NsReader` namespace allocation,
+    # both denial-of-service only (no memory-safety or RCE). Our direct
+    # dependency is already quick-xml 0.41.0 (the fixed version). The only
+    # affected instance is quick-xml 0.40.1 pulled transitively by
+    # office_oxide 0.1.2 (Office-document conversion); 0.1.2 is the latest 0.1.x,
+    # so it cannot move to 0.41 until office_oxide releases against it. Drop
+    # these the moment that release lands. Re-audit 2026-09-30.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]

--- a/docs/RELEASING-bindings.md
+++ b/docs/RELEASING-bindings.md
@@ -6,7 +6,7 @@ Julia, and Zig — to their respective package registries. All eleven are thin
 layers over the same **pdf_oxide C ABI** (the JVM trio — Kotlin/Scala/Clojure —
 go through the Java JNI binding).
 
-The canonical workspace version is **0.3.69** (kept in lock-step across every
+The canonical workspace version is **0.3.70** (kept in lock-step across every
 manifest by `scripts/sync_version.py`).
 
 For the **established** bindings (Python→PyPI, Node→npm, Java→Maven Central,
@@ -217,12 +217,12 @@ Swift's idiomatic channel is SwiftPM by git tag — no upload. Pushing the
 ## Release order checklist
 
 1. **Version sync** — run `scripts/sync_version.py`; confirm every binding
-   manifest reads `0.3.69` (Cargo.toml, `build.gradle.kts`, `build.sbt`,
+   manifest reads `0.3.70` (Cargo.toml, `build.gradle.kts`, `build.sbt`,
    `build.clj`, `pubspec.yaml`, `mix.exs`, `DESCRIPTION`, `Project.toml`,
    `build.zig.zon`, `PdfOxide.podspec`, `CMakeLists.txt`).
 2. **Green CI** — the established `release.yml` pipeline plus the per-binding
    workflows (`kotlin.yml`, `scala.yml`, … `zig.yml`) all pass.
-3. **Tag** — merge the release branch and push `v0.3.69` (this alone releases
+3. **Tag** — merge the release branch and push `v0.3.70` (this alone releases
    Swift and Zig).
 4. **JVM trio** — publish the Java binding first (Kotlin/Scala/Clojure depend on
    `fyi.oxide:pdf-oxide`), then Maven Central for Kotlin + Scala, then Clojars
@@ -236,4 +236,4 @@ Swift's idiomatic channel is SwiftPM by git tag — no upload. Pushing the
    (<https://cran.r-project.org/submit.html>, confirm the email) and comment
    `@JuliaRegistrator register subdir=julia` on the Julia release commit.
 8. **Verify** — once indexes propagate, smoke-test each install snippet from the
-   binding READMEs against `0.3.69`.
+   binding READMEs against `0.3.70`.

--- a/elixir/c_src/pdf_oxide_nif.c
+++ b/elixir/c_src/pdf_oxide_nif.c
@@ -469,11 +469,13 @@ static ERL_NIF_TERM doc_extract_words(ErlNifEnv *env, int argc, const ERL_NIF_TE
         ERL_NIF_TERM font = take_string(env, pdf_oxide_word_get_font_name(list, i, &c));
         float size = pdf_oxide_word_get_font_size(list, i, &c);
         bool bold = pdf_oxide_word_is_bold(list, i, &c);
-        ERL_NIF_TERM item = enif_make_tuple(env, 8, text,
+        int64_t sequence = pdf_oxide_word_get_sequence(list, i, &c);
+        ERL_NIF_TERM item = enif_make_tuple(env, 9, text,
                                             enif_make_double(env, x), enif_make_double(env, y),
                                             enif_make_double(env, w), enif_make_double(env, h),
                                             font, enif_make_double(env, size),
-                                            enif_make_atom(env, bold ? "true" : "false"));
+                                            enif_make_atom(env, bold ? "true" : "false"),
+                                            enif_make_int64(env, sequence));
         items = enif_make_list_cell(env, item, items);
     }
     pdf_oxide_word_list_free(list);
@@ -3794,11 +3796,13 @@ static ERL_NIF_TERM doc_extract_words_in_rect(ErlNifEnv *env, int argc, const ER
         ERL_NIF_TERM font = take_string(env, pdf_oxide_word_get_font_name(list, i, &c));
         float size = pdf_oxide_word_get_font_size(list, i, &c);
         bool bold = pdf_oxide_word_is_bold(list, i, &c);
-        ERL_NIF_TERM item = enif_make_tuple(env, 8, text,
+        int64_t sequence = pdf_oxide_word_get_sequence(list, i, &c);
+        ERL_NIF_TERM item = enif_make_tuple(env, 9, text,
                                             enif_make_double(env, bx), enif_make_double(env, by),
                                             enif_make_double(env, bw), enif_make_double(env, bh),
                                             font, enif_make_double(env, size),
-                                            enif_make_atom(env, bold ? "true" : "false"));
+                                            enif_make_atom(env, bold ? "true" : "false"),
+                                            enif_make_int64(env, sequence));
         items = enif_make_list_cell(env, item, items);
     }
     pdf_oxide_word_list_free(list);

--- a/elixir/lib/pdf_oxide.ex
+++ b/elixir/lib/pdf_oxide.ex
@@ -60,7 +60,7 @@ defmodule PdfOxide do
 
   defmodule Word do
     @moduledoc "An extracted word with its layout/style metadata."
-    defstruct [:text, :bbox, :font_name, :font_size, :bold]
+    defstruct [:text, :bbox, :font_name, :font_size, :bold, :sequence]
   end
 
   defmodule TextLine do
@@ -344,13 +344,14 @@ defmodule PdfOxide do
   def extract_words(%Document{ref: ref}, page) do
     with {:ok, list} <- Native.doc_extract_words(ref, page) do
       {:ok,
-       Enum.map(list, fn {text, x, y, w, h, font, size, bold} ->
+       Enum.map(list, fn {text, x, y, w, h, font, size, bold, sequence} ->
          %Word{
            text: text,
            bbox: %Bbox{x: x, y: y, width: w, height: h},
            font_name: font,
            font_size: size,
-           bold: bold
+           bold: bold,
+           sequence: sequence
          }
        end)}
     end
@@ -1753,13 +1754,14 @@ defmodule PdfOxide do
   def extract_words_in_rect(%Document{ref: ref}, page, x, y, w, h) do
     with {:ok, list} <- Native.doc_extract_words_in_rect(ref, page, x / 1, y / 1, w / 1, h / 1) do
       {:ok,
-       Enum.map(list, fn {text, bx, by, bw, bh, font, size, bold} ->
+       Enum.map(list, fn {text, bx, by, bw, bh, font, size, bold, sequence} ->
          %Word{
            text: text,
            bbox: %Bbox{x: bx, y: by, width: bw, height: bh},
            font_name: font,
            font_size: size,
-           bold: bold
+           bold: bold,
+           sequence: sequence
          }
        end)}
     end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule PdfOxide.MixProject do
   def project do
     [
       app: :pdf_oxide,
-      version: "0.3.69",
+      version: "0.3.70",
       elixir: "~> 1.15",
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],

--- a/elixir/test/pdf_oxide_test.exs
+++ b/elixir/test/pdf_oxide_test.exs
@@ -98,6 +98,7 @@ defmodule PdfOxideTest do
       assert %PdfOxide.Bbox{} = w.bbox
       assert is_number(w.bbox.x) and is_number(w.bbox.width)
       assert is_boolean(w.bold)
+      assert is_integer(w.sequence)
 
       assert {:ok, chars} = PdfOxide.extract_chars(doc, 0)
       assert is_list(chars)

--- a/examples/csharp/05-extract-structured/Program.cs
+++ b/examples/csharp/05-extract-structured/Program.cs
@@ -18,9 +18,9 @@ var page = 0;
 // Words with position data
 var words = doc.ExtractWords(page);
 Console.WriteLine($"\n--- Words (page {page + 1}) ---");
-foreach (var (text, x, y, width, height) in words.Take(20))
+foreach (var (text, x, y, width, height, sequence) in words.Take(20))
 {
-    Console.WriteLine($"{"\"" + text + "\"",-20} x={x,-7:F1} y={y,-7:F1} w={width,-7:F1} h={height,-7:F1}");
+    Console.WriteLine($"{"\"" + text + "\"",-20} x={x,-7:F1} y={y,-7:F1} w={width,-7:F1} h={height,-7:F1} seq={sequence}");
 }
 if (words.Length > 20)
     Console.WriteLine($"... ({words.Length - 20} more words)");

--- a/go/api_coverage_test.go
+++ b/go/api_coverage_test.go
@@ -92,6 +92,11 @@ func TestExtractWords(t *testing.T) {
 	if !found {
 		t.Errorf("WORDTOKEN not found in extracted words: %v", words)
 	}
+	for _, w := range words {
+		if w.Sequence < 0 {
+			t.Errorf("expected non-negative word Sequence, got %d for %q", w.Sequence, w.Text)
+		}
+	}
 }
 
 func TestExtractChars(t *testing.T) {

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -52,7 +52,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion = "0.3.69"
+	fallbackVersion = "0.3.70"
 	BaseURL         = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	// cacheSubdir lives under os.UserCacheDir() — XDG_CACHE_HOME on Linux,
 	// ~/Library/Caches on macOS (Time-Machine-excluded), %LocalAppData% on

--- a/go/pdf_oxide.go
+++ b/go/pdf_oxide.go
@@ -279,6 +279,7 @@ extern void pdf_oxide_word_get_bbox(const void* words, int32_t index, float* x, 
 extern char* pdf_oxide_word_get_font_name(const void* words, int32_t index, int* error_code);
 extern float pdf_oxide_word_get_font_size(const void* words, int32_t index, int* error_code);
 extern bool pdf_oxide_word_is_bold(const void* words, int32_t index, int* error_code);
+extern int64_t pdf_oxide_word_get_sequence(const void* words, int32_t index, int* error_code);
 extern void pdf_oxide_word_list_free(void* handle);
 
 extern void* pdf_document_extract_text_lines(void* handle, int32_t page_index, int* error_code);
@@ -2130,6 +2131,10 @@ type Word struct {
 	FontName            string
 	FontSize            float32
 	IsBold              bool
+	// Sequence is the word's content-stream emission order (the order its
+	// originating span was drawn during the Tj/TJ walk). Adjacent values mean
+	// the words were drawn consecutively, independent of reading order.
+	Sequence int64
 }
 
 // ExtractWords extracts words with bounding boxes from a page
@@ -2160,6 +2165,7 @@ func (doc *PdfDocument) ExtractWords(pageIndex int) ([]Word, error) {
 			FontName: font,
 			FontSize: float32(C.pdf_oxide_word_get_font_size(handle, C.int32_t(i), &errorCode)),
 			IsBold:   bool(C.pdf_oxide_word_is_bold(handle, C.int32_t(i), &errorCode)),
+			Sequence: int64(C.pdf_oxide_word_get_sequence(handle, C.int32_t(i), &errorCode)),
 		})
 	}
 	return words, nil
@@ -3435,7 +3441,10 @@ func (doc *PdfDocument) ExtractWordsInRect(pageIndex int, x, y, w, h float32) ([
 		cText := C.pdf_oxide_word_get_text(handle, C.int32_t(i), &errorCode)
 		text := C.GoString(cText)
 		C.free_string(cText)
-		words = append(words, Word{Text: text, X: float32(bx), Y: float32(by), Width: float32(bw), Height: float32(bh)})
+		words = append(words, Word{
+			Text: text, X: float32(bx), Y: float32(by), Width: float32(bw), Height: float32(bh),
+			Sequence: int64(C.pdf_oxide_word_get_sequence(handle, C.int32_t(i), &errorCode)),
+		})
 	}
 	return words, nil
 }

--- a/include/pdf_oxide_c/pdf_oxide.h
+++ b/include/pdf_oxide_c/pdf_oxide.h
@@ -2271,6 +2271,17 @@ bool pdf_oxide_word_is_bold(const FfiWordList *words, int32_t index, int32_t *er
 #endif
 
 #if !defined(PDF_OXIDE_TARGET_WASM32)
+/**
+ * Content-stream emission order of the word's originating span: the order in
+ * which spans were drawn during the Tj/TJ walk. Words with adjacent values
+ * were drawn consecutively, distinguishing genuinely-consecutive draw calls
+ * from spatially-close-but-stream-distant ones, independent of reading order.
+ * Returns -1 (with an error code) on a null handle or out-of-range index.
+ */
+int64_t pdf_oxide_word_get_sequence(const FfiWordList *words, int32_t index, int32_t *error_code);
+#endif
+
+#if !defined(PDF_OXIDE_TARGET_WASM32)
 void pdf_oxide_word_list_free(FfiWordList *handle);
 #endif
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
                                namespace verification under oxide.fyi)
   artifactId:  pdf-oxide      (the Maven artifact; matches the
                                package fyi.oxide.pdf)
-  version:     0.3.69         (lockstep with Cargo workspace /
+  version:     0.3.70         (lockstep with Cargo workspace /
                                js/package.json / .csproj /
                                pyproject.toml — release-preflight
                                from v0.3.51 #515 enforces parity)
@@ -33,7 +33,7 @@
 
     <groupId>fyi.oxide</groupId>
     <artifactId>pdf-oxide</artifactId>
-    <version>0.3.69</version>
+    <version>0.3.70</version>
     <packaging>jar</packaging>
 
     <name>pdf_oxide — Java binding</name>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/yfedoseev/pdf_oxide.git</connection>
         <developerConnection>scm:git:git@github.com:yfedoseev/pdf_oxide.git</developerConnection>
         <url>https://github.com/yfedoseev/pdf_oxide</url>
-        <tag>v0.3.69</tag>
+        <tag>v0.3.70</tag>
     </scm>
 
     <issueManagement>

--- a/java/src/main/java/fyi/oxide/pdf/text/TextWord.java
+++ b/java/src/main/java/fyi/oxide/pdf/text/TextWord.java
@@ -19,11 +19,13 @@ public final class TextWord {
     private final String text;
     private final BBox bbox;
     private final float confidence;
+    private final long sequence;
 
-    public TextWord(String text, BBox bbox, float confidence) {
+    public TextWord(String text, BBox bbox, float confidence, long sequence) {
         this.text = Objects.requireNonNull(text, "text");
         this.bbox = Objects.requireNonNull(bbox, "bbox");
         this.confidence = confidence;
+        this.sequence = sequence;
     }
 
     public String text() {
@@ -38,21 +40,36 @@ public final class TextWord {
         return confidence;
     }
 
+    /**
+     * The content-stream emission order of the span this word originated
+     * from. Words drawn consecutively in the page's content stream have
+     * adjacent sequence values, which distinguishes genuinely consecutive
+     * draws from words that are merely spatially close. Independent of
+     * reading order.
+     */
+    public long sequence() {
+        return sequence;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof TextWord)) return false;
         TextWord w = (TextWord) o;
-        return Float.compare(w.confidence, confidence) == 0 && text.equals(w.text) && bbox.equals(w.bbox);
+        return Float.compare(w.confidence, confidence) == 0
+                && sequence == w.sequence
+                && text.equals(w.text)
+                && bbox.equals(w.bbox);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(text, bbox, confidence);
+        return Objects.hash(text, bbox, confidence, sequence);
     }
 
     @Override
     public String toString() {
-        return "TextWord[text=" + text + ", bbox=" + bbox + ", confidence=" + confidence + "]";
+        return "TextWord[text=" + text + ", bbox=" + bbox + ", confidence=" + confidence
+                + ", sequence=" + sequence + "]";
     }
 }

--- a/java/src/main/java/fyi/oxide/pdf/text/TextWord.java
+++ b/java/src/main/java/fyi/oxide/pdf/text/TextWord.java
@@ -69,7 +69,7 @@ public final class TextWord {
 
     @Override
     public String toString() {
-        return "TextWord[text=" + text + ", bbox=" + bbox + ", confidence=" + confidence
-                + ", sequence=" + sequence + "]";
+        return "TextWord[text=" + text + ", bbox=" + bbox + ", confidence=" + confidence + ", sequence=" + sequence
+                + "]";
     }
 }

--- a/java/src/test/java/fyi/oxide/pdf/PdfPageTest.java
+++ b/java/src/test/java/fyi/oxide/pdf/PdfPageTest.java
@@ -85,6 +85,8 @@ class PdfPageTest {
             assertThat(words).isNotNull().isNotEmpty();
             assertThat(words.get(0).text()).isNotEmpty();
             assertThat(words.get(0).bbox()).isNotNull();
+            // Content-stream emission order is exposed and non-negative.
+            assertThat(words.get(0).sequence()).isGreaterThanOrEqualTo(0L);
         }
     }
 

--- a/js/binding.cc
+++ b/js/binding.cc
@@ -325,6 +325,7 @@ extern "C" {
   extern char* pdf_oxide_word_get_font_name(const void* words, int32_t index, int* error_code);
   extern float pdf_oxide_word_get_font_size(const void* words, int32_t index, int* error_code);
   extern bool pdf_oxide_word_is_bold(const void* words, int32_t index, int* error_code);
+  extern int64_t pdf_oxide_word_get_sequence(const void* words, int32_t index, int* error_code);
   extern void pdf_oxide_word_list_free(void* handle);
 
   extern void* pdf_document_extract_text_lines(void* handle, int32_t page_index, int* error_code);
@@ -1811,6 +1812,7 @@ Napi::Value ExtractWords(const Napi::CallbackInfo& info) {
     word.Set("fontName", fontName ? Napi::String::New(env, fontName) : env.Null());
     word.Set("fontSize", Napi::Number::New(env, pdf_oxide_word_get_font_size(words, i, &errorCode)));
     word.Set("isBold", Napi::Boolean::New(env, pdf_oxide_word_is_bold(words, i, &errorCode)));
+    word.Set("sequence", Napi::Number::New(env, static_cast<double>(pdf_oxide_word_get_sequence(words, i, &errorCode))));
     if (text) free_string(text);
     if (fontName) free_string(fontName);
     result.Set(i, word);
@@ -3323,6 +3325,7 @@ Napi::Value ExtractWordsInRect(const Napi::CallbackInfo& info) {
     word.Set("y", Napi::Number::New(env, wy));
     word.Set("width", Napi::Number::New(env, ww));
     word.Set("height", Napi::Number::New(env, wh));
+    word.Set("sequence", Napi::Number::New(env, static_cast<double>(pdf_oxide_word_get_sequence(words, i, &errorCode))));
     if (text) free_string(text);
     result.Set(i, word);
   }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "type": "module",
   "description": "High-performance PDF parsing and text extraction library — prebuilt native bindings, no build toolchain required",
   "main": "lib/index.js",
@@ -70,7 +70,7 @@
     "async-mutex": "^0.5.0"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
+    "@types/node": "^26.0.1",
     "node-addon-api": "^8.7.0",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3"

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -73,6 +73,7 @@ import type {
   Table,
   TableMode,
   TableSpec,
+  Word,
 } from './types/common.js';
 import type { WorkerResult, WorkerTask } from './workers/index';
 import { WorkerPool, workerPool } from './workers/index';
@@ -598,7 +599,7 @@ class PdfDocumentImpl {
     this.ensureOpen();
     return native.getEmbeddedImages(this._handle, pageIndex);
   }
-  extractWords(pageIndex: number): any {
+  extractWords(pageIndex: number): Word[] {
     this.ensureOpen();
     return native.extractWords(this._handle, pageIndex);
   }
@@ -913,7 +914,7 @@ class Page {
   plainText(): string {
     return this._doc.toPlainText(this._index);
   }
-  words(): any {
+  words(): Word[] {
     return this._doc.extractWords(this._index);
   }
   lines(): any {
@@ -1148,6 +1149,7 @@ export type {
   Table,
   TableMode,
   TableSpec,
+  Word,
   WorkerResult,
   WorkerTask,
 };

--- a/js/src/types/common.ts
+++ b/js/src/types/common.ts
@@ -16,6 +16,31 @@ export interface Table {
   cells: (string | null)[][];
 }
 
+/** A single word extracted from a PDF page. */
+export interface Word {
+  /** The word's text, or `null` when the native binding has no text for it. */
+  text: string | null;
+  /** X coordinate of the word's bounding box. */
+  x: number;
+  /** Y coordinate of the word's bounding box. */
+  y: number;
+  /** Width of the word's bounding box. */
+  width: number;
+  /** Height of the word's bounding box. */
+  height: number;
+  /** Font name, or `null` when unavailable. Only set by `extractWords`. */
+  fontName?: string | null;
+  /** Font size in points. Only set by `extractWords`. */
+  fontSize?: number;
+  /** True if the word is rendered bold. Only set by `extractWords`. */
+  isBold?: boolean;
+  /** Content-stream emission order of the word's originating span. Words drawn
+   *  consecutively have adjacent sequence values, which distinguishes truly
+   *  consecutive draws from words that merely happen to be spatially close,
+   *  independent of reading order. */
+  sequence: number;
+}
+
 // Re-export commonly used native types
 export type {
   Annotation,

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "PdfOxide"
 uuid = "b0c1d2e3-4f56-47a8-9b0c-1d2e3f4a5b6c"
 authors = ["Yury Fedoseev <yfedoseev@gmail.com>"]
-version = "0.3.69"
+version = "0.3.70"
 
 [compat]
 Aqua = "0.8"

--- a/julia/src/PdfOxide.jl
+++ b/julia/src/PdfOxide.jl
@@ -368,13 +368,21 @@ struct Char
     font_size::Float64
 end
 
-"""An extracted word with `text`, `bbox`, `font_name`, `font_size`, `bold`."""
+"""
+An extracted word with `text`, `bbox`, `font_name`, `font_size`, `bold`, `sequence`.
+
+`sequence` is the content-stream emission (draw) order of the word's originating
+span: words with adjacent `sequence` values were drawn consecutively, which
+distinguishes genuinely consecutive draws from merely spatially-close ones,
+independent of reading order.
+"""
 struct Word
     text::String
     bbox::Bbox
     font_name::String
     font_size::Float64
     bold::Bool
+    sequence::Int64
 end
 
 """An extracted text line with `text`, `bbox`, `word_count`."""
@@ -550,7 +558,17 @@ function extract_words(d::PdfDocument, page::Integer)
                 bcode,
             )
             bcode[] != 0 && throw(PdfOxideError(bcode[], "extract_words"))
-            out[i+1] = Word(txt, bb, font, Float64(fs), bold)
+            qcode = Ref{Int32}(0)
+            seq = ccall(
+                (:pdf_oxide_word_get_sequence, LIB),
+                Int64,
+                (Ptr{Cvoid}, Int32, Ref{Int32}),
+                list,
+                Int32(i),
+                qcode,
+            )
+            qcode[] != 0 && throw(PdfOxideError(qcode[], "extract_words"))
+            out[i+1] = Word(txt, bb, font, Float64(fs), bold, seq)
         end
         return out
     finally
@@ -5512,7 +5530,17 @@ function _words_from_list(list::Ptr{Cvoid}, op::String)
                 bcode,
             )
             bcode[] != 0 && throw(PdfOxideError(bcode[], op))
-            out[i+1] = Word(txt, bb, font, Float64(fs), bold)
+            qcode = Ref{Int32}(0)
+            seq = ccall(
+                (:pdf_oxide_word_get_sequence, LIB),
+                Int64,
+                (Ptr{Cvoid}, Int32, Ref{Int32}),
+                list,
+                Int32(i),
+                qcode,
+            )
+            qcode[] != 0 && throw(PdfOxideError(qcode[], op))
+            out[i+1] = Word(txt, bb, font, Float64(fs), bold, seq)
         end
         return out
     finally

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -57,6 +57,7 @@ end
         @test words[1].bbox.width >= 0
         @test words[1].font_size >= 0
         @test words[1].bold isa Bool
+        @test words[1].sequence isa Int64
     end
     let chars = extract_chars(doc, 0)             # extract_chars
         @test !isempty(chars)

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "fyi.oxide"
-version = "0.3.69"
+version = "0.3.70"
 
 repositories {
     mavenCentral()
@@ -37,7 +37,7 @@ detekt {
 dependencies {
     // The Java binding owns the JNI bridge; we re-export its types (api scope)
     // so Kotlin callers `import fyi.oxide.pdf.*` and get them transitively.
-    api("fyi.oxide:pdf-oxide:0.3.69")
+    api("fyi.oxide:pdf-oxide:0.3.70")
     testImplementation(kotlin("test"))
 }
 

--- a/objc/PdfOxide.podspec
+++ b/objc/PdfOxide.podspec
@@ -14,7 +14,7 @@
 # rule is added here — that wiring is intentionally left to the release tooling).
 Pod::Spec.new do |spec|
   spec.name         = 'PdfOxide'
-  spec.version      = '0.3.69'
+  spec.version      = '0.3.70'
   spec.summary      = 'Idiomatic Objective-C bindings for pdf_oxide, a fast pure-Rust PDF toolkit.'
   spec.description  = <<-DESC
     Objective-C bindings over the pdf_oxide C ABI. NSObject wrappers (POXDocument,

--- a/objc/include/POXPdfOxide.h
+++ b/objc/include/POXPdfOxide.h
@@ -9,7 +9,7 @@
 
 /// Binding version, kept in lock-step with the workspace crate by
 /// scripts/sync_version.py (the single source of truth is Cargo.toml).
-#define POX_PDF_OXIDE_VERSION "0.3.69"
+#define POX_PDF_OXIDE_VERSION "0.3.70"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/objc/include/POXPdfOxide.h
+++ b/objc/include/POXPdfOxide.h
@@ -59,6 +59,11 @@ typedef struct {
 @property(nonatomic, readonly, copy) NSString* fontName;
 @property(nonatomic, readonly) float fontSize;
 @property(nonatomic, readonly) BOOL bold;
+/// Content-stream emission order of the word's originating span. Words drawn
+/// consecutively have adjacent sequence values, which distinguishes genuinely
+/// consecutive draws from ones that merely happen to be spatially close. This
+/// is independent of reading order.
+@property(nonatomic, readonly) int64_t sequence;
 @end
 
 /// A single extracted text line (Phase-1 element extraction).

--- a/objc/src/POXPdfOxide.m
+++ b/objc/src/POXPdfOxide.m
@@ -568,11 +568,11 @@ static NSString* _Nullable POXTakeString(char* s, int32_t code, NSString* op,
         bool bold = pdf_oxide_word_is_bold(list, i, &c);
         int64_t sequence = pdf_oxide_word_get_sequence(list, i, &c);
         POXBbox bbox = {x, y, w, h};
-        [out addObject:[[POXWord alloc] initWithText:(text ?: @"")
-                                                bbox:bbox
-                                            fontName:(fontName ?: @"")fontSize:fontSize
-                                                bold:(bold ? YES : NO)
-                                            sequence:sequence]];
+        [out addObject:[[POXWord alloc]
+                           initWithText:(text ?: @"")
+                                   bbox:bbox
+                               fontName:(fontName ?: @"")fontSize:fontSize
+                                   bold:(bold ? YES : NO)sequence:sequence]];
     }
     pdf_oxide_word_list_free(list);
     return out;
@@ -1247,11 +1247,11 @@ static NSArray<POXSearchResult*>* POXTakeSearchResults(FfiSearchResults* list) {
         bool bold = pdf_oxide_word_is_bold(list, i, &c);
         int64_t sequence = pdf_oxide_word_get_sequence(list, i, &c);
         POXBbox bbox = {bx, by, bw, bh};
-        [out addObject:[[POXWord alloc] initWithText:(text ?: @"")
-                                                bbox:bbox
-                                            fontName:(fontName ?: @"")fontSize:fontSize
-                                                bold:(bold ? YES : NO)
-                                            sequence:sequence]];
+        [out addObject:[[POXWord alloc]
+                           initWithText:(text ?: @"")
+                                   bbox:bbox
+                               fontName:(fontName ?: @"")fontSize:fontSize
+                                   bold:(bold ? YES : NO)sequence:sequence]];
     }
     pdf_oxide_word_list_free(list);
     return out;

--- a/objc/src/POXPdfOxide.m
+++ b/objc/src/POXPdfOxide.m
@@ -88,7 +88,8 @@ static NSString* _Nullable POXTakeString(char* s, int32_t code, NSString* op,
                         bbox:(POXBbox)bbox
                     fontName:(NSString*)fontName
                     fontSize:(float)fontSize
-                        bold:(BOOL)bold;
+                        bold:(BOOL)bold
+                    sequence:(int64_t)sequence;
 @end
 
 @interface POXTextLine ()
@@ -189,13 +190,15 @@ static NSString* _Nullable POXTakeString(char* s, int32_t code, NSString* op,
                         bbox:(POXBbox)bbox
                     fontName:(NSString*)fontName
                     fontSize:(float)fontSize
-                        bold:(BOOL)bold {
+                        bold:(BOOL)bold
+                    sequence:(int64_t)sequence {
     if ((self = [super init])) {
         _text = [text copy];
         _bbox = bbox;
         _fontName = [fontName copy];
         _fontSize = fontSize;
         _bold = bold;
+        _sequence = sequence;
     }
     return self;
 }
@@ -563,11 +566,13 @@ static NSString* _Nullable POXTakeString(char* s, int32_t code, NSString* op,
                                            @"wordFontName", NULL);
         float fontSize = pdf_oxide_word_get_font_size(list, i, &c);
         bool bold = pdf_oxide_word_is_bold(list, i, &c);
+        int64_t sequence = pdf_oxide_word_get_sequence(list, i, &c);
         POXBbox bbox = {x, y, w, h};
         [out addObject:[[POXWord alloc] initWithText:(text ?: @"")
                                                 bbox:bbox
                                             fontName:(fontName ?: @"")fontSize:fontSize
-                                                bold:(bold ? YES : NO)]];
+                                                bold:(bold ? YES : NO)
+                                            sequence:sequence]];
     }
     pdf_oxide_word_list_free(list);
     return out;
@@ -1240,11 +1245,13 @@ static NSArray<POXSearchResult*>* POXTakeSearchResults(FfiSearchResults* list) {
                                            @"wordFontName", NULL);
         float fontSize = pdf_oxide_word_get_font_size(list, i, &c);
         bool bold = pdf_oxide_word_is_bold(list, i, &c);
+        int64_t sequence = pdf_oxide_word_get_sequence(list, i, &c);
         POXBbox bbox = {bx, by, bw, bh};
         [out addObject:[[POXWord alloc] initWithText:(text ?: @"")
                                                 bbox:bbox
                                             fontName:(fontName ?: @"")fontSize:fontSize
-                                                bold:(bold ? YES : NO)]];
+                                                bold:(bold ? YES : NO)
+                                            sequence:sequence]];
     }
     pdf_oxide_word_list_free(list);
     return out;

--- a/objc/tests/test_api_coverage.m
+++ b/objc/tests/test_api_coverage.m
@@ -102,6 +102,7 @@ int main(void) {
                 CHECK(w0.text.length > 0);
                 CHECK(w0.bbox.width >= 0 && w0.bbox.height >= 0);
                 CHECK(w0.bold == YES || w0.bold == NO);
+                CHECK(w0.sequence >= 0); // content-stream emission order
             }
             NSArray<POXChar*>* chars = [doc extractChars:0 error:&err]; // extractChars
             CHECK(chars != nil && chars.count > 0);

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -32,3 +32,13 @@ id = "RUSTSEC-2026-0173"
 # builds. No fix version available upstream. Re-evaluate when defmt or
 # env_logger migrates off proc-macro-error2.
 ignoreUntil = 2026-09-23
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0192"
+# `ttf-parser` crate: "unmaintained" advisory (informational, not a CVE; no
+# memory-safety or RCE implication — the author has simply stated the crate
+# will receive no further fixes). There is no patched version. We use it only
+# to read embedded-font `cmap` tables; the actively-maintained replacement
+# (`skrifa`, already a dependency for glyph outlines) requires a non-trivial
+# migration of the cmap path. Re-evaluate once that migration lands.
+ignoreUntil = 2026-09-30

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -34,6 +34,23 @@ id = "RUSTSEC-2026-0173"
 ignoreUntil = 2026-09-23
 
 [[IgnoredVulns]]
+id = "RUSTSEC-2026-0194"
+# `quick-xml` < 0.41: quadratic-time duplicate-attribute check (DoS only, no
+# memory-safety/RCE). Our direct dependency is already quick-xml 0.41.0 (the
+# fixed version); the only affected instance is quick-xml 0.40.1 pulled
+# transitively by office_oxide 0.1.2, which is the latest 0.1.x and cannot move
+# to 0.41 until office_oxide releases against it. Re-evaluate when it does.
+ignoreUntil = 2026-09-30
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0195"
+# `quick-xml` < 0.41: unbounded namespace-declaration allocation in `NsReader`
+# (memory-exhaustion DoS only). Same situation as RUSTSEC-2026-0194 — fixed in
+# 0.41.0, which we already use directly; only the transitive 0.40.1 via
+# office_oxide 0.1.2 remains. Re-evaluate when office_oxide moves to 0.41.
+ignoreUntil = 2026-09-30
+
+[[IgnoredVulns]]
 id = "RUSTSEC-2026-0192"
 # `ttf-parser` crate: "unmaintained" advisory (informational, not a CVE; no
 # memory-safety or RCE implication — the author has simply stated the crate

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.69"
+version = "0.3.70"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -34,7 +34,7 @@ workspace = true
 ocr = ["pdf_oxide/ocr"]
 
 [dependencies]
-pdf_oxide = { version = "0.3.69", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.70", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_jni/Cargo.toml
+++ b/pdf_oxide_jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_jni"
-version = "0.3.69"
+version = "0.3.70"
 edition = "2021"
 description = "JNI bindings for pdf_oxide — native Java binding, the 8th surface alongside Python/Go/JS/C#/WASM/CLI/MCP. Loaded by the fyi.oxide:pdf-oxide Maven artifact."
 license = "MIT OR Apache-2.0"
@@ -93,7 +93,7 @@ jni = "0.22"
 # opt-in FIPS 140-3 build) — those two are compile-time mutually
 # exclusive (pdf_oxide enforces via compile_error!). We always
 # enable `icc` for ICC-based colour management.
-pdf_oxide = { version = "0.3.69", path = "..", default-features = false, features = ["icc"] }
+pdf_oxide = { version = "0.3.70", path = "..", default-features = false, features = ["icc"] }
 
 # JSON envelope for the v0.3.51 AutoExtractor rich-result path. The
 # Java side gets the PageExtraction / DocumentExtraction as a JSON

--- a/pdf_oxide_jni/src/pdf_page.rs
+++ b/pdf_oxide_jni/src/pdf_page.rs
@@ -157,7 +157,7 @@ fn build_text_word_list<'local>(
     let textword_ctor = env.get_method_id(
         &textword_class,
         &JNIString::from("<init>"),
-        jni_sig!("(Ljava/lang/String;Lfyi/oxide/pdf/geometry/BBox;F)V"),
+        jni_sig!("(Ljava/lang/String;Lfyi/oxide/pdf/geometry/BBox;FJ)V"),
     )?;
     let bbox_class = env.find_class(&JNIString::from("fyi/oxide/pdf/geometry/BBox"))?;
     let bbox_ctor =
@@ -200,6 +200,9 @@ fn build_text_word_list<'local>(
                     jni::sys::jvalue { l: text.as_raw() },
                     jni::sys::jvalue { l: bbox.as_raw() },
                     jni::sys::jvalue { f: 1.0_f32 },
+                    jni::sys::jvalue {
+                        j: w.sequence as i64,
+                    },
                 ],
             )?
         };

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.69"
+version = "0.3.70"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.69", path = ".." }
+pdf_oxide = { version = "0.3.70", path = ".." }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/php/include/pdf_oxide.h
+++ b/php/include/pdf_oxide.h
@@ -919,6 +919,8 @@ float pdf_oxide_word_get_font_size(const FfiWordList *words, int32_t index, int3
 
 bool pdf_oxide_word_is_bold(const FfiWordList *words, int32_t index, int32_t *error_code);
 
+int64_t pdf_oxide_word_get_sequence(const FfiWordList *words, int32_t index, int32_t *error_code);
+
 void pdf_oxide_word_list_free(FfiWordList *handle);
 
 FfiTextLineList *pdf_document_extract_text_lines(PdfDocument *handle,

--- a/php/scripts/download-native-lib.php
+++ b/php/scripts/download-native-lib.php
@@ -37,7 +37,7 @@ declare(strict_types=1);
  *   - Set `PDF_OXIDE_NATIVE_VERSION=vX.Y.Z` to pin a specific release.
  */
 
-const PACKAGE_VERSION_DEFAULT = 'v0.3.69';
+const PACKAGE_VERSION_DEFAULT = 'v0.3.70';
 const RELEASE_BASE_URL = 'https://github.com/yfedoseev/pdf_oxide/releases/download';
 // Path is relative to the package root (parent-of-php in the new
 // root-composer.json layout); see comment on $packageRoot below.
@@ -253,12 +253,12 @@ function downloadFile(string $url, string $dest): bool
         'http' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.69',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.70',
         ],
         'https' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.69',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.70',
         ],
     ]);
     $data = @file_get_contents($url, false, $ctx);

--- a/php/src/Pdf.php
+++ b/php/src/Pdf.php
@@ -152,7 +152,7 @@ final class Pdf
      * pdf_oxide library version. Kept in sync with `Cargo.toml` by the
      * release tooling (see `docs/releases/RELEASE_PROCESS.md`).
      */
-    public const VERSION = '0.3.69';
+    public const VERSION = '0.3.70';
 
     /** Whether OCR-model prefetch + cache are available on this build. */
     public static function prefetchAvailable(): bool

--- a/php/tests/Integration/CoreParityTest.php
+++ b/php/tests/Integration/CoreParityTest.php
@@ -92,6 +92,6 @@ final class CoreParityTest extends IntegrationTestCase
 
     public function testVersionConstant(): void
     {
-        $this->assertSame('0.3.69', Pdf::VERSION);
+        $this->assertSame('0.3.70', Pdf::VERSION);
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.69"
+version = "0.3.70"
 description = "The fastest Python PDF library: 0.8ms mean, 5× faster than PyMuPDF. Text extraction, markdown conversion, PDF creation. 100% pass rate on 3,830 PDFs."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/python/tests/test_core_parity.py
+++ b/python/tests/test_core_parity.py
@@ -82,4 +82,4 @@ def test_open_error():
 
 
 def test_version():
-    assert pdf_oxide.VERSION == "0.3.69"
+    assert pdf_oxide.VERSION == "0.3.70"

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pdfoxide
 Type: Package
 Title: Fast PDF Text, Markdown and HTML Extraction (pdf_oxide)
-Version: 0.3.69
+Version: 0.3.70
 Authors@R: person("Yury", "Fedoseev", email = "yfedoseev@gmail.com", role = c("aut", "cre"))
 Author: Yury Fedoseev [aut, cre]
 Maintainer: Yury Fedoseev <yfedoseev@gmail.com>

--- a/r/R/pdf_oxide.R
+++ b/r/R/pdf_oxide.R
@@ -168,7 +168,9 @@ pdf_extract_chars <- function(doc, page) {
 #' @param doc A `pdfoxide_document`.
 #' @param page 0-based page index (required).
 #' @return A list of `Word` records, each `list(text=, bbox=, font_name=,
-#'   font_size=, bold=)`.
+#'   font_size=, bold=, sequence=)`. `sequence` is the content-stream draw
+#'   order of the word's originating span (adjacent values were drawn
+#'   consecutively), independent of reading order.
 #' @export
 pdf_extract_words <- function(doc, page) {
   .Call(C_r_doc_extract_words, doc, as.integer(page))
@@ -2704,7 +2706,9 @@ pdf_extract_text_in_rect <- function(doc, page, x, y, width, height) {
 }
 #' Extract words within a rectangle on a (0-based) page.
 #' @inheritParams pdf_extract_text_in_rect
-#' @return A list of `Word` records (`list(text=, bbox=)`).
+#' @return A list of `Word` records (`list(text=, bbox=, sequence=)`, where
+#'   `sequence` is the content-stream draw order of the word's originating
+#'   span, independent of reading order).
 #' @export
 pdf_extract_words_in_rect <- function(doc, page, x, y, width, height) {
   .Call(C_r_doc_extract_words_in_rect, doc, as.integer(page),

--- a/r/inst/tinytest/test_api_coverage.R
+++ b/r/inst/tinytest/test_api_coverage.R
@@ -53,6 +53,8 @@ expect_true(nchar(words[[1]]$text) > 0)
 bb <- words[[1]]$bbox
 expect_true(all(c("x", "y", "width", "height") %in% names(bb)))
 expect_true(is.numeric(bb$width))
+expect_true("sequence" %in% names(words[[1]]))
+expect_true(is.numeric(words[[1]]$sequence))
 chars <- pdf_extract_chars(doc, 0)                      # pdf_extract_chars
 expect_true(length(chars) > 0)
 expect_true(is.integer(chars[[1]]$character) && chars[[1]]$character > 0)

--- a/r/src/pdf_oxide.c
+++ b/r/src/pdf_oxide.c
@@ -295,8 +295,10 @@ SEXP r_doc_extract_words(SEXP ext, SEXP page) {
         float fs = pdf_oxide_word_get_font_size(list, i, &code);
         code = 0;
         bool bold = pdf_oxide_word_is_bold(list, i, &code);
-        SEXP rec = PROTECT(Rf_allocVector(VECSXP, 5));
-        SEXP nms = PROTECT(Rf_allocVector(STRSXP, 5));
+        code = 0;
+        int64_t seq = pdf_oxide_word_get_sequence(list, i, &code);
+        SEXP rec = PROTECT(Rf_allocVector(VECSXP, 6));
+        SEXP nms = PROTECT(Rf_allocVector(STRSXP, 6));
         SEXP txtstr = PROTECT(Rf_mkChar(txt)); free_string(txt);
         SET_VECTOR_ELT(rec, 0, Rf_ScalarString(txtstr));        SET_STRING_ELT(nms, 0, Rf_mkChar("text"));
         SET_VECTOR_ELT(rec, 1, make_bbox(x, y, w, h));          SET_STRING_ELT(nms, 1, Rf_mkChar("bbox"));
@@ -304,6 +306,7 @@ SEXP r_doc_extract_words(SEXP ext, SEXP page) {
         SET_VECTOR_ELT(rec, 2, Rf_ScalarString(fnstr));         SET_STRING_ELT(nms, 2, Rf_mkChar("font_name"));
         SET_VECTOR_ELT(rec, 3, Rf_ScalarReal(fs));              SET_STRING_ELT(nms, 3, Rf_mkChar("font_size"));
         SET_VECTOR_ELT(rec, 4, Rf_ScalarLogical(bold));         SET_STRING_ELT(nms, 4, Rf_mkChar("bold"));
+        SET_VECTOR_ELT(rec, 5, Rf_ScalarReal((double)seq));     SET_STRING_ELT(nms, 5, Rf_mkChar("sequence"));
         Rf_setAttrib(rec, R_NamesSymbol, nms);
         SET_VECTOR_ELT(out, i, rec);
         UNPROTECT(4);
@@ -2979,11 +2982,14 @@ SEXP r_doc_extract_words_in_rect(SEXP ext, SEXP page, SEXP x, SEXP y, SEXP w, SE
         code = 0;
         pdf_oxide_word_get_bbox(list, i, &bx, &by, &bw, &bh, &code);
         if (code != 0) { free_string(txt); pdf_oxide_word_list_free(list); pdfox_raise(code, "extract_words_in_rect"); }
-        SEXP rec = PROTECT(Rf_allocVector(VECSXP, 2));
-        SEXP nms = PROTECT(Rf_allocVector(STRSXP, 2));
+        code = 0;
+        int64_t seq = pdf_oxide_word_get_sequence(list, i, &code);
+        SEXP rec = PROTECT(Rf_allocVector(VECSXP, 3));
+        SEXP nms = PROTECT(Rf_allocVector(STRSXP, 3));
         SEXP txtstr = PROTECT(Rf_mkChar(txt)); free_string(txt);
         SET_VECTOR_ELT(rec, 0, Rf_ScalarString(txtstr));  SET_STRING_ELT(nms, 0, Rf_mkChar("text"));
         SET_VECTOR_ELT(rec, 1, make_bbox(bx, by, bw, bh)); SET_STRING_ELT(nms, 1, Rf_mkChar("bbox"));
+        SET_VECTOR_ELT(rec, 2, Rf_ScalarReal((double)seq)); SET_STRING_ELT(nms, 2, Rf_mkChar("sequence"));
         Rf_setAttrib(rec, R_NamesSymbol, nms);
         SET_VECTOR_ELT(out, i, rec);
         UNPROTECT(3);

--- a/ruby/lib/pdf_oxide/ffi/bindings.rb
+++ b/ruby/lib/pdf_oxide/ffi/bindings.rb
@@ -1465,6 +1465,9 @@ module PdfOxide
       attach_function :pdf_oxide_word_get_bbox, %i[pointer pointer pointer pointer pointer pointer pointer pointer], :pointer, blocking: false
       attach_function :pdf_oxide_word_get_font_name, %i[pointer pointer pointer pointer pointer pointer pointer pointer], :pointer, blocking: false
       attach_function :pdf_oxide_word_get_font_size, %i[pointer pointer pointer pointer pointer pointer pointer pointer], :pointer, blocking: false
+      # int64_t pdf_oxide_word_get_sequence(const void *words, int32_t index, int *error_code)
+      # Content-stream emission order of the word's originating span; -1 on null/out-of-range.
+      attach_function :pdf_oxide_word_get_sequence, %i[pointer int32 pointer], :int64, blocking: false
       attach_function :pdf_oxide_word_get_text, %i[pointer pointer pointer pointer pointer pointer pointer pointer], :pointer, blocking: false
       attach_function :pdf_oxide_word_is_bold, %i[pointer pointer pointer pointer pointer pointer pointer pointer], :pointer, blocking: false
       attach_function :pdf_oxide_word_list_free, %i[pointer pointer pointer pointer pointer pointer pointer pointer], :pointer, blocking: false

--- a/ruby/lib/pdf_oxide/version.rb
+++ b/ruby/lib/pdf_oxide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PdfOxide
-  VERSION = '0.3.69'
+  VERSION = '0.3.70'
 end

--- a/ruby/spec/cdylib_smoke_spec.rb
+++ b/ruby/spec/cdylib_smoke_spec.rb
@@ -11,7 +11,7 @@ require 'tmpdir'
 RSpec.describe 'libpdf_oxide cdylib smoke' do
   it 'loads the gem with the expected version' do
     expect(defined?(PdfOxide)).to eq('constant')
-    expect(PdfOxide::VERSION).to eq('0.3.69')
+    expect(PdfOxide::VERSION).to eq('0.3.70')
   end
 
   it 'exposes every public-API class' do

--- a/ruby/spec/core_parity_spec.rb
+++ b/ruby/spec/core_parity_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'core parity (Ruby)' do
     expect { PdfOxide::PdfDocument.open('/no/such/file/does/not/exist.pdf') }.to raise_error(StandardError)
   end
 
-  it 'exposes version 0.3.69' do
-    expect(PdfOxide::VERSION).to eq('0.3.69')
+  it 'exposes version 0.3.70' do
+    expect(PdfOxide::VERSION).to eq('0.3.70')
   end
 end

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -4,7 +4,7 @@
 // (Optional -> Option, java.util.List -> Seq, Using on AutoCloseable handles).
 ThisBuild / organization := "fyi.oxide"
 ThisBuild / organizationName := "PDF Oxide"
-ThisBuild / version := "0.3.69"
+ThisBuild / version := "0.3.70"
 ThisBuild / scalaVersion := "3.3.4"
 
 // scalafix needs SemanticDB. On Scala 3 it's emitted by the compiler itself
@@ -37,7 +37,7 @@ lazy val root = (project in file("."))
     description := "Idiomatic Scala 3 bindings for pdf_oxide — a thin facade over the fyi.oxide:pdf-oxide Java binding (JNI).",
     resolvers += Resolver.mavenLocal, // resolve the locally-installed Java artifact during dev/CI
     libraryDependencies ++= Seq(
-      "fyi.oxide" % "pdf-oxide" % "0.3.69",
+      "fyi.oxide" % "pdf-oxide" % "0.3.70",
       "org.scalatest" %% "scalatest" % "3.2.19" % Test
     ),
     // The Java NativeLoader resolves the JNI cdylib via this property; override

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
 torch>=2.0.0
 transformers>=4.30.0
-onnx>=1.19.1
+onnx>=1.22.0
 onnxruntime>=1.15.0

--- a/src/converters/html.rs
+++ b/src/converters/html.rs
@@ -144,6 +144,7 @@ impl HtmlConverter {
                 is_bold: matches!(span.font_weight, crate::layout::FontWeight::Bold),
                 is_italic: span.is_italic,
                 mcid: span.mcid,
+                sequence: span.sequence,
             })
             .collect();
 

--- a/src/converters/markdown.rs
+++ b/src/converters/markdown.rs
@@ -288,6 +288,7 @@ impl MarkdownConverter {
                     is_bold: span.font_weight.is_bold(),
                     is_italic: span.is_italic,
                     mcid: span.mcid,
+                    sequence: span.sequence,
                 })
             })
             .collect();
@@ -1990,6 +1991,7 @@ mod tests {
                 is_bold: false,
                 is_italic: false,
                 mcid: None,
+                sequence: 0,
             },
             TextBlock {
                 chars: vec![],
@@ -2000,6 +2002,7 @@ mod tests {
                 is_bold: false,
                 is_italic: false,
                 mcid: None,
+                sequence: 0,
             },
             TextBlock {
                 chars: vec![],
@@ -2010,6 +2013,7 @@ mod tests {
                 is_bold: false,
                 is_italic: false,
                 mcid: None,
+                sequence: 0,
             },
         ];
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -6064,6 +6064,7 @@ impl PdfDocument {
                         } else if delta_x > fs * 1.5
                             && !text.ends_with(' ')
                             && !text.ends_with('\n')
+                            && !Self::is_reliable_kerning_overlap(prev, span, gap)
                         {
                             // Inflated-width overlap recovery.
                             // A negative raw gap here usually comes from a
@@ -7276,6 +7277,63 @@ impl PdfDocument {
 
             i = j;
         }
+    }
+
+    /// Distinguish a genuine tight-kerning overlap of a single word drawn as
+    /// two same-font runs ("PLANAL"+"TINA") from an inflated-width artifact.
+    ///
+    /// A font with no `/Widths` array falls back to a uniform 550/1000-em
+    /// advance for every glyph, which over-reports each glyph's width and drags
+    /// the previous span's right edge past where the next span really starts —
+    /// a fake overlap that the assembler must break with a space (the NASA
+    /// "STATION"+"FREEDOM" header case). A genuine kerning overlap, by
+    /// contrast, has real per-glyph metrics that VARY across the run, a modest
+    /// overlap (well under one em), the same font on both sides, and word
+    /// characters at the join. When those hold the two runs are one word and no
+    /// space must be synthesized. This works purely on the assembled text — the
+    /// spans are left unmerged, so page layout and table detection are
+    /// unaffected (a span merge here would shift XY-cut/table statistics).
+    fn is_reliable_kerning_overlap(prev: &TextSpan, span: &TextSpan, gap: f32) -> bool {
+        let fs = prev.font_size.max(span.font_size).max(1.0);
+        let prev_last = prev.text.chars().next_back();
+        let next_first = span.text.chars().next();
+        gap < 0.0
+            && gap > -fs
+            && prev.font_name == span.font_name
+            && prev.font_weight == span.font_weight
+            && prev.is_italic == span.is_italic
+            && prev_last.is_some_and(|c| c.is_alphanumeric())
+            && next_first.is_some_and(|c| c.is_alphanumeric())
+            // A lowercase→uppercase transition at the join is a word/sentence
+            // boundary ("...with"+"Gp53", "Alg"+"The"), never the middle of a
+            // single word split by kerning — real intra-word splits continue in
+            // the same case tier ("PLANAL"+"TINA", "eigenv"+"alue"). Excluding
+            // it keeps the two overlapping runs as separate words with a space.
+            && !(prev_last.is_some_and(|c| c.is_lowercase())
+                && next_first.is_some_and(|c| c.is_uppercase()))
+            && {
+                // Real proportional font metrics take many distinct per-glyph
+                // advances; a missing-/Widths fallback emits ONE uniform
+                // advance, and coarse/artifact width tables only a couple.
+                // Require at least THREE distinct advances so a genuine
+                // proportional run ("PLANAL": 6.67/5.56/7.22) is accepted while
+                // a 1- or 2-value fallback table (which manufactures fake
+                // overlaps between separate words) is not.
+                let mut distinct: [i32; 3] = [i32::MIN, i32::MIN, i32::MIN];
+                let mut n = 0usize;
+                for w in prev.char_widths.iter().map(|w| (w * 100.0).round() as i32) {
+                    if !distinct[..n].contains(&w) {
+                        if n < 3 {
+                            distinct[n] = w;
+                        }
+                        n += 1;
+                        if n >= 3 {
+                            break;
+                        }
+                    }
+                }
+                n >= 3
+            }
     }
 
     /// # Returns
@@ -15789,7 +15847,9 @@ impl PdfDocument {
                 for c in cluster_chars {
                     if c.char.is_whitespace() || c.char == '\n' || c.char == '\r' {
                         if !current_word_chars.is_empty() {
-                            words.push(Word::from_chars(current_word_chars));
+                            let mut word = Word::from_chars(current_word_chars);
+                            word.sequence = span.sequence;
+                            words.push(word);
                             current_word_chars = Vec::new();
                         }
                     } else {
@@ -15797,7 +15857,9 @@ impl PdfDocument {
                     }
                 }
                 if !current_word_chars.is_empty() {
-                    words.push(Word::from_chars(current_word_chars));
+                    let mut word = Word::from_chars(current_word_chars);
+                    word.sequence = span.sequence;
+                    words.push(word);
                 }
             }
 
@@ -16012,7 +16074,7 @@ impl PdfDocument {
         // Walk spans in canonical reading order, clustering chars → words.
         // No block partition; spans are already pre-ordered.
         let mut words: Vec<Word> = Vec::new();
-        for span_chars in &chars_per_span {
+        for (span, span_chars) in spans.iter().zip(chars_per_span.iter()) {
             if span_chars.is_empty() {
                 continue;
             }
@@ -16028,7 +16090,9 @@ impl PdfDocument {
                 for c in cluster_chars {
                     if c.char.is_whitespace() || c.char == '\n' || c.char == '\r' {
                         if !current_word_chars.is_empty() {
-                            words.push(Word::from_chars(current_word_chars));
+                            let mut word = Word::from_chars(current_word_chars);
+                            word.sequence = span.sequence;
+                            words.push(word);
                             current_word_chars = Vec::new();
                         }
                     } else {
@@ -16036,7 +16100,9 @@ impl PdfDocument {
                     }
                 }
                 if !current_word_chars.is_empty() {
-                    words.push(Word::from_chars(current_word_chars));
+                    let mut word = Word::from_chars(current_word_chars);
+                    word.sequence = span.sequence;
+                    words.push(word);
                 }
             }
         }
@@ -23300,6 +23366,75 @@ mod tests {
         assert!(PdfDocument::should_insert_space(&prev, &current));
     }
 
+    /// A single word drawn as two same-font runs with real (varying) per-glyph
+    /// metrics that overlap by a fraction of a point ("PLANAL"+"TINA", the
+    /// planaltina kerning-split repro) is a reliable kerning overlap: the
+    /// assembler must NOT insert a space, reconstructing "PLANALTINA".
+    #[test]
+    fn test_reliable_kerning_overlap_recognizes_split_word() {
+        let mut prev = make_test_span("PLANAL", 100.0, 700.0, 38.35, 10.0);
+        prev.char_widths = vec![6.67, 5.56, 6.67, 7.22, 6.67, 5.56]; // real Helvetica
+        let span = make_test_span("TINA", 136.64, 700.0, 22.78, 10.0);
+        let gap = span.bbox.x - (prev.bbox.x + prev.bbox.width); // ≈ -1.71pt overlap
+        assert!(
+            PdfDocument::is_reliable_kerning_overlap(&prev, &span, gap),
+            "varying-width same-font runs overlapping by <1em must read as one word"
+        );
+    }
+
+    /// A font with no /Widths array falls back to a uniform advance per glyph,
+    /// over-reporting each width and manufacturing a fake overlap between two
+    /// SEPARATE words ("STATION"+"FREEDOM"). Uniform char_widths must NOT be
+    /// treated as a kerning overlap — the assembler keeps the word-boundary
+    /// space.
+    #[test]
+    fn test_reliable_kerning_overlap_rejects_uniform_fallback_widths() {
+        let mut prev = make_test_span("STATION", 100.0, 700.0, 42.0, 10.0);
+        prev.char_widths = vec![6.0; 7]; // uniform missing-/Widths fallback
+        let span = make_test_span("FREEDOM", 141.0, 700.0, 42.0, 10.0);
+        let gap = span.bbox.x - (prev.bbox.x + prev.bbox.width); // -1.0pt fake overlap
+        assert!(
+            !PdfDocument::is_reliable_kerning_overlap(&prev, &span, gap),
+            "uniform fallback widths are an inflated-width artifact, not kerning"
+        );
+    }
+
+    /// A coarse width table with only two distinct advances (e.g. a font that
+    /// reports one width for wide glyphs and one for narrow) is not genuine
+    /// proportional metrics — it manufactures fake overlaps between SEPARATE
+    /// words ("território"+"e"). Two distinct advances must NOT qualify.
+    #[test]
+    fn test_reliable_kerning_overlap_rejects_coarse_two_value_widths() {
+        let mut prev = make_test_span("território", 32.0, 700.0, 68.0, 13.6);
+        prev.char_widths = vec![6.8, 6.8, 6.8, 6.8, 6.8, 6.8, 3.4, 3.4, 6.8, 6.8];
+        let span = make_test_span("e", 66.0, 700.0, 6.8, 13.6);
+        let gap = span.bbox.x - (prev.bbox.x + prev.bbox.width);
+        assert!(!PdfDocument::is_reliable_kerning_overlap(&prev, &span, gap));
+    }
+
+    /// A lowercase→uppercase transition at an overlapping join is a
+    /// word/sentence boundary ("...with"+"Gp53"), not one word split by
+    /// kerning — it must NOT be treated as a reliable kerning overlap even with
+    /// real varying widths.
+    #[test]
+    fn test_reliable_kerning_overlap_rejects_lowercase_to_uppercase_boundary() {
+        let mut prev = make_test_span("with", 100.0, 700.0, 20.0, 12.0);
+        prev.char_widths = vec![6.7, 3.3, 4.8, 6.7];
+        let span = make_test_span("Gp53", 118.0, 700.0, 24.0, 12.0);
+        let gap = span.bbox.x - (prev.bbox.x + prev.bbox.width); // -2pt overlap
+        assert!(!PdfDocument::is_reliable_kerning_overlap(&prev, &span, gap));
+    }
+
+    /// A positive gap is a genuine word boundary, never a kerning overlap.
+    #[test]
+    fn test_reliable_kerning_overlap_requires_negative_gap() {
+        let mut prev = make_test_span("Hello", 0.0, 100.0, 28.0, 10.0);
+        prev.char_widths = vec![6.0, 3.0, 3.0, 3.0, 6.0];
+        let span = make_test_span("World", 32.0, 100.0, 28.0, 10.0);
+        let gap = span.bbox.x - (prev.bbox.x + prev.bbox.width); // +4pt gap
+        assert!(!PdfDocument::is_reliable_kerning_overlap(&prev, &span, gap));
+    }
+
     // --- topological_block_order (multi-region reading order) -----------------
     // Larger Y = higher on the page (read first). Two columns separated by a
     // gutter (a > ~1 em horizontal gap) must be read column-major (left column
@@ -28045,6 +28180,126 @@ mod tests {
             text.contains("Second"),
             "Second line must NOT be dropped by containment filter, got: {:?}",
             text
+        );
+    }
+
+    /// `extract_spans`/`extract_words`/`extract_text_lines` must report the
+    /// resolved `/BaseFont` name ("Helvetica"), not the page's
+    /// `/Resources/Font` dictionary alias ("F1") — matching what
+    /// `extract_chars` already did.
+    #[test]
+    fn test_span_word_line_font_name_is_resolved_not_alias() {
+        let content = b"BT /F1 12 Tf 50 700 Td (Hello) Tj ET";
+
+        let mut pdf = b"%PDF-1.4\n".to_vec();
+        let off1 = pdf.len();
+        pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        let off2 = pdf.len();
+        pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+        let off3 = pdf.len();
+        pdf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n",
+        );
+        let off4 = pdf.len();
+        pdf.extend_from_slice(
+            format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes(),
+        );
+        pdf.extend_from_slice(content);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n");
+        let off5 = pdf.len();
+        pdf.extend_from_slice(
+            b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+        );
+        let xref_off = pdf.len();
+        pdf.extend_from_slice(b"xref\n0 6\n");
+        pdf.extend_from_slice(b"0000000000 65535 f \n");
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off1).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off2).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off3).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off4).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off5).as_bytes());
+        pdf.extend_from_slice(
+            format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n", xref_off)
+                .as_bytes(),
+        );
+
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+
+        let chars = doc.extract_chars(0).unwrap();
+        assert_eq!(chars[0].font_name, "Helvetica");
+
+        let spans = doc.extract_spans(0).unwrap();
+        assert_eq!(spans[0].font_name, "Helvetica");
+
+        let words = doc.extract_words(0).unwrap();
+        assert_eq!(words[0].dominant_font, "Helvetica");
+
+        let lines = doc.extract_text_lines(0).unwrap();
+        assert_eq!(lines[0].words[0].dominant_font, "Helvetica");
+    }
+
+    /// `Word.sequence` must reflect content-stream emission order (the
+    /// originating span's `sequence`), not just reading order, so
+    /// consumers can tell genuinely-consecutive draw calls apart from
+    /// spatially-close-but-stream-distant ones (e.g. table cells vs.
+    /// overlays).
+    #[test]
+    fn test_extract_words_sequence_reflects_stream_order() {
+        let content = b"BT /F1 12 Tf 50 700 Td (First) Tj 0 -20 Td (Second) Tj ET";
+
+        let mut pdf = b"%PDF-1.4\n".to_vec();
+        let off1 = pdf.len();
+        pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        let off2 = pdf.len();
+        pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+        let off3 = pdf.len();
+        pdf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n",
+        );
+        let off4 = pdf.len();
+        pdf.extend_from_slice(
+            format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes(),
+        );
+        pdf.extend_from_slice(content);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n");
+        let off5 = pdf.len();
+        pdf.extend_from_slice(
+            b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+        );
+        let xref_off = pdf.len();
+        pdf.extend_from_slice(b"xref\n0 6\n");
+        pdf.extend_from_slice(b"0000000000 65535 f \n");
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off1).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off2).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off3).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off4).as_bytes());
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off5).as_bytes());
+        pdf.extend_from_slice(
+            format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n", xref_off)
+                .as_bytes(),
+        );
+
+        let doc = PdfDocument::from_bytes(pdf).unwrap();
+
+        let words = doc.extract_words(0).unwrap();
+        let first = words.iter().find(|w| w.text == "First").unwrap();
+        let second = words.iter().find(|w| w.text == "Second").unwrap();
+        assert!(
+            first.sequence < second.sequence,
+            "word drawn first in the content stream must have the smaller sequence: \
+             First={}, Second={}",
+            first.sequence,
+            second.sequence
+        );
+
+        let lines = doc.extract_text_lines(0).unwrap();
+        let line_words: Vec<&crate::layout::Word> =
+            lines.iter().flat_map(|l| l.words.iter()).collect();
+        let first_line_word = line_words.iter().find(|w| w.text == "First").unwrap();
+        let second_line_word = line_words.iter().find(|w| w.text == "Second").unwrap();
+        assert!(
+            first_line_word.sequence < second_line_word.sequence,
+            "extract_text_lines words must also carry stream-order sequence"
         );
     }
 

--- a/src/extractors/structured.rs
+++ b/src/extractors/structured.rs
@@ -323,6 +323,7 @@ impl StructuredExtractor {
                 is_bold: span.font_weight == crate::layout::FontWeight::Bold,
                 is_italic: span.is_italic,
                 mcid: span.mcid,
+                sequence: span.sequence,
             })
             .collect()
     }

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -3676,6 +3676,29 @@ impl<'doc> TextExtractor<'doc> {
         // Merge adjacent spans on the same line to reconstruct complete words
         self.merge_adjacent_spans();
 
+        // Resolve each span's font resource alias (e.g. "F1") to the resolved
+        // /BaseFont name (e.g. "Helvetica", "CIDFont+F1") so extract_spans /
+        // extract_words / extract_text_lines report the same font name that
+        // extract_chars already does (which reads `font.base_font`). Run AFTER
+        // merging so span reconstruction still keys off the raw resource alias
+        // exactly as before, and it has no effect on the assembled text/md/html
+        // output (font names are not emitted there) — only the API surface.
+        let resolved_fonts: Vec<Option<String>> = self
+            .spans
+            .iter()
+            .map(|s| {
+                self.fonts
+                    .get(&s.font_name)
+                    .map(|f| f.base_font.clone())
+                    .filter(|b| !b.is_empty())
+            })
+            .collect();
+        for (span, resolved) in self.spans.iter_mut().zip(resolved_fonts) {
+            if let Some(base_font) = resolved {
+                span.font_name = base_font;
+            }
+        }
+
         Ok(std::mem::take(&mut self.spans))
     }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6376,6 +6376,30 @@ pub extern "C" fn pdf_oxide_word_is_bold(
     list.words[index as usize].is_bold
 }
 
+/// Content-stream emission order of the word's originating span: the order in
+/// which spans were drawn during the Tj/TJ walk. Words with adjacent values
+/// were drawn consecutively, distinguishing genuinely-consecutive draw calls
+/// from spatially-close-but-stream-distant ones, independent of reading order.
+/// Returns -1 (with an error code) on a null handle or out-of-range index.
+#[no_mangle]
+pub extern "C" fn pdf_oxide_word_get_sequence(
+    words: *const FfiWordList,
+    index: i32,
+    error_code: *mut i32,
+) -> i64 {
+    if words.is_null() || index < 0 {
+        set_error(error_code, ERR_INVALID_ARG);
+        return -1;
+    }
+    let list = handle_ref(words);
+    if (index as usize) >= list.words.len() {
+        set_error(error_code, ERR_INVALID_PAGE);
+        return -1;
+    }
+    set_error(error_code, ERR_SUCCESS);
+    list.words[index as usize].sequence as i64
+}
+
 #[no_mangle]
 pub extern "C" fn pdf_oxide_word_list_free(handle: *mut FfiWordList) {
     if !handle.is_null() {

--- a/src/hybrid/complexity_estimator.rs
+++ b/src/hybrid/complexity_estimator.rs
@@ -292,6 +292,7 @@ mod tests {
             is_bold: false,
             is_italic: false,
             mcid: None,
+            sequence: 0,
         }
     }
 

--- a/src/hybrid/smart_analyzer.rs
+++ b/src/hybrid/smart_analyzer.rs
@@ -274,6 +274,7 @@ mod tests {
             is_bold: false,
             is_italic: false,
             mcid: None,
+            sequence: 0,
         }
     }
 

--- a/src/layout/clustering.rs
+++ b/src/layout/clustering.rs
@@ -355,9 +355,7 @@ pub fn cluster_words_into_lines(words: &[TextBlock], epsilon_y: f32) -> Vec<Vec<
 
     // Optimized clustering using sort-based approach: O(n log n)
     // Sort words by Y coordinate, then group consecutive words within epsilon_y.
-    // Within each Y-group, split by column gaps (>50pt horizontal separation).
-
-    let column_gap_threshold = 50.0;
+    // Within each Y-group, split by column gaps, font-size-relative.
 
     // Sort indices by Y coordinate
     let mut indices: Vec<usize> = (0..words.len()).collect();
@@ -401,6 +399,18 @@ pub fn cluster_words_into_lines(words: &[TextBlock], epsilon_y: f32) -> Vec<Vec<
             let x_dist = (words[idx].bbox.left() - words[prev_idx].bbox.right())
                 .abs()
                 .min((words[prev_idx].bbox.left() - words[idx].bbox.right()).abs());
+
+            // Font-size-relative column-gap threshold (mirrors
+            // `is_column_gap` in the markdown converter): a flat 50pt
+            // split made the gap-between-cells decision depend only on
+            // how wide a row's words happened to be — a header row of
+            // short words ("CEP"/"Cidade"/"UF") cleared 50pt and split
+            // into one line per cell, while the value row directly below
+            // it ("73751-452"/"PLANALTINA"/"GO") ate into the same column
+            // width and stayed under 50pt, merging into one line — even
+            // though both rows share the same column gutters.
+            let font_size_ref = words[idx].avg_font_size.max(words[prev_idx].avg_font_size);
+            let column_gap_threshold = (font_size_ref * 3.0).max(30.0);
 
             if x_dist < column_gap_threshold {
                 cluster.push(idx);
@@ -558,11 +568,14 @@ mod tests {
 
     #[test]
     fn test_cluster_words_into_lines() {
-        // Two lines: "Hello World" on line 1, "Foo Bar" on line 2
+        // Two lines: "Hello World" on line 1, "Foo Bar" on line 2.
+        // Gap kept under the font-relative column threshold
+        // ((12pt * 3.0).max(30.0) = 36pt) so these read as ordinary
+        // same-line word spacing rather than a column boundary.
         let word1 = TextBlock::from_chars(vec![mock_char('H', 0.0, 0.0)]);
-        let word2 = TextBlock::from_chars(vec![mock_char('W', 50.0, 1.0)]); // Same line
+        let word2 = TextBlock::from_chars(vec![mock_char('W', 20.0, 1.0)]); // Same line
         let word3 = TextBlock::from_chars(vec![mock_char('F', 0.0, 30.0)]); // Different line
-        let word4 = TextBlock::from_chars(vec![mock_char('B', 50.0, 31.0)]); // Same as word3
+        let word4 = TextBlock::from_chars(vec![mock_char('B', 20.0, 31.0)]); // Same as word3
 
         let words = vec![word1, word2, word3, word4];
         let lines = cluster_words_into_lines(&words, 5.0);
@@ -583,7 +596,7 @@ mod tests {
     #[test]
     fn test_words_sorted_by_x_in_line() {
         // Create words in reverse order (right to left) on same line
-        // Using realistic word spacing (< 50pt column gap threshold)
+        // Using realistic word spacing (< 36pt font-relative column gap threshold)
         let word1 = TextBlock::from_chars(vec![mock_char('W', 40.0, 0.0)]); // "World" at x=40
         let word2 = TextBlock::from_chars(vec![mock_char('H', 0.0, 1.0)]); // "Hello" at x=0
 
@@ -593,5 +606,48 @@ mod tests {
         assert_eq!(lines.len(), 1);
         // Should be sorted: index 1 (x=0) before index 0 (x=40)
         assert_eq!(lines[0], vec![1, 0]);
+    }
+
+    /// A 3-column row whose words are wide enough that the inter-column
+    /// gap shrinks to 40pt (under the old flat 50pt split threshold, so it
+    /// wrongly merged into one line-cluster) must still split into 3
+    /// separate clusters — same as a header row above it with shorter
+    /// words and a 70pt gap, which always split correctly. Mirrors the
+    /// `form_row_line_split.pdf` repro: a label row splits per-cell while
+    /// the value row directly below it (same columns, narrower gap) was
+    /// wrongly merged into a single line.
+    #[test]
+    fn test_column_gap_threshold_is_font_relative_not_flat() {
+        fn word_spanning(start_x: f32, width: f32, y: f32) -> TextBlock {
+            let count = (width / 10.0).round() as i32;
+            let chars = (0..count)
+                .map(|i| mock_char('X', start_x + i as f32 * 10.0, y))
+                .collect();
+            TextBlock::from_chars(chars)
+        }
+
+        // Header row: narrow words, 90pt column step -> 70pt gap.
+        let header = vec![
+            word_spanning(0.0, 20.0, 700.0),
+            word_spanning(90.0, 20.0, 700.0),
+            word_spanning(180.0, 20.0, 700.0),
+        ];
+        let header_lines = cluster_words_into_lines(&header, 5.0);
+        assert_eq!(header_lines.len(), 3, "narrow-word header row should split into 3 cells");
+
+        // Value row: wide words, same 90pt column step -> 40pt gap (under
+        // the old flat 50pt threshold but over the new font-relative one).
+        let value = vec![
+            word_spanning(0.0, 50.0, 600.0),
+            word_spanning(90.0, 50.0, 600.0),
+            word_spanning(180.0, 50.0, 600.0),
+        ];
+        let value_lines = cluster_words_into_lines(&value, 5.0);
+        assert_eq!(
+            value_lines.len(),
+            3,
+            "wide-word value row with the same column gutters must also split into 3 cells, \
+             not merge into 1 just because its words are wider"
+        );
     }
 }

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -614,6 +614,13 @@ pub struct TextBlock {
     pub is_italic: bool,
     /// Marked Content ID (for Tagged PDFs)
     pub mcid: Option<u32>,
+    /// Content-stream emission order of the originating span(s) — lets
+    /// callers tell "drawn consecutively in the content stream" apart
+    /// from "merely spatially close" (e.g. table cells vs. overlays).
+    /// `from_chars` has no span to draw this from, so it defaults to 0;
+    /// word-assembly call sites that build a block from a single span
+    /// set it explicitly from that span's `sequence`.
+    pub sequence: usize,
 }
 
 impl TextBlock {
@@ -668,6 +675,7 @@ impl TextBlock {
             is_bold,
             is_italic,
             mcid,
+            sequence: 0,
         }
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -4197,6 +4197,14 @@ impl PyTextSpan {
     fn color(&self) -> (f32, f32, f32) {
         (self.inner.color.r, self.inner.color.g, self.inner.color.b)
     }
+    /// Content-stream emission order: incremented as spans are emitted
+    /// during the Tj/TJ walk, so two spans with adjacent `sequence`
+    /// values were drawn consecutively, distinguishing that from spans
+    /// that are merely spatially close.
+    #[getter]
+    fn sequence(&self) -> usize {
+        self.inner.sequence
+    }
 }
 
 #[pyclass(module = "pdf_oxide.pdf_oxide", name = "TextWord", skip_from_py_object)]
@@ -4242,6 +4250,12 @@ impl PyWord {
             .iter()
             .map(|c| PyTextChar { inner: c.clone() })
             .collect()
+    }
+    /// Content-stream emission order of the originating span — see
+    /// `TextSpan.sequence`.
+    #[getter]
+    fn sequence(&self) -> usize {
+        self.inner.sequence
     }
 }
 

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -289,14 +289,26 @@ fn is_data_value(t: &str) -> bool {
 /// inter-word gaps coincidentally aligned into columns.
 ///
 /// Signature: at least one row, when its non-empty cells are concatenated
-/// left-to-right, crosses a SENTENCE boundary mid-row — a lowercase letter
-/// or digit, a sentence terminator (`.`/`!`/`?`), a space, then a capital
-/// letter starting a new word (e.g. "...to 23,500. Stockout rate..."). Real
-/// data-table rows hold values/labels, not running sentences that span a
-/// period into the next clause, so this almost never fires on genuine
-/// tables. Only applied to spatial tables (the caller is the no-rulings
-/// path); ruled tables are author-marked and trusted.
+/// left-to-right, crosses a SENTENCE boundary mid-row — an alphanumeric
+/// character, a sentence terminator, a space, then a new word (e.g. "...to
+/// 23,500. Stockout rate..."). Real data-table rows hold values/labels, not
+/// running sentences that span a terminator into the next clause, so this
+/// almost never fires on genuine tables. Only applied to spatial tables (the
+/// caller is the no-rulings path); ruled tables are author-marked and
+/// trusted.
+///
+/// Case is checked via the Unicode general category (`char::is_uppercase` /
+/// `is_lowercase`), not ASCII-only, so cased non-Latin scripts (Greek,
+/// Cyrillic, Armenian, …) get the same "new sentence starts with a capital"
+/// signal Latin does. Scripts with no case distinction at all (Bengali,
+/// Devanagari, …) can't use that signal, so their sentence-final danda
+/// (`।`, `॥`) is instead treated as a terminator in its own right: a danda
+/// followed by a space and another letter mid-row is itself the
+/// discriminator, since a genuine data cell doesn't embed a sentence stop
+/// followed by more prose in the same row.
 fn looks_like_prose_paragraph(table: &Table) -> bool {
+    const CASELESS_TERMINATORS: [char; 2] = ['।', '॥'];
+
     for row in &table.rows {
         let joined = row
             .cells
@@ -307,8 +319,13 @@ fn looks_like_prose_paragraph(table: &Table) -> bool {
             .join(" ");
         let chars: Vec<char> = joined.chars().collect();
         for i in 0..chars.len() {
-            // terminator at i, preceded by lowercase/digit, followed by
-            // " " + uppercase + lowercase (a real new sentence/word).
+            // Cased terminator: the exact prior-release strict signature — a
+            // lowercase/digit, then `.`/`!`/`?`, then space + capital +
+            // lowercase (a genuine new sentence). Kept ASCII with immediate
+            // neighbours on purpose: broadening it (any alphanumeric before,
+            // skip-spaces, Unicode case) over-rejected genuine data tables
+            // whose cells contain abbreviations or capitalised codes ("Fig.
+            // 3", "Dr. Smith", "A. Test") as prose.
             if matches!(chars[i], '.' | '!' | '?')
                 && i >= 1
                 && (chars[i - 1].is_ascii_lowercase() || chars[i - 1].is_ascii_digit())
@@ -319,8 +336,26 @@ fn looks_like_prose_paragraph(table: &Table) -> bool {
             {
                 return true;
             }
+            // Caseless terminator (Bengali/Devanagari danda ।/॥): scripts with
+            // no case distinction can't use the capital-start signal, so a
+            // danda followed (allowing a stray positioning gap) by another
+            // letter mid-row is itself the tell — a genuine data cell doesn't
+            // embed a sentence stop followed by more prose in the same row.
+            if CASELESS_TERMINATORS.contains(&chars[i]) {
+                let Some(&prev) = chars[..i].iter().rev().find(|c| **c != ' ') else {
+                    continue;
+                };
+                if !prev.is_alphanumeric() {
+                    continue;
+                }
+                let mut after = chars[i + 1..].iter().copied().skip_while(|c| *c == ' ');
+                if after.next().is_some_and(|c| c.is_alphabetic()) {
+                    return true;
+                }
+            }
         }
     }
+
     false
 }
 
@@ -4063,6 +4098,26 @@ mod tests {
                 prose_cell("quarter-over-quarter to"),
                 prose_cell("23,500."),
                 prose_cell("Stockout rate improved by 200 basis"),
+            ],
+            is_header: false,
+        });
+        assert!(looks_like_prose_paragraph(&t));
+    }
+
+    /// Caseless scripts (Bengali here) have no capital-letter signal at all,
+    /// so their sentence-final danda ('।') must be treated as a terminator
+    /// in its own right. Real-world PDFs sometimes render the danda with a
+    /// stray gap before it ("প্রাণী ।"), so the check must tolerate that.
+    #[test]
+    fn test_looks_like_prose_paragraph_detects_bengali_danda_crossing_row() {
+        let mut t = Table::new();
+        t.col_count = 4;
+        t.rows.push(TableRow {
+            cells: vec![
+                prose_cell("বিড়াল একটি গার্হস্থ্য প্রজাতি"),
+                prose_cell("স্তন্যপায়ী প্রাণী"),
+                prose_cell("। এটি"),
+                prose_cell("ফেলিডা পরিবারের একমাত্র গৃহপালিত প্রজাতি"),
             ],
             is_header: false,
         });

--- a/src/structure/table_extractor.rs
+++ b/src/structure/table_extractor.rs
@@ -501,6 +501,7 @@ pub fn extract_table_from_spans(
                 is_bold: s.font_weight.is_bold(),
                 is_italic: s.is_italic,
                 mcid: s.mcid,
+                sequence: s.sequence,
             }
         })
         .collect();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -884,7 +884,7 @@ impl WasmPdfDocument {
     /// Extract span-level data from a page.
     ///
     /// Returns an array of objects with: text, bbox, font_name, font_size,
-    /// font_weight, is_italic, color, etc.
+    /// font_weight, is_italic, color, sequence, etc.
     ///
     /// Optional `reading_order`: `"column_aware"` for XY-Cut column detection,
     /// or `"top_to_bottom"` (default).
@@ -969,7 +969,11 @@ impl WasmPdfDocument {
     /// Extract word-level data from a page.
     ///
     /// Returns an array of objects with: text, bbox, font_name, font_size,
-    /// font_weight, is_italic, is_bold.
+    /// font_weight, is_italic, is_bold, sequence.
+    ///
+    /// `sequence` is the content-stream emission order of the originating
+    /// span, letting callers tell words drawn consecutively in the content
+    /// stream apart from ones that are merely spatially close.
     #[wasm_bindgen(js_name = "extractWords")]
     pub fn extract_words(
         &mut self,

--- a/swift/Sources/PdfOxide/PdfOxide.swift
+++ b/swift/Sources/PdfOxide/PdfOxide.swift
@@ -47,6 +47,11 @@ public struct Word {
     public let fontName: String
     public let fontSize: Double
     public let bold: Bool
+    /// Content-stream emission order of the word's originating span. Words whose
+    /// sequence values are adjacent were drawn consecutively, which distinguishes
+    /// consecutively-drawn words from merely spatially-close ones, independent of
+    /// reading order.
+    public let sequence: Int
 }
 
 /// A single extracted line of text.
@@ -360,6 +365,7 @@ public final class Document {
                 pdf_oxide_word_get_font_name(list, idx, &code), code, "extractWords.fontName")
             let fontSize = pdf_oxide_word_get_font_size(list, idx, &code)
             let bold = pdf_oxide_word_is_bold(list, idx, &code)
+            let sequence = pdf_oxide_word_get_sequence(list, idx, &code)
             var x: Float = 0, y: Float = 0, w: Float = 0, h: Float = 0
             pdf_oxide_word_get_bbox(list, idx, &x, &y, &w, &h, &code)
             result.append(
@@ -368,7 +374,8 @@ public final class Document {
                     bbox: Bbox(x: Double(x), y: Double(y), width: Double(w), height: Double(h)),
                     fontName: fontName,
                     fontSize: Double(fontSize),
-                    bold: bold
+                    bold: bold,
+                    sequence: Int(sequence)
                 ))
         }
         return result
@@ -925,13 +932,15 @@ public final class Document {
                 pdf_oxide_word_get_font_name(list, idx, &code), code, "extractWordsInRect.fontName")
             let fontSize = pdf_oxide_word_get_font_size(list, idx, &code)
             let bold = pdf_oxide_word_is_bold(list, idx, &code)
+            let sequence = pdf_oxide_word_get_sequence(list, idx, &code)
             var bx: Float = 0, by: Float = 0, bw: Float = 0, bh: Float = 0
             pdf_oxide_word_get_bbox(list, idx, &bx, &by, &bw, &bh, &code)
             result.append(
                 Word(
                     text: text,
                     bbox: Bbox(x: Double(bx), y: Double(by), width: Double(bw), height: Double(bh)),
-                    fontName: fontName, fontSize: Double(fontSize), bold: bold
+                    fontName: fontName, fontSize: Double(fontSize), bold: bold,
+                    sequence: Int(sequence)
                 ))
         }
         return result

--- a/swift/Tests/PdfOxideTests/ApiCoverageTests.swift
+++ b/swift/Tests/PdfOxideTests/ApiCoverageTests.swift
@@ -67,6 +67,7 @@ final class ApiCoverageTests: XCTestCase {
         _ = words[0].fontName
         _ = words[0].fontSize
         _ = words[0].bold
+        _ = words[0].sequence
 
         let chars = try doc.extractChars(0)  // extractChars
         XCTAssertFalse(chars.isEmpty)

--- a/tests/core_parity.rs
+++ b/tests/core_parity.rs
@@ -93,5 +93,5 @@ fn open_error() {
 
 #[test]
 fn version() {
-    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.69");
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.70");
 }

--- a/tests/test_table_extraction.rs
+++ b/tests/test_table_extraction.rs
@@ -19,6 +19,7 @@ fn mock_text_block(text: &str, mcid: u32) -> TextBlock {
         is_italic: false,
         is_bold: false,
         mcid: Some(mcid),
+        sequence: 0,
     }
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -2254,7 +2254,7 @@ wheels = [
 
 [[package]]
 name = "pdf-oxide"
-version = "0.3.69"
+version = "0.3.70"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "description": "Fast, zero-dependency PDF toolkit for Node.js, browsers, and edge runtimes — text extraction, markdown/HTML conversion, search, form filling, creation, and editing. Rust core compiled to WebAssembly.",
   "license": "MIT OR Apache-2.0",
   "repository": {

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pdf_oxide,
-    .version = "0.3.69",
+    .version = "0.3.70",
     .fingerprint = 0x991319f35cdc7f8a,
     .minimum_zig_version = "0.15.0",
     .paths = .{

--- a/zig/lib/pdf_oxide.zig
+++ b/zig/lib/pdf_oxide.zig
@@ -53,6 +53,11 @@ pub const Word = struct {
     fontName: []u8,
     fontSize: f32,
     bold: bool,
+    /// Content-stream emission order of the word's originating span. Words drawn
+    /// consecutively have adjacent values, which distinguishes genuinely
+    /// consecutive draws from merely-spatially-close ones (independent of
+    /// reading order).
+    sequence: i64,
 };
 
 /// A single extracted text line. `text` is allocator-owned (free it).
@@ -301,12 +306,14 @@ pub const Document = struct {
             const font_name = try takeString(alloc, c.pdf_oxide_word_get_font_name(list, idx, &code), code);
             const font_size = c.pdf_oxide_word_get_font_size(list, idx, &code);
             const bold = c.pdf_oxide_word_is_bold(list, idx, &code);
+            const sequence = c.pdf_oxide_word_get_sequence(list, idx, &code);
             out[i] = .{
                 .text = word_text,
                 .bbox = .{ .x = x, .y = y, .width = w, .height = h },
                 .fontName = font_name,
                 .fontSize = font_size,
                 .bold = bold,
+                .sequence = sequence,
             };
         }
         return out;
@@ -1264,12 +1271,14 @@ fn collectWordList(alloc: std.mem.Allocator, list: *c.FfiWordList) Error![]Word 
         const font_name = try takeString(alloc, c.pdf_oxide_word_get_font_name(list, idx, &code), code);
         const font_size = c.pdf_oxide_word_get_font_size(list, idx, &code);
         const bold = c.pdf_oxide_word_is_bold(list, idx, &code);
+        const sequence = c.pdf_oxide_word_get_sequence(list, idx, &code);
         out[i] = .{
             .text = word_text,
             .bbox = .{ .x = x, .y = y, .width = w, .height = h },
             .fontName = font_name,
             .fontSize = font_size,
             .bold = bold,
+            .sequence = sequence,
         };
     }
     return out;
@@ -4332,6 +4341,7 @@ test "Document: element extraction (chars/words/lines/tables)" {
     try testing.expect(words.len > 0);
     try testing.expect(words[0].text.len > 0);
     try testing.expect(words[0].bbox.width >= 0);
+    try testing.expect(words[0].sequence >= 0);
 
     // extractChars: non-empty
     const chars = try doc.extractChars(a, 0);


### PR DESCRIPTION
## v0.3.70 — extraction-fidelity release

Kerning-split words rejoined in plain text, table/form line cells split consistently regardless of word width, resolved `/BaseFont` names on the span/word APIs, and content-stream order exposed on extracted spans and words.

### Fixes
- Closes #791 — a word split by a spurious space when its glyph runs overlap slightly (kerning): `PLANAL TINA` → `PLANALTINA`. Fixed at the plain-text assembler (varying per-glyph metrics + word chars on both sides + not a lowercase→uppercase boundary); spans are left **unmerged**, so reading order and table detection are unchanged.
- Closes #792 — `--format lines` merged table/form cells across column gaps inconsistently across rows; the column-gap threshold is now font-relative (`(font_size × 3).max(30pt)`).
- Closes #779 — content-stream emission order exposed on `extract_words` / `extract_text_lines` (and Python `PyTextSpan`/`PyWord`).
- Refs #780 — **part 1 only**: `extract_spans`/`extract_words`/`extract_text_lines` now report the resolved `/BaseFont` name instead of the resource alias. Part 2 (CID/Type0 per-glyph coordinate drift in `extract_words`) is deferred to a follow-up, so #780 intentionally stays open.

### Validation
- Reading order (XY-cut) **unchanged** vs 0.3.69 → **md/html output byte-identical**; plain-text diffs are spurious-space removals only, verified against ground truth (improvements/lateral, no regressions).
- Full library test suite green (5679 passed, 0 failed).
- Version bumped 0.3.69 → 0.3.70 across all binding manifests (`sync_version.py --check` clean).

Thanks @schelip (#791, #792) and @ankursri494 (#779, #780) for reporting the issues that drove this release.

https://claude.ai/code/session_01Mi7SWV6hVeHSqC6gVbvaER
