### PR TITLE
feat(outline): make resolve_named_destination public

### DIFF
--- a/src/outline.rs
+++ b/src/outline.rs
@@ -200,7 +200,23 @@ impl PdfDocument {
     /// PDF 1.2+ `/Names` → `/Dests` name tree, ISO 32000-1 §12.3.2.3 /
     /// §7.9.6) to a 0-based page index. `Ok(None)` when the name is
     /// genuinely unresolvable (caller keeps [`Destination::Named`]).
-    pub(crate) fn resolve_named_destination(&self, name: &str) -> Result<Option<usize>> {
+    ///
+    /// Named destinations are referenced by string from Link/GoTo actions and
+    /// outline items; a consumer that follows those references needs to turn a
+    /// name into the page it targets.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use pdf_oxide::PdfDocument;
+    ///
+    /// let doc = PdfDocument::open("doc.pdf")?;
+    /// if let Some(page) = doc.resolve_named_destination("section.1")? {
+    ///     println!("named destination -> page {page}");
+    /// }
+    /// # Ok::<(), pdf_oxide::error::Error>(())
+    /// ```
+    pub fn resolve_named_destination(&self, name: &str) -> Result<Option<usize>> {
         let catalog = self.catalog()?;
         let Some(cat) = catalog.as_dict() else {
             return Ok(None);


### PR DESCRIPTION
## What

Make `PdfDocument::resolve_named_destination` public (it was `pub(crate)`), with a
doctest.

## Why

Named destinations (ISO 32000-1 §12.3.2.3 / §7.9.6) are referenced by string from
Link/GoTo actions and outline items. The crate already resolves a name to a 0-based
page index - `get_outline()` uses it internally for named outline dests - but the
resolver is not reachable, so a downstream consumer that follows **link** targets (or
wants to resolve a name it obtained some other way) has to re-walk the catalog
`/Dests` dict + `/Names` → `/Dests` name tree itself, duplicating logic that already
lives here and is tested.

Exposing it lets a consumer turn any named destination into the page it targets with
one call, so e.g. a `/Link` annotation whose action is `GoTo` a named dest can be
rendered as an internal page jump.

## Change

- `resolve_named_destination(&self, name: &str) -> Result<Option<usize>>`:
  `pub(crate)` → `pub`.
- Adds a `# Example` doctest (this repo requires doctests on public items).

No behavior change; purely a visibility + documentation change.

## Checklist

- [x] `cargo build`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --doc resolve_named_destination` (the new doctest)
- [x] `cargo fmt`
- [x] DCO sign-off
