### PR TITLE
fix: text extraction panic on vertical-text (tategaki) pages — sort comparator violated total order

### DIFF
--- a/src/converters/layout_lines.rs
+++ b/src/converters/layout_lines.rs
@@ -63,16 +63,8 @@ pub(crate) fn group_spans_into_lines(spans: Vec<TextSpan>) -> Vec<Line> {
     let mut sorted = spans;
     // Sort by descending y (top-of-page first), then by x within a line.
     sorted.sort_by(|a, b| {
-        b.bbox
-            .y
-            .partial_cmp(&a.bbox.y)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| {
-                a.bbox
-                    .x
-                    .partial_cmp(&b.bbox.x)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+        crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y)
+            .then_with(|| crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x))
     });
 
     let mut lines: Vec<Line> = Vec::new();
@@ -159,12 +151,8 @@ pub(crate) fn group_spans_into_lines(spans: Vec<TextSpan>) -> Vec<Line> {
     // in sorted-input order, but later lines could pick up an
     // earlier-x span if Y tolerance bridged two lines).
     for line in &mut lines {
-        line.spans.sort_by(|a, b| {
-            a.bbox
-                .x
-                .partial_cmp(&b.bbox.x)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        line.spans
+            .sort_by(|a, b| crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x));
     }
 
     lines

--- a/src/converters/music_region_finder.rs
+++ b/src/converters/music_region_finder.rs
@@ -117,7 +117,7 @@ pub(crate) fn find_music_regions(doc: &PdfDocument, page_idx: usize) -> Vec<Rect
 
     // Sort lines by y (ascending = bottom-up in PDF space) and group
     // consecutive lines whose vertical gap is ≤ 6 pt.
-    hlines.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal));
+    hlines.sort_by(|a, b| crate::utils::safe_float_cmp(a.y, b.y));
 
     struct Cluster {
         y_min: f32,
@@ -170,7 +170,7 @@ pub(crate) fn find_music_regions(doc: &PdfDocument, page_idx: usize) -> Vec<Rect
     // "music systems" (treble + bass staves on one line of music).
     // We DON'T union across the 80-pt vertical gap between systems —
     // the 5-pt slack here is well below that gap.
-    regions.sort_by(|a, b| a.y.partial_cmp(&b.y).unwrap_or(std::cmp::Ordering::Equal));
+    regions.sort_by(|a, b| crate::utils::safe_float_cmp(a.y, b.y));
     let mut merged: Vec<Rect> = Vec::new();
     for r in regions {
         let unioned = merged.last_mut().and_then(|m| {

--- a/src/converters/pdf_to_ir.rs
+++ b/src/converters/pdf_to_ir.rs
@@ -590,7 +590,7 @@ fn page_to_section(
     // when we cross its y-position (i.e. between the paragraph above
     // it and the paragraph below it).
     let mut rules_top_down: Vec<f32> = rules.iter().map(|r| r.y_pdf).collect();
-    rules_top_down.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    rules_top_down.sort_by(|a, b| crate::utils::safe_float_cmp(*b, *a));
     let mut rules_iter = rules_top_down.into_iter().peekable();
 
     let mut prev_para_min_y: Option<f32> = None;
@@ -986,7 +986,7 @@ fn group_into_paragraphs_with_lines(
     sorted.sort_by(|a, b| {
         let ay = a.bbox.y + a.bbox.height * 0.5;
         let by = b.bbox.y + b.bbox.height * 0.5;
-        by.partial_cmp(&ay).unwrap_or(std::cmp::Ordering::Equal)
+        crate::utils::safe_float_cmp(by, ay)
     });
 
     if sorted.is_empty() {
@@ -1014,12 +1014,7 @@ fn group_into_paragraphs_with_lines(
 
     // 3. Sort each line left-to-right by X.
     for line in &mut lines {
-        line.sort_by(|a, b| {
-            a.bbox
-                .x
-                .partial_cmp(&b.bbox.x)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        line.sort_by(|a, b| crate::utils::safe_float_cmp(a.bbox.x, b.bbox.x));
     }
 
     // Materialise lines as owned `Vec<TextSpan>` for downstream use.
@@ -1174,7 +1169,7 @@ fn detect_columns(all_lines: &[Vec<TextSpan>], page_w_pt: f32) -> Option<ColumnL
     // MIN_GUTTER_PT if too few samples.
     let col1_right = if col1_rights_on_two_col_lines.len() >= 5 {
         let mut v = col1_rights_on_two_col_lines.clone();
-        v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        v.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
         v[(v.len() as f32 * 0.9) as usize]
     } else {
         col2_left - MIN_GUTTER_PT
@@ -1359,7 +1354,7 @@ fn char_spacing_opt(spacing_pt: f32) -> Option<i32> {
 
 fn median_font_size(spans: &[TextSpan]) -> f32 {
     let mut sizes: Vec<f32> = spans.iter().map(|s| s.font_size).collect();
-    sizes.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sizes.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
     let n = sizes.len();
     if n == 0 {
         return 12.0;

--- a/src/document.rs
+++ b/src/document.rs
@@ -2896,13 +2896,7 @@ impl PdfDocument {
         if labels.is_empty() {
             return;
         }
-        labels.sort_by(|&a, &b| {
-            spans[b]
-                .bbox
-                .y
-                .partial_cmp(&spans[a].bbox.y)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        labels.sort_by(|&a, &b| crate::utils::safe_float_cmp(spans[b].bbox.y, spans[a].bbox.y));
 
         // Labels that sit at near-identical Y values almost always
         // annotate the same logical row block (e.g. a test-name in the
@@ -5377,7 +5371,7 @@ impl PdfDocument {
         if widths.is_empty() {
             return None;
         }
-        widths.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        widths.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
         let gw = widths[widths.len() / 2];
 
         // Discriminate vertical (tategaki) from horizontal CJK by each glyph's
@@ -11113,7 +11107,7 @@ impl PdfDocument {
         if body_sizes.is_empty() {
             return;
         }
-        body_sizes.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        body_sizes.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
         let body_size = body_sizes[body_sizes.len() / 2];
 
         // Span indices sorted by left edge, and the widest font on the page, so
@@ -11381,31 +11375,10 @@ impl PdfDocument {
         // horizontal corpus untouched.
         let vertical_count = spans.iter().filter(|s| s.wmode == 1).count();
         if !spans.is_empty() && vertical_count * 2 >= spans.len() {
-            // Cluster tolerance: median span width. Wide enough to keep one
-            // vertical column together, narrow enough to separate adjacent
-            // columns. Robust to single rotated outliers.
-            //
-            // Assumption (M7): tategaki CJK body text is functionally
-            // monospaced (full-width kanji/kana, half-width digits all
-            // advance by similar widths), so the median span width
-            // approximates the column pitch. Mixed-pitch tategaki (rare —
-            // typically only ruby annotations) may overcluster; that
-            // would be an explicit follow-up if it shows up in real
-            // corpora.
-            let mut widths: Vec<f32> = spans.iter().map(|s| s.bbox.width.max(1.0)).collect();
-            widths.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
-            let tol = widths[widths.len() / 2].max(1.0);
-            spans.sort_by(|a, b| {
-                let ax = a.bbox.x + a.bbox.width * 0.5;
-                let bx = b.bbox.x + b.bbox.width * 0.5;
-                if (ax - bx).abs() <= tol {
-                    // Same column: top first (descending y in PDF user space).
-                    crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y)
-                } else {
-                    // Different column: rightmost first.
-                    crate::utils::safe_float_cmp(bx, ax)
-                }
-            });
+            // See `crate::utils::sort_vertical_tategaki` for the
+            // median-width column clustering and the total-order
+            // rationale (issue #807).
+            spans = crate::utils::sort_vertical_tategaki(spans, |s| &s.bbox);
         } else if let Some(ordered) = Self::sidebar_body_reading_order(&spans) {
             // RW-1: narrow-sidebar + wide-body first pages (full-width title band
             // over a metadata sidebar + body). Handled before the XY-cut so the
@@ -13691,7 +13664,7 @@ impl PdfDocument {
             if total == 0 {
                 return 0.0;
             }
-            xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            xs.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
             let mut best = 1usize;
             let mut current = 1usize;
             let mut last = xs[0];

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -3872,12 +3872,7 @@ impl<'doc> TextExtractor<'doc> {
         let max_fs = snapshot.iter().map(|s| s.3).fold(0.0f32, f32::max);
         let max_half_em = max_fs * 0.5;
         let mut by_order: Vec<usize> = (0..n).collect();
-        by_order.sort_by(|&a, &b| {
-            snapshot[a]
-                .1
-                .partial_cmp(&snapshot[b].1)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        by_order.sort_by(|&a, &b| crate::utils::safe_float_cmp(snapshot[a].1, snapshot[b].1));
         let ys_sorted: Vec<f32> = by_order.iter().map(|&idx| snapshot[idx].1).collect();
 
         for i in 0..n {
@@ -3998,56 +3993,12 @@ impl<'doc> TextExtractor<'doc> {
     }
 
     /// Sort spans in vertical writing (tategaki) order: right-to-left
-    /// across columns, top-to-bottom within each column. Spans whose
-    /// horizontal X-centers cluster together belong to the same column.
-    ///
-    /// The cluster tolerance is the median span width — wide enough to keep
-    /// glyphs of one body column together, narrow enough to separate
-    /// adjacent columns. PDF user-space y increases upward, so within a
-    /// column we sort by descending y (top first).
+    /// across columns, top-to-bottom within each column. See
+    /// [`crate::utils::sort_vertical_tategaki`] for the clustering
+    /// algorithm and the total-order rationale (issue #807).
     fn sort_spans_vertical_tategaki(&mut self) {
-        if self.spans.is_empty() {
-            return;
-        }
-
-        // Estimate a per-column-grouping tolerance from the median span
-        // width (cheap, robust to outliers from rotated annotations).
-        //
-        // Assumption (M7): tategaki CJK body text is functionally
-        // monospaced — every glyph occupies roughly one em (full-width
-        // kanji, hiragana, katakana, halfwidth digits all advance by
-        // similar widths). The median span width therefore approximates
-        // the column pitch, and `tol = median_w` cleanly separates a
-        // column whose glyphs cluster around one X-center from an
-        // adjacent column shifted by another median width. Mixed-pitch
-        // tategaki (rare — typically only ruby annotations) may
-        // overcluster; that is an explicit follow-up if it shows up in
-        // real corpora.
-        let mut widths: Vec<f32> = self.spans.iter().map(|s| s.bbox.width.max(1.0)).collect();
-        widths.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
-        let median_w = widths[widths.len() / 2].max(1.0);
-        let tol = median_w; // ±median width groups glyphs of the same vertical run
-
-        // Compute each span's X center, then cluster centers by proximity.
-        let mut sorted_idx: Vec<usize> = (0..self.spans.len()).collect();
-        let x_center = |i: usize| -> f32 { self.spans[i].bbox.x + self.spans[i].bbox.width * 0.5 };
-        // Right-to-left primary: descending x_center, then descending y.
-        sorted_idx.sort_by(|&a, &b| {
-            let ax = x_center(a);
-            let bx = x_center(b);
-            if (ax - bx).abs() <= tol {
-                // Same column: top first (PDF user space — descending y).
-                crate::utils::safe_float_cmp(self.spans[b].bbox.y, self.spans[a].bbox.y)
-            } else {
-                crate::utils::safe_float_cmp(bx, ax) // descending x_center
-            }
-        });
-
-        let new_spans: Vec<TextSpan> = sorted_idx
-            .into_iter()
-            .map(|i| self.spans[i].clone())
-            .collect();
-        self.spans = new_spans;
+        self.spans =
+            crate::utils::sort_vertical_tategaki(std::mem::take(&mut self.spans), |s| &s.bbox);
     }
 
     /// Simple Y-then-X sorting for single-column layouts.
@@ -11567,6 +11518,37 @@ mod tests {
         // Should not panic with NaN values
         extractor.sort_by_reading_order();
         assert_eq!(extractor.chars.len(), 2);
+    }
+
+    /// Regression for issue #807: a vertical-majority page whose span
+    /// X-centers chain within the column tolerance (each neighbor ≤ tol
+    /// apart, endpoints far apart) made the tategaki comparator
+    /// non-transitive; `slice::sort_by` detected the broken total order and
+    /// panicked, aborting text extraction for the whole page. The chained
+    /// centers form one column, so the sorted output must be top-to-bottom.
+    #[test]
+    fn test_tategaki_chained_centers_total_order() {
+        let mut extractor = TextExtractor::new();
+        // Width 12 → tol (median width) = 12; center step 10 < tol chains
+        // all 64 spans; the extreme centers are 630 apart (≫ tol).
+        extractor.spans = (0..64)
+            .map(|i| TextSpan {
+                text: format!("s{i}"),
+                bbox: Rect::new(i as f32 * 10.0, ((i * 37) % 64) as f32 * 7.0, 12.0, 12.0),
+                font_size: 12.0,
+                wmode: 1,
+                ..TextSpan::default()
+            })
+            .collect();
+
+        extractor.sort_spans_by_reading_order();
+
+        assert_eq!(extractor.spans.len(), 64);
+        let ys: Vec<f32> = extractor.spans.iter().map(|s| s.bbox.y).collect();
+        assert!(
+            ys.windows(2).all(|w| w[0] >= w[1]),
+            "chained centers must read as one column, top-to-bottom: {ys:?}"
+        );
     }
 
     // ========================================================================

--- a/src/layout/font_stats.rs
+++ b/src/layout/font_stats.rs
@@ -161,7 +161,7 @@ fn compute_line_height(spans: &[TextSpan], body_font: &str, dominant_em: f32) ->
     }
 
     // Sort descending (highest y = top of page first in PDF coords).
-    ys.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    ys.sort_by(|a, b| crate::utils::safe_float_cmp(*b, *a));
 
     // Deduplicate baselines within 0.5 pt: multiple spans on the same
     // text line (bold run, mixed font) would otherwise inject zero-gaps.
@@ -181,7 +181,7 @@ fn compute_line_height(spans: &[TextSpan], body_font: &str, dominant_em: f32) ->
     if gaps.is_empty() {
         return None;
     }
-    gaps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    gaps.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
     Some(gaps[gaps.len() / 2])
 }
 

--- a/src/layout/region_classifier.rs
+++ b/src/layout/region_classifier.rs
@@ -191,7 +191,7 @@ fn median_height(spans: &[TextSpan], indices: &[usize]) -> f32 {
     if hs.is_empty() {
         return 1.0;
     }
-    hs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    hs.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
     hs[hs.len() / 2]
 }
 
@@ -199,18 +199,8 @@ fn median_height(spans: &[TextSpan], indices: &[usize]) -> f32 {
 fn cluster_lines(spans: &[TextSpan], indices: &[usize], med_h: f32) -> Vec<LineStat> {
     let mut order: Vec<usize> = indices.to_vec();
     order.sort_by(|&a, &b| {
-        spans[a]
-            .bbox
-            .top()
-            .partial_cmp(&spans[b].bbox.top())
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| {
-                spans[a]
-                    .bbox
-                    .left()
-                    .partial_cmp(&spans[b].bbox.left())
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+        crate::utils::safe_float_cmp(spans[a].bbox.top(), spans[b].bbox.top())
+            .then_with(|| crate::utils::safe_float_cmp(spans[a].bbox.left(), spans[b].bbox.left()))
     });
 
     let tol = med_h * 0.6;
@@ -249,7 +239,7 @@ fn cluster_lines(spans: &[TextSpan], indices: &[usize], med_h: f32) -> Vec<LineS
             .copied()
             .zip(l.span_rights.iter().copied())
             .collect();
-        paired.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        paired.sort_by(|a, b| crate::utils::safe_float_cmp(a.0, b.0));
         l.span_lefts = paired.iter().map(|p| p.0).collect();
         l.span_rights = paired.iter().map(|p| p.1).collect();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,6 +516,87 @@ pub(crate) mod utils {
         });
     }
 
+    /// Sort spans into tategaki (vertical-writing) reading order:
+    /// right-to-left across columns, top-to-bottom within each column
+    /// (PDF user-space Y increases upward, so top-first means Y descending).
+    ///
+    /// Columns are found by single-linkage clustering of span X-centers:
+    /// after ordering the centers right-to-left, a gap greater than the
+    /// tolerance starts a new column. The tolerance is the median span
+    /// width — tategaki CJK body text is functionally monospaced (full-width
+    /// kanji/kana advance by similar widths), so the median width
+    /// approximates the column pitch: wide enough to keep one vertical
+    /// column together, narrow enough to separate adjacent columns, robust
+    /// to rotated-annotation outliers.
+    ///
+    /// Clustering first, then sorting by `(column, Y)` keeps every
+    /// comparison a total order. Comparing raw X-centers with a tolerance
+    /// *inside* the comparator (`|ax − bx| ≤ tol` → same column) is
+    /// non-transitive when centers chain — a ≈ b and b ≈ c but a ≉ c — and
+    /// `slice::sort_by` detects the broken total order and panics
+    /// ("user-provided comparison function does not correctly implement a
+    /// total order", issue #807). Same trap as [`row_aware_span_cmp`]'s
+    /// banding, solved the same way: derive a discrete key, sort by the key.
+    ///
+    /// Non-finite coordinates follow the crate's NaN policy
+    /// ([`safe_float_cmp`]); a non-finite X-center never chains, so each
+    /// such span forms its own column.
+    pub fn sort_vertical_tategaki<T>(
+        items: Vec<T>,
+        get_bbox: impl Fn(&T) -> &crate::geometry::Rect,
+    ) -> Vec<T> {
+        if items.len() < 2 {
+            return items;
+        }
+
+        let mut widths: Vec<f32> = items.iter().map(|it| get_bbox(it).width.max(1.0)).collect();
+        widths.sort_by(|a, b| safe_float_cmp(*a, *b));
+        let tol = widths[widths.len() / 2].max(1.0);
+
+        let centers: Vec<f32> = items
+            .iter()
+            .map(|it| {
+                let b = get_bbox(it);
+                b.x + b.width * 0.5
+            })
+            .collect();
+        let ys: Vec<f32> = items.iter().map(|it| get_bbox(it).y).collect();
+
+        // Right-to-left pass assigning column ids (stable sort → ties keep
+        // input order, so the clustering is deterministic).
+        let mut order: Vec<usize> = (0..items.len()).collect();
+        order.sort_by(|&a, &b| safe_float_cmp(centers[b], centers[a]));
+
+        let mut column = vec![0u32; items.len()];
+        let mut current = 0u32;
+        let mut prev = centers[order[0]];
+        for &idx in &order[1..] {
+            let center = centers[idx];
+            // `prev - center` is NaN when either end is non-finite —
+            // a non-finite center never chains, so it starts a new column.
+            let gap = prev - center;
+            if gap.is_nan() || gap > tol {
+                current += 1;
+            }
+            column[idx] = current;
+            prev = center;
+        }
+
+        // Column ascending (columns were numbered right-to-left above),
+        // then top-to-bottom. Both keys are total orders.
+        order.sort_by(|&a, &b| {
+            column[a]
+                .cmp(&column[b])
+                .then_with(|| safe_float_cmp(ys[b], ys[a]))
+        });
+
+        let mut slots: Vec<Option<T>> = items.into_iter().map(Some).collect();
+        order
+            .into_iter()
+            .map(|i| slots[i].take().expect("each index appears once"))
+            .collect()
+    }
+
     /// Total-order wrapper over `f32` for use as a sort key. For finite values
     /// `total_cmp` is identical to `safe_float_cmp` / `partial_cmp`.
     #[derive(Clone, Copy, PartialEq)]
@@ -553,6 +634,61 @@ pub(crate) mod utils {
             sort_by_row_band(&mut a, |t| t.0, |t| t.1);
             b.sort_by(|p, q| row_aware_span_cmp(p.0, p.1, q.0, q.1));
             assert_eq!(a, b, "cached-key sort must match the comparator permutation");
+        }
+
+        fn tategaki_rect(x: f32, y: f32, w: f32) -> crate::geometry::Rect {
+            crate::geometry::Rect::new(x, y, w, 12.0)
+        }
+
+        /// Two well-separated columns: rightmost column first, top-to-bottom
+        /// within each (same ordering the pre-#807 comparator produced).
+        #[test]
+        fn test_sort_vertical_tategaki_two_columns() {
+            let items = vec![
+                ("D", tategaki_rect(300.0, 700.0, 12.0)),
+                ("F", tategaki_rect(300.0, 676.0, 12.0)),
+                ("B", tategaki_rect(500.0, 688.0, 12.0)),
+                ("C", tategaki_rect(500.0, 676.0, 12.0)),
+                ("A", tategaki_rect(500.0, 700.0, 12.0)),
+                ("E", tategaki_rect(300.0, 688.0, 12.0)),
+            ];
+            let sorted = sort_vertical_tategaki(items, |it| &it.1);
+            let order: String = sorted.iter().map(|it| it.0).collect();
+            assert_eq!(order, "ABCDEF");
+        }
+
+        /// X-centers chaining within the tolerance form ONE column
+        /// (single-linkage), read top-to-bottom — the input class that made
+        /// the old banded comparator non-transitive and panicked driftsort
+        /// (issue #807).
+        #[test]
+        fn test_sort_vertical_tategaki_chained_centers() {
+            let items: Vec<(usize, crate::geometry::Rect)> = (0..64)
+                .map(|i| (i, tategaki_rect(i as f32 * 10.0, ((i * 37) % 64) as f32 * 7.0, 12.0)))
+                .collect();
+            let sorted = sort_vertical_tategaki(items, |it| &it.1);
+            assert_eq!(sorted.len(), 64);
+            assert!(
+                sorted.windows(2).all(|w| w[0].1.y >= w[1].1.y),
+                "one chained column must read top-to-bottom"
+            );
+        }
+
+        /// Non-finite coordinates must not panic and every item must
+        /// survive the permutation exactly once.
+        #[test]
+        fn test_sort_vertical_tategaki_non_finite() {
+            let mut items: Vec<(usize, crate::geometry::Rect)> = (0..32)
+                .map(|i| (i, tategaki_rect((i % 8) as f32 * 40.0, i as f32 * 5.0, 12.0)))
+                .collect();
+            items[3].1.x = f32::NAN;
+            items[11].1.y = f32::NAN;
+            items[17].1.width = f32::NAN;
+            items[23].1.x = f32::INFINITY;
+            let sorted = sort_vertical_tategaki(items, |it| &it.1);
+            let mut ids: Vec<usize> = sorted.iter().map(|it| it.0).collect();
+            ids.sort_unstable();
+            assert_eq!(ids, (0..32).collect::<Vec<_>>());
         }
 
         #[test]

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -2454,20 +2454,8 @@ fn detect_footnotes(spans: &[&OrderedTextSpan], base_font_size: f32) -> Footnote
         .filter(|&i| spans[i].span.bbox.y <= bottom_cut)
         .collect();
     bottom.sort_by(|&a, &b| {
-        spans[b]
-            .span
-            .bbox
-            .y
-            .partial_cmp(&spans[a].span.bbox.y)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then(
-                spans[a]
-                    .span
-                    .bbox
-                    .x
-                    .partial_cmp(&spans[b].span.bbox.x)
-                    .unwrap_or(std::cmp::Ordering::Equal),
-            )
+        crate::utils::safe_float_cmp(spans[b].span.bbox.y, spans[a].span.bbox.y)
+            .then_with(|| crate::utils::safe_float_cmp(spans[a].span.bbox.x, spans[b].span.bbox.x))
     });
     // Group bottom-band spans into lines by baseline proximity.
     let mut def_lines: Vec<Vec<usize>> = Vec::new();
@@ -2488,12 +2476,7 @@ fn detect_footnotes(spans: &[&OrderedTextSpan], base_font_size: f32) -> Footnote
     for line in &def_lines {
         let mut ordered = line.clone();
         ordered.sort_by(|&a, &b| {
-            spans[a]
-                .span
-                .bbox
-                .x
-                .partial_cmp(&spans[b].span.bbox.x)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            crate::utils::safe_float_cmp(spans[a].span.bbox.x, spans[b].span.bbox.x)
         });
         // The leading (marker) span must be in a smaller-than-body font.
         if spans[ordered[0]].span.font_size >= base_font_size * 0.92 {

--- a/src/pipeline/converters/plain_text.rs
+++ b/src/pipeline/converters/plain_text.rs
@@ -254,13 +254,7 @@ impl PlainTextConverter {
             for run_idx in run_start..run_end {
                 let run_len = runs[run_idx].2;
                 let mut col: Vec<&'a OrderedTextSpan> = sorted[cursor..cursor + run_len].to_vec();
-                col.sort_by(|a, b| {
-                    b.span
-                        .bbox
-                        .y
-                        .partial_cmp(&a.span.bbox.y)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                col.sort_by(|a, b| crate::utils::safe_float_cmp(b.span.bbox.y, a.span.bbox.y));
                 columns.push(col);
                 cursor += run_len;
             }
@@ -354,12 +348,7 @@ impl PlainTextConverter {
         // Within each cluster, sort spans by X-position (left to right).
         for cluster in &mut clusters {
             cluster.1.sort_by(|&a, &b| {
-                sorted[a]
-                    .span
-                    .bbox
-                    .x
-                    .partial_cmp(&sorted[b].span.bbox.x)
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                crate::utils::safe_float_cmp(sorted[a].span.bbox.x, sorted[b].span.bbox.x)
             });
         }
 
@@ -544,15 +533,8 @@ impl PlainTextConverter {
                 let ya = a.span.bbox.y;
                 let yb = b.span.bbox.y;
                 // Higher Y = higher on page = comes first in reading order
-                yb.partial_cmp(&ya)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    .then_with(|| {
-                        a.span
-                            .bbox
-                            .x
-                            .partial_cmp(&b.span.bbox.x)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    })
+                crate::utils::safe_float_cmp(yb, ya)
+                    .then_with(|| crate::utils::safe_float_cmp(a.span.bbox.x, b.span.bbox.x))
             });
 
             // Group orphans that share the same Y-line (within tolerance).

--- a/src/pipeline/ordered_span.rs
+++ b/src/pipeline/ordered_span.rs
@@ -332,13 +332,7 @@ impl OrderedSpans {
         }
 
         let mut sorted: Vec<_> = self.spans.iter().collect();
-        sorted.sort_by(|a, b| {
-            b.span
-                .bbox
-                .y
-                .partial_cmp(&a.span.bbox.y)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        sorted.sort_by(|a, b| crate::utils::safe_float_cmp(b.span.bbox.y, a.span.bbox.y));
 
         let mut lines: Vec<Vec<&OrderedTextSpan>> = Vec::new();
         let mut current_line: Vec<&OrderedTextSpan> = vec![sorted[0]];

--- a/src/pipeline/reading_order/detectors.rs
+++ b/src/pipeline/reading_order/detectors.rs
@@ -137,13 +137,13 @@ pub fn detect_dense_single_line(glyphs: &[DetectorGlyph]) -> bool {
         .filter(|g| (g.y * 2.0).round() as i32 == dominant_key)
         .map(|g| g.x)
         .collect();
-    xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    xs.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
     let mut gaps: Vec<f32> = xs.windows(2).map(|w| w[1] - w[0]).collect();
     if gaps.is_empty() {
         return false;
     }
     let max_gap = gaps.iter().cloned().fold(0.0f32, f32::max);
-    gaps.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    gaps.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
     let median_gap = gaps[gaps.len() / 2];
     // Bimodal: one gap is much larger than the typical (median)
     // intra-glyph gap. Ratio > 4 catches the SEC DEF 14A case
@@ -201,7 +201,7 @@ pub fn detect_narrow_tracked(glyphs: &[DetectorGlyph]) -> bool {
     }
     // Sort an index vector by X instead of cloning the glyph slice.
     let mut order: Vec<usize> = (0..glyphs.len()).collect();
-    order.sort_by(|&a, &b| glyphs[a].x.partial_cmp(&glyphs[b].x).unwrap());
+    order.sort_by(|&a, &b| crate::utils::safe_float_cmp(glyphs[a].x, glyphs[b].x));
     let mut gaps: Vec<f32> = order
         .windows(2)
         .map(|w| {
@@ -212,7 +212,7 @@ pub fn detect_narrow_tracked(glyphs: &[DetectorGlyph]) -> bool {
     if gaps.is_empty() {
         return false;
     }
-    gaps.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    gaps.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
     // Median gap.
     let median = gaps[gaps.len() / 2];
     // Expected intra-word gap for proportional font @ avg font_size:

--- a/src/pipeline/reading_order/tategaki.rs
+++ b/src/pipeline/reading_order/tategaki.rs
@@ -19,12 +19,10 @@ use super::{ReadingOrderContext, ReadingOrderStrategy};
 /// Right-to-left, top-to-bottom reading order for vertical writing
 /// (CJK tategaki).
 ///
-/// Algorithm: cluster spans into columns by X-center proximity (using
-/// the median span width as the tolerance — wide enough to keep glyphs
-/// of one body column together, narrow enough to separate adjacent
-/// columns). Sort primarily by descending X-center (right column first)
-/// and secondarily by descending Y (PDF user space y increases upward,
-/// so descending y means top-first within a column).
+/// Delegates to [`crate::utils::sort_vertical_tategaki`]: spans are
+/// clustered into columns by X-center proximity (median span width as
+/// the tolerance), then ordered rightmost column first, top-to-bottom
+/// within each column.
 pub struct TategakiStrategy;
 
 impl ReadingOrderStrategy for TategakiStrategy {
@@ -37,33 +35,14 @@ impl ReadingOrderStrategy for TategakiStrategy {
             return Ok(Vec::new());
         }
 
-        // Median span width as the per-column-clustering tolerance.
-        // Robust to outliers from rotated annotations / single-glyph
-        // ruby annotations.
-        let mut widths: Vec<f32> = spans.iter().map(|s| s.bbox.width.max(1.0)).collect();
-        widths.sort_by(|a, b| crate::utils::safe_float_cmp(*a, *b));
-        let median_w = widths[widths.len() / 2].max(1.0);
-        let tol = median_w;
+        // See `crate::utils::sort_vertical_tategaki` for the median-width
+        // column clustering and the total-order rationale (issue #807).
+        let sorted = crate::utils::sort_vertical_tategaki(spans, |s| &s.bbox);
 
-        let mut indexed: Vec<(usize, TextSpan)> = spans.into_iter().enumerate().collect();
-        let x_center = |s: &TextSpan| -> f32 { s.bbox.x + s.bbox.width * 0.5 };
-
-        indexed.sort_by(|(_, a), (_, b)| {
-            let ax = x_center(a);
-            let bx = x_center(b);
-            if (ax - bx).abs() <= tol {
-                // Same column: top first (PDF user space — descending y).
-                crate::utils::safe_float_cmp(b.bbox.y, a.bbox.y)
-            } else {
-                // Different columns: rightmost first (descending x_center).
-                crate::utils::safe_float_cmp(bx, ax)
-            }
-        });
-
-        Ok(indexed
+        Ok(sorted
             .into_iter()
             .enumerate()
-            .map(|(order, (_, span))| {
+            .map(|(order, span)| {
                 OrderedTextSpan::with_info(span, order, ReadingOrderInfo::simple())
             })
             .collect())
@@ -107,6 +86,50 @@ mod tests {
         let ordered = strategy.apply(spans, &context).unwrap();
         let combined: String = ordered.iter().map(|o| o.span.text.as_str()).collect();
         assert_eq!(combined, "ABCDEF");
+    }
+
+    /// Regression for issue #807: X-centers that chain within the cluster
+    /// tolerance (each neighbor ≤ tol apart, endpoints far apart) made the
+    /// old banded comparator non-transitive, and `slice::sort_by` panicked
+    /// with "user-provided comparison function does not correctly implement
+    /// a total order". The chained centers form one column under
+    /// single-linkage clustering, so the output must be top-to-bottom.
+    #[test]
+    fn tategaki_chained_centers_total_order() {
+        // Width 12 → tol (median width) = 12; center step 10 < tol chains
+        // all 64 spans; the extreme centers are 630 apart (≫ tol).
+        let spans: Vec<TextSpan> = (0..64)
+            .map(|i| {
+                let x = i as f32 * 10.0;
+                let y = ((i * 37) % 64) as f32 * 7.0; // distinct, scrambled
+                mk(&format!("s{i}"), x, y)
+            })
+            .collect();
+        let strategy = TategakiStrategy;
+        let context = ReadingOrderContext::new();
+        let ordered = strategy.apply(spans, &context).unwrap();
+        assert_eq!(ordered.len(), 64);
+        let ys: Vec<f32> = ordered.iter().map(|o| o.span.bbox.y).collect();
+        assert!(
+            ys.windows(2).all(|w| w[0] >= w[1]),
+            "chained centers must read as one column, top-to-bottom: {ys:?}"
+        );
+    }
+
+    /// Non-finite coordinates must not panic the sort (total order holds
+    /// for NaN too) and every span must survive.
+    #[test]
+    fn tategaki_nan_coordinates_do_not_panic() {
+        let mut spans: Vec<TextSpan> = (0..32)
+            .map(|i| mk(&format!("s{i}"), (i % 8) as f32 * 10.0, i as f32 * 5.0))
+            .collect();
+        spans[3].bbox.x = f32::NAN;
+        spans[11].bbox.y = f32::NAN;
+        spans[17].bbox.width = f32::NAN;
+        let strategy = TategakiStrategy;
+        let context = ReadingOrderContext::new();
+        let ordered = strategy.apply(spans, &context).unwrap();
+        assert_eq!(ordered.len(), 32);
     }
 
     /// A single column produces a top-down sequence.

--- a/src/rendering/blend_nonsep.rs
+++ b/src/rendering/blend_nonsep.rs
@@ -204,7 +204,7 @@ fn set_sat(c: (f32, f32, f32), s: f32) -> (f32, f32, f32) {
     let (r, g, b) = c;
     // Sort channels by value, tracking original positions.
     let mut chans = [(r, 0u8), (g, 1u8), (b, 2u8)];
-    chans.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    chans.sort_by(|a, b| crate::utils::safe_float_cmp(a.0, b.0));
 
     let (cmin, cmid, cmax) = (chans[0].0, chans[1].0, chans[2].0);
     let (imin, imid, imax) = (chans[0].1, chans[1].1, chans[2].1);

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -231,7 +231,7 @@ fn detect_gutter_x(body: &[&TextSpan], page_width: f32) -> Option<f32> {
     if boxes.len() < 4 {
         return None;
     }
-    boxes.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    boxes.sort_by(|a, b| crate::utils::safe_float_cmp(a.0, b.0));
 
     // Sweep-merge the extents left-to-right; the widest forward jump between the
     // running right edge and the next span's left edge is the widest empty


### PR DESCRIPTION
## Description

**What this fixes:** text extraction hard-panics on PDFs with vertical (tategaki) text, aborting the whole page/document:

```
thread panicked: user-provided comparison function does not correctly implement a total order
```

Affected pages: ≥50% vertical-mode spans (`wmode = 1`, `Identity-V` fonts) — in practice scanned pages with vertical CJK OCR text layers and typeset vertical-Japanese books. Fixes #807.

**The bug:** the tategaki reading-order comparator decides "same column" with `(ax - bx).abs() <= tol` *inside* the comparator. Closeness isn't transitive (A≈B, B≈C, but A≉C), so when X-centers chain, the comparator contradicts itself and Rust ≥ 1.81 detects it and panics. The comparator is copy-pasted in three places, each reachable through a different API:

| copy | reached via |
|------|-------------|
| `extractors/text.rs` — `sort_spans_vertical_tategaki` | `extract_text`, `extract_spans` |
| `document.rs` — `postprocess_spans` tategaki intercept | `extract_spans` post-processing |
| `pipeline/reading_order/tategaki.rs` — `TategakiStrategy` | `extract_words`, `extract_tables` |

**The fix:**

- All three sites now delegate to one new helper, `utils::sort_vertical_tategaki`, which computes column membership *before* sorting: cluster X-centers by single-linkage (gap > median span width starts a new column — the same tolerance as before), then sort by `(column, Y descending)`. That's a genuine total order, so the panic is impossible by construction.
- Ordering on well-separated columns (normal tategaki) is byte-identical to before; chained centers — previously undefined behavior/panic — now deterministically read as one column, top-to-bottom.
- Crate-wide sweep: the remaining `partial_cmp().unwrap()` / `.unwrap_or(Equal)` sort comparators (same defect class, but only misbehave when NaN is present) are converted to the existing NaN-safe `safe_float_cmp`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #807

## Changes Made

- New `utils::sort_vertical_tategaki` (cluster-then-sort, total order) replacing the three copy-pasted tolerance-band comparators
- Crate-wide sweep of NaN-unsafe float sort comparators to `safe_float_cmp`
- Regression tests: chained-center tategaki ordering (previously panicked) in `extractors/text.rs` and `TategakiStrategy`, NaN-coordinate safety, plus unit tests for the new helper

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [x] I have run `cargo test --all-features`
- [x] I have run `cargo clippy -- -D warnings`
- [x] I have run `cargo fmt`

Verified end-to-end against both originally-reported documents (each crashes through a *different* comparator copy — one via `extract_text`, one only via `extract_words`), three public vertical-Japanese PDFs, and the hand-built `Identity-V` repro from #807. All panic on 0.3.72 and extract cleanly with this fix via `extract_text`, `extract_page_text_with_options(ColumnAware)`, and `extract_words`.

## Python Bindings (if applicable)

- [ ] Not applicable — no public API change (the helper is `pub(crate)`)

## Documentation

- [x] Code comments updated (`TategakiStrategy` docs, helper rustdoc)
- [ ] CHANGELOG.md — left for the release flow, following the existing per-release entry convention

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)
