### PR TITLE
ci: bump Go toolchain pin to 1.26.5 (GO-2026-5856)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -891,11 +891,12 @@ jobs:
         with:
           # go.mod's `go 1.21` directive keeps us compatible with older
           # consumers; CI builds with the newest patched toolchain (>=1.25
-          # required by govulncheck v1.3+). Pinned to 1.26.4 because the
-          # setup-go `stable` alias lagged at 1.26.3, which govulncheck flags
-          # for GO-2026-5037 (crypto/x509) and GO-2026-5039 (net/textproto),
-          # both fixed in go1.26.4. Bump as new patch releases land.
-          go-version: '1.26.4'
+          # required by govulncheck v1.3+). Pinned to 1.26.5 because the
+          # setup-go `stable` alias lagged behind it, which govulncheck flags
+          # for GO-2026-5037 (crypto/x509), GO-2026-5039 (net/textproto), and
+          # GO-2026-5856 (crypto/tls ECH privacy leak), all fixed in
+          # go1.26.5. Bump as new patch releases land.
+          go-version: '1.26.5'
 
       # Download the pre-built native lib (extended features: barcodes,
       # rendering, signatures, tsa-client, system-fonts). Artifact preserves


### PR DESCRIPTION
## Summary
- `govulncheck` in the Go Bindings CI job flags `GO-2026-5856`, an Encrypted Client Hello privacy leak in `crypto/tls`, present in the currently-pinned `go1.26.4` and fixed in `go1.26.5`.
- Discovered while triaging an unrelated failure on #817's "Go Bindings (ubuntu-latest)" check — it's a toolchain/infra issue, not caused by that PR's diff, and affects every open PR that touches the Go bindings job.

## Change
Bump `go-version` in `.github/workflows/ci.yml`'s "Set up Go" step from `1.26.4` to `1.26.5`, updating the adjacent comment to list the newly-fixed CVE alongside the two it already references.

## Test plan
- [x] Verified `1.26.4` had no other references anywhere else in `.github/workflows/*.yml`
- [ ] CI green on this PR (Go Bindings job specifically)