### PR TITLE
fix(headers): require position-consistency before removing repeated text as chrome

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -6535,7 +6535,12 @@ impl PdfDocument {
             return Ok(0);
         }
 
-        let mut occurrences: HashMap<String, HashSet<usize>> = HashMap::new();
+        // Each entry records the IN-ZONE occurrences of a repeated string as
+        // (page, bbox). Keeping the bbox (not just the page set) lets us both
+        // (a) erase only the header/footer occurrence and never an identically
+        // worded span elsewhere on the page, and (b) require the occurrences to
+        // share a position before treating the string as chrome.
+        let mut occurrences: HashMap<String, Vec<(usize, crate::geometry::Rect)>> = HashMap::new();
 
         // Sanitize threshold to avoid min_occurrences becoming 0 for invalid inputs.
         let clamped_threshold = if threshold.is_finite() {
@@ -6545,9 +6550,6 @@ impl PdfDocument {
         };
         let raw_min = (page_count as f32 * clamped_threshold).ceil();
         let min_occurrences = if raw_min < 1.0 { 1 } else { raw_min as usize };
-
-        // Cache spans per page to avoid redundant extraction in Pass 2
-        let mut page_spans: HashMap<usize, Vec<crate::layout::TextSpan>> = HashMap::new();
 
         for page_idx in 0..page_count {
             let height = self.get_page_media_box(page_idx)?.3;
@@ -6566,26 +6568,49 @@ impl PdfDocument {
                 if is_in_zone {
                     let text = span.text.trim().to_string();
                     if text.len() > 3 && !text.chars().all(|c| c.is_numeric()) {
-                        occurrences.entry(text).or_default().insert(page_idx);
+                        occurrences
+                            .entry(text)
+                            .or_default()
+                            .push((page_idx, span.bbox));
                     }
                 }
             }
-            page_spans.insert(page_idx, spans);
         }
 
-        for (text, pages) in occurrences {
-            if pages.len() >= min_occurrences {
-                for page_idx in pages {
-                    // Reuse cached spans
-                    if let Some(spans) = page_spans.get(&page_idx) {
-                        for span in spans {
-                            if span.text.trim() == text {
-                                self.erase_region(page_idx, span.bbox)?;
-                                removed_count += 1;
-                            }
-                        }
-                    }
-                }
+        // Genuine running headers/footers are position-locked: the same string
+        // lands at the same x/y on every page. A form label or instruction that
+        // merely happens to recur — e.g. "Check if:", "(see instructions)",
+        // "Name(s) shown on return" on a multi-page tax form — drifts in x or y
+        // between pages. Requiring positional consistency separates "recurs
+        // because it is chrome" from "recurs because it is the same real label"
+        // without deleting content.
+        const POS_TOL_X: f32 = 40.0;
+        const POS_TOL_Y: f32 = 24.0;
+
+        for (_text, occs) in occurrences {
+            let distinct_pages: HashSet<usize> = occs.iter().map(|(p, _)| *p).collect();
+            if distinct_pages.len() < min_occurrences {
+                continue;
+            }
+
+            // Positional spread across every in-zone occurrence.
+            let (mut min_x, mut max_x) = (f32::MAX, f32::MIN);
+            let (mut min_y, mut max_y) = (f32::MAX, f32::MIN);
+            for (_, bbox) in &occs {
+                min_x = min_x.min(bbox.x);
+                max_x = max_x.max(bbox.x);
+                min_y = min_y.min(bbox.y);
+                max_y = max_y.max(bbox.y);
+            }
+            if (max_x - min_x) > POS_TOL_X || (max_y - min_y) > POS_TOL_Y {
+                continue; // drifts between pages → real content, not chrome
+            }
+
+            // Erase only the header/footer occurrences that qualified — never a
+            // same-text span outside the band.
+            for (page_idx, bbox) in occs {
+                self.erase_region(page_idx, bbox)?;
+                removed_count += 1;
             }
         }
 

--- a/tests/test_remove_footer_preserves_content.rs
+++ b/tests/test_remove_footer_preserves_content.rs
@@ -252,3 +252,83 @@ fn remove_footers_preserves_common_word_across_unique_sentences() {
         }
     }
 }
+
+/// A phrase that legitimately repeats across pages of a form but at a
+/// DIFFERENT horizontal position each time (e.g. a per-field instruction like
+/// "see instructions" that sits beside a different control on each page) must
+/// not be mistaken for chrome. Genuine running footers are position-locked;
+/// this one drifts in x, so it is real content.
+#[test]
+fn remove_footers_preserves_repeated_phrase_that_drifts_in_x() {
+    let phrase = "See the instructions";
+    // Same phrase, in the footer band (y=30) on all 5 pages, but shifted well
+    // beyond the x tolerance (72, 152, 232, 312, 392 → spread 320pt).
+    let bytes = build_pdf_with_page_extras(5, |i| {
+        let x = 72 + (i as i32) * 80;
+        format!("BT /F1 10 Tf 1 0 0 1 {x} 30 Tm ({phrase}) Tj ET\n")
+    });
+    let doc = PdfDocument::from_bytes(bytes).unwrap();
+    doc.remove_footers(0.5).unwrap();
+
+    for page in 0..5 {
+        let text = doc.extract_text(page).unwrap();
+        assert!(
+            text.contains(phrase),
+            "page {page}: phrase {phrase:?} repeats at a different x per page (real \
+             content, not a running footer) but was removed: {text:?}"
+        );
+    }
+}
+
+/// The complementary guard: a genuine, position-locked running footer must
+/// still be removed. Without this, "preserve everything" would silently
+/// neuter the feature.
+#[test]
+fn remove_footers_still_removes_position_locked_footer() {
+    let phrase = "Confidential Draft Only";
+    // Identical (x=72, y=30) on every page — a real running footer.
+    let bytes = build_pdf_with_page_extras(5, |_i| {
+        format!("BT /F1 10 Tf 1 0 0 1 72 30 Tm ({phrase}) Tj ET\n")
+    });
+    let doc = PdfDocument::from_bytes(bytes).unwrap();
+    let removed = doc.remove_footers(0.5).unwrap();
+    assert!(removed >= 5, "expected the running footer removed on every page, got {removed}");
+
+    for page in 0..5 {
+        let text = doc.extract_text(page).unwrap();
+        assert!(
+            !text.contains(phrase),
+            "page {page}: position-locked running footer {phrase:?} should have been \
+             removed: {text:?}"
+        );
+    }
+}
+
+/// Zone-scoped erasure: when a string qualifies as footer chrome, only the
+/// occurrence IN the footer band is erased — an identically worded span
+/// elsewhere on the page (a real body label) must survive. The old heuristic
+/// erased every span whose text matched, deleting body content.
+#[test]
+fn remove_footers_preserves_body_twin_of_footer_text() {
+    let phrase = "Company Confidential";
+    // Footer occurrence at (72, 30) [removed] and a body twin at (72, 350)
+    // [must survive], on every page.
+    let bytes = build_pdf_with_page_extras(5, |_i| {
+        format!(
+            "BT /F1 10 Tf 1 0 0 1 72 30 Tm ({phrase}) Tj ET\n\
+             BT /F1 10 Tf 1 0 0 1 72 350 Tm ({phrase}) Tj ET\n"
+        )
+    });
+    let doc = PdfDocument::from_bytes(bytes).unwrap();
+    doc.remove_footers(0.5).unwrap();
+
+    for page in 0..5 {
+        let text = doc.extract_text(page).unwrap();
+        let hits = text.matches(phrase).count();
+        assert_eq!(
+            hits, 1,
+            "page {page}: footer occurrence of {phrase:?} should be removed and the body \
+             twin kept (expected 1 remaining, got {hits}): {text:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the `remove_footers` / `remove_headers` / `remove_artifacts` heuristic erasing real form content on IRS Forms 706, 1040, 8863 (reported by @ultrasaurus). Root cause is **two compounding bugs** in `remove_repeated_text` (`src/document.rs`):

1. **Zone-blind erasure** — once a string qualified as chrome, the erase loop deleted **every** span whose text matched on the page, *not just the header/footer occurrence*. This is what deleted body content like `"(see instructions)"` at y=362/614/410.
2. **Position-blind qualification** — no check that the occurrences share a position. Real labels that legitimately recur (`"Check if:"`, `"see instructions"`, `"Name(s) shown on return"`) **drift in x or y** between pages, yet were treated as chrome.

The reporter's evidence shows the discriminator cleanly: genuine chrome (`"Form 706…"` x=36/y=748.5, `"Page "` x=552/y=747.9) is position-locked, while every false positive breaks consistency on at least one axis.

## Fix

- Record each **in-zone** occurrence's bbox (page + `Rect`), not just the page set.
- Require the occurrences to cluster within a small tolerance (`POS_TOL_X = 40`, `POS_TOL_Y = 24` pt) before treating the string as chrome.
- Erase **only** the qualifying in-zone occurrences — never a same-text span elsewhere on the page.

The new behavior removes a **strict subset** of the old behavior (adds a gate, restricts erasure scope), so existing "preserve content" guards cannot regress — verified.

## Tests (fixture-free, in-code PDFs)

Added to `tests/test_remove_footer_preserves_content.rs`:
- `remove_footers_preserves_repeated_phrase_that_drifts_in_x` — bug 2 (a repeat at drifting x is kept).
- `remove_footers_still_removes_position_locked_footer` — the feature still works (a locked footer is removed).
- `remove_footers_preserves_body_twin_of_footer_text` — bug 1 (footer occurrence removed, identically-worded body span kept).

All 5 tests in the file pass (3 new + 2 existing). `cargo fmt` ✅ · `cargo clippy` ✅

## Note on #794

#794 is the opposite complaint (footer *under*-removal). This change only makes removal **stricter**, but the tolerance is deliberately loose enough that genuine (position-locked) footers are still removed, so it should not push #794 further away. Flagging for awareness.

Closes #879