### PR TITLE
docs: fix broken --all-features test commands in PR template and dev guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,7 @@ Fixes #
 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] All new and existing tests pass locally
-- [ ] I have run `cargo test --all-features`
+- [ ] I have run `cargo test` (see [CONTRIBUTING.md](../CONTRIBUTING.md#4-test-your-changes) — `--all-features` fails to build: `fips` and `legacy-crypto` are mutually exclusive by design)
 - [ ] I have run `cargo clippy -- -D warnings`
 - [ ] I have run `cargo fmt`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,20 @@ cargo test --features ml
 cargo watch -x test
 ```
 
+> **Don't use `cargo test --all-features`** — it fails to build. The
+> `fips` feature and the default-on `legacy-crypto` feature are
+> mutually exclusive (FIPS 140-3 forbids the MD5 that `legacy-crypto`
+> pulls in) and enforced with a `compile_error!`. This applies to any
+> command that compiles the crate (`build`, `check`, `test`, `doc`),
+> not just `test`. If your change touches FIPS-gated code, verify it
+> separately with:
+> ```bash
+> cargo test --no-default-features --features fips,icc
+> ```
+> CI's own feature-matrix job (`cargo hack --each-feature`) excludes
+> `fips` from the powerset for the same reason and covers it with a
+> dedicated job instead — that's the pattern to follow locally too.
+
 ### 5. Format and Lint
 
 ```bash

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -39,10 +39,20 @@ git clone <repository-url>
 cd pdf_oxide
 
 # Verify setup
-cargo check --all-features
+cargo check
 cargo test
 cargo clippy --all-targets
 ```
+
+> **Never use `--all-features`** on a command that compiles the crate
+> (`build`/`check`/`test`/`doc`) — `fips` and the default-on
+> `legacy-crypto` are mutually exclusive by design (`compile_error!`;
+> FIPS 140-3 forbids the MD5 `legacy-crypto` pulls in) and `--all-features`
+> enables both at once. Test FIPS-gated code separately:
+> `cargo test --no-default-features --features fips,icc`. See
+> [CONTRIBUTING.md](../CONTRIBUTING.md#4-test-your-changes) for details.
+> (`cargo-deny` is the one exception — it only reads `Cargo.toml`
+> metadata and never compiles, so `--all-features` is safe there.)
 
 ### Daily Development
 
@@ -50,7 +60,7 @@ cargo clippy --all-targets
 # Quick checks before committing
 cargo fmt
 cargo clippy --all-targets -- -D warnings
-cargo test --all-features
+cargo test
 ```
 
 ## Project Structure
@@ -312,7 +322,7 @@ Run automated checks:
 ```bash
 cargo fmt
 cargo clippy --all-targets -- -D warnings
-cargo test --all-features
+cargo test
 ```
 
 Or use: `/review`
@@ -408,8 +418,8 @@ mod tests {
 ### Running Tests
 
 ```bash
-# All tests
-cargo test --all-features
+# All tests (default features — `--all-features` fails, see note above)
+cargo test
 
 # Specific module
 cargo test object
@@ -631,10 +641,10 @@ Run with: `cargo test --doc`
 
 ```bash
 # Build docs
-cargo doc --no-deps --all-features
+cargo doc --no-deps
 
 # Open in browser
-cargo doc --no-deps --all-features --open
+cargo doc --no-deps --open
 ```
 
 ## Git Workflow


### PR DESCRIPTION
## Summary

Fixes #833. `cargo test --all-features` fails to compile on this crate: the `fips` feature and the default-on `legacy-crypto` feature are mutually exclusive by design (FIPS 140-3 forbids the MD5 that `legacy-crypto` pulls in), enforced with a `compile_error!` in `src/lib.rs`. This is the correct, Cargo-team-recommended pattern for genuinely mutually-exclusive features (there's no native Cargo mechanism to declare it — verified against Cargo's own features reference docs) — the bug isn't the exclusivity, it's that our contributor-facing docs told people to run a command that can't work.

- `.github/PULL_REQUEST_TEMPLATE.md` said `cargo test --all-features` — disagreed with `CONTRIBUTING.md`'s already-correct `cargo test`
- `docs/DEVELOPMENT_GUIDE.md` had 5 more broken instances: `cargo check --all-features`, `cargo test --all-features` ×3, `cargo doc --no-deps --all-features` ×2
- None of these match what CI itself verifies — CI never compiles with `--all-features`. It runs `cargo hack check --each-feature --exclude-features fips` (the feature-powerset job) plus a dedicated FIPS-only job (`--no-default-features --features fips,icc`). The one legitimate `--all-features` use in CI is `cargo-deny`, which only reads `Cargo.toml` metadata and never invokes rustc, so it's unaffected.

## Changes Made

- Replaced every compiling `--all-features` invocation in the PR template and `DEVELOPMENT_GUIDE.md` with the working equivalent (plain `cargo test`/`check`/`doc`, matching `CONTRIBUTING.md`)
- Added a short explanatory note in both `CONTRIBUTING.md` and `DEVELOPMENT_GUIDE.md` covering *why* (the compile_error, the FIPS 140-3 rationale) and the correct command for FIPS-gated changes: `cargo test --no-default-features --features fips,icc`
- Left `cargo-deny`'s `--all-features` in `ci.yml` untouched — that one is correct as-is

## Test plan

- [x] Doc-only change — no code compiled or behavior changed
- [x] Verified the replacement commands (`cargo test`, `cargo check`, `cargo doc --no-deps`, `cargo test --no-default-features --features fips,icc`) are exactly what CI's own jobs already run successfully
- [x] Verified the CONTRIBUTING.md anchor link (`#4-test-your-changes`) matches the existing heading

Claude-Session: https://claude.ai/code/session_01D8bcUo6Xk1UhRyuCn7sXSd