### PR TITLE
fix: stop misclassifying born-digital pages as Scanned

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1526,6 +1526,18 @@ impl PdfDocument {
             let frag =
                 words.iter().filter(|w| w.chars().count() <= 2).count() as f32 / words.len() as f32;
             let rep = words.windows(2).filter(|w| w[0] == w[1]).count() as f32 / words.len() as f32;
+            // CJK/Hangul text has no inter-word spaces, so glyph-adjacency
+            // clustering naturally produces short (often 1-2 character)
+            // tokens — `frag` here is calibrated for space-separated Latin
+            // text and would otherwise read ordinary dense CJK prose as
+            // fragmented (this ratio directly gates `usable_text` in
+            // `classify_from_signals`). The repeat ratio is script-agnostic
+            // and stays as computed.
+            let frag = if crate::extractors::auto::is_cjk_dominant_text(&word_text) {
+                0.0
+            } else {
+                frag
+            };
             (frag, rep)
         };
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -1501,7 +1501,25 @@ impl PdfDocument {
             })
             .count();
         let garbled_ratio = bad as f32 / total as f32;
-        let words: Vec<&str> = text.split_whitespace().collect();
+        // Word-boundary signals (fragmentation, consecutive-repeat) need
+        // real words, not one token per span. Each span above is a raw
+        // content-stream text-showing run; in math typesetting every atom
+        // ((, ∞, ), a subscript, an operator) is its own span, so joining
+        // spans with a forced space makes every span boundary look like a
+        // word boundary and inflates the fragmented-word ratio on ordinary
+        // dense LaTeX pages until the text-quality gate mistakes them for
+        // scans. `extract_words` already does the real glyph/span
+        // clustering (adaptive gap thresholds, same-line merge, backtrack
+        // guard) that `extract_text` relies on — reuse its output here
+        // instead of re-deriving word boundaries from span punctuation.
+        let word_text: String = self
+            .extract_words(page)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|w| w.text)
+            .collect::<Vec<_>>()
+            .join(" ");
+        let words: Vec<&str> = word_text.split_whitespace().collect();
         let (fragmented_word_ratio, consecutive_repeat_ratio) = if words.is_empty() {
             (0.0, 0.0)
         } else {
@@ -1652,7 +1670,10 @@ impl PdfDocument {
             producer_prior,
             page_is_empty,
         };
-        let gate = crate::extractors::auto::text_quality_gate(&text);
+        // `text_quality_gate` does its own word-splitting internally; feed
+        // it the same word-clustered text as `fragmented_word_ratio` above
+        // (not the raw span-joined `text`), for the same reason.
+        let gate = crate::extractors::auto::text_quality_gate(&word_text);
         Ok((signals, gate))
     }
 

--- a/src/extractors/auto.rs
+++ b/src/extractors/auto.rs
@@ -698,6 +698,37 @@ pub struct PageClassification {
     pub signals: PageSignals,
 }
 
+/// Whether `text` is CJK/Hangul-dominant: a majority of its non-whitespace
+/// characters fall in the Han, Hiragana, Katakana, or Hangul Unicode
+/// blocks. These scripts don't use inter-word spaces, so glyph-adjacency
+/// word clustering naturally produces short (often 1-2 character) tokens —
+/// a `frag`/`avg_word_len` signal calibrated for space-separated Latin
+/// text misreads that as fragmentation. Used to skip the Latin-specific
+/// checks in [`text_quality_gate`] for such text; script-agnostic signals
+/// (garbled/repeat ratio) still apply normally.
+#[must_use]
+pub fn is_cjk_dominant_text(text: &str) -> bool {
+    let mut total = 0usize;
+    let mut cjk = 0usize;
+    for c in text.chars() {
+        if c.is_whitespace() {
+            continue;
+        }
+        total += 1;
+        let cp = c as u32;
+        if (0x4E00..=0x9FFF).contains(&cp)   // CJK Unified Ideographs
+            || (0x3400..=0x4DBF).contains(&cp) // CJK Extension A
+            || (0x3040..=0x309F).contains(&cp) // Hiragana
+            || (0x30A0..=0x30FF).contains(&cp) // Katakana
+            || (0xAC00..=0xD7A3).contains(&cp)
+        // Hangul Syllables
+        {
+            cjk += 1;
+        }
+    }
+    total > 0 && (cjk as f32 / total as f32) > 0.5
+}
+
 /// T0.5 enriched text-quality gate (research §3a).
 /// Pure: operates on the native-extracted text only. Returns the
 /// degrading [`ReasonCode`] if the "born-digital" text is unusable, or
@@ -741,8 +772,15 @@ pub fn text_quality_gate(text: &str) -> Option<ReasonCode> {
     if words.len() >= 8 {
         let frag =
             words.iter().filter(|w| w.chars().count() <= 2).count() as f32 / words.len() as f32;
+        // CJK/Hangul text has no inter-word spaces, so glyph-adjacency
+        // clustering naturally produces short tokens — `frag` and
+        // `avg_word_len` below are calibrated for space-separated Latin
+        // text and would otherwise misread ordinary dense CJK prose as
+        // fragmented. The repeat-ratio check (script-agnostic) still
+        // applies normally.
+        let cjk_dominant = is_cjk_dominant_text(text);
         // Critical hard-trigger (broken CMap splitting every glyph).
-        if frag > 0.80 {
+        if frag > 0.80 && !cjk_dominant {
             return Some(ReasonCode::GlyphMappingMissing);
         }
         // Consecutive-repeat / 2-column scramble: long runs of the
@@ -756,7 +794,7 @@ pub fn text_quality_gate(text: &str) -> Option<ReasonCode> {
         let repeat_ratio = repeats as f32 / words.len() as f32;
         let avg_word_len =
             words.iter().map(|w| w.chars().count()).sum::<usize>() as f32 / words.len() as f32;
-        if repeat_ratio > 0.30 || (frag > 0.55 && avg_word_len < 2.5) {
+        if repeat_ratio > 0.30 || (frag > 0.55 && avg_word_len < 2.5 && !cjk_dominant) {
             return Some(ReasonCode::TextLayerBelowThreshold);
         }
     }
@@ -1924,6 +1962,24 @@ mod tests {
         // Consecutive-repeat / 2-column scramble.
         let scramble = "alpha alpha beta beta gamma gamma delta delta epsilon epsilon zeta zeta";
         assert_eq!(text_quality_gate(scramble), Some(ReasonCode::TextLayerBelowThreshold));
+    }
+
+    #[test]
+    fn quality_gate_does_not_flag_dense_cjk_prose_as_fragmented() {
+        // Real Japanese sentence about cats (no inter-word spaces — this
+        // script never has them). Naturally clusters into short 1-3
+        // character "words" once split at whatever boundary a caller
+        // uses; that must not read as glyph-per-span CMap breakage the
+        // way it legitimately would for Latin text.
+        let ja = "ネコ 猫 は 狭義 に は 食肉目 ネコ科 ネコ属 に 分類 される \
+                  リビア ヤマネコ が 家畜 化 された イエネコ に 対する 通称 である";
+        assert_eq!(
+            text_quality_gate(ja),
+            None,
+            "dense CJK prose must not trigger the text-quality gate"
+        );
+        assert!(is_cjk_dominant_text(ja));
+        assert!(!is_cjk_dominant_text("The quick brown fox jumps over the lazy dog."));
     }
 
     #[test]

--- a/src/extractors/auto.rs
+++ b/src/extractors/auto.rs
@@ -811,7 +811,20 @@ pub fn classify_from_signals(
             } else {
                 0.85
             };
-            return (PageKind::Scanned, conf, ReasonCode::NoTextLayerPresent);
+            // A full-bleed background image with a real, usable text
+            // layer (a slide headline, a deck cover) is not "no text
+            // layer" — the text is there, mapped correctly, and
+            // extractable; it just doesn't cover enough of the page to
+            // outweigh the scan-dominant image coverage. Report the
+            // honest reason (coverage too low) rather than claiming no
+            // text layer exists at all, which would tell a caller who
+            // inspects `reason` there is nothing to extract.
+            let reason = if usable_text {
+                ReasonCode::TextLayerBelowThreshold
+            } else {
+                ReasonCode::NoTextLayerPresent
+            };
+            return (PageKind::Scanned, conf, reason);
         }
     }
 

--- a/tests/test_page_classification_accuracy.rs
+++ b/tests/test_page_classification_accuracy.rs
@@ -25,6 +25,18 @@
 //!    same raw text — routes a real text page to OCR. Both places now
 //!    build their word list from `extract_words` (the same glyph/span
 //!    clustering `extract_text` relies on) instead of raw span punctuation.
+//!
+//! Switching to `extract_words` clustering (cause 2's fix) surfaced a third
+//! issue during corpus validation: CJK/Hangul scripts have no inter-word
+//! spaces, so glyph-adjacency clustering naturally produces short (often
+//! 1-3 character) "words" — real, correct text, not fragmentation. The
+//! `frag`/`avg_word_len` checks (in both `text_quality_gate` and the
+//! `fragmented_word_ratio` feeding `classify_from_signals`) are calibrated
+//! for space-separated Latin text and misread this as a broken CMap,
+//! routing ordinary Japanese/Chinese/Korean pages to `Scanned`. Both now
+//! skip that specific check for CJK-dominant text via
+//! `is_cjk_dominant_text` (script-agnostic signals — garbled ratio,
+//! consecutive-repeat — still apply normally).
 
 use pdf_oxide::document::PdfDocument;
 use pdf_oxide::extractors::auto::{PageKind, ReasonCode};
@@ -84,6 +96,28 @@ fn split_span_words_do_not_trigger_scanned_misclassification() {
         cls.kind,
         cls.reason,
         words.iter().map(|w| &w.text).collect::<Vec<_>>()
+    );
+}
+
+/// Opt-in real-document guard for the CJK false-positive: an ordinary
+/// Japanese Wikipedia article (about cats), no images, no garbling. Not
+/// fetched automatically per this repo's fixture policy — place a copy at
+/// the path below to run this locally; it skips cleanly when absent.
+#[test]
+fn real_japanese_article_is_not_misclassified_scanned() {
+    let p = "tests/fixtures/real/wiki_cat_ja.pdf";
+    if !std::path::Path::new(p).exists() {
+        eprintln!("[classification] CJK fixture missing, skipping: {p}");
+        return;
+    }
+    let doc = PdfDocument::from_bytes(std::fs::read(p).expect("read")).expect("parse");
+    let cls = doc.classify_page(0).expect("classify_page");
+    assert!(
+        matches!(cls.kind, PageKind::TextLayer),
+        "ordinary CJK prose (no inter-word spaces, naturally short glyph-clustered \
+         tokens) must not be misclassified Scanned, got {:?} (reason {:?})",
+        cls.kind,
+        cls.reason
     );
 }
 

--- a/tests/test_page_classification_accuracy.rs
+++ b/tests/test_page_classification_accuracy.rs
@@ -1,0 +1,238 @@
+//! `classify_page` must not call a born-digital page `Scanned` when it
+//! carries real, usable, extractable text — `pages_needing_ocr` is meant to
+//! be safe to act on, and OCR-ing a page that already has good native text
+//! replaces it with worse output.
+//!
+//! Two independent causes, both in the coverage/text-quality decision path:
+//!
+//! 1. A full-bleed background image (`image_area_ratio` ~1.0) with a real
+//!    text headline drawn over it covers only a few percent of the page by
+//!    area. The sparse-coverage branch in `classify_from_signals` correctly
+//!    keeps the page `Scanned` on coverage grounds (that judgment call is
+//!    out of scope here), but it always reported `ReasonCode::
+//!    NoTextLayerPresent` even when the text is real, mapped correctly, and
+//!    visible (`usable_text == true`) — telling a caller who inspects the
+//!    reason that there is nothing to extract, when there is. Fixed to
+//!    report `TextLayerBelowThreshold` when text is actually usable.
+//!
+//! 2. `gather_page_signals` built its fragmentation-detection input by
+//!    joining raw content-stream spans with a forced space after every one.
+//!    Math typesetting draws each atom (a parenthesis, an operator, a
+//!    subscript) as its own span, so a page of ordinary dense LaTeX text
+//!    gets treated as a wall of one- and two-character "words", the
+//!    fragmented-word ratio spikes, and the text-quality gate — fed via
+//!    `text_quality_gate`, which does its own independent word-split on the
+//!    same raw text — routes a real text page to OCR. Both places now
+//!    build their word list from `extract_words` (the same glyph/span
+//!    clustering `extract_text` relies on) instead of raw span punctuation.
+
+use pdf_oxide::document::PdfDocument;
+use pdf_oxide::extractors::auto::{PageKind, ReasonCode};
+
+/// A full-bleed background image with a real text headline drawn over it —
+/// a slide, a magazine cover, a deck title page. `usable_text` is true (the
+/// text is short but clean and visible) and `image_area_ratio` is ~1.0, so
+/// coverage-driven `Scanned` is a defensible verdict; the reason must not
+/// claim there is no text layer.
+#[test]
+fn full_bleed_image_with_real_headline_gets_honest_reason() {
+    let pdf = full_bleed_slide_pdf();
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let cls = doc.classify_page(0).expect("classify_page");
+
+    // The text is real and must remain fully extractable regardless of
+    // how the page gets classified.
+    let text = doc.extract_text(0).expect("extract_text");
+    assert!(text.contains("Quarterly"), "headline text must still extract, got: {text:?}");
+
+    if matches!(cls.kind, PageKind::Scanned) {
+        assert_ne!(
+            cls.reason,
+            ReasonCode::NoTextLayerPresent,
+            "a page with a real, visible, usable text headline must not be reported as having no text layer"
+        );
+    }
+}
+
+/// Ordinary dense text where every "word" is drawn as 2-3 separate,
+/// tightly-abutting text-showing operations (no real gap between the
+/// pieces) — the same span-per-atom shape displayed math produces, just
+/// with plain Latin text so the expected recombined word is unambiguous.
+/// Raw span-joining (one forced space per span) fragments each word into
+/// its 2-3 pieces; real word-clustering recombines them.
+#[test]
+fn split_span_words_do_not_trigger_scanned_misclassification() {
+    let pdf = fragmented_span_words_pdf();
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let cls = doc.classify_page(0).expect("classify_page");
+
+    // `gather_page_signals`/`text_quality_gate` build their word list from
+    // `extract_words`, not `extract_text` (a separate emitter) — check the
+    // fixture's precondition through the same lens the fix operates on.
+    let words = doc.extract_words(0).expect("extract_words");
+    assert!(
+        words.len() >= 8,
+        "fixture must produce enough real words to exercise the gate, got: {:?}",
+        words.iter().map(|w| &w.text).collect::<Vec<_>>()
+    );
+
+    assert!(
+        matches!(cls.kind, PageKind::TextLayer),
+        "a page of ordinary text split across tightly-kerned spans (the same shape \
+         math typesetting produces) must not be misclassified Scanned, got {:?} \
+         (reason {:?}), words: {:?}",
+        cls.kind,
+        cls.reason,
+        words.iter().map(|w| &w.text).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+fn full_bleed_slide_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut off = vec![0usize; 7];
+
+    off[1] = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    off[2] = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    off[3] = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 720 540] \
+         /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> \
+         /XObject << /Im0 6 0 R >> >> >>\nendobj\n",
+    );
+
+    // Full-bleed image placement, then a short headline drawn on top.
+    let content = b"q 720 0 0 540 0 0 cm /Im0 Do Q\n\
+                     BT /F1 28 Tf 1 0 0 1 60 400 Tm (Quarterly Results) Tj ET";
+    off[4] = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    off[5] = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    // Minimal raw (uncompressed) 1x1 DeviceGray image, scaled to cover the
+    // whole page by the `cm` in the content stream above.
+    off[6] = pdf.len();
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /XObject /Subtype /Image /Width 1 /Height 1 \
+         /ColorSpace /DeviceGray /BitsPerComponent 8 /Length 1 >>\nstream\n",
+    );
+    pdf.extend_from_slice(&[0x80]);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    write_xref_trailer(&mut pdf, &off);
+    pdf
+}
+
+/// 10 words, each split into 2 tightly-abutting Tj pieces (zero gap between
+/// the pieces of one word, a real space-sized gap between words).
+fn fragmented_span_words_pdf() -> Vec<u8> {
+    const PIECES: &[(&str, &str)] = &[
+        ("entry", "wise"),
+        ("nonneg", "ative"),
+        ("matr", "ix"),
+        ("writ", "ing"),
+        ("sys", "tem"),
+        ("equa", "tion"),
+        ("vec", "tor"),
+        ("solu", "tion"),
+        ("prob", "lem"),
+        ("theo", "rem"),
+    ];
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT\n");
+    // Fixed, generous offsets rather than character-count-derived widths —
+    // real Helvetica glyph widths vary per letter, so a per-char estimate
+    // drifts across a run and can't reliably guarantee "abutting" vs.
+    // "clearly separated". A deliberate small overlap between a word's two
+    // pieces guarantees a merge (well within the ordinary tight-kerning
+    // tolerance, nowhere near the multi-em backtrack threshold); a large
+    // fixed jump to the next word guarantees a real gap regardless of how
+    // wide any piece actually rendered. Alternating the font size (12 /
+    // 12.5, visually imperceptible) between every text-showing op forces
+    // a genuine span boundary at each one — matching the real-document
+    // shape this bug depends on (math typesetting draws each atom with
+    // its own state, so it never lands in one span to begin with).
+    let mut x = 50.0f32;
+    let y = 700.0f32;
+    for (a, b) in PIECES {
+        content
+            .extend_from_slice(format!("/F1 12 Tf 1 0 0 1 {x:.2} {y:.2} Tm ({a}) Tj\n").as_bytes());
+        x += 1.0; // deliberate near-zero advance: piece 2 overlaps piece 1's tail
+        content.extend_from_slice(
+            format!("/F1 12.5 Tf 1 0 0 1 {x:.2} {y:.2} Tm ({b}) Tj\n").as_bytes(),
+        );
+        x += 150.0; // unambiguous real gap before the next word
+    }
+    content.extend_from_slice(b"ET");
+    // Wide enough for 10 words at a 150pt stride plus margin — content
+    // extraction / page-bounds filtering silently drops glyphs placed
+    // outside the MediaBox, which a standard 612pt-wide page can't fit.
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 1700 792]")
+}
+
+fn write_xref_trailer(pdf: &mut Vec<u8>, off: &[usize]) {
+    let xref_pos = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", off.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f\r\n");
+    for &o in &off[1..] {
+        pdf.extend_from_slice(format!("{o:010} 00000 n\r\n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n", off.len())
+            .as_bytes(),
+    );
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}


### PR DESCRIPTION
## Summary

Fixes #840. `classify_page`'s coverage/text-quality decision path had two independent bugs, both making a caller's `pages_needing_ocr` list unsafe to act on: routing a page there when it already carries good native text means OCR-ing it replaces that text with worse output.

**Cause 1 — a headline over a full-page image.** `classify_from_signals`'s sparse-coverage branch fires whenever `image_area_ratio >= 0.80` and text coverage is below 10% of the page (a defensible verdict for e.g. a slide with a full-bleed background photo and a small title — coverage-driven `Scanned` is out of scope to change here). But it *always* returned `ReasonCode::NoTextLayerPresent`, even when `usable_text` was `true` — the text is real, mapped correctly, and extractable; it just doesn't cover enough of the page. A caller inspecting `reason` would conclude there's nothing to extract, when there is. Now reports `TextLayerBelowThreshold` when the text is actually usable.

**Cause 2 — math typesetting defeats the text-quality gate (the larger share).** `gather_page_signals` built its word-fragmentation-detection input by joining raw content-stream spans with a forced space after every one. Math typesetting draws each atom — a parenthesis, an operator, a subscript — as its own span, so `(∞)` becomes three separate one-character "words". On an ordinary dense LaTeX page this inflates the fragmented-word ratio and collapses average word length until `text_quality_gate` mistakes it for a scan and overrides an otherwise-correct `TextLayer` verdict. `text_quality_gate` is invoked from a second call site with the *same* raw span-joined text and has the identical bug independently, so both needed the fix. Both now build their word list from `extract_words` — the same glyph/span clustering `extract_text` already relies on (including the backtrack-fusion guard from #839) — instead of one token per span.

The reporter's own real-document numbers (not independently re-verified in this PR — see Test plan):
- arXiv 2606.25826, page 33 (dense LaTeX, no image, 1,512 extractable glyphs): raw span-joining gives `frag=0.736, avg_word_len=2.48` → misclassified `Scanned`; the same page through proper word segmentation gives `frag=0.497, avg_word_len=3.57`, well clear of the gate's threshold.
- A 25-page born-digital deck (Ethernet Alliance, "100G Networking Technology Overview"): `pages_needing_ocr=25/25` even though page 1 already correctly classifies `ImageText`/`Ok` — every other page in the same deck was wrongly flagged by cause 1.

## Out of scope

Two smaller design notes from the issue are **not** addressed here, left for future consideration:
- `PageKind` conflates two independent facts (is this page a raster image of a document vs. is usable text available) — a scanner page with an invisible OCR sidecar collapses to `TextLayer`, so a consumer can't ask "is this a scan?" through the public API alone.
- The only public route to `PageSignals` is `classify_page()`, which also extracts and grades page text (~15ms/page) — a `page_signals()`-only accessor that skips the text pass would avoid callers re-deriving signals like image coverage themselves to stay cheap.

## Test plan

- [x] New `tests/test_page_classification_accuracy.rs`: a synthetic full-bleed-image-with-headline fixture (cause 1) and a synthetic fixture reproducing the span-per-atom shape (cause 2, plain Latin text split across tightly-abutting spans so the expected recombined word is unambiguous) — both passing
- [x] Full `cargo test --lib`: 5719 passed, 0 failed
- [x] Related existing classify_page test files (`test_auto_semantics_519`, `test_auto_ocr_image_519`, `test_auto_hybrid_text_image_520`) — all passing (two are OCR-feature-gated and compile to 0 tests without it, expected)
- [x] `cargo fmt --check` and `cargo clippy --all-targets --workspace -- -D warnings` clean
- [ ] Not independently re-verified against the reporter's exact real documents (arXiv 2606.25826, the Ethernet Alliance deck) — only synthetic fixtures built to reproduce the same structural shape

Claude-Session: https://claude.ai/code/session_01D8bcUo6Xk1UhRyuCn7sXSd