### PR TITLE
fix: de-fuse backtracking math tokens at the word layer, harden table detection

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -16207,6 +16207,24 @@ impl PdfDocument {
         // Merge condition: same line (y_diff ≤ 0.5 × max line height) AND
         // horizontal gap ≤ 0.15 × font_size (same threshold as should_insert_space).
         // Skip merge when the current word index is a split boundary.
+        //
+        // `gap` has no lower bound above, so a word that BACKTRACKS far behind
+        // the previous word's origin also satisfies `gap ≤ 0.15 × font_size`
+        // (a large negative number is always ≤ a small positive one). Displayed
+        // math draws a fraction's denominator AFTER the relation sign that
+        // follows the numerator (`dx/dt = …` → the `=` is emitted, then `dt`
+        // starts ~2em further left at a small baseline offset) — this is the
+        // exact geometry `assemble_text_from_spans`'s backtrack branch breaks
+        // the line on, just reached here through word bboxes instead of span
+        // bboxes. Left unguarded, this loop fuses the pair into `"=dt"`, and
+        // because the merge is incremental (`prev` grows to the union bbox),
+        // a chain of such backtracks collapses into one word spanning an
+        // entire equation — the far worse case reported against `main`.
+        // Mirror the emitter's guard: a word that starts at-or-left of the
+        // previous word's ORIGIN (not just its end), with a real baseline
+        // offset and an overlap far beyond ordinary kerning, is a backtrack,
+        // not a same-line neighbour — never merge across it. Gated off for
+        // RTL text, whose leftward flow is ordinary reading order.
         let mut merged: Vec<Word> = Vec::with_capacity(words.len());
         let mut prev_rotated = false;
         for (idx, word) in words.into_iter().enumerate() {
@@ -16215,9 +16233,15 @@ impl PdfDocument {
                 if let Some(prev) = merged.last_mut() {
                     let gap = word.bbox.x - (prev.bbox.x + prev.bbox.width);
                     let y_diff = (word.bbox.y - prev.bbox.y).abs();
+                    let delta_x = word.bbox.x - prev.bbox.x;
                     let line_h = prev.bbox.height.max(word.bbox.height);
                     let font_size = prev.avg_font_size.max(word.avg_font_size).max(1.0);
-                    if y_diff <= line_h * 0.5 && gap <= font_size * 0.15 {
+                    let is_math_backtrack = y_diff > 1.0
+                        && delta_x <= 0.5
+                        && gap < -font_size
+                        && !crate::text::bidi::looks_rtl(&prev.text)
+                        && !crate::text::bidi::looks_rtl(&word.text);
+                    if y_diff <= line_h * 0.5 && gap <= font_size * 0.15 && !is_math_backtrack {
                         // Incremental merge — O(k) per merge, O(total_chars) overall.
                         // Avoids the O(n²) clone+from_chars pattern that caused
                         // catastrophic slowdown on TOC dot-leader pages.
@@ -17214,7 +17238,15 @@ impl PdfDocument {
             })
             .collect();
 
-        Ok(detect_tables_with_lines(&spans, &lines, &config))
+        // Same prose-rejection filter `extract_page_tables` applies to the
+        // extract_text/to_markdown/to_html path — this public API called
+        // `detect_tables_with_lines` directly with no post-filter at all, so
+        // it was already able to fabricate/garble tables on any prose-shaped
+        // spatial candidate, independent of anything else in this function.
+        Ok(detect_tables_with_lines(&spans, &lines, &config)
+            .into_iter()
+            .filter(|t| t.is_real_grid() && !looks_like_prose_table(t))
+            .collect())
     }
 
     /// Process paths from a Form XObject.

--- a/src/document.rs
+++ b/src/document.rs
@@ -16236,12 +16236,28 @@ impl PdfDocument {
                     let delta_x = word.bbox.x - prev.bbox.x;
                     let line_h = prev.bbox.height.max(word.bbox.height);
                     let font_size = prev.avg_font_size.max(word.avg_font_size).max(1.0);
-                    let is_math_backtrack = y_diff > 1.0
-                        && delta_x <= 0.5
-                        && gap < -font_size
-                        && !crate::text::bidi::looks_rtl(&prev.text)
+                    let not_rtl = !crate::text::bidi::looks_rtl(&prev.text)
                         && !crate::text::bidi::looks_rtl(&word.text);
-                    if y_diff <= line_h * 0.5 && gap <= font_size * 0.15 && !is_math_backtrack {
+                    let is_math_backtrack =
+                        y_diff > 1.0 && delta_x <= 0.5 && gap < -font_size && not_rtl;
+                    // A LINE WRAP can land at nearly the same y as the line
+                    // above it (some producers emit sub-1pt baseline drift
+                    // between consecutive lines, so `y_diff > 1.0` above
+                    // doesn't always hold), but it always resets x back
+                    // toward the page's left margin — an order of magnitude
+                    // further than any real same-line construct (ordinary
+                    // kerning is near 0; the math backtrack above is ~1-2em).
+                    // A multi-em backtrack this large can only be two
+                    // different lines, never a genuine adjacency — reject it
+                    // regardless of y_diff, or a wrapped line's tail gets
+                    // fused onto its own next line's head (e.g. "of whom" +
+                    // "tered with books" → "whomteredwithbooks").
+                    let is_line_wrap_reset = delta_x < -5.0 * font_size && not_rtl;
+                    if y_diff <= line_h * 0.5
+                        && gap <= font_size * 0.15
+                        && !is_math_backtrack
+                        && !is_line_wrap_reset
+                    {
                         // Incremental merge — O(k) per merge, O(total_chars) overall.
                         // Avoids the O(n²) clone+from_chars pattern that caused
                         // catastrophic slowdown on TOC dot-leader pages.

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -356,6 +356,64 @@ fn looks_like_prose_paragraph(table: &Table) -> bool {
         }
     }
 
+    // Punctuation-independent fallback: a wrapped-prose row whose column
+    // break fell mid-clause carries no sentence terminator at all (a title
+    // caption, a clause with no `.`/`!`/`?`), so the checks above miss it.
+    // Real data-cell values are atomic (numbers, codes, capitalised labels)
+    // and essentially never start with a lowercase letter; running-sentence
+    // fragments frequently do ("text with", "a smaller", "on"). This mirrors
+    // `looks_like_prose_table`'s per-cell signal in document.rs, but applies
+    // PER ROW with no minimum cell count — that function's ≥10-cell floor
+    // (needed there to avoid over-rejecting small genuine tables under a
+    // table-wide ratio) is exactly what lets a small (2–3 row) fabricated
+    // table slip through untested. A 2-cell floor plus a majority-of-row
+    // requirement keeps ordinary short data rows (a units column, a coded
+    // abbreviation) safe: those cells are numeric/capitalised, not lowercase
+    // clause fragments, so they rarely cross the 50% bar even at n=2.
+    for row in &table.rows {
+        let cells: Vec<&str> = row
+            .cells
+            .iter()
+            .map(|c| c.text.trim())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if cells.len() < 2 {
+            continue;
+        }
+        let lower_starts = cells
+            .iter()
+            .filter(|c| c.chars().next().is_some_and(char::is_lowercase))
+            .count();
+        if lower_starts as f32 / cells.len() as f32 > 0.5 {
+            return true;
+        }
+    }
+
+    // Vertically-stacked single-character lines: a rotated axis label or
+    // figure legend, drawn one glyph per line so its bbox flattens into the
+    // page's normal (unrotated) column grid, reads as a cell whose text is
+    // mostly 1-character lines joined by `\n` (e.g. "k\nc\no\nc\nE-Box" for a
+    // vertically-drawn "clock"-style label). A genuine multi-line data cell
+    // wraps at WORD boundaries — its lines hold whole words, not lone
+    // letters — so this shape is essentially unique to misread rotated text.
+    for row in &table.rows {
+        for cell in &row.cells {
+            let lines: Vec<&str> = cell
+                .text
+                .split('\n')
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .collect();
+            if lines.len() < 3 {
+                continue;
+            }
+            let single_char_lines = lines.iter().filter(|l| l.chars().count() == 1).count();
+            if single_char_lines as f32 / lines.len() as f32 > 0.5 {
+                return true;
+            }
+        }
+    }
+
     false
 }
 

--- a/tests/test_word_level_math_fusion.rs
+++ b/tests/test_word_level_math_fusion.rs
@@ -28,6 +28,15 @@
 //! `extract_tables` API additionally got the same real-grid/prose filter the
 //! internal path already had, since it had none at all.
 //!
+//! A third, related shape found during corpus validation: the same
+//! unbounded-`gap` merge also fires across an ordinary line wrap when the
+//! producer emits two consecutive lines at nearly the same y (some PDF
+//! generators have sub-1pt baseline drift between lines), since the
+//! backtrack guard's `y_diff > 1.0` check doesn't catch it. Guarded
+//! separately by rejecting any merge whose `delta_x` backs up more than 5
+//! font-sizes regardless of `y_diff` — no genuine same-line construct
+//! backtracks that far.
+//!
 //! Verified empirically against real documents (not committed — this repo's
 //! fixture policy keeps third-party PDFs out of the tree; fetch instructions
 //! are in each opt-in test below): a displayed-math-heavy arXiv page, a
@@ -120,6 +129,35 @@ fn backtracking_price_and_quantity_split() {
     assert!(
         !fused,
         "backtracking price/quantity pair must split into separate words, got: {:?}",
+        words.iter().map(|w| &w.text).collect::<Vec<_>>()
+    );
+}
+
+/// A line wrap whose two lines happen to sit at nearly the same y (some
+/// producers emit sub-1pt baseline drift between consecutive lines — the
+/// `y_diff > 1.0` half of the math-backtrack guard doesn't catch this) must
+/// still not fuse the wrapped line's tail onto the next line's head. The
+/// line's end (far right) and the next line's start (far left, ~35 em back)
+/// is an order of magnitude beyond any genuine same-line construct (ordinary
+/// kerning is near 0; a fraction backtrack is ~1-2 em) and can only be two
+/// different lines. Reproduces a real `main` regression: "of whom" (end of
+/// one line) fusing onto "tered with books" (start of the next) into
+/// "whomteredwithbooks".
+#[test]
+fn line_wrap_with_near_zero_y_delta_does_not_fuse() {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT\n");
+    content.extend_from_slice(b"/F1 10 Tf 1 0 0 1 361.08 600.76 Tm (of whom) Tj\n");
+    content.extend_from_slice(b"/F1 10 Tf 1 0 0 1 36.48 600.08 Tm (tered with books) Tj\n");
+    content.extend_from_slice(b"ET");
+    let pdf = build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]");
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let words = doc.extract_words(0).expect("words");
+    let fused = words.iter().any(|w| w.text.contains("whomtered"));
+    assert!(
+        !fused,
+        "a wrapped line must not fuse onto the next line's start even when \
+         y_diff is under 1pt, got: {:?}",
         words.iter().map(|w| &w.text).collect::<Vec<_>>()
     );
 }

--- a/tests/test_word_level_math_fusion.rs
+++ b/tests/test_word_level_math_fusion.rs
@@ -1,0 +1,294 @@
+//! `extract_words` must not fuse a relation sign with a backtracking
+//! denominator, nor let the resulting word-topology change fabricate tables.
+//!
+//! A prior fix taught `extract_text` (via `assemble_text_from_spans`) to
+//! break the line between a relation sign and a backtracking fraction
+//! denominator (`dx1/dt = …` no longer extracts as `dx1 =dt`). That fix was
+//! deliberately scoped to the composed-text path only: `extract_words` has
+//! its own, separate post-clustering merge step (in `extract_words_inner`)
+//! that joins adjacent words abutting or overlapping on the same line — and
+//! it had the identical bug. Its `gap` check had no lower bound, so a word
+//! that backtracks far behind the previous word's ORIGIN (not just its end)
+//! also satisfies "gap ≤ a small positive number", and because the merge is
+//! incremental (the merged word's bbox keeps growing), a chain of such
+//! backtracks can collapse an entire displayed equation — and, in the worst
+//! observed real-document case, the start of the following sentence — into
+//! one word.
+//!
+//! Fixing that alone is not safe on its own: `extract_tables` (both the
+//! internal path `extract_text`/`to_markdown`/`to_html` use, and the public
+//! `extract_tables` API) feeds `extract_words` output into the spatial table
+//! detector as its word geometry. Changing word topology changes what the
+//! detector sees, and its punctuation-based prose-rejection guard
+//! (`looks_like_prose_paragraph`) let a fabricated or garbled table through
+//! whenever the newly-separated prose had no sentence terminator inside it
+//! (a caption, a mid-clause fragment) or held vertically-stacked
+//! single-character lines (a misread rotated axis label). Both gaps are
+//! closed here with punctuation-independent, shape-based signals; the public
+//! `extract_tables` API additionally got the same real-grid/prose filter the
+//! internal path already had, since it had none at all.
+//!
+//! Verified empirically against real documents (not committed — this repo's
+//! fixture policy keeps third-party PDFs out of the tree; fetch instructions
+//! are in each opt-in test below): a displayed-math-heavy arXiv page, a
+//! small Apache PDFBox regression PDF, and a PubMed Central article. All
+//! three fabricated or garbled a table when the word-layer fix landed alone;
+//! none does with the detector hardening also in place.
+
+use pdf_oxide::document::PdfDocument;
+use std::path::Path;
+
+/// Same geometry as the composed-text fixture: numerator `dx1` above a
+/// vinculum, relation `=` at mid-height, denominator `dt` drawn AFTER it,
+/// starting behind the `=` origin at a lower baseline. On `main` this fuses
+/// into one `extract_words` token containing `"=dt"`.
+fn display_fraction_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"0.4 w 131.8 719.5 m 145.0 719.5 l S\n");
+    content.extend_from_slice(b"BT\n");
+    content.extend_from_slice(b"/F1 8 Tf 1 0 0 1 131.81 721.00 Tm (dx) Tj\n");
+    content.extend_from_slice(b"/F1 6 Tf 1 0 0 1 141.28 721.00 Tm (1) Tj\n");
+    content.extend_from_slice(b"/F1 12 Tf 1 0 0 1 149.94 718.04 Tm (=) Tj\n");
+    content.extend_from_slice(b"/F1 8 Tf 1 0 0 1 134.74 710.00 Tm (dt) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+#[test]
+fn relation_sign_stays_separate_in_extract_words() {
+    let doc = PdfDocument::from_bytes(display_fraction_pdf()).expect("parse");
+    let words = doc.extract_words(0).expect("words");
+    let fused: Vec<&str> = words
+        .iter()
+        .map(|w| w.text.as_str())
+        .filter(|t| t.contains("=dt"))
+        .collect();
+    assert!(
+        fused.is_empty(),
+        "extract_words must not fuse the relation sign with the backtracking \
+         denominator into one token, got fused tokens: {fused:?} (all words: {:?})",
+        words.iter().map(|w| &w.text).collect::<Vec<_>>()
+    );
+}
+
+/// Genuine same-line, tightly-kerned neighbours (no baseline backtrack) must
+/// still merge — this is the ordinary-adjacent-glyph-run feature the merge
+/// step exists for (tagged CJK documents split typographically-adjacent
+/// glyphs across marked-content runs). The backtrack guard must not
+/// over-trigger on this shape: same baseline (`y_diff` ≈ 0), small negative
+/// gap from a genuine kerning overlap, not a multi-em backtrack.
+#[test]
+fn tight_kerning_neighbours_still_merge() {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT\n");
+    content.extend_from_slice(b"/F1 12 Tf 1 0 0 1 100.00 700.00 Tm (Q) Tj\n");
+    // 0.18pt overlap: ordinary tight kerning, not a math backtrack.
+    content.extend_from_slice(b"/F1 12 Tf 1 0 0 1 109.82 700.00 Tm (mark) Tj\n");
+    content.extend_from_slice(b"ET");
+    let pdf = build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]");
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let words = doc.extract_words(0).expect("words");
+    let joined: String = words
+        .iter()
+        .map(|w| w.text.as_str())
+        .collect::<Vec<_>>()
+        .join("|");
+    assert!(
+        joined.contains("Qmark"),
+        "ordinary tightly-kerned same-line neighbours must still merge, got words: {joined:?}"
+    );
+}
+
+/// A unit price backtracking into a quantity column (`$0.14` then `50,170`
+/// drawn starting behind the price's origin) is the same backtrack geometry
+/// as the math case, just with digits instead of a relation sign. `main`
+/// fuses this into one word/cell (`$0.1450,170`); after the fix the two
+/// values are separate. This is an intentional behaviour change — a whole-
+/// document diff against `main` will show it, and that is correct, not a
+/// regression to revert.
+#[test]
+fn backtracking_price_and_quantity_split() {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT\n");
+    content.extend_from_slice(b"/F1 10 Tf 1 0 0 1 200.00 500.00 Tm ($0.14) Tj\n");
+    content.extend_from_slice(b"/F1 10 Tf 1 0 0 1 160.00 494.00 Tm (50,170) Tj\n");
+    content.extend_from_slice(b"ET");
+    let pdf = build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]");
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let words = doc.extract_words(0).expect("words");
+    let fused = words.iter().any(|w| w.text.contains("0.1450"));
+    assert!(
+        !fused,
+        "backtracking price/quantity pair must split into separate words, got: {:?}",
+        words.iter().map(|w| &w.text).collect::<Vec<_>>()
+    );
+}
+
+/// Opt-in real-document guard. Fetch:
+/// `curl -sL -o tests/fixtures/real/2503.09472.pdf https://arxiv.org/pdf/2503.09472v1`.
+/// Page index 14 (1-based page 15) is the densest fraction layout in the
+/// paper; on `main` its `extract_words` output contains fused tokens
+/// including one that swallows the start of the following sentence.
+#[test]
+fn real_arxiv_page_has_no_fused_math_words_or_fabricated_tables() {
+    let p = "tests/fixtures/real/2503.09472.pdf";
+    if !Path::new(p).exists() {
+        eprintln!("[word-fusion] fixture missing, skipping: {p}");
+        return;
+    }
+    let doc = PdfDocument::from_bytes(std::fs::read(p).expect("read")).expect("parse");
+    let words = doc.extract_words(14).expect("words");
+    let bad: Vec<&str> = words
+        .iter()
+        .map(|w| w.text.as_str())
+        .filter(|t| t.contains('=') && t.chars().count() > 3)
+        .collect();
+    assert!(bad.is_empty(), "no word should contain a fused '=' token, got: {bad:?}");
+    let longest = words
+        .iter()
+        .map(|w| w.text.chars().count())
+        .max()
+        .unwrap_or(0);
+    assert!(
+        longest < 40,
+        "no word should exceed ordinary token length, longest was {longest} chars"
+    );
+
+    let text = doc.extract_text(14).expect("text");
+    assert_eq!(text.matches("=dt").count(), 0, "extract_text must stay free of '=dt' fusion");
+
+    let tables = doc.extract_tables(14).expect("tables");
+    assert!(
+        tables.is_empty(),
+        "no table should be detected on this prose+math page, got {} tables",
+        tables.len()
+    );
+}
+
+/// Opt-in real-document guard for the table-fabrication risk. Fetch:
+/// `curl -sL -o "tests/fixtures/real/PDFBOX-5002.pdf" "https://issues.apache.org/jira/secure/attachment/13014135/small%26Big.pdf"`
+/// — a minimal Apache PDFBox regression PDF (single caption sentence, no
+/// real table). On `main`, the word-layer fix alone fabricates a 3-row
+/// table out of this ordinary wrapped caption; the detector hardening keeps
+/// it rejected.
+#[test]
+fn real_pdfbox_caption_produces_no_fabricated_table() {
+    let p = "tests/fixtures/real/PDFBOX-5002.pdf";
+    if !Path::new(p).exists() {
+        eprintln!("[word-fusion] fixture missing, skipping: {p}");
+        return;
+    }
+    let doc = PdfDocument::from_bytes(std::fs::read(p).expect("read")).expect("parse");
+    let tables = doc.extract_tables(0).expect("tables");
+    assert!(
+        tables.is_empty(),
+        "an ordinary wrapped caption must not be detected as a table, got {} tables: {:?}",
+        tables.len(),
+        tables.iter().map(|t| &t.rows).collect::<Vec<_>>()
+    );
+}
+
+/// Opt-in real-document guard for the second table-fabrication shape: a
+/// rotated axis label whose glyphs are drawn one per line, which reads as a
+/// cell of mostly single-character lines. Fetch:
+/// `curl -sL -o tests/fixtures/real/pmc8129076.pdf https://europepmc.org/articles/PMC8129076?pdf=render`.
+#[test]
+fn real_pmc_article_produces_no_rotated_label_table() {
+    let p = "tests/fixtures/real/pmc8129076.pdf";
+    if !Path::new(p).exists() {
+        eprintln!("[word-fusion] fixture missing, skipping: {p}");
+        return;
+    }
+    let doc = PdfDocument::from_bytes(std::fs::read(p).expect("read")).expect("parse");
+    let tables = doc.extract_tables(1).expect("tables");
+    for t in &tables {
+        for row in &t.rows {
+            for cell in &row.cells {
+                let lines: Vec<&str> = cell
+                    .text
+                    .split('\n')
+                    .map(str::trim)
+                    .filter(|l| !l.is_empty())
+                    .collect();
+                if lines.len() >= 3 {
+                    let single = lines.iter().filter(|l| l.chars().count() == 1).count();
+                    assert!(
+                        (single as f32 / lines.len() as f32) <= 0.5,
+                        "a rotated-label-shaped cell must not survive as a table cell, got: {:?}",
+                        cell.text
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The emitter's backtrack branch is gated OFF for right-to-left runs, and
+/// the word-merge guard mirrors that gating. Opt-in real-document guard.
+/// Fetch: `curl -sL -o tests/fixtures/real/wiki_cat_ar.pdf
+/// https://ar.wikipedia.org/api/rest_v1/page/pdf/%D9%82%D8%B7`.
+#[test]
+fn rtl_words_are_not_broken_by_the_backtrack_guard() {
+    let p = "tests/fixtures/real/wiki_cat_ar.pdf";
+    if !Path::new(p).exists() {
+        eprintln!("[word-fusion] RTL fixture missing, skipping: {p}");
+        return;
+    }
+    let doc = PdfDocument::from_bytes(std::fs::read(p).expect("read")).expect("parse");
+    let words = doc.extract_words(0).expect("words");
+    let arabic_chars: usize = words
+        .iter()
+        .flat_map(|w| w.text.chars())
+        .filter(|c| ('\u{0600}'..='\u{06FF}').contains(c))
+        .count();
+    assert!(
+        arabic_chars > 100,
+        "Arabic content must survive word extraction intact, saw {arabic_chars} Arabic chars"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Minimal raw PDF builder (same pattern as test_display_math_word_fusion.rs)
+// ---------------------------------------------------------------------------
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}


### PR DESCRIPTION
## Summary

Fixes #836. Follow-up to #831, which fixed backtracking-denominator fusion (`dx1/dt = …` → `dx1 =dt`) in `extract_text`/`to_markdown`/`to_html` only, by design — the word-layer fix was deferred because it changes word geometry, which table detection consumes, and that risk needed its own review cycle. This PR does both halves, since neither is safe alone.

**1. Word-layer de-fusion.** `extract_words_inner`'s post-clustering merge step (separate from the composed-text emitter #831 fixed) had the identical bug: its `gap` check (`gap ≤ font_size × 0.15`) has no lower bound, so a word backtracking far behind the previous word's *origin* (not just its end) still satisfies "a large negative number ≤ a small positive one". Because the merge is incremental, a chain of such backtracks can collapse an entire displayed equation — and in the worst case found in the corpus, the start of the following sentence — into one word. Added a guard mirroring #831's emitter branch (real baseline offset, origin-or-left backtrack, multi-em overlap, gated off for RTL) to `extract_words_inner`.

**2. Table-detector hardening.** `extract_tables` (both the internal path `extract_text`/`to_markdown`/`to_html` use, and the public `extract_tables` API) feeds `extract_words` output into the spatial table detector. Changing word topology changes what the detector sees, and `looks_like_prose_paragraph`'s only signal was a sentence-terminator pattern — it missed punctuation-free prose (a caption, a mid-clause fragment with no `.`/`!`/`?`) and a second shape entirely: a rotated axis label drawn one glyph per line, which reads as a cell of mostly single-character lines (`"k\nc\no\nc\nE-Box"`). Added two punctuation-independent, shape-based checks. Also: the public `extract_tables` API had *no* post-filter at all (unlike the internal `extract_page_tables` path, which already applies `is_real_grid`/`looks_like_prose_table`) — gave it the same filter, since it was equally exposed regardless of this change.

## Empirical validation

Verified against 4 real documents (not committed — this repo's fixture policy keeps third-party PDFs out of the tree; fetch URLs are documented in each opt-in test in `tests/test_word_level_math_fusion.rs`):

- **arXiv 2503.09472, page 15** (densest fraction layout in the paper): `extract_words` no longer contains fused `=` tokens or absurd-length words; `extract_tables`/`to_markdown` produce 0 tables (unchanged from `main`).
- **Apache PDFBox `small&Big.pdf`** (JIRA PDFBOX-5002, an ordinary wrapped caption): `main` + the word-layer fix alone fabricates a 3-row table out of this caption; with the detector hardening, 0 tables (matches `main`).
- **PubMed Central PMC8129076, page 2**: word-layer fix alone both fabricates a table from a rotated "clock"-style axis label (read as `"k\nc\no\nc\nE-Box"`) and produces a second, garbled version of the page's one pre-existing table. With hardening, only the pre-existing table survives, matching `main`'s table count.
- **Arabic Wikipedia page** (RTL guard, same fixture #831 uses): `extract_words` still recovers 100+ Arabic characters intact — the backtrack guard is gated off for RTL text, whose leftward flow is ordinary reading order, not a backtrack.

## Corpus regression sweep

Wrote a throwaway Rust sweep tool (not committed) and ran it against 113 documents in the `arxiv_math` and `F. Tables GUARD` categories of the existing 419-doc regression corpus, comparing `extract_words` word count/longest-word length and `extract_tables` table count/cell content against `main` (`c03fb579`). The existing `regr_worker.py`/`compare_v0373.py` harness only diffs `extract_text`/`md`/`html`, which is blind to word-layer-only regressions — this sweep specifically targets what those miss.

**Word-layer results were far more dramatic than the 3 known repro cases suggested.** Across ~90 arXiv math pages, word counts increased substantially and longest-word lengths collapsed almost everywhere — e.g. one page went from **21 words** (longest word: **4185 characters**) on `main` to **996 words** (longest: **111 characters**) on this branch; another from 17 words/1977-char longest to 585 words/65-char longest. These are full-page cascade-fusion failures on `main` that weren't visible from the 3 fixtures alone.

**Table-count changes were concentrated on IRS tax forms** (Form 1040, 1065, 1120, 941, W-2/`fw2`) — investigated individually before opening this PR, not waved through. Dumped actual cell content on `fw2.pdf` and `IRS_Form_1040_2024.pdf`:
- `fw2.pdf`: `main` detects 3 "tables" on page 1. One is `["12c",""],["C",""],["o",""],["d",""]` — the word "Code" spelled vertically down 4 rows, the exact rotated-label bug this PR fixes, just manifesting across rows instead of within one cell's newlines. Another holds only static, already-empty field-label captions (no data in any cell). The genuine data-bearing table (wage/tax fields) is preserved byte-identical on this branch.
- `IRS_Form_1040_2024.pdf`: `main` detects 5 "tables" on page 0. One is literally the sentence **"your filing status is MFS or HOH and you lived apart from your spouse for the last 6 months of 2025, or you..."** split word-by-word into 7 fake table columns (6 of 7 cells start lowercase) — a textbook instance of the exact false-positive class `looks_like_prose_paragraph`/`looks_like_prose_table` exist to catch. Another is a garbled, repeated column header.

None of these lost cells contained real filled-in taxpayer data — only printed template labels or these misdetected artifacts. This branch rejecting them is a correct improvement, not a regression, though it's a visible side effect worth flagging explicitly since it wasn't part of the original bug report.

**Known residual, out of scope for this fix:** `pmc8129076.pdf` still shows one long fused word (`"mTOR.Theserhythmichormonesregulatefeedingandevening/night17"`, 59 chars) — a different fusion pattern (dense reference-list/citation text, "mTOR." immediately followed by "These" with no rendered space) unrelated to the backtrack-math class this PR targets. No table fabrication results from it. Flagging for a possible separate follow-up rather than folding into this PR's scope.

## Test plan

- [x] New `tests/test_word_level_math_fusion.rs`: synthetic backtrack-fusion test, tight-kerning-still-merges regression guard (the pre-existing CJK abutting-glyph merge feature must survive), a synthetic GPO-bid-pricing-style test documenting the intentional price/quantity de-fusion, and opt-in real-fixture tests for all 4 documents above (7 tests total, all passing)
- [x] Pre-existing `tests/test_display_math_word_fusion.rs` (#831) still passes unmodified
- [x] Full `cargo test --lib`: 5719 passed, 0 failed
- [x] `cargo fmt --check` and `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] 113-document corpus regression sweep (arxiv_math + Tables GUARD categories) against `main`, reviewed by hand per this repo's regression-sweep convention — findings summarized above

Claude-Session: https://claude.ai/code/session_01D8bcUo6Xk1UhRyuCn7sXSd