### PR TITLE
fix(bindings): clang-format + dart format the provenance accessors (unbreak main C++ & Dart CI)

### DIFF
--- a/cpp/include/pdf_oxide/pdf_oxide.hpp
+++ b/cpp/include/pdf_oxide/pdf_oxide.hpp
@@ -905,9 +905,9 @@ class Document {
                 e.text = detail::take_string(pdf_oxide_element_get_text(list, i, &code),
                                              code, "Document::page_get_elements");
                 code = 0;
-                if (char *p = pdf_oxide_element_get_provenance(list, i, &code)) {
-                    e.provenance = detail::take_string(p, code,
-                                                       "Document::page_get_elements");
+                if (char* p = pdf_oxide_element_get_provenance(list, i, &code)) {
+                    e.provenance =
+                        detail::take_string(p, code, "Document::page_get_elements");
                 }
                 Bbox b{0, 0, 0, 0};
                 pdf_oxide_element_get_rect(list, i, &b.x, &b.y, &b.width, &b.height,

--- a/dart/lib/pdf_oxide.dart
+++ b/dart/lib/pdf_oxide.dart
@@ -1169,8 +1169,8 @@ class _Native {
             .lookupFunction<_ListStrC, _ListStrD>('pdf_oxide_element_get_type'),
         elementGetText = lib
             .lookupFunction<_ListStrC, _ListStrD>('pdf_oxide_element_get_text'),
-        elementGetProvenance = lib
-            .lookupFunction<_ListStrC, _ListStrD>('pdf_oxide_element_get_provenance'),
+        elementGetProvenance = lib.lookupFunction<_ListStrC, _ListStrD>(
+            'pdf_oxide_element_get_provenance'),
         elementGetRect = lib.lookupFunction<_ElemRectC, _ElemRectD>(
             'pdf_oxide_element_get_rect'),
         elementsFree = lib


### PR DESCRIPTION
#893 landed the C++ and Dart provenance accessors without running their formatters, red-ing **two** binding CIs on main:
- **C++ Bindings CI** — clang-format (`-Wclang-format-violations`, exit 123, `pdf_oxide.hpp:908`)
- **Dart Bindings CI** — `dart format --set-exit-if-changed` (exit 1, `pdf_oxide.dart`)

Both are formatting-only. Verified locally with the exact CI commands:
- `clang-format --dry-run --Werror --style=file:cpp/.clang-format` → exit 0
- `dart format --output=none --set-exit-if-changed lib test example` → 0 changed, exit 0

Neither check is in the 5 required set, which is why #893 merged despite them. No functional change.