### PR TITLE
ci(r): install backports explicitly so lintr can load

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -73,9 +73,15 @@ jobs:
         # Fail hard if any package is missing after install (install.packages
         # only warns on a failed install). Uses the RSPM binary repo configured
         # above (no explicit repos= override, which would force source).
+        #
+        # `backports` is a hard Imports dependency of lintr. On the RSPM binary
+        # path it was intermittently not pulled in, leaving lintr installed but
+        # unloadable ("there is no package called 'backports'") in the Lint
+        # step. Install and hard-verify it explicitly so the failure surfaces
+        # here (as a missing-package error) rather than later at library(lintr).
         run: |
-          Rscript -e 'install.packages(c("tinytest", "lintr", "roxygen2", "rcmdcheck"))' \
-                  -e 'pkgs <- c("tinytest","lintr","roxygen2","rcmdcheck")' \
+          Rscript -e 'install.packages(c("backports", "tinytest", "lintr", "roxygen2", "rcmdcheck"))' \
+                  -e 'pkgs <- c("backports","tinytest","lintr","roxygen2","rcmdcheck")' \
                   -e 'miss <- pkgs[!pkgs %in% rownames(installed.packages())]' \
                   -e 'if (length(miss)) { cat("Failed to install:", miss, "\n"); quit(status=1) }'
 


### PR DESCRIPTION
## Problem

The `R on macos-latest` job fails intermittently with:
```
Error: package or namespace load failed for 'lintr':
  .onLoad failed in loadNamespace() for 'lintr', details:
  error: there is no package called 'backports'
```
The Rust lib compiles and `pdfoxide.so` builds fine — the failure is in the **Lint** step, and it's **deterministic when `backports` is absent** (not flaky; it only "passes" on CI re-run when a cache happens to include backports).

## Root cause

`backports` is a hard **Imports** dependency of `lintr`. The `Install R deps` step installs `lintr` via the RSPM binary repo but only hard-verifies the 4 top-level packages — not their deps. On the RSPM binary path `backports` was intermittently not pulled in (the same silent-install issue the step's own comment already notes), leaving `lintr` installed but unloadable at `library(lintr)`.

## Fix

Add `backports` to the `install.packages()` list **and** the hard-verify list, so a failed `backports` install fails the deps step deterministically (with a clear "Failed to install" message) instead of surfacing later as a confusing lint-load error.

One workflow file, additive only. No behavior change beyond guaranteeing `backports` is present.

https://claude.ai/code/session_01VfT1dvLWaMNh4SpaXV8kcp