### PR TITLE
Fix Hebrew/Arabic OCR-sandwich text reversed in extract_text (#826)

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -1851,6 +1851,14 @@ struct TjBuffer {
     /// ratio so it is text/CTM-scale-independent and directly comparable to a
     /// font-size fraction by the sub/superscript rejoin.
     text_rise: f32,
+    /// Text render mode (`Tr`, ISO 32000-1 §9.3.6), captured from the
+    /// graphics state when the buffer started. `3`/`7` (invisible — neither
+    /// filled nor stroked) means this run has no rendering-correctness
+    /// pressure: an OCR-sandwich producer has no visual reason to mirror
+    /// already-logical RTL glyph positions the way a *visible*-text
+    /// producer would, so the geometric visual/logical detector's ascending-
+    /// x signal is uninformative here (#826) — see `bidi::apply_rtl_verdict`.
+    render_mode: u8,
 }
 
 /// Snap a run's display rotation (from the composed `CTM × T_m` rotation block,
@@ -1946,6 +1954,7 @@ impl TjBuffer {
             } else {
                 0.0
             },
+            render_mode: state.render_mode,
         }
     }
 
@@ -7001,22 +7010,43 @@ impl<'doc> TextExtractor<'doc> {
             .take()
             .unwrap_or_else(|| "Unknown".to_string());
 
-        // RTL text correction: if text contains RTL characters and spans left-to-right
-        // on the page, the characters are in visual LTR order. Reverse to logical order.
+        // RTL text correction (#826): use the confidence-gated geometric
+        // detector (#537) when `char_widths` gives us per-character user-space
+        // x-positions, falling back to the coarse "buffer's net horizontal
+        // advance is positive" heuristic only for genuinely ambiguous/short
+        // runs. Mirrors `flush_tj_span_buffer`'s handling — this used to be
+        // the one flush site still on the pre-#537 `accumulated_width > 0.0`
+        // check, which (since `accumulated_width` only ever sums *positive*
+        // glyph widths — TJ kerning offsets never subtract from it) is true
+        // for nearly every non-empty RTL buffer and so was unconditionally
+        // reversing every RTL run regardless of its actual source order.
         let mut text = std::mem::take(&mut buffer.unicode);
         if text.len() > 1 {
             let has_rtl = text
                 .chars()
                 .any(|c| crate::text::rtl_detector::is_rtl_text(c as u32));
             if has_rtl {
-                // In the tiebreaker path, characters are appended left-to-right in content
-                // stream order. For RTL scripts displayed right-to-left, this means the
-                // leftmost visual character (last logical character) is first in the buffer.
-                // Reverse to get logical reading order.
-                // Only reverse if user_pos_x indicates LTR placement (positive width).
-                if buffer.accumulated_width > 0.0 {
-                    text = crate::text::bidi::reverse_rtl_keep_numbers(&text);
-                }
+                let chars: Vec<char> = text.chars().collect();
+                let verdict = if chars.len() == buffer.char_widths.len()
+                    && !buffer.char_widths.is_empty()
+                {
+                    let mut chars_with_x: Vec<(char, f32)> = Vec::with_capacity(chars.len());
+                    let mut cursor_text_space = 0.0_f32;
+                    for (i, c) in chars.iter().enumerate() {
+                        let user_x = buffer.user_pos_x + cursor_text_space * buffer.user_h_scale;
+                        chars_with_x.push((*c, user_x));
+                        cursor_text_space += buffer.char_widths[i];
+                    }
+                    crate::text::bidi::detect_visual_order_run(&chars_with_x)
+                } else {
+                    crate::text::bidi::RunOrder::Ambiguous
+                };
+                text = crate::text::bidi::apply_rtl_verdict(
+                    &text,
+                    verdict,
+                    buffer.accumulated_width > 0.0,
+                    matches!(buffer.render_mode, 3 | 7),
+                );
             }
         }
 
@@ -7497,34 +7527,25 @@ impl<'doc> TextExtractor<'doc> {
                     }
                 }
                 let verdict = crate::text::bidi::detect_visual_order_run(&chars_with_x);
-                match verdict {
-                    crate::text::bidi::RunOrder::Visual => {
-                        // Confidence-gated visual-order detection — reverse.
-                        unicode_text = crate::text::bidi::reverse_rtl_keep_numbers(&unicode_text);
-                    },
-                    crate::text::bidi::RunOrder::Logical => {
-                        // Confidence-gated logical-order — leave alone.
-                        // The pdfium `hebrew_mirrored.pdf` test fixture
-                        // and similar lands here.
-                    },
-                    crate::text::bidi::RunOrder::Ambiguous => {
-                        // Short cluster or mixed signal — fall back to
-                        // the pre-v0.3.54 simple heuristic so existing
-                        // 2-3-char RTL runs keep working.
-                        let first_x = {
-                            let p = text_matrix.transform_point(cluster[0].x_position, 0.0);
-                            ctm.transform_point(p.x, p.y).x
-                        };
-                        let last_x = {
-                            let p = text_matrix.transform_point(last.x_position, 0.0);
-                            ctm.transform_point(p.x, p.y).x
-                        };
-                        if last_x > first_x {
-                            unicode_text =
-                                crate::text::bidi::reverse_rtl_keep_numbers(&unicode_text);
-                        }
-                    },
-                }
+                // Pre-v0.3.54 simple heuristic — used only as the
+                // `Ambiguous` fallback (short cluster or mixed signal) so
+                // existing 2-3-char RTL runs keep working; the pdfium
+                // `hebrew_mirrored.pdf` fixture and similar land on
+                // `Logical` above and are left alone regardless.
+                let first_x = {
+                    let p = text_matrix.transform_point(cluster[0].x_position, 0.0);
+                    ctm.transform_point(p.x, p.y).x
+                };
+                let last_x = {
+                    let p = text_matrix.transform_point(last.x_position, 0.0);
+                    ctm.transform_point(p.x, p.y).x
+                };
+                unicode_text = crate::text::bidi::apply_rtl_verdict(
+                    &unicode_text,
+                    verdict,
+                    last_x > first_x,
+                    matches!(state.render_mode, 3 | 7),
+                );
             }
         }
 
@@ -8370,27 +8391,21 @@ impl<'doc> TextExtractor<'doc> {
                     .take()
                     .unwrap_or_else(|| "Unknown".to_string());
 
-                // #537: RTL visual-order detection for the Tj-span
-                // path. This was the gap on the Magic Palace Eilat Hebrew
-                // PDF — the Tj-span buffer flush had no RTL correction at
-                // all, so Hebrew came out in content-stream (visual)
-                // order regardless of what the geometric signals said.
-                // Mirrors the existing logic in `flush_tj_buffer`
-                // `cluster_to_span`: detect RTL content, use the geometric
-                // detector when `char_widths` give us per-char x; fall back
-                // to the `accumulated_width > 0` simple check (text drawn
-                // left-to-right in user space → visual order → reverse).
+                // #537/#826: RTL visual-order detection for the Tj-span
+                // path, via the shared `apply_rtl_verdict` decision point
+                // (also used by `flush_tj_buffer` and `cluster_to_span`) —
+                // geometric detector when `char_widths` give us per-char x,
+                // falling back to the coarse `accumulated_width > 0`
+                // heuristic only when ambiguous.
                 let mut text = std::mem::take(&mut buffer.unicode);
                 if text.len() > 1 {
                     let has_rtl = text
                         .chars()
                         .any(|c| crate::text::rtl_detector::is_rtl_text(c as u32));
                     if has_rtl {
-                        // Try the geometric detector first when char_widths
-                        // give us per-character X positions. char_widths
-                        // contains text-space relative widths; reconstruct
-                        // absolute user-space x by accumulating, scaling by
-                        // user_h_scale and offsetting by user_pos_x.
+                        // char_widths contains text-space relative widths;
+                        // reconstruct absolute user-space x by accumulating,
+                        // scaling by user_h_scale and offsetting by user_pos_x.
                         let chars: Vec<char> = text.chars().collect();
                         let verdict = if chars.len() == buffer.char_widths.len()
                             && !buffer.char_widths.is_empty()
@@ -8408,23 +8423,12 @@ impl<'doc> TextExtractor<'doc> {
                         } else {
                             crate::text::bidi::RunOrder::Ambiguous
                         };
-                        match verdict {
-                            crate::text::bidi::RunOrder::Visual => {
-                                text = crate::text::bidi::reverse_rtl_keep_numbers(&text);
-                            },
-                            crate::text::bidi::RunOrder::Logical => {
-                                // Detected logical order — leave alone.
-                            },
-                            crate::text::bidi::RunOrder::Ambiguous => {
-                                // Fall back to the simple `accumulated_width
-                                // > 0` heuristic used elsewhere — text drawn
-                                // left-to-right in text space implies visual
-                                // order for RTL scripts.
-                                if buffer.accumulated_width > 0.0 {
-                                    text = crate::text::bidi::reverse_rtl_keep_numbers(&text);
-                                }
-                            },
-                        }
+                        text = crate::text::bidi::apply_rtl_verdict(
+                            &text,
+                            verdict,
+                            buffer.accumulated_width > 0.0,
+                            matches!(buffer.render_mode, 3 | 7),
+                        );
                     }
                 }
 

--- a/src/text/bidi.rs
+++ b/src/text/bidi.rs
@@ -362,6 +362,89 @@ pub(crate) fn detect_visual_order_run(chars_with_x: &[(char, f32)]) -> RunOrder 
     RunOrder::Ambiguous
 }
 
+/// Single decision point for "given this [`RunOrder`] verdict (from
+/// [`detect_visual_order_run`]), should this flushed RTL run be reversed
+/// to logical order?" — shared by every `Tj`/`TJ` buffer-flush site
+/// (`flush_tj_buffer`, `flush_tj_span_buffer`, `cluster_to_span` in
+/// `extractors/text.rs`).
+///
+/// Before this existed, each flush site independently re-implemented the
+/// identical three-way `match` on the verdict — and one site
+/// (`flush_tj_buffer`, the default `WordBoundaryMode::Tiebreaker` path)
+/// never called the geometric detector at all, only its coarse fallback.
+/// That fallback (`accumulated_width > 0.0`, a sum of *only positive*
+/// glyph advance widths — TJ kerning offsets never subtract from it) is
+/// true for nearly every non-empty RTL buffer, so that site was
+/// unconditionally reversing every RTL run it flushed rather than
+/// detecting direction at all (issue #826: an already-logical-order OCR
+/// word got wrongly flipped, and the flipped-but-still-pure-Hebrew word
+/// then had its span order *also* reversed by
+/// `document::PdfDocument::reverse_rtl_visual_order_runs`, compounding
+/// into a full mirror image of the correct line).
+///
+/// Callers remain responsible for deciding whether they have usable
+/// per-character geometry to hand `detect_visual_order_run` (that gating
+/// differs slightly per site — e.g. `cluster_to_span` tolerates a
+/// `chars_with_x` shorter than the decoded text on ligature expansion)
+/// and for computing `coarse_visual_order_heuristic`, the best coarse
+/// direction signal available (e.g. "buffer's net horizontal advance is
+/// positive" / "last glyph's x > first glyph's x") for the genuinely
+/// [`RunOrder::Ambiguous`] case (short runs, sparse geometry).
+///
+/// `is_invisible_render_mode` — was this run drawn with text render mode
+/// `3`/`7` (ISO 32000-1 §9.3.6, "neither fill nor stroke" — the mode
+/// OCR-sandwich text layers use so the recognized text is searchable but
+/// the original scan stays the only visible thing)? Both `verdict` and
+/// `coarse_visual_order_heuristic` are built on the same premise —
+/// glyphs placed at *ascending* x are visual order, *descending* x are
+/// logical order — which only holds when the producer has
+/// rendering-correctness pressure to mirror already-logical RTL content
+/// so it *looks* right on the page. Invisible text has no such pressure:
+/// a competent OCR engine (the modern default — Tesseract's LSTM model,
+/// cloud OCR APIs) outputs correct per-word logical Unicode but has no
+/// reason to also mirror the invisible glyph *positions*, so it places
+/// them at plain ascending x — geometrically identical to genuinely
+/// visual-order content. Neither `verdict` nor the coarse fallback can
+/// tell the two apart in that case (issue #826: this was exactly why
+/// wiring the geometric detector into every flush site alone didn't fix
+/// the bug — an already-correct OCR word was still being flipped). When
+/// `true`, skip both signals entirely and trust the extracted content
+/// order as-is — the modern-OCR prior plus this crate's own stated
+/// design principle (`detect_visual_order_run`'s doc: "the cost of an
+/// unwarranted reversal is higher than the cost of a missed reversal")
+/// both favor not reversing when the signal is this unreliable.
+/// Cross-word reading order for invisible OCR lines is still corrected
+/// separately, by the span-position-based reading-order sort and
+/// `document::PdfDocument::reverse_rtl_visual_order_runs` Pass 0.5, which
+/// this function has no bearing on.
+///
+/// Known accepted trade-off: an invisible OCR layer from a genuinely
+/// non-language-aware/legacy engine that emits *visual*-order Unicode
+/// will no longer get auto-reversed — today it coincidentally does, for
+/// the same ascending-x-is-uninformative reason #826 mis-fires. This is
+/// a deliberate choice favoring the now-dominant case.
+pub(crate) fn apply_rtl_verdict(
+    text: &str,
+    verdict: RunOrder,
+    coarse_visual_order_heuristic: bool,
+    is_invisible_render_mode: bool,
+) -> String {
+    if is_invisible_render_mode {
+        return text.to_string();
+    }
+    match verdict {
+        RunOrder::Visual => reverse_rtl_keep_numbers(text),
+        RunOrder::Logical => text.to_string(),
+        RunOrder::Ambiguous => {
+            if coarse_visual_order_heuristic {
+                reverse_rtl_keep_numbers(text)
+            } else {
+                text.to_string()
+            }
+        },
+    }
+}
+
 /// Unicode bidi-isolation markers (UAX #9 §2.4).
 ///
 /// These four code points isolate a directional run from the

--- a/tests/rtl_ocr_multiscript_regression.rs
+++ b/tests/rtl_ocr_multiscript_regression.rs
@@ -158,11 +158,39 @@ const WORDS: &[(&str, bool, &str, f32, f32, &str)] = &[
     ("spa", false, "060104030705", 336.00, 708.00, "\u{a1}Hola!"),
     ("fra", false, "0804090A040B0C05", 36.00, 636.00, "Bonjour!"),
     ("deu", false, "0D0C0E0F100D04111105", 336.00, 636.00, "Gr\u{fc}\u{df} Gott!"),
-    ("rus", false, "12131415161705", 36.00, 564.00, "\u{41f}\u{440}\u{438}\u{432}\u{435}\u{442}!"),
-    ("ell", false, "18191A1B101C1D1E05", 336.00, 564.00, "\u{393}\u{3b5}\u{3b9}\u{3ac} \u{3c3}\u{3bf}\u{3c5}!"),
+    (
+        "rus",
+        false,
+        "12131415161705",
+        36.00,
+        564.00,
+        "\u{41f}\u{440}\u{438}\u{432}\u{435}\u{442}!",
+    ),
+    (
+        "ell",
+        false,
+        "18191A1B101C1D1E05",
+        336.00,
+        564.00,
+        "\u{393}\u{3b5}\u{3b9}\u{3ac} \u{3c3}\u{3bf}\u{3c5}!",
+    ),
     ("chi_sim", false, "1F2122", 36.00, 492.00, "\u{4f60}\u{597d}\u{ff01}"),
-    ("jpn", false, "232425262722", 336.00, 492.00, "\u{3053}\u{3093}\u{306b}\u{3061}\u{306f}\u{ff01}"),
-    ("kor", false, "28292A2B2C05", 36.00, 420.00, "\u{c548}\u{b155}\u{d558}\u{c138}\u{c694}!"),
+    (
+        "jpn",
+        false,
+        "232425262722",
+        336.00,
+        492.00,
+        "\u{3053}\u{3093}\u{306b}\u{3061}\u{306f}\u{ff01}",
+    ),
+    (
+        "kor",
+        false,
+        "28292A2B2C05",
+        36.00,
+        420.00,
+        "\u{c548}\u{b155}\u{d558}\u{c138}\u{c694}!",
+    ),
     ("tur", false, "2D020C2E072F0705", 336.00, 420.00, "Merhaba!"),
     (
         "hin",
@@ -172,7 +200,14 @@ const WORDS: &[(&str, bool, &str, f32, f32, &str)] = &[
         348.00,
         "\u{928}\u{92e}\u{938}\u{94d}\u{924}\u{947}!",
     ),
-    ("ara", true, "05363738393A", 336.00, 348.00, "!\u{645}\u{631}\u{62d}\u{628}\u{627}"),
+    (
+        "ara",
+        true,
+        "05363738393A",
+        336.00,
+        348.00,
+        "!\u{645}\u{631}\u{62d}\u{628}\u{627}",
+    ),
     ("heb", true, "3B3C3D3E", 36.00, 276.00, "\u{5e9}\u{5dc}\u{5d5}\u{5dd}"),
     ("por", false, "3F034005", 336.00, 276.00, "Ol\u{e1}!"),
     ("ita", false, "4142070405", 48.00, 204.00, "Ciao!"),
@@ -194,7 +229,14 @@ const WORDS: &[(&str, bool, &str, f32, f32, &str)] = &[
         60.00,
         "\u{3a7}\u{3b1}\u{3af}\u{3c1}\u{3b5}\u{3c4}\u{3b5}!",
     ),
-    ("ara", true, "055253543A55", 432.00, 60.00, "!\u{623}\u{647}\u{644}\u{627}\u{64b}"),
+    (
+        "ara",
+        true,
+        "055253543A55",
+        432.00,
+        60.00,
+        "!\u{623}\u{647}\u{644}\u{627}\u{64b}",
+    ),
 ];
 
 /// Untagged one-page PDF: a simple TrueType font (`/FirstChar 0`,
@@ -214,9 +256,7 @@ fn build_ocr_sandwich_pdf() -> Vec<u8> {
 
     let mut content_ops = String::new();
     for (_, _, hex, x, y, _) in WORDS {
-        content_ops.push_str(&format!(
-            "BT /F1 24 Tf 3 Tr 1 0 0 1 {x} {y} Tm [<{hex}>] TJ ET\n"
-        ));
+        content_ops.push_str(&format!("BT /F1 24 Tf 3 Tr 1 0 0 1 {x} {y} Tm [<{hex}>] TJ ET\n"));
     }
     let content_bytes = content_ops.as_bytes();
 

--- a/tests/rtl_ocr_multiscript_regression.rs
+++ b/tests/rtl_ocr_multiscript_regression.rs
@@ -1,0 +1,346 @@
+//! Automated regression test for the OCR-sandwich text-extraction flow
+//! across Hebrew, Arabic, and 16 other scripts — built from **real**
+//! OCR-engine-format data, not hand-invented text.
+//!
+//! Issue #826: a scanned Hebrew OCR PDF (invisible `Tr 3` text layer,
+//! simple TrueType font, one `TJ` array **per recognized word** placed at
+//! plain ascending x) extracted with every Hebrew word both
+//! letter-reversed and word-order-reversed. `tests/rtl_tj_array_word_buffer.rs`
+//! pins the exact minimal repro; this file is the broader regression
+//! guard — every script that shares the same buffer-flush code path
+//! (`flush_tj_buffer`, `WordBoundaryMode::Tiebreaker`, the default) run
+//! through text/markdown/HTML together, so a future change to that path
+//! can't silently regress one script while "fixing" another.
+//!
+//! This is the **per-word** OCR-sandwich shape (one show op per whole
+//! word). There is a distinct **per-glyph** shape (one show op per
+//! character — see PR#828 / `tests/rtl_ocr_multiscript_regression.rs`'s
+//! sibling repros under `~/projects/pdf_oxide_corpora/issue_826_repro/`)
+//! that this fix does **not** address — it lives in a different part of
+//! the pipeline (`merge_adjacent_spans`) and needs its own, separately
+//! render-mode-gated fix. Confirmed via the full 419-PDF corpus
+//! regression sweep that naively fixing the per-glyph shape (as PR#828
+//! currently does) regresses ordinary, non-OCR Hebrew/Arabic PDFs
+//! (Wikipedia-style exports) by reversing already-correct text — so this
+//! fix's scope is intentionally narrower: real bug, zero regressions.
+//!
+//! RTL (Hebrew/Arabic) coverage below is scoped to plain `extract_text`
+//! only — `to_markdown_all`/`to_html_all` route RTL through a *different*
+//! pass (`document.rs`'s `apply_rtl_logical_order_to_ordered_spans`) that
+//! is deliberately left unchanged for the same regression reason; see the
+//! per-format tests below for details.
+//!
+//! ## Provenance
+//!
+//! Word text + bounding-box data below is derived from
+//! `tests/resources/hello_world_scripts.hocr` in
+//! <https://github.com/ocrmypdf/OCRmyPDF> (MPL-2.0), a genuine hOCR
+//! fixture (Tesseract-format OCR engine output) OCRmyPDF's own test
+//! suite uses to validate its hOCR→PDF "invisible text sandwich"
+//! renderer — i.e. this is the real data shape a real OCR-sandwich tool
+//! consumes, not a synthetic approximation. Word content per script is
+//! already-correct, logical-order Unicode (a competent OCR engine's
+//! actual output); bounding boxes are converted from the fixture's
+//! pixel coordinates (300 DPI, 2550×3300px page) to PDF points.
+//!
+//! Placement here uses the plain-positive-advance-per-word convention —
+//! the shape issue #826's reporter described and the one that exposed
+//! the bug — rather than OCRmyPDF's own `-1`-x-scale trick (a separate,
+//! also-correct encoding some fpdf2-based renderers use to route around
+//! a ligature-shaping quirk in that specific library; both encodings
+//! must extract correctly, but only the plain form is exercised here).
+//!
+//! Confirmed straight from OCRmyPDF's renderer source
+//! (`src/ocrmypdf/fpdf_renderer/renderer.py`) that invisible RTL words
+//! are deliberately encoded "1:1 in logical order" precisely because,
+//! quote, "the text is invisible" so there is no rendering-correctness
+//! pressure to mirror glyph positions — the exact premise this fix's
+//! `bidi::apply_rtl_verdict` invisible-render-mode gating relies on.
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::PdfDocument;
+
+// Auto-generated from OCRmyPDF's hello_world_scripts.hocr (MPL-2.0,
+// github.com/ocrmypdf/OCRmyPDF/blob/main/tests/resources/hello_world_scripts.hocr).
+// 20 words, 84 unique codepoints, page 612.0x792.0pt (8.5x11in @ 300dpi).
+const TOUNICODE_BFCHARS: &str = "\
+<01> <0048>\n\
+<02> <0065>\n\
+<03> <006C>\n\
+<04> <006F>\n\
+<05> <0021>\n\
+<06> <00A1>\n\
+<07> <0061>\n\
+<08> <0042>\n\
+<09> <006E>\n\
+<0A> <006A>\n\
+<0B> <0075>\n\
+<0C> <0072>\n\
+<0D> <0047>\n\
+<0E> <00FC>\n\
+<0F> <00DF>\n\
+<10> <0020>\n\
+<11> <0074>\n\
+<12> <041F>\n\
+<13> <0440>\n\
+<14> <0438>\n\
+<15> <0432>\n\
+<16> <0435>\n\
+<17> <0442>\n\
+<18> <0393>\n\
+<19> <03B5>\n\
+<1A> <03B9>\n\
+<1B> <03AC>\n\
+<1C> <03C3>\n\
+<1D> <03BF>\n\
+<1E> <03C5>\n\
+<1F> <4F60>\n\
+<21> <597D>\n\
+<22> <FF01>\n\
+<23> <3053>\n\
+<24> <3093>\n\
+<25> <306B>\n\
+<26> <3061>\n\
+<27> <306F>\n\
+<28> <C548>\n\
+<29> <B155>\n\
+<2A> <D558>\n\
+<2B> <C138>\n\
+<2C> <C694>\n\
+<2D> <004D>\n\
+<2E> <0068>\n\
+<2F> <0062>\n\
+<30> <0928>\n\
+<31> <092E>\n\
+<32> <0938>\n\
+<33> <094D>\n\
+<34> <0924>\n\
+<35> <0947>\n\
+<36> <0645>\n\
+<37> <0631>\n\
+<38> <062D>\n\
+<39> <0628>\n\
+<3A> <0627>\n\
+<3B> <05E9>\n\
+<3C> <05DC>\n\
+<3D> <05D5>\n\
+<3E> <05DD>\n\
+<3F> <004F>\n\
+<40> <00E1>\n\
+<41> <0043>\n\
+<42> <0069>\n\
+<43> <007A>\n\
+<44> <015B>\n\
+<45> <0107>\n\
+<46> <60A8>\n\
+<47> <0417>\n\
+<48> <0434>\n\
+<49> <0430>\n\
+<4A> <0441>\n\
+<4B> <0443>\n\
+<4C> <0439>\n\
+<4D> <03A7>\n\
+<4E> <03B1>\n\
+<4F> <03AF>\n\
+<50> <03C1>\n\
+<51> <03C4>\n\
+<52> <0623>\n\
+<53> <0647>\n\
+<54> <0644>\n\
+<55> <064B>\n\
+";
+const LAST_CHAR: usize = 85;
+const WIDTHS: &str = "600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600 600";
+
+// (lang, is_rtl, hex_byte_string_for_TJ, x_pt, y_pt, expected_logical_text)
+const WORDS: &[(&str, bool, &str, f32, f32, &str)] = &[
+    ("eng", false, "010203030405", 36.00, 708.00, "Hello!"),
+    ("spa", false, "060104030705", 336.00, 708.00, "\u{a1}Hola!"),
+    ("fra", false, "0804090A040B0C05", 36.00, 636.00, "Bonjour!"),
+    ("deu", false, "0D0C0E0F100D04111105", 336.00, 636.00, "Gr\u{fc}\u{df} Gott!"),
+    ("rus", false, "12131415161705", 36.00, 564.00, "\u{41f}\u{440}\u{438}\u{432}\u{435}\u{442}!"),
+    ("ell", false, "18191A1B101C1D1E05", 336.00, 564.00, "\u{393}\u{3b5}\u{3b9}\u{3ac} \u{3c3}\u{3bf}\u{3c5}!"),
+    ("chi_sim", false, "1F2122", 36.00, 492.00, "\u{4f60}\u{597d}\u{ff01}"),
+    ("jpn", false, "232425262722", 336.00, 492.00, "\u{3053}\u{3093}\u{306b}\u{3061}\u{306f}\u{ff01}"),
+    ("kor", false, "28292A2B2C05", 36.00, 420.00, "\u{c548}\u{b155}\u{d558}\u{c138}\u{c694}!"),
+    ("tur", false, "2D020C2E072F0705", 336.00, 420.00, "Merhaba!"),
+    (
+        "hin",
+        false,
+        "30313233343505",
+        36.00,
+        348.00,
+        "\u{928}\u{92e}\u{938}\u{94d}\u{924}\u{947}!",
+    ),
+    ("ara", true, "05363738393A", 336.00, 348.00, "!\u{645}\u{631}\u{62d}\u{628}\u{627}"),
+    ("heb", true, "3B3C3D3E", 36.00, 276.00, "\u{5e9}\u{5dc}\u{5d5}\u{5dd}"),
+    ("por", false, "3F034005", 336.00, 276.00, "Ol\u{e1}!"),
+    ("ita", false, "4142070405", 48.00, 204.00, "Ciao!"),
+    ("pol", false, "414302444505", 240.00, 156.00, "Cze\u{15b}\u{107}!"),
+    ("chi_tra", false, "462122", 432.00, 156.00, "\u{60a8}\u{597d}\u{ff01}"),
+    (
+        "rus",
+        false,
+        "47481349154A17154B4C05",
+        48.00,
+        60.00,
+        "\u{417}\u{434}\u{440}\u{430}\u{432}\u{441}\u{442}\u{432}\u{443}\u{439}!",
+    ),
+    (
+        "ell",
+        false,
+        "4D4E4F5019511905",
+        240.00,
+        60.00,
+        "\u{3a7}\u{3b1}\u{3af}\u{3c1}\u{3b5}\u{3c4}\u{3b5}!",
+    ),
+    ("ara", true, "055253543A55", 432.00, 60.00, "!\u{623}\u{647}\u{644}\u{627}\u{64b}"),
+];
+
+/// Untagged one-page PDF: a simple TrueType font (`/FirstChar 0`,
+/// `/Widths`, `/ToUnicode`) plus a content stream drawing each of
+/// `WORDS` as its own invisible (`3 Tr`) `TJ` array at its real hOCR
+/// position — one `TJ` call per word, matching the buffer scoping that
+/// exposed #826 (`process_tj_array_tiebreaker`'s buffer never persists
+/// across separate `TJ` operators).
+fn build_ocr_sandwich_pdf() -> Vec<u8> {
+    let tounicode = format!(
+        "/CIDInit /ProcSet findresource begin\n12 dict begin begincmap\n\
+         1 begincodespacerange <00> <FF> endcodespacerange\n\
+         {} beginbfchar\n{}endbfchar\nendcmap CMapName currentdict /CMap defineresource pop end end",
+        TOUNICODE_BFCHARS.lines().filter(|l| !l.trim().is_empty()).count(),
+        TOUNICODE_BFCHARS,
+    );
+
+    let mut content_ops = String::new();
+    for (_, _, hex, x, y, _) in WORDS {
+        content_ops.push_str(&format!(
+            "BT /F1 24 Tf 3 Tr 1 0 0 1 {x} {y} Tm [<{hex}>] TJ ET\n"
+        ));
+    }
+    let content_bytes = content_ops.as_bytes();
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 7];
+    let obj = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, body: &str| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    let stream = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, dict: &str, data: &[u8]| {
+        off[id] = buf.len();
+        buf.extend_from_slice(
+            format!("{id} 0 obj\n<< {dict} /Length {} >>\nstream\n", data.len()).as_bytes(),
+        );
+        buf.extend_from_slice(data);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+    };
+
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    stream(&mut buf, &mut off, 4, "", content_bytes);
+    obj(
+        &mut buf,
+        &mut off,
+        5,
+        &format!(
+            "<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic \
+             /FirstChar 0 /LastChar {LAST_CHAR} /Widths [{WIDTHS}] /ToUnicode 6 0 R >>"
+        ),
+    );
+    stream(&mut buf, &mut off, 6, "", tounicode.as_bytes());
+
+    let xref_off = buf.len();
+    buf.extend_from_slice(b"xref\n0 7\n0000000000 65535 f \n");
+    for id in 1..=6 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref_off}\n%%EOF\n").as_bytes());
+    buf
+}
+
+/// All 20 words across 18 language codes (incl. Hebrew + 2 Arabic) must
+/// come out in correct, un-reversed logical order in plain-text
+/// extraction — the core #826 regression guard, broadened to every
+/// script sharing the same buffer-flush code path.
+#[test]
+fn ocr_sandwich_multiscript_text_extraction() {
+    let doc = PdfDocument::from_bytes(build_ocr_sandwich_pdf()).expect("parse OCR-sandwich PDF");
+    let text = doc.extract_text(0).expect("extract_text");
+    for (lang, is_rtl, _, _, _, expected) in WORDS {
+        assert!(
+            text.contains(expected),
+            "[{lang}] (rtl={is_rtl}) expected {expected:?} not found in extracted text: {text:?}"
+        );
+    }
+}
+
+/// Same corpus through `to_markdown_all` — the non-RTL scripts (which
+/// share the same buffer-flush code path and aren't affected by the RTL
+/// gap below) must survive the markdown conversion layer too, not just
+/// plain text extraction.
+///
+/// Markdown output legitimately wraps RTL runs in UAX #9 bidi-isolation
+/// markers (U+2066-2069, `bidi::wrap_rtl_isolates`) so viewers don't
+/// re-shuffle a neutral character (like this fixture's trailing `!`)
+/// across the RTL/LTR boundary — strip those before the substring check
+/// so the assertion validates *content* correctness, not marker-free
+/// byte-identity with `extract_text`.
+///
+/// RTL (Hebrew/Arabic) is intentionally excluded here: `to_markdown_all`/
+/// `to_html_all` route through `PdfDocument::apply_rtl_logical_order_to_ordered_spans`
+/// (`document.rs`), a *separate* RTL pass from the one this fix corrected
+/// in `extractors/text.rs`. That pass still unconditionally character-reverses
+/// pure-RTL spans with no render-mode gating — deliberately left as-is
+/// (see the corpus-regression-sweep finding: gating it the same way regressed
+/// real-world visual-order-storing Hebrew/Arabic producers, e.g. Wikipedia
+/// PDF exports, which rely on that unconditional reversal being correct for
+/// *their* shape). Fixing the OCR-sandwich case for md/html too needs
+/// render-mode threaded onto `TextSpan`/`OrderedTextSpan`, which is a larger,
+/// separate change — tracked as a follow-up, not silently dropped.
+#[test]
+fn ocr_sandwich_multiscript_markdown_extraction() {
+    let doc = PdfDocument::from_bytes(build_ocr_sandwich_pdf()).expect("parse OCR-sandwich PDF");
+    let opts = ConversionOptions::default();
+    let md = doc.to_markdown_all(&opts).expect("to_markdown_all");
+    let md_stripped: String = md
+        .chars()
+        .filter(|c| !matches!(*c, '\u{2066}'..='\u{2069}'))
+        .collect();
+    for (lang, is_rtl, _, _, _, expected) in WORDS {
+        if *is_rtl {
+            continue;
+        }
+        assert!(
+            md_stripped.contains(expected),
+            "[{lang}] (rtl={is_rtl}) expected {expected:?} not found in markdown \
+             (isolation markers stripped): {md_stripped:?}"
+        );
+    }
+}
+
+/// Same corpus through `to_html_all` — see the markdown test above for why
+/// RTL (Hebrew/Arabic) is excluded from this check.
+#[test]
+fn ocr_sandwich_multiscript_html_extraction() {
+    let doc = PdfDocument::from_bytes(build_ocr_sandwich_pdf()).expect("parse OCR-sandwich PDF");
+    let opts = ConversionOptions::default();
+    let html = doc.to_html_all(&opts).expect("to_html_all");
+    for (lang, is_rtl, _, _, _, expected) in WORDS {
+        if *is_rtl {
+            continue;
+        }
+        assert!(
+            html.contains(expected),
+            "[{lang}] (rtl={is_rtl}) expected {expected:?} not found in HTML: {html:?}"
+        );
+    }
+}

--- a/tests/rtl_tj_array_word_buffer.rs
+++ b/tests/rtl_tj_array_word_buffer.rs
@@ -1,0 +1,247 @@
+//! Integration tests for RTL correction on the `TJ`-array
+//! (`WordBoundaryMode::Tiebreaker`, the default) text-showing path.
+//!
+//! Issue #826: a scanned Hebrew OCR PDF (simple TrueType font, one `TJ`
+//! array per recognized word, physically left-to-right word placement,
+//! invisible `Tr 3` render mode — the standard OCR-text-sandwich shape)
+//! extracted with every Hebrew word both letter-reversed *and*
+//! word-order-reversed, even though the geometric visual-order detector
+//! added for #537/#657 was supposed to prevent exactly this class of bug.
+//!
+//! Two compounding root causes, both fixed here:
+//!
+//! 1. `flush_tj_buffer` (the flush function backing the default
+//!    `WordBoundaryMode::Tiebreaker` `TJ`-array path) never received the
+//!    #537 confidence-gated geometric detector — it still used the
+//!    pre-#537 `has_rtl && buffer.accumulated_width > 0.0` heuristic.
+//!    Because `accumulated_width` only ever sums positive glyph advance
+//!    widths (`TJ` kerning offsets never modify it), the check was true
+//!    for nearly every non-empty RTL buffer — so this path didn't
+//!    *detect* direction, it unconditionally reversed every RTL `TJ`
+//!    buffer it flushed. Fixed by routing all three flush sites
+//!    (`flush_tj_buffer`, `flush_tj_span_buffer`, `cluster_to_span`)
+//!    through the shared `bidi::apply_rtl_verdict`.
+//! 2. Even with the geometric detector wired in everywhere, it still
+//!    can't tell "already-logical content placed at plain ascending x"
+//!    (the OCR case — no rendering-correctness pressure on invisible
+//!    text) from "genuinely visual-order content" (also ascending x) —
+//!    both produce an identical geometric signature. Fixed by threading
+//!    text render mode (`Tr`) through: for invisible (`3`/`7`) runs, the
+//!    geometric/coarse heuristics are skipped entirely and the extracted
+//!    content order is trusted as-is (see `bidi::apply_rtl_verdict`'s
+//!    doc comment for the full rationale and the accepted trade-off).
+//!
+//! Both PDFs below are hand-built, untagged, single-page, with a simple
+//! (non-Type0) TrueType-subtype font (`/FirstChar 0`, no /Encoding —
+//! same minimal shape as the pdfium `hebrew_mirrored.pdf` fixture) plus
+//! a `/ToUnicode` CMap, and draw each of two Hebrew words as its own
+//! `[...] TJ` array (byte codes with small kerning numbers between them)
+//! at increasing x — i.e. physically left-to-right word placement, the
+//! shape that scopes each word to its own flush-buffer call.
+//!
+//! Words: ביצה (bet-yod-tsadi-he, "egg" — codes <01><02><03><04> in
+//! logical reading order) and פרק (pe-resh-qof, "chapter" — codes
+//! <05><06><07> in logical reading order), matching the real tractate
+//! (Beitza) from issue #826. Hebrew reads right-to-left, so the correct
+//! logical line is "ביצה פרק" (ביצה first) even though — matching real
+//! OCR/scan placement — פרק is drawn first (it sits physically to the
+//! left) and ביצה is drawn second (physically to the right).
+
+use pdf_oxide::PdfDocument;
+
+/// Minimal untagged one-page PDF: a simple TrueType font (`/FirstChar 0`,
+/// `/Widths`, `/ToUnicode`) and a plain content stream. `content_ops` is
+/// the full `BT ... ET` body.
+fn build_pdf(tounicode_bfchars: &str, widths: &str, last_char: usize, content_ops: &str) -> Vec<u8> {
+    let tounicode = format!(
+        "/CIDInit /ProcSet findresource begin\n12 dict begin begincmap\n\
+         1 begincodespacerange <00> <FF> endcodespacerange\n\
+         {} beginbfchar\n{}endbfchar\nendcmap CMapName currentdict /CMap defineresource pop end end",
+        tounicode_bfchars.lines().filter(|l| !l.trim().is_empty()).count(),
+        tounicode_bfchars,
+    );
+
+    let content_bytes = content_ops.as_bytes();
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 7];
+    let obj = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, body: &str| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    let stream = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, dict: &str, data: &[u8]| {
+        off[id] = buf.len();
+        buf.extend_from_slice(
+            format!("{id} 0 obj\n<< {dict} /Length {} >>\nstream\n", data.len()).as_bytes(),
+        );
+        buf.extend_from_slice(data);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+    };
+
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    stream(&mut buf, &mut off, 4, "", content_bytes);
+    obj(
+        &mut buf,
+        &mut off,
+        5,
+        &format!(
+            "<< /Type /Font /Subtype /TrueType /BaseFont /Synthetic \
+             /FirstChar 0 /LastChar {last_char} /Widths [{widths}] /ToUnicode 6 0 R >>"
+        ),
+    );
+    stream(&mut buf, &mut off, 6, "", tounicode.as_bytes());
+
+    let xref_off = buf.len();
+    buf.extend_from_slice(b"xref\n0 7\n0000000000 65535 f \n");
+    for id in 1..=6 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref_off}\n%%EOF\n").as_bytes());
+    buf
+}
+
+const TOUNICODE: &str = "\
+<01> <05D1>
+<02> <05D9>
+<03> <05E6>
+<04> <05D4>
+<05> <05E4>
+<06> <05E8>
+<07> <05E7>
+<20> <0020>
+";
+const WIDTHS: &str = "600 600 600 600 600 600 600 600";
+const LAST_CHAR: usize = 7;
+const WORD_ONE_LOGICAL: &str = "\u{05D1}\u{05D9}\u{05E6}\u{05D4}"; // ביצה
+const WORD_ONE_REVERSED: &str = "\u{05D4}\u{05E6}\u{05D9}\u{05D1}"; // הציב
+const WORD_TWO_LOGICAL: &str = "\u{05E4}\u{05E8}\u{05E7}"; // פרק
+const WORD_TWO_REVERSED: &str = "\u{05E7}\u{05E8}\u{05E4}"; // קרפ
+
+/// #826 shape (the bug): each word's glyph codes are stored in
+/// **logical** (already correct) reading order inside its own **invisible
+/// (`3 Tr`)** `TJ` array — a Hebrew-aware OCR engine recognizes a whole
+/// word correctly, but since the glyphs are never actually shown there's
+/// no reason to also mirror their positions; it just places words
+/// left-to-right by physical page position. Word one (ביצה) is drawn
+/// second at higher x (physically rightmost, since it's read first);
+/// word two (פרק) is drawn first at lower x.
+#[test]
+fn tj_array_invisible_logical_order_per_word_is_not_reversed() {
+    let pdf = build_pdf(
+        TOUNICODE,
+        WIDTHS,
+        LAST_CHAR,
+        "BT /F1 12 Tf 3 Tr\n\
+         50 100 Td [<05>0<06>0<07>] TJ\n\
+         80 0 Td [<01>0<02>0<03>0<04>] TJ\nET",
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse synthetic PDF");
+    let text = doc.extract_text(0).expect("extract_text");
+    eprintln!("[826] invisible logical-per-word extracted: {text:?}");
+
+    // Correct logical reading order: ביצה (word one) then פרק (word two).
+    assert!(
+        text.contains(WORD_ONE_LOGICAL),
+        "word one (ביצה) letters got reversed — invisible-text run wrongly \
+         ran through the visual-order heuristic: {text:?}"
+    );
+    assert!(
+        text.contains(WORD_TWO_LOGICAL),
+        "word two (פרק) letters got reversed: {text:?}"
+    );
+}
+
+/// Visible-mode counterpart (documents the fix's boundary, not a bug):
+/// the identical already-logical, ascending-x content as above, but
+/// drawn with the *default visible* render mode (no `Tr`). For visible
+/// text, ascending x is a meaningful signal — a producer whose Hebrew
+/// renders correctly on screen would have mirrored logical content to
+/// descending x, so a real producer emitting ascending-x visible RTL
+/// most likely *did* store it in visual order. The invisible-mode fix
+/// above must not change this case.
+#[test]
+fn tj_array_visible_logical_order_per_word_still_reversed() {
+    let pdf = build_pdf(
+        TOUNICODE,
+        WIDTHS,
+        LAST_CHAR,
+        "BT /F1 12 Tf\n\
+         50 100 Td [<05>0<06>0<07>] TJ\n\
+         80 0 Td [<01>0<02>0<03>0<04>] TJ\nET",
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse synthetic PDF");
+    let text = doc.extract_text(0).expect("extract_text");
+    eprintln!("[visible] logical-per-word extracted: {text:?}");
+
+    assert!(
+        text.contains(WORD_ONE_REVERSED) && text.contains(WORD_TWO_REVERSED),
+        "visible-mode ascending-x RTL behavior changed — the invisible-mode \
+         fix must be scoped to Tr 3/7 only: {text:?}"
+    );
+}
+
+/// #657/hebrew_mirrored.pdf-style shape (regression guard): each word's
+/// glyph codes are stored in **visual** (mirrored) order inside its own
+/// visible `TJ` array — the case the existing fix is supposed to handle.
+/// Must stay correct after the render-mode change.
+#[test]
+fn tj_array_visual_order_per_word_regression() {
+    let pdf = build_pdf(
+        TOUNICODE,
+        WIDTHS,
+        LAST_CHAR,
+        "BT /F1 12 Tf\n\
+         50 100 Td [<07>0<06>0<05>] TJ\n\
+         80 0 Td [<04>0<03>0<02>0<01>] TJ\nET",
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse synthetic PDF");
+    let text = doc.extract_text(0).expect("extract_text");
+    eprintln!("[657] visual-per-word extracted: {text:?}");
+
+    assert!(
+        text.contains(WORD_ONE_LOGICAL),
+        "word one (ביצה) not reconstructed from visual order: {text:?}"
+    );
+    assert!(
+        text.contains(WORD_TWO_LOGICAL),
+        "word two (פרק) not reconstructed from visual order: {text:?}"
+    );
+}
+
+/// Known accepted trade-off (documented, not silently left uncovered):
+/// genuinely visual-order content drawn *invisible* no longer gets
+/// auto-reversed, because invisible-mode runs now trust content order
+/// unconditionally (issue #826's fix). This asserts the actual,
+/// intentional post-fix behavior for this narrower, now-deprioritized
+/// case, so a future change to this trade-off is a deliberate, visible
+/// diff here rather than a silent regression.
+#[test]
+fn tj_array_invisible_visual_order_per_word_is_not_reversed_known_tradeoff() {
+    let pdf = build_pdf(
+        TOUNICODE,
+        WIDTHS,
+        LAST_CHAR,
+        "BT /F1 12 Tf 3 Tr\n\
+         50 100 Td [<07>0<06>0<05>] TJ\n\
+         80 0 Td [<04>0<03>0<02>0<01>] TJ\nET",
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("parse synthetic PDF");
+    let text = doc.extract_text(0).expect("extract_text");
+    eprintln!("[tradeoff] invisible visual-per-word extracted: {text:?}");
+
+    assert!(
+        text.contains(WORD_ONE_REVERSED) && text.contains(WORD_TWO_REVERSED),
+        "expected the documented trade-off (invisible content trusted as-is, \
+         so visual-order invisible text stays unreversed): {text:?}"
+    );
+}

--- a/tests/rtl_tj_array_word_buffer.rs
+++ b/tests/rtl_tj_array_word_buffer.rs
@@ -52,7 +52,12 @@ use pdf_oxide::PdfDocument;
 /// Minimal untagged one-page PDF: a simple TrueType font (`/FirstChar 0`,
 /// `/Widths`, `/ToUnicode`) and a plain content stream. `content_ops` is
 /// the full `BT ... ET` body.
-fn build_pdf(tounicode_bfchars: &str, widths: &str, last_char: usize, content_ops: &str) -> Vec<u8> {
+fn build_pdf(
+    tounicode_bfchars: &str,
+    widths: &str,
+    last_char: usize,
+    content_ops: &str,
+) -> Vec<u8> {
     let tounicode = format!(
         "/CIDInit /ProcSet findresource begin\n12 dict begin begincmap\n\
          1 begincodespacerange <00> <FF> endcodespacerange\n\
@@ -155,10 +160,7 @@ fn tj_array_invisible_logical_order_per_word_is_not_reversed() {
         "word one (ביצה) letters got reversed — invisible-text run wrongly \
          ran through the visual-order heuristic: {text:?}"
     );
-    assert!(
-        text.contains(WORD_TWO_LOGICAL),
-        "word two (פרק) letters got reversed: {text:?}"
-    );
+    assert!(text.contains(WORD_TWO_LOGICAL), "word two (פרק) letters got reversed: {text:?}");
 }
 
 /// Visible-mode counterpart (documents the fix's boundary, not a bug):


### PR DESCRIPTION
## Summary

Fixes #826 for the **per-word** OCR-sandwich shape: a scanned Hebrew/Arabic
PDF whose invisible OCR text layer emits one `TJ` array per recognized word
(the standard OCR-sandwich shape produced by e.g. Tesseract-style tools)
came out with every word both letter-reversed and word-order-reversed in
`extract_text()`.

## Root cause (two compounding bugs, both in the `Tj`/`TJ` buffer-flush path)

1. `flush_tj_buffer` (the default `WordBoundaryMode::Tiebreaker` path) never
   received the #537 confidence-gated geometric RTL detector — it still used
   the pre-#537 `accumulated_width > 0.0` heuristic. Since `accumulated_width`
   only ever sums *positive* glyph advance widths (`TJ` kerning offsets never
   subtract from it), that check is true for nearly every non-empty RTL
   buffer — so this path wasn't *detecting* direction, it was unconditionally
   reversing every RTL buffer it flushed.
2. Even with the geometric detector wired into every flush site, it still
   can't distinguish "already-logical content placed at plain ascending x"
   (invisible OCR text — no rendering-correctness pressure to mirror glyph
   positions) from "genuinely visual-order content" (identical geometric
   signature). Fixed by threading text render mode (`Tr`) through: invisible
   runs (`3`/`7`) skip the geometric/coarse heuristics entirely and trust the
   extracted content order as-is.

Both fixes are unified behind one shared decision point, `bidi::apply_rtl_verdict`.

## Scope (intentionally narrower than #826's full symptom set)

This fixes `extract_text()` for the per-word OCR-sandwich shape. It
deliberately does **not** touch:

- `to_markdown_all`/`to_html_all`'s separate RTL pass in `document.rs`
  (`apply_rtl_logical_order_to_ordered_spans`) — gating that pass the same
  way regressed real-world, non-OCR, visual-order-storing Hebrew/Arabic
  producers (confirmed via corpus sweep — see below). Left unchanged
  pending a proper render-mode-aware fix there, tracked as a follow-up.
- the **per-glyph** OCR-sandwich shape (one show op per character rather
  than per word) — a related but distinct bug in a different function
  (`merge_adjacent_spans`), which also needs its own separately-scoped fix
  (see the review comment on #828, which targets that shape but currently
  regresses the same non-OCR content this PR is careful to avoid).

## Verification

- `cargo test --lib`: 5,714/5,714 pass.
- New regression tests: `tests/rtl_ocr_multiscript_regression.rs` (18
  languages incl. Hebrew + 2 Arabic dialects, built from OCRmyPDF's real
  hOCR test fixture data) and `tests/rtl_tj_array_word_buffer.rs` (minimal
  #826 repro, pinned to the exact Beitza tractate word shape from the
  issue) — 7/7 pass.
- Full 419-PDF corpus regression sweep (byte-diff vs `main`, every
  category): **zero regressions**. This sweep is also what caught an
  earlier version of this fix touching `document.rs` and regressing two
  real Hebrew/Arabic Wikipedia-export PDFs in the corpus — that hunk was
  reverted before this PR.

https://claude.ai/code/session_011BDGGBXi8cekUtVYni8Awo