### PR TITLE
fix: subscript index digits in scientific PDFs extract as decimals (#816)

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -4637,11 +4637,20 @@ impl<'doc> TextExtractor<'doc> {
             // gaps was being mangled into "201.3", losing the year token from
             // word-F1 scoring. Real "$123 _ 45" split-box layouts always have
             // a gap > ~half the font size; tight letter spacing is < 0.1 em.
+            //
+            // The gap also needs an upper ceiling. In scientific and math
+            // PDFs, subscript index pairs like `P_{1,0}` draw the two subscript
+            // digits in a smaller font (~7pt) spaced ~1.5-1.7x the font size
+            // apart; too loose a ceiling lets the rule fire and invent a
+            // decimal ("1" + "0" -> "1.0"). Genuine split-box amounts cluster
+            // near ~0.8-1.0x the font size, so a 1.3x ceiling separates real
+            // integer/cents boxes from widely-spaced subscripts.
             let min_decimal_gap = current.font_size * 0.4;
+            let max_decimal_gap = current.font_size * 1.3;
             let decimal_merge = same_line
                 && same_mcid
                 && gap > min_decimal_gap
-                && gap < current.font_size * 2.0
+                && gap < max_decimal_gap
                 && !current.text.is_empty()
                 && !span.text.is_empty()
                 && current.text.chars().all(|c| c.is_ascii_digit())
@@ -16381,6 +16390,162 @@ mod profile_based_space_tests {
             2,
             "3-digit decimal part should not trigger decimal merge"
         );
+    }
+
+    #[test]
+    fn test_no_decimal_merge_for_wide_subscript_digits() {
+        // Subscript index pairs (e.g. `P_{1,0}` in scientific PDFs) draw the
+        // two subscript digits in a smaller font (~7pt) spaced far apart
+        // (~1.5-1.7x the font size). The decimal-merge rule was joining them
+        // into an invented decimal ("1" + "0" -> "1.0"). A real split-box
+        // dollar amount clusters near ~0.8-1.0x the font size, so a wide gap is
+        // not an integer/cents amount and must stay separate.
+        let mut extractor = TextExtractor::new();
+        extractor.merging_config = SpanMergingConfig::legacy();
+
+        // 7pt subscript digits: "1" at x=100.0 (w=3.5), "0" at x=114.5 (w=3.5).
+        // gap = 114.5 - (100.0 + 3.5) = 11.0pt -> 11.0 / 7.0 = 1.57x font size.
+        extractor.spans = vec![
+            TextSpan {
+                text_rise: 0.0,
+                artifact_type: None,
+                text: "1".to_string(),
+                bbox: Rect::new(100.0, 700.0, 3.5, 7.0),
+                font_name: "F1".to_string(),
+                font_size: 7.0,
+                font_weight: FontWeight::Normal,
+                color: Color::black(),
+                mcid: None,
+                mcid_scope: None,
+                sequence: 0,
+                split_boundary_before: false,
+                offset_semantic: false,
+                is_italic: false,
+                is_monospace: false,
+                char_spacing: 0.0,
+                word_spacing: 0.0,
+                horizontal_scaling: 100.0,
+                primary_detected: false,
+                char_widths: vec![],
+                char_x_offsets: Vec::new(),
+                heading_level: None,
+                rotation_degrees: 0.0,
+                wmode: 0,
+                rtl_draw_logical: false,
+            },
+            TextSpan {
+                text_rise: 0.0,
+                artifact_type: None,
+                text: "0".to_string(),
+                bbox: Rect::new(114.5, 700.0, 3.5, 7.0), // 11.0pt gap = 1.57x font
+                font_name: "F1".to_string(),
+                font_size: 7.0,
+                font_weight: FontWeight::Normal,
+                color: Color::black(),
+                mcid: None,
+                mcid_scope: None,
+                sequence: 1,
+                split_boundary_before: false,
+                offset_semantic: false,
+                is_italic: false,
+                is_monospace: false,
+                char_spacing: 0.0,
+                word_spacing: 0.0,
+                horizontal_scaling: 100.0,
+                primary_detected: false,
+                char_widths: vec![],
+                char_x_offsets: Vec::new(),
+                heading_level: None,
+                rotation_degrees: 0.0,
+                wmode: 0,
+                rtl_draw_logical: false,
+            },
+        ];
+
+        extractor.merge_adjacent_spans();
+        // Widely-spaced subscript digits must NOT be joined into a decimal.
+        assert_eq!(
+            extractor.spans.len(),
+            2,
+            "Widely-spaced subscript digits should not merge into a decimal value"
+        );
+        assert!(
+            !extractor.spans.iter().any(|s| s.text.contains('.')),
+            "No invented decimal point should appear between subscript digits"
+        );
+    }
+
+    #[test]
+    fn test_decimal_merge_just_under_ceiling_still_joins() {
+        // The ceiling that stops subscripts must not be so tight that it drops
+        // genuine split-box amounts. Real amounts cluster near ~0.8-1.0x the
+        // font size; this locks the ceiling by proving an amount at ~1.2x the
+        // font size (just under the 1.3x cap) still merges.
+        let mut extractor = TextExtractor::new();
+        extractor.merging_config = SpanMergingConfig::legacy();
+
+        // 12pt digits: "1234" at x=200.0 (w=24.0), "56" at x=238.4 (w=12.0).
+        // gap = 238.4 - (200.0 + 24.0) = 14.4pt -> 14.4 / 12.0 = 1.2x font size.
+        extractor.spans = vec![
+            TextSpan {
+                text_rise: 0.0,
+                artifact_type: None,
+                text: "1234".to_string(),
+                bbox: Rect::new(200.0, 700.0, 24.0, 12.0),
+                font_name: "F1".to_string(),
+                font_size: 12.0,
+                font_weight: FontWeight::Normal,
+                color: Color::black(),
+                mcid: None,
+                mcid_scope: None,
+                sequence: 0,
+                split_boundary_before: false,
+                offset_semantic: false,
+                is_italic: false,
+                is_monospace: false,
+                char_spacing: 0.0,
+                word_spacing: 0.0,
+                horizontal_scaling: 100.0,
+                primary_detected: false,
+                char_widths: vec![],
+                char_x_offsets: Vec::new(),
+                heading_level: None,
+                rotation_degrees: 0.0,
+                wmode: 0,
+                rtl_draw_logical: false,
+            },
+            TextSpan {
+                text_rise: 0.0,
+                artifact_type: None,
+                text: "56".to_string(),
+                bbox: Rect::new(238.4, 700.0, 12.0, 12.0), // 14.4pt gap = 1.2x font
+                font_name: "F1".to_string(),
+                font_size: 12.0,
+                font_weight: FontWeight::Normal,
+                color: Color::black(),
+                mcid: None,
+                mcid_scope: None,
+                sequence: 1,
+                split_boundary_before: false,
+                offset_semantic: false,
+                is_italic: false,
+                is_monospace: false,
+                char_spacing: 0.0,
+                word_spacing: 0.0,
+                horizontal_scaling: 100.0,
+                primary_detected: false,
+                char_widths: vec![],
+                char_x_offsets: Vec::new(),
+                heading_level: None,
+                rotation_degrees: 0.0,
+                wmode: 0,
+                rtl_draw_logical: false,
+            },
+        ];
+
+        extractor.merge_adjacent_spans();
+        assert_eq!(extractor.spans.len(), 1, "Amount just under the ceiling should still merge");
+        assert_eq!(extractor.spans[0].text, "1234.56");
     }
 
     #[test]


### PR DESCRIPTION
## Description

In scientific and math PDFs, a subscript index pair like `P₁,₀` was extracting as `P1.0` — text extraction invented a decimal point between two subscript digits that the document never contained.

The cause is the decimal-merge rule in `src/extractors/text.rs`. It joins two adjacent pure-digit runs with a `.` to reassemble split-box dollar amounts, where a form prints the whole part and the cents in separate fixed-width boxes (`123456` + `72` → `123456.72`). The rule's upper gap bound was too loose: real split-box amounts sit about 0.8–1.0× the font size apart, but subscript index digits are drawn in a smaller font spaced about 1.5–1.7× apart, so the old `2.0×` ceiling let the rule fire and assert a decimal value. On the topology paper `tests/fixtures/1008.3918v2.pdf` this fired 28 times on the first affected page (`1.0`, `0.1`, `1.1`, …).

The fix tightens the ceiling from `2.0×` to `1.3×` the font size, which cleanly separates genuine integer/cents boxes from widely-spaced subscripts. The existing lower floor (`0.4×`, guarding against tightly-packed CJK glyphs) is unchanged. The change is geometric (gap versus font size), not linguistic, per the extraction rules in `AGENTS.md`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Tests
- [ ] CI/CD changes

## Related Issues

Fixes #816

## Changes Made

- Tighten the decimal-merge ceiling in `src/extractors/text.rs` from `2.0×` to `1.3×` the font size (named `max_decimal_gap`), so two widely-spaced digit runs are no longer joined into a decimal point.
- Add `test_no_decimal_merge_for_wide_subscript_digits` — two 7pt digit spans ~1.57× the font size apart must stay separate.
- Add `test_decimal_merge_just_under_ceiling_still_joins` — a genuine amount at ~1.2× the font size (just under the cap) still merges to `1234.56`, locking the ceiling from the other side.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass locally
- [ ] I have run `cargo test --all-features` — not runnable in this repo: the `fips` feature is mutually exclusive with the default `legacy-crypto` (compile-time error). Ran the project's canonical `make test-rust` (`cargo test --features python`) instead → **5996 passed, 0 failed**.
- [x] I have run `cargo clippy -- -D warnings` — via `make lint` (`cargo clippy --features python -- -D warnings`); clean, no new warnings.
- [x] I have run `cargo fmt`

## Python Bindings (if applicable)

Not applicable — this is a fix inside the Rust text-extraction core. No binding code changed; every language binding picks up the corrected output through the shared `extract_text` path, with no API-surface change.

## Documentation

- [x] I have updated the documentation (README, docs/, code comments) — added explaining comments at the changed rule and both new tests.
- [ ] I have added/updated examples (if applicable) — n/a.
- [ ] I have updated CHANGELOG.md — deferred to release: the CHANGELOG has no `[Unreleased]` section and its latest section (`0.3.73`) is already released and dated, so this fix is folded into the next release notes by a maintainer (see *Additional Notes*).

## Checklist

- [x] My code follows the project's coding guidelines (see CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] The PR title follows conventional commits format (e.g., `feat:`, `fix:`, `docs:`)

## Screenshots (if applicable)

Not applicable — library/CLI change with no visual output.

## Additional Notes

- **Relationship to #814:** the #814 review confirmed this ceiling fixes the wide-gap band (1.3-2.0x) and that narrow-gap comma-separated pairs need a second signal; #814 now carries that signal (an intervening-glyph check in the same `decimal_merge` block). The two changes compose but touch the same lines, so whichever lands second needs a small rebase - I'll handle it.
- **Scope:** two production lines plus two unit tests, confined to `src/extractors/text.rs`. No type, enum, FFI, config, or public-API surface is touched, so no binding needs updating.
- **Corpus regression:** this rule serves real-world split-box forms, so the change should be re-checked against the full corpus-regression sweep (`scripts/regression_harness.py`) before release. That sweep depends on an external PDF corpus not part of this repo, so a maintainer with corpus access should run it.
- **DCO:** the commit carries a `Signed-off-by` trailer as required by CONTRIBUTING.md.

<!-- CI_TABLE -->
## CI Status

CI on fork PRs needs maintainer approval, so I ran the **full workflow matrix on my fork** against the exact commit in this PR (`4ec51844`): **[tobocop2/pdf_oxide#2](https://github.com/tobocop2/pdf_oxide/pull/2)**. Auto-updated 14:30 UTC.

Legend: 🟢 pass · 🔴 fail (this PR) · 🟠 fail (pre-existing) · ⚪ running/queued · ⚫ skipped

| Workflow | |
|---|:--:|
| C++ Bindings CI | 🟢 |
| CI | 🟠 |
| Changelog Gate | 🟢 |
| Clojure Bindings CI | 🟢 |
| Dart Bindings CI | 🟢 |
| Elixir Bindings CI | 🟢 |
| FIPS CryptoProvider CI | 🟢 |
| Julia Bindings CI | 🟢 |
| Kotlin Bindings CI | 🟢 |
| Objective-C Bindings CI | 🟢 |
| PHP Bindings CI | 🟢 |
| Python Bindings CI | 🟢 |
| R Bindings CI | 🟢 |
| Release | ⚫ |
| Release (FIPS variant) | 🟢 |
| Ruby Bindings CI | 🟠 |
| Scala Bindings CI | 🟢 |
| Swift Bindings CI | 🟢 |
| Version Consistency | 🟢 |
| Zig Bindings CI | 🟢 |

**🟠 Pre-existing (not caused by this PR):** `CI`, `Ruby Bindings CI` — unrelated to this text-extraction change.
Both are **dependency-advisory scanners**, not code/build/test failures. In `CI` only the **Dependency Check (cargo-deny)** and **Security Audit** jobs are red — every code job passes: `Format Check`, `Clippy`, `Feature Tests`, `Feature Tests (python)`, `Code Coverage`, `MSRV build`, and the full `Build lib` / CLI / MCP / Go / Java / C# / Node.js matrix. `Ruby Bindings CI` is red on the same **Security audit** job. They flag advisories in transitive deps (e.g. [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) in `crossbeam-epoch` via `rayon`, plus `rsa`/Marvin); this PR does not touch `Cargo.lock` / `Gemfile.lock`, so they are pre-existing and clear with a dependency bump.
<!-- /CI_TABLE -->



































































































































































































































































































