### PR TITLE
chore: consolidate dependabot updates (cargo + github-actions), 2026-07

### DIFF
--- a/.github/workflows/ci-fips.yml
+++ b/.github/workflows/ci-fips.yml
@@ -306,7 +306,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,7 +887,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           # go.mod's `go 1.21` directive keeps us compatible with older
           # consumers; CI builds with the newest patched toolchain (>=1.25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,7 +937,7 @@ jobs:
       # v2.0.2 was built with go1.24 and can't typecheck go1.26 stdlib.
       - name: golangci-lint
         if: matrix.os == 'ubuntu-latest'
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.4
           working-directory: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Create virtual environment
         run: uv venv
@@ -571,7 +571,7 @@ jobs:
           key: python-examples-${{ matrix.os }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Build + install wheel
         shell: bash

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -78,7 +78,7 @@ jobs:
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v4
 
       # Install the Java binding to the local Maven repo so the facade resolves
       # `fyi.oxide:pdf-oxide`. Skip the `dev` profile (it would rebuild the Rust

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -66,7 +66,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Create virtual environment with uv
         run: uv venv
@@ -133,7 +133,7 @@ jobs:
         run: cargo clippy --features python --all-targets --workspace -- -D warnings
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Pin Python version
         run: uv python pin 3.11

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -193,7 +193,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1

--- a/.github/workflows/release-fips.yml
+++ b/.github/workflows/release-fips.yml
@@ -911,7 +911,7 @@ jobs:
           ref: ${{ inputs.version || (github.event_name != 'pull_request' && github.ref_name || github.sha) }}
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 'stable'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -916,7 +916,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.22'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2102,7 +2102,7 @@ jobs:
           java-version: '17'
 
       - name: Set up sbt
-        uses: sbt/setup-sbt@234370af1319038bf8dc432f8a7e4b83078a1781 # v1
+        uses: sbt/setup-sbt@66fb4376e81982c7d92a4074170846fff88e2e30 # v1
 
       - name: Build & install Java binding to local Maven repo
         working-directory: java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1273,7 +1273,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Generate type stubs
         run: uvx rylai -o python/pdf_oxide/
@@ -1346,7 +1346,7 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Install maturin
         run: uv pip install --system maturin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2059,7 +2059,7 @@ jobs:
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v4
 
       # The facade is pure-JVM and depends on fyi.oxide:pdf-oxide — install
       # it to the local Maven repo so the publish build resolves it (skip

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -78,7 +78,7 @@ jobs:
           java-version: '17'
 
       - name: Set up sbt
-        uses: sbt/setup-sbt@234370af1319038bf8dc432f8a7e4b83078a1781 # v1
+        uses: sbt/setup-sbt@66fb4376e81982c7d92a4074170846fff88e2e30 # v1
 
       # Install the Java binding to the local Maven repo so the facade resolves
       # `fyi.oxide:pdf-oxide` (skip the dev profile's Rust rebuild + tests).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,12 +423,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
@@ -1024,18 +1018,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
@@ -1312,7 +1294,6 @@ dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.6",
- "subtle",
 ]
 
 [[package]]
@@ -1379,28 +1360,14 @@ checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der 0.8.0",
  "digest 0.11.3",
- "elliptic-curve 0.14.1",
- "rfc6979 0.6.0",
+ "elliptic-curve",
+ "rfc6979",
  "signature 3.0.0",
  "spki 0.8.0",
  "zeroize",
@@ -1414,41 +1381,21 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest 0.10.7",
- "ff 0.13.1",
- "generic-array",
- "group 0.13.0",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sec1 0.7.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
- "base16ct 1.0.0",
- "crypto-bigint 0.7.5",
+ "base16ct",
+ "crypto-bigint",
  "crypto-common 0.2.2",
  "digest 0.11.3",
- "ff 0.14.0",
- "group 0.14.0",
+ "ff",
+ "group",
  "hybrid-array",
  "pem-rfc7468 1.0.0",
  "pkcs8 0.11.0",
  "rand_core 0.10.1",
- "sec1 0.8.1",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1588,16 +1535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1752,7 +1689,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1853,22 +1789,11 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff 0.13.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
- "ff 0.14.0",
+ "ff",
  "rand_core 0.10.1",
  "subtle",
 ]
@@ -1944,15 +1869,6 @@ name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "hmac"
@@ -3043,7 +2959,7 @@ dependencies = [
  "der 0.8.0",
  "des",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "pkcs12",
  "pkcs5",
  "pkcs8 0.11.0",
@@ -3057,14 +2973,15 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder 0.13.6",
- "sha2 0.10.9",
+ "ecdsa",
+ "elliptic-curve",
+ "primefield",
+ "primeorder",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3073,11 +2990,11 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
- "ecdsa 0.17.0",
- "elliptic-curve 0.14.1",
+ "ecdsa",
+ "elliptic-curve",
  "fiat-crypto",
  "primefield",
- "primeorder 0.14.0",
+ "primeorder",
  "sha2 0.11.0",
 ]
 
@@ -3133,7 +3050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
- "hmac 0.13.0",
+ "hmac",
 ]
 
 [[package]]
@@ -3601,21 +3518,12 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
- "crypto-bigint 0.7.5",
+ "crypto-bigint",
  "crypto-common 0.2.2",
- "ff 0.14.0",
+ "ff",
  "rand_core 0.10.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -3624,7 +3532,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
- "elliptic-curve 0.14.1",
+ "elliptic-curve",
  "once_cell",
  "primefield",
  "serdect",
@@ -4090,22 +3998,12 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "crypto-bigint 0.7.5",
- "hmac 0.13.0",
+ "crypto-bigint",
+ "hmac",
 ]
 
 [[package]]
@@ -4346,25 +4244,11 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
- "generic-array",
- "pkcs8 0.10.2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "ctutils",
  "der 0.8.0",
  "hybrid-array",
@@ -4438,7 +4322,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "serde",
 ]
 
@@ -5684,8 +5568,8 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
- "ff 0.14.0",
- "group 0.14.0",
+ "ff",
+ "group",
  "hybrid-array",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfde4e2f8595f222ceaae1fb16b4963952e9b33e358869dc4cd6316b0e0790cd"
+checksum = "73afc801dd6bd47529eaa7c7e90557f107527d1b7c9c7ed7d7803c7b8d0c357f"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1035,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,7 +1066,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1063,6 +1087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1360,10 +1385,25 @@ checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.0",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1378,17 +1418,37 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
- "hkdf",
+ "group 0.13.0",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1539,6 +1599,22 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -1781,8 +1857,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1859,15 +1946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,7 +1985,9 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2981,22 +3061,24 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "fiat-crypto",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3125,7 +3207,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.9",
  "sha2 0.11.0",
- "signature",
+ "signature 2.2.0",
  "smallvec",
  "spki 0.7.3",
  "stringprep",
@@ -3514,12 +3596,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -3990,6 +4099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,7 +4148,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
+ "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
  "zeroize",
@@ -4231,10 +4350,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -4300,6 +4433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4352,6 +4495,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5524,6 +5677,17 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
 
 [[package]]
 name = "write-fonts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ sha1 = { version = "0.11", optional = true }          # SHA-1 for legacy signatu
 # module use sha2 0.10 types specifically where rsa::pss / ecdsa crate generics
 # require it, without changing the rest of the codebase. See issue #420.
 sha2_v10 = { package = "sha2", version = "0.10", optional = true }
-p256 = { version = "0.13", optional = true }                       # ECDSA P-256 signature verification
+p256 = { version = "0.14", optional = true }                       # ECDSA P-256 signature verification
 p384 = { version = "0.14", optional = true }                       # ECDSA P-384 signature verification
 
 # Parallel extraction

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ brotli = "8"                                                                   #
 ttf-parser = "0.25" # TrueType font parser for embedded font cmap tables
 subsetter = "0.2"   # Binary TrueType/OpenType subsetting (Typst's; MIT/Apache). Used by writer-side
 # EmbeddedFont to shrink embedded fonts to only the glyphs actually used.
-taffy = { version = "0.11", default-features = false, features = [
+taffy = { version = "0.12", default-features = false, features = [
     "std",
     "taffy_tree",
     "block_layout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ sha1 = { version = "0.11", optional = true }          # SHA-1 for legacy signatu
 # require it, without changing the rest of the codebase. See issue #420.
 sha2_v10 = { package = "sha2", version = "0.10", optional = true }
 p256 = { version = "0.13", optional = true }                       # ECDSA P-256 signature verification
-p384 = { version = "0.13", optional = true }                       # ECDSA P-384 signature verification
+p384 = { version = "0.14", optional = true }                       # ECDSA P-384 signature verification
 
 # Parallel extraction
 rayon = { version = "1.12", optional = true }

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -1221,25 +1221,20 @@ fn find_matching_et(data: &[u8], start: usize) -> Option<usize> {
     let len = data.len();
     // Use memchr to find 'E' candidates
     loop {
-        match memchr::memchr(b'E', &data[offset..]) {
-            None => return None,
-            Some(rel) => {
-                let pos = offset + rel;
-                offset = pos + 1;
-                if pos + 1 < len && data[pos + 1] == b'T' {
-                    let before_ok = pos == 0
-                        || data[pos - 1].is_ascii_whitespace()
-                        || matches!(data[pos - 1], b')' | b'>' | b']' | b'}' | b'/' | b'%');
-                    let after_ok = pos + 2 >= len || {
-                        let next = data[pos + 2];
-                        next.is_ascii_whitespace()
-                            || matches!(next, b'(' | b'<' | b'[' | b'/' | b'%')
-                    };
-                    if before_ok && after_ok {
-                        return Some(pos + 2);
-                    }
-                }
-            },
+        let rel = memchr::memchr(b'E', &data[offset..])?;
+        let pos = offset + rel;
+        offset = pos + 1;
+        if pos + 1 < len && data[pos + 1] == b'T' {
+            let before_ok = pos == 0
+                || data[pos - 1].is_ascii_whitespace()
+                || matches!(data[pos - 1], b')' | b'>' | b']' | b'}' | b'/' | b'%');
+            let after_ok = pos + 2 >= len || {
+                let next = data[pos + 2];
+                next.is_ascii_whitespace() || matches!(next, b'(' | b'<' | b'[' | b'/' | b'%')
+            };
+            if before_ok && after_ok {
+                return Some(pos + 2);
+            }
         }
     }
 }

--- a/src/converters/form_xobject_finder.rs
+++ b/src/converters/form_xobject_finder.rs
@@ -222,20 +222,20 @@ fn get_page_xobjects(
 ) -> Option<HashMap<String, Object>> {
     let page = doc.get_page(page_idx).ok()?;
     let page_dict = page.as_dict()?;
-    let resources = match page_dict.get("Resources") {
-        Some(r) => match r.as_reference() {
+    let resources = {
+        let r = page_dict.get("Resources")?;
+        match r.as_reference() {
             Some(rref) => doc.load_object(rref).ok()?,
             None => r.clone(),
-        },
-        None => return None,
+        }
     };
     let res_dict = resources.as_dict()?;
-    let xobjects = match res_dict.get("XObject") {
-        Some(x) => match x.as_reference() {
+    let xobjects = {
+        let x = res_dict.get("XObject")?;
+        match x.as_reference() {
             Some(xref) => doc.load_object(xref).ok()?,
             None => x.clone(),
-        },
-        None => return None,
+        }
     };
     let dict = xobjects.as_dict()?;
     Some(dict.clone())

--- a/src/converters/pptx_layout.rs
+++ b/src/converters/pptx_layout.rs
@@ -320,7 +320,7 @@ fn merge_hyphenated_spans(spans: &mut Vec<crate::layout::text_block::TextSpan>) 
             .unwrap_or(false);
         if curr_ends_hyphen && same_size && next_starts_lower {
             // Merge: drop trailing '-', concatenate, expand bbox.
-            let merged_text = format!("{}{}", &cur.text[..cur.text.len() - 1], &next.text);
+            let merged_text = format!("{}{}", &cur.text[..cur.text.len() - 1], next.text);
             cur.text = merged_text;
             cur.bbox.width += next.bbox.width;
         } else {

--- a/src/converters/xlsx_layout.rs
+++ b/src/converters/xlsx_layout.rs
@@ -321,7 +321,7 @@ fn merge_hyphenated_spans(spans: &mut Vec<crate::layout::text_block::TextSpan>) 
             .map(|c| c.is_ascii_lowercase())
             .unwrap_or(false);
         if curr_ends_hyphen && same_size && next_starts_lower {
-            let merged_text = format!("{}{}", &cur.text[..cur.text.len() - 1], &next.text);
+            let merged_text = format!("{}{}", &cur.text[..cur.text.len() - 1], next.text);
             cur.text = merged_text;
             cur.bbox.width += next.bbox.width;
         } else {

--- a/src/document.rs
+++ b/src/document.rs
@@ -1200,7 +1200,7 @@ impl PdfDocument {
         // Some PDFs store /O, /U, /V, /R, /P as indirect references (e.g., `7 0 R`).
         let encrypt_obj = if let Some(dict) = encrypt_obj.as_dict() {
             let mut resolved_dict = dict.clone();
-            for (_key, value) in resolved_dict.iter_mut() {
+            for value in resolved_dict.values_mut() {
                 if let Object::Reference(obj_ref) = value {
                     match self.load_object(*obj_ref) {
                         Ok(resolved) => *value = resolved,
@@ -3010,7 +3010,7 @@ impl PdfDocument {
                 }
             },
             Object::Dictionary(dict) => {
-                for (_, value) in dict.iter_mut() {
+                for value in dict.values_mut() {
                     Self::decrypt_strings_in_object(handler, value, obj_num, gen_num);
                 }
             },
@@ -3018,7 +3018,7 @@ impl PdfDocument {
                 // Stream *data* is decrypted separately in
                 // `decode_stream_with_encryption`. Its dict may still
                 // contain encrypted strings (e.g., /Metadata).
-                for (_, value) in dict.iter_mut() {
+                for value in dict.values_mut() {
                     Self::decrypt_strings_in_object(handler, value, obj_num, gen_num);
                 }
             },
@@ -9170,8 +9170,11 @@ impl PdfDocument {
         // Create a temporary text extractor for this AP stream
         let mut extractor = TextExtractor::new();
 
-        // Load fonts from the AP/N stream's own /Resources
-        if let Some(resources) = n_dict.get("Resources") {
+        // Load fonts from the AP/N stream's own /Resources. No resources on
+        // the AP stream — try the annotation's /DR or parent page resources
+        // — means we can't decode fonts, so bail.
+        {
+            let resources = n_dict.get("Resources")?;
             let res_obj = if let Some(r) = resources.as_reference() {
                 self.load_object(r)
                     .ok()
@@ -9182,10 +9185,6 @@ impl PdfDocument {
             extractor.set_resources(res_obj.clone());
             extractor.set_document(self);
             let _ = self.load_fonts(&res_obj, &mut extractor);
-        } else {
-            // No resources on the AP stream — try the annotation's /DR or parent page resources
-            // For now, skip if no resources (can't decode fonts)
-            return None;
         }
 
         // Extract text spans from the AP stream
@@ -21934,10 +21933,9 @@ impl PdfDocument {
                 for (i, val) in array.iter().take(6).enumerate() {
                     let num = if let Some(f) = val.as_real() {
                         f as f32
-                    } else if let Some(i_val) = val.as_integer() {
-                        i_val as f32
                     } else {
-                        return None;
+                        let i_val = val.as_integer()?;
+                        i_val as f32
                     };
                     values[i] = num;
                 }

--- a/src/editor/document_editor.rs
+++ b/src/editor/document_editor.rs
@@ -3151,7 +3151,7 @@ impl DocumentEditor {
                                                             .iter()
                                                             .map(|(id, _, _, _)| *id),
                                                     );
-                                                    for (_name, font_ref) in fdict.iter() {
+                                                    for font_ref in fdict.values() {
                                                         if let Some(ref_obj) =
                                                             font_ref.as_reference()
                                                         {
@@ -3221,7 +3221,7 @@ impl DocumentEditor {
                                                     _ => None,
                                                 };
                                                 if let Some(xobj_dict) = xobject_dict {
-                                                    for (_name, xobj_ref) in xobj_dict.iter() {
+                                                    for xobj_ref in xobj_dict.values() {
                                                         if let Some(ref_obj) =
                                                             xobj_ref.as_reference()
                                                         {
@@ -3282,7 +3282,7 @@ impl DocumentEditor {
                                                     _ => None,
                                                 };
                                                 if let Some(gsd) = gs_dict {
-                                                    for (_name, gs_ref) in gsd.iter() {
+                                                    for gs_ref in gsd.values() {
                                                         if let Some(ref_obj) = gs_ref.as_reference()
                                                         {
                                                             if !written_ids.contains(&ref_obj.id) {

--- a/src/extractors/xmp.rs
+++ b/src/extractors/xmp.rs
@@ -201,7 +201,7 @@ impl XmpExtractor {
 
         // Get stream data
         let xml_bytes = match &metadata_resolved {
-            Object::Stream { data: _, .. } => {
+            Object::Stream { .. } => {
                 // XMP metadata streams are typically not filtered (or use FlateDecode)
                 // Try to decode the stream
                 let decoded = metadata_resolved.decode_stream_data()?;

--- a/src/fonts/cmap.rs
+++ b/src/fonts/cmap.rs
@@ -787,11 +787,7 @@ fn parse_bfchar_line(line: &str) -> Vec<(u32, String)> {
                 } else if dst_hex.len() <= 6 {
                     // 5-6 hex digits: direct supplementary Unicode code point (e.g., 020BB7 = U+20BB7)
                     let dst_code = u32::from_str_radix(&dst_hex, 16).ok()?;
-                    if let Some(ch) = char::from_u32(dst_code) {
-                        ch.to_string()
-                    } else {
-                        return None;
-                    }
+                    char::from_u32(dst_code)?.to_string()
                 } else if dst_hex.len() == 8 {
                     let dst_code = u32::from_str_radix(&dst_hex, 16).ok()?;
                     if let Some(decoded) = decode_utf16_surrogate_pair(dst_code) {

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -5144,11 +5144,9 @@ pub(crate) fn glyph_name_to_unicode_string(glyph_name: &str) -> Option<String> {
     if glyph_name.contains('_') {
         let mut result = String::new();
         for part in glyph_name.split('_') {
-            if let Some(ch) = glyph_name_to_unicode(part) {
-                result.push(ch);
-            } else {
-                return None; // If any component is unknown, fail entirely
-            }
+            // If any component is unknown, fail entirely.
+            let ch = glyph_name_to_unicode(part)?;
+            result.push(ch);
         }
         if !result.is_empty() {
             return Some(result);

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -323,15 +323,11 @@ fn walk_name_tree(
     let dict = node.as_dict()?;
 
     // Leaf: `/Names` is a flat [key1 val1 key2 val2 …] array.
-    if let Some(names) = dict.get("Names").and_then(|n| {
-        deref_obj(n, resolve).and_then(|d| {
-            if d.as_array().is_some() {
-                Some(d)
-            } else {
-                None
-            }
-        })
-    }) {
+    if let Some(names) = dict
+        .get("Names")
+        .and_then(|n| deref_obj(n, resolve))
+        .filter(|d| d.as_array().is_some())
+    {
         let arr = names.as_array().expect("checked array above");
         let mut i = 0;
         while i + 1 < arr.len() {
@@ -351,13 +347,7 @@ fn walk_name_tree(
     if let Some(kids) = dict
         .get("Kids")
         .and_then(|k| deref_obj(k, resolve))
-        .and_then(|k| {
-            if k.as_array().is_some() {
-                Some(k)
-            } else {
-                None
-            }
-        })
+        .filter(|k| k.as_array().is_some())
     {
         for kid in kids.as_array().expect("checked array above") {
             let Some(kid_node) = deref_obj(kid, resolve) else {

--- a/src/signatures/cms_verify.rs
+++ b/src/signatures/cms_verify.rs
@@ -474,7 +474,7 @@ mod tests {
         use p256::ecdsa::{signature::Signer, Signature, SigningKey};
         let sk = SigningKey::from_slice(&[1u8; 32]).expect("valid test key");
         let vk = *sk.verifying_key();
-        let pub_key_bytes = vk.to_encoded_point(false).as_bytes().to_vec();
+        let pub_key_bytes = vk.to_sec1_point(false).as_bytes().to_vec();
         let msg = b"round-trip test";
         let sig: Signature = sk.sign(msg);
         let sig_der = sig.to_der();
@@ -498,7 +498,7 @@ mod tests {
         use p384::ecdsa::{signature::Signer, Signature, SigningKey};
         let sk = SigningKey::from_slice(&[2u8; 48]).expect("valid test key");
         let vk = *sk.verifying_key();
-        let pub_key_bytes = vk.to_encoded_point(false).as_bytes().to_vec();
+        let pub_key_bytes = vk.to_sec1_point(false).as_bytes().to_vec();
         let msg = b"round-trip test";
         let sig: Signature = sk.sign(msg);
         let sig_der = sig.to_der();

--- a/src/structure/converter.rs
+++ b/src/structure/converter.rs
@@ -63,7 +63,7 @@ impl StructureConverter {
                     let nested_structure = self.convert_struct_elem(nested)?;
                     children.push(ContentElement::Structure(nested_structure));
                 },
-                StructChild::MarkedContentRef { mcid, page: _, .. } => {
+                StructChild::MarkedContentRef { mcid, .. } => {
                     // Lookup content by MCID
                     if let Some(content_elements) = self.mcid_map.get(mcid) {
                         children.extend(content_elements.clone());


### PR DESCRIPTION
## Summary
Consolidates 8 open dependabot PRs into one, per request. Closes/supersedes #818, #819, #820, #821, #822, #823, #824, #825.

**Cargo:**
- `taffy` 0.11.0 → 0.12.1
- `p256` 0.13.2 → 0.14.0
- `p384` 0.13.1 → 0.14.0

**GitHub Actions:**
- `golangci/golangci-lint-action` 9.2.1 → 9.3.0
- `astral-sh/setup-uv` 8.2.0 → 8.3.2
- `gradle/actions/setup-gradle` 4.3.1 → 6.2.0
- `actions/setup-go` 6.4.0 → 6.5.0
- `sbt/setup-sbt` 1.1.11 → 1.5.0

Each dependabot commit cherry-picked as-is (unmodified) plus one fix commit for a real breaking change surfaced by the p256/p384 bump: `elliptic-curve`'s `VerifyingKey::to_encoded_point` was renamed to `to_sec1_point`. Both call sites were test-only (`ecdsa_p256_round_trip`, `ecdsa_p384_round_trip` in `src/signatures/cms_verify.rs`); production verification code doesn't use this method.

Relates to the standing dependency-freshness tracking issue (#793) — not the same crates, but same bookkeeping category.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo test --release --lib` (default features): 5719 passed, 0 failed
- [x] `cargo test --release --lib --no-default-features --features fips,icc,signatures`: 5795 passed, 0 failed (includes both fixed p256/p384 round-trip tests)