### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
Unblocks all currently-open PRs: `main`'s branch protection requires the `Security Audit` and `Dependency Check (cargo-deny)` checks, and both are failing repo-wide since RUSTSEC-2026-0204 (invalid-pointer-dereference in `crossbeam-epoch`'s `fmt::Display` for `Atomic`/`Shared` when the underlying pointer is null) was published 2026-07-06 against the currently-pinned `crossbeam-epoch 0.9.18` (pulled in transitively via `rayon`).

## Fix
`cargo update -p crossbeam-epoch` → `0.9.18` → `0.9.20` (patched version). Confirmed via `--dry-run` and a full re-resolve that this is the *only* dependency that changes — no other lockfile churn, no `rayon` version bump needed.

## Testing
- `cargo check --lib` passes.
- No source code changes — `Cargo.lock` only.