### PR TITLE
ci: CI/CD hardening — OpenSSF Scorecard + deterministic PR-quality gates

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -31,6 +31,11 @@ env:
   # via PDF_OXIDE_CDYLIB_PATH (see php/tests/bootstrap.php).
   PDF_OXIDE_CDYLIB_DIR: ${{ github.workspace }}/target/release
 
+# Least-privilege default token (OpenSSF Scorecard Token-Permissions). Jobs
+# opt into wider scopes only where they actually need them.
+permissions:
+  contents: read
+
 jobs:
   # Per-cell test job. Builds the cdylib once and runs Unit + Integration.
   test:

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,98 @@
+# Deterministic PR-quality gates — no LLM/agent judgment, pure rule checks.
+# These substitute for the human reviewer a solo maintainer doesn't have:
+#   - title:     PR title must follow Conventional Commits (load-bearing for squash-merge)
+#   - no-binary: block committed compiled/library artifacts (reinforces Binary-Artifacts + fixture policy)
+#   - ai-label:  label (never block) PRs whose commits disclose AI co-authorship
+#
+# Security: uses `pull_request_target` for write access on fork PRs, but only
+# reads strings from the event payload / REST API via github-script and never
+# checks out or runs PR code, and never interpolates untrusted input into a
+# shell — so there is no injection surface (only integer PR numbers appear in
+# `${{ }}`).
+name: PR quality gates
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-quality-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    name: PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title || '';
+            const conventional = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9,\-_ /]+\))?!?: .+/;
+            const release = /^Release v?\d+\.\d+/;   // maintainer release PRs
+            if (conventional.test(title) || release.test(title)) return;
+            core.setFailed(
+              'PR title must follow Conventional Commits — e.g. "fix(text): …", "feat: …", ' +
+              '"docs: …" (or a "Release vX.Y.Z …" title). Got: "' + title + '"'
+            );
+
+  no-binary:
+    name: No compiled / binary artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            // Compiled libraries / bytecode / executables — build from source,
+            // ship via release assets. (PDFs are handled by fixture-hygiene;
+            // fonts/images/ICC are legitimate fixtures and intentionally allowed.)
+            const disallowed = /\.(so|dll|dylib|a|rlib|o|class|pyc|pyo|exe|wasm|jar|node|dSYM)$/i;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const offenders = files
+              .filter(f => f.status === 'added' && disallowed.test(f.filename))
+              .map(f => f.filename);
+            if (offenders.length) {
+              core.setFailed(
+                'These compiled/binary artifacts must not be committed:\n' +
+                offenders.map(f => '  - ' + f).join('\n')
+              );
+            }
+
+  ai-label:
+    name: Label AI-assisted contributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            // Label (never block) — disclosed AI co-authorship is legitimate;
+            // this is for reviewer routing/metrics. Catches only *disclosed* AI
+            // (trailers / an Assisted-by line); undisclosed use is undetectable.
+            const marker = /(co-authored-by:[^\n]*(claude|copilot|cursor|devin|chatgpt|gpt|gemini|codex)|assisted-by:)/i;
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const body = context.payload.pull_request.body || '';
+            const disclosed = marker.test(body) || commits.some(c => marker.test(c.commit.message || ''));
+            if (!disclosed) return;
+            const common = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            };
+            const existing = (await github.rest.issues.listLabelsOnIssue(common)).data.map(l => l.name);
+            if (!existing.includes('ai-assisted')) {
+              await github.rest.issues.addLabels({ ...common, labels: ['ai-assisted'] });
+            }

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,6 +17,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default token (OpenSSF Scorecard Token-Permissions). Jobs
+# opt into wider scopes only where they actually need them.
+permissions:
+  contents: read
+
 jobs:
   # Test job - builds extension and runs tests
   test:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,6 +28,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default token (OpenSSF Scorecard Token-Permissions). Jobs
+# opt into wider scopes only where they actually need them.
+permissions:
+  contents: read
+
 jobs:
   # Lint job — RuboCop 1.86 (FFI-tuned config in ruby/.rubocop.yml).
   # Cheap (~1 min); runs in parallel with the matrix.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [".", "pdf_oxide_mcp", "pdf_oxide_cli", "pdf_oxide_jni"]
-exclude = ["js"]
+exclude = ["js", "fuzz"]
 
 # cargo-shear exemptions: these optional deps are referenced from `[features]`
 # via `dep:X` and only link when their feature is on. cargo-shear reports them

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+# cargo-fuzz targets for pdf_oxide.
+#
+# A PDF parser is a prime fuzzing surface: it consumes fully untrusted bytes
+# (malformed xref tables, cyclic object graphs, bogus stream lengths, hostile
+# filters). Targets here must never panic on any input — only return `Err`.
+#
+# This is a standalone workspace (own `[workspace]` below, and excluded from the
+# root workspace) so the nightly + sanitizer toolchain cargo-fuzz needs never
+# affects the normal `cargo build`/`cargo test` matrix.
+#
+# Run locally:  cargo +nightly fuzz run fuzz_parse -- -max_total_time=300
+[package]
+name = "pdf-oxide-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.pdf_oxide]
+path = ".."
+
+[[bin]]
+name = "fuzz_parse"
+path = "fuzz_targets/fuzz_parse.rs"
+test = false
+doc = false
+bench = false
+
+# Standalone workspace — keep the fuzz crate out of the root workspace's
+# resolver so its nightly/sanitizer build never perturbs the library build.
+[workspace]

--- a/fuzz/fuzz_targets/fuzz_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_parse.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use pdf_oxide::PdfDocument;
+
+// Feed arbitrary bytes to the in-memory parse entry point, then exercise a
+// little more of the pipeline on anything that parses. The contract under test
+// is robustness: no input may panic, overflow, or hang — malformed PDFs must
+// surface as `Err`, not a crash.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(doc) = PdfDocument::from_bytes(data.to_vec()) {
+        // Only touch a real parse succeeded — extract text from the first page
+        // to reach the content-stream / font / cmap paths as well.
+        let _ = doc.extract_text(0);
+    }
+});


### PR DESCRIPTION
Implements the safe, zero-tuning, ~0-false-positive items from the CI/CD hardening analysis. **No GitHub "required human review" is added** (that would lock out a solo maintainer) and **no new third-party action is introduced** — everything reuses actions already SHA-pinned in the repo.

## OpenSSF Scorecard (commit 1)
- **Token-Permissions** (High weight): added `permissions: contents: read` to **php/python/ruby.yml** — the three workflows that had *no* permissions block (token defaulted to broad write). Jobs opt into wider scopes only where needed; none of these three need any.
- **Fuzzing** (Medium weight, failing → 10): added an in-repo **cargo-fuzz** target. Scorecard's Rust probe greps for `libfuzzer_sys`, but it's a *real* target hitting `PdfDocument::from_bytes` → `extract_text` (a PDF parser is a genuine fuzz surface). The `fuzz/` crate is a **standalone workspace, excluded from the root workspace**, so its nightly/sanitizer toolchain never touches the normal build/test matrix (verified: root `cargo metadata` members unchanged).

## Deterministic PR-quality gates (commit 2) — `pr-quality.yml`
Rule-based checks that substitute for the reviewer you don't have — all github-script:
- **title** — PR title must be Conventional Commits (allows your `Release vX.Y.Z` titles); hard-fail.
- **no-binary** — blocks newly committed compiled/library artifacts (`.so/.dll/.dylib/.a/.class/.pyc/.exe/.wasm/.jar/…`). PDFs stay with `fixture-hygiene`; fonts/images/ICC remain allowed.
- **ai-label** — *labels* (never blocks) PRs whose commits disclose AI co-authorship (`Co-authored-by: Claude/Copilot/Cursor/…`, `Assisted-by:`). Catches only *disclosed* AI — it's for routing/metrics, not detection. (`ai-assisted` label created.)

**Security:** `pull_request_target` for fork-PR write access, but reads only strings from the payload/REST API via github-script — no PR-code checkout, no shell interpolation of untrusted input; only integer PR numbers in `${{ }}`.

## Deliberately deferred (need their own PRs / your call)
- **typos** — the repo has never run a spellchecker; even with a domain allowlist (`Flate`/`Parms`/`Paeth`/`threed`) ~300 flags remain, a mix of genuine typos and **intentional** RTL/OCR test fixtures. Needs a dedicated cleanup PR, not a bundle here.
- **Signed-Releases (SLSA provenance)** — the single biggest Scorecard lever (~0→10, High weight), but it modifies the release pipeline and can only be validated on a real release. Recommend `slsa-github-generator` with `upload-assets: true`; happy to do it as a focused follow-up.
- **Branch protection / required reviews** — skipped intentionally: as a solo maintainer you'd lock yourself out. The solo-friendly option is making these CI checks *required status checks* (green CI, no second human) — your call.
- **Advisory checks** (patch-coverage, tests-with-source label, PR-size label, stale-bot) — worth adding as warn/label once you want them.

Note: `pull_request_target`/token-permission workflows take effect once merged to `main` (base-branch semantics), so they won't run on this PR itself.

https://claude.ai/code/session_01QXMiKnxkmFs3tCQNz1vMc5