### PR TITLE
fix(fonts): fold referenced /Encoding /Differences into the font identity hash

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -18189,6 +18189,49 @@ impl PdfDocument {
                 self.fold_stream_bytes(to_unicode, &mut hasher);
             }
 
+            // /Encoding CONTENT for a referenced or inline encoding dictionary.
+            // The cheap hash can only fold a constant marker for a
+            // referenced/dict /Encoding (it does not resolve), so two simple
+            // fonts that share a /BaseFont name but re-encode through DIFFERENT
+            // /Differences arrays collide on the cheap key. That is common in
+            // subsetted PDFs: several /BaseFont "Times-Roman" instances each
+            // carry a per-instance, frequency-ordered /Encoding (code 1 -> first
+            // glyph used, ...). With no /ToUnicode and no embedded program (a
+            // non-embedded base font) NOTHING else distinguishes them, so the
+            // per-document cache served the first font's parsed FontInfo for the
+            // second, decoding its body text through the wrong /Differences - a
+            // substitution-cipher scramble ("the" -> "bis"). Fold the resolved
+            // base encoding name and the /Differences [code -> glyph name] pairs
+            // so such fonts get distinct keys, while genuinely identical
+            // encodings still dedup.
+            if let Some(enc) = d.get("Encoding") {
+                if let Some(enc_obj) = self.resolve_indirect_for_hash(enc) {
+                    if let Some(enc_dict) = enc_obj.as_dict() {
+                        20u8.hash(&mut hasher);
+                        if let Some(Object::Name(base)) = enc_dict.get("BaseEncoding") {
+                            base.hash(&mut hasher);
+                        }
+                        if let Some(diffs) = enc_dict.get("Differences") {
+                            if let Some(diffs_obj) = self.resolve_indirect_for_hash(diffs) {
+                                if let Some(arr) = diffs_obj.as_array() {
+                                    for item in arr {
+                                        match item {
+                                            Object::Integer(i) => i.hash(&mut hasher),
+                                            Object::Name(n) => n.hash(&mut hasher),
+                                            Object::Reference(r) => {
+                                                r.id.hash(&mut hasher);
+                                                r.gen.hash(&mut hasher);
+                                            },
+                                            _ => {},
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // Simple fonts (Type1/TrueType) carry their embedded program on the
             // top-level /FontDescriptor. Two subset fonts that share a
             // /BaseFont name but embed different glyph programs must not alias.
@@ -27708,6 +27751,52 @@ mod tests {
             Object::Array(vec![Object::Reference(ObjectRef::new(20, 0))]),
         );
         assert_ne!(PdfDocument::font_identity_hash_cheap(&Object::Dictionary(d)), 0);
+    }
+
+    // Regression: two same-named, non-embedded simple fonts whose /Encoding are
+    // REFERENCES to different /Differences arrays must not share an identity
+    // hash. The cheap hash folds only a constant marker for a referenced
+    // /Encoding, so without folding the referenced encoding's CONTENT they
+    // collide and the second font decodes through the first's /Differences (a
+    // substitution-cipher scramble). font_identity_hash_with_descendants must
+    // distinguish them.
+    #[test]
+    fn test_font_identity_hash_folds_referenced_encoding_differences() {
+        let doc = PdfDocument::from_bytes(build_minimal_pdf(b"")).unwrap();
+
+        let enc = |names: &[&str]| {
+            let mut diffs = vec![Object::Integer(1)];
+            diffs.extend(names.iter().map(|n| Object::Name((*n).to_string())));
+            let mut d = std::collections::HashMap::new();
+            d.insert("Type".to_string(), Object::Name("Encoding".to_string()));
+            d.insert("Differences".to_string(), Object::Array(diffs));
+            Object::Dictionary(d)
+        };
+        // Two distinct encoding objects with different frequency-ordered maps.
+        doc.object_cache
+            .lock_or_recover()
+            .insert(ObjectRef::new(100, 0), enc(&["T", "h", "i", "s"]));
+        doc.object_cache
+            .lock_or_recover()
+            .insert(ObjectRef::new(101, 0), enc(&["one", "T", "h", "e"]));
+
+        let font = |enc_ref: u32| {
+            let mut f = std::collections::HashMap::new();
+            f.insert("BaseFont".to_string(), Object::Name("Times-Roman".to_string()));
+            f.insert("Subtype".to_string(), Object::Name("Type1".to_string()));
+            f.insert("Encoding".to_string(), Object::Reference(ObjectRef::new(enc_ref, 0)));
+            Object::Dictionary(f)
+        };
+
+        let h100 = doc.font_identity_hash_with_descendants(&font(100));
+        let h101 = doc.font_identity_hash_with_descendants(&font(101));
+        assert_ne!(h100, h101, "fonts with different referenced /Differences must not collide");
+
+        // Two fonts pointing at the SAME encoding object still dedup.
+        assert_eq!(
+            doc.font_identity_hash_with_descendants(&font(100)),
+            doc.font_identity_hash_with_descendants(&font(100)),
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## Problem

Two same-named, **non-embedded simple fonts** whose `/Encoding` are **references** to
different `/Differences` arrays collide on the per-document font identity hash, so the
cache serves the first font's parsed `FontInfo` for the second. The second font's body
text then decodes through the **wrong** `/Differences` - a substitution-cipher scramble:

```
"The present state of research" -> "Cpe suoue ta esfisoeai"
```

This is common in subsetted PDFs that re-encode each font instance with a
frequency-ordered `/Encoding` (`code 1 -> first glyph used`, ...). A single `/BaseFont`
name (e.g. `Times-Roman`) can appear several times with completely different
`/Differences` maps.

## Root cause

`font_identity_hash_cheap` folds only a **constant marker** for a referenced or
dictionary `/Encoding`:

```rust
Object::Reference(_) => b"enc_ref".hash(&mut hasher),
Object::Dictionary(_) => b"enc_dict".hash(&mut hasher),
```

so the encoding's content never enters the key. When the two fonts also have **no
`/ToUnicode`** and **no embedded program** (a non-embedded base font), nothing else
distinguishes them - same `/BaseFont`, same `/Subtype`, same `/Widths` - and they alias.

This is the same collision class the cross-document hardening in #595 / #597 / #598
addressed (which folds the `/ToUnicode` stream bytes, the embedded `/FontFile{,2,3}`
bytes, and `/Widths`). That work covered every text-decoding field **except** the one
here: the `/Encoding` itself.

## Fix

`font_identity_hash_with_descendants` (the document-aware hash, which can resolve
references) now folds the resolved `/Encoding`'s `/BaseEncoding` name and its
`/Differences [code -> glyph name]` pairs. Fonts with different re-encodings get distinct
keys; genuinely identical encodings still dedup. The change only ever makes keys **more**
distinct, so it cannot introduce wrong-sharing.

Adds a regression test (`test_font_identity_hash_folds_referenced_encoding_differences`)
asserting two fonts with different referenced `/Differences` do not share an identity
hash, while two pointing at the same encoding still do.

## Impact

Validated on a 575-document corpus (text extraction vs an independent extractor):
**+0.0032 mean F1 overall with zero regressions**, and two documents recovered from a
near-total loss - `0.068 -> 0.928` and `0.364 -> 0.989` (both hit this same collision on
their body fonts).

## Checklist

- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (regression test added; validated standalone on `main`)
- [x] DCO sign-off
