### PR TITLE
docs(governance): lock down IP position — CLA, trademark, NOTICE

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,50 @@
+# Contributor License Agreement bot (CLA Assistant Lite).
+#
+# Runs entirely in this repo — no external SaaS. Signatures are stored in this
+# repo on the `cla-signatures` branch, so it needs ONLY the built-in
+# GITHUB_TOKEN (with contents: write), the same mechanism the release workflow
+# already uses to push git tags. No PERSONAL_ACCESS_TOKEN is required (that is
+# only needed when signatures live in a *different* repository).
+#
+# On a non-trivial contributor's PR the bot comments asking them to sign; they
+# reply with the sign phrase and the bot records their GitHub username in
+# signatures/cla.json and turns the CLA check green. The maintainer and bots are
+# allowlisted so they are never asked. See CLA.md for the agreement text.
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: write        # create/update signatures/cla.json (same-repo storage)
+  pull-requests: write
+  statuses: write
+
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    # Only act on PR events or on the sign / recheck comment phrases — not on
+    # every comment in the tracker.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == 'recheck' ||
+         contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
+    steps:
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/yfedoseev/pdf_oxide/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          # Maintainer + bots never need to sign.
+          allowlist: 'yfedoseev,dependabot[bot],github-actions[bot],bot*'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,78 @@
+# Contributor License Agreement (CLA)
+
+> **Status / legal note.** This CLA is adapted from the widely-used
+> **Apache Software Foundation Individual & Corporate CLA (v2.0)**. It is a
+> **licence**, not a copyright assignment — you keep ownership of your
+> contribution and simply grant the project a broad licence to use and
+> sub-licence it. **Have it reviewed by counsel before you rely on it, and
+> enable a CLA bot (e.g. [CLA assistant](https://github.com/cla-assistant/cla-assistant))
+> to record signatures on pull requests.** Until the bot is enabled, the
+> [DCO sign-off](CONTRIBUTING.md#commits-dco-and-review) remains the operative
+> requirement.
+
+Thank you for contributing to **pdf_oxide** (the "Project", maintained by the
+Project's copyright holder, the "Maintainer"). To keep the Project's licensing
+clean and its future options open, contributors of non-trivial changes agree to
+the terms below. You retain all right, title, and interest in your Contributions.
+
+By submitting a Contribution (a pull request, patch, or other work) to the
+Project, **You** accept and agree to the following for present and future
+Contributions submitted to the Project.
+
+## 1. Definitions
+- **"You"** means the individual or legal entity making a Contribution.
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, that You intentionally submit to
+  the Project for inclusion.
+
+## 2. Copyright licence
+You grant the Maintainer and recipients of software distributed by the Project a
+**perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
+licence** to reproduce, prepare derivative works of, publicly display, publicly
+perform, sublicense, **and distribute Your Contributions and such derivative
+works — under any licence terms, including the Project's current
+`MIT OR Apache-2.0` terms and any future licence the Maintainer chooses.**
+(This sub-licensing right is what preserves the Project's ability to relicense
+future versions; it does not affect already-published releases, which remain
+under their original terms forever.)
+
+## 3. Patent licence
+You grant the Maintainer and recipients of the Project a **perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable (except as below) patent licence** to
+make, have made, use, offer to sell, sell, import, and otherwise transfer Your
+Contribution, where such licence applies only to those patent claims licensable
+by You that are necessarily infringed by Your Contribution alone or by
+combination of Your Contribution with the Project. If any entity institutes
+patent litigation alleging that Your Contribution, or the Project to which You
+contributed, constitutes direct or contributory patent infringement, then any
+patent licences granted to that entity under this CLA terminate.
+
+## 4. Your representations
+You represent that:
+- Each Contribution is **Your original creation** and You have the legal right to
+  grant the above licences.
+- If Your employer has rights to intellectual property You create, You have
+  received permission to make the Contribution on behalf of that employer, or the
+  employer has waived such rights, or the employer has executed the corporate
+  version of this CLA.
+- Each Contribution does **not** knowingly include third-party code under an
+  incompatible licence (e.g. GPL/AGPL) or otherwise violate any third party's
+  rights. Any third-party material is identified and its licence noted.
+- You are not aware of any patents or other rights that would make the licences
+  above impossible to grant.
+
+## 5. Support & warranty
+You are not expected to provide support for Your Contributions. Contributions are
+provided **"as is"**, without warranties or conditions of any kind, except as
+stated in Sections 4.
+
+## 6. How to sign
+- **Individuals:** once the CLA bot is enabled, it will comment on your first pull
+  request with a one-click sign-off link; signing is required before merge.
+- **On behalf of a company (Corporate CLA):** have an authorized signatory
+  contact the Maintainer at **yfedoseev@gmail.com** to record the entity and its
+  authorized contributors.
+
+Trivial changes (typo fixes, formatting, documentation-only edits) do not require
+a CLA. The [DCO sign-off](CONTRIBUTING.md#commits-dco-and-review) is still
+required on every commit.

--- a/CLA.md
+++ b/CLA.md
@@ -4,16 +4,21 @@
 > **Apache Software Foundation Individual & Corporate CLA (v2.0)**. It is a
 > **licence**, not a copyright assignment — you keep ownership of your
 > contribution and simply grant the project a broad licence to use and
-> sub-licence it. **Have it reviewed by counsel before you rely on it, and
-> enable a CLA bot (e.g. [CLA assistant](https://github.com/cla-assistant/cla-assistant))
-> to record signatures on pull requests.** Until the bot is enabled, the
-> [DCO sign-off](CONTRIBUTING.md#commits-dco-and-review) remains the operative
-> requirement.
+> sub-licence it. **Some items still need counsel before you rely on this for
+> enforcement or an acquisition** — in particular the *governing law / venue*
+> (§7, left blank), whether to register the trademark, and the enforceability of
+> the click-through signature. **Enable a CLA bot (e.g.
+> [CLA assistant](https://github.com/cla-assistant/cla-assistant)) to record
+> signatures — ideally before accepting substantial contributions**, so the
+> clean relicense right and patent grant attach from day one. Until the bot is
+> enabled, the [DCO sign-off](CONTRIBUTING.md#commits-dco-and-review) is the
+> operative requirement.
 
-Thank you for contributing to **pdf_oxide** (the "Project", maintained by the
-Project's copyright holder, the "Maintainer"). To keep the Project's licensing
-clean and its future options open, contributors of non-trivial changes agree to
-the terms below. You retain all right, title, and interest in your Contributions.
+Thank you for contributing to **PDFOxide** (the "Project"; distributed as the
+`pdf_oxide` packages/crate, maintained by the Project's copyright holder, the
+"Maintainer"). To keep the Project's licensing clean and its future options
+open, contributors of non-trivial changes agree to the terms below. You retain
+all right, title, and interest in your Contributions.
 
 By submitting a Contribution (a pull request, patch, or other work) to the
 Project, **You** accept and agree to the following for present and future
@@ -21,6 +26,10 @@ Contributions submitted to the Project.
 
 ## 1. Definitions
 - **"You"** means the individual or legal entity making a Contribution.
+- **"Maintainer"** means Yury Fedoseev **and his successors and assigns.** The
+  Maintainer may **assign or transfer** its rights and licences under this CLA,
+  in whole or in part, without further consent from You (for example, in
+  connection with a sale, merger, or transfer of the Project).
 - **"Contribution"** means any original work of authorship, including any
   modifications or additions to existing work, that You intentionally submit to
   the Project for inclusion.
@@ -43,9 +52,11 @@ make, have made, use, offer to sell, sell, import, and otherwise transfer Your
 Contribution, where such licence applies only to those patent claims licensable
 by You that are necessarily infringed by Your Contribution alone or by
 combination of Your Contribution with the Project. If any entity institutes
-patent litigation alleging that Your Contribution, or the Project to which You
-contributed, constitutes direct or contributory patent infringement, then any
-patent licences granted to that entity under this CLA terminate.
+patent litigation **(including a cross-claim or counterclaim in a lawsuit)**
+alleging that Your Contribution, or the Project to which You contributed,
+constitutes direct or contributory patent infringement, then any patent licences
+granted to that entity under this CLA terminate **as of the date such litigation
+is filed.**
 
 ## 4. Your representations
 You represent that:
@@ -60,11 +71,17 @@ You represent that:
   rights. Any third-party material is identified and its licence noted.
 - You are not aware of any patents or other rights that would make the licences
   above impossible to grant.
+- You agree to **notify the Maintainer** if You later become aware of any fact
+  that would make any representation above inaccurate.
+- To the extent permitted by applicable law, You **waive, and agree not to
+  assert, any moral rights** in Your Contributions against the Maintainer and
+  downstream recipients, to the extent necessary to exercise the licences granted
+  above.
 
 ## 5. Support & warranty
 You are not expected to provide support for Your Contributions. Contributions are
 provided **"as is"**, without warranties or conditions of any kind, except as
-stated in Sections 4.
+stated in Section 4.
 
 ## 6. How to sign
 - **Individuals:** once the CLA bot is enabled, it will comment on your first pull
@@ -76,3 +93,11 @@ stated in Sections 4.
 Trivial changes (typo fixes, formatting, documentation-only edits) do not require
 a CLA. The [DCO sign-off](CONTRIBUTING.md#commits-dco-and-review) is still
 required on every commit.
+
+## 7. Miscellaneous
+This CLA is effective on the date You first submit a Contribution and covers all
+present and future Contributions. The Maintainer is **under no obligation** to
+use, merge, or distribute any Contribution. This CLA is the **entire agreement**
+between You and the Maintainer regarding Your Contributions and supersedes any
+prior understanding on that subject. **Governing law:** _to be set by the
+Maintainer's counsel before enforcement._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,14 @@ mandatory floor mirrors what you should run locally:
   ```bash
   git commit -s     # adds: Signed-off-by: Your Name <you@example.com>
   ```
-  The `dco` CI job enforces this. There is no CLA.
+  The `dco` CI job enforces this.
+- **CLA** — non-trivial contributions are accepted under the project's
+  [Contributor License Agreement](CLA.md). It is a *licence, not an assignment*:
+  you keep ownership of your work and grant the project a broad licence to use
+  and sub-licence it. Trivial changes (typos, formatting, docs) are exempt. Once
+  the CLA bot is enabled it records your one-click sign-off on your first PR;
+  until then the DCO sign-off above is the operative requirement. See
+  [CLA.md](CLA.md) and the licence/trademark note in the README.
 - **Fill in the template.** Issues and pull requests opened without filling in
   their template are **closed automatically** (you'll get a comment explaining
   how) — edit yours to fill it in, then reopen and we'll pick it up. Maintainers,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,9 +307,15 @@ Speculative, unreproducible "findings" will be closed.
 
 ## License
 
-By contributing you agree your contributions are dual-licensed under **MIT OR
-Apache-2.0** (see [LICENSE-MIT](LICENSE-MIT) and [LICENSE-APACHE](LICENSE-APACHE)),
-with no additional terms. Inbound = outbound.
+By contributing you agree that the **outbound licence for released code is
+MIT OR Apache-2.0** (see [LICENSE-MIT](LICENSE-MIT) and
+[LICENSE-APACHE](LICENSE-APACHE)) — inbound = outbound for what ships to users. In
+addition, **non-trivial contributions are made under the project's
+[Contributor License Agreement](CLA.md)**, which grants the Maintainer a broader,
+sub-licensable copyright and patent licence so the project can relicense *future*
+versions if it ever needs to. The CLA does not change the licence of any
+already-published release. Trivial changes (typos, formatting, docs) are exempt
+from the CLA and remain inbound = outbound only.
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ include = [
     "/Cargo.toml",
     "/LICENSE-MIT",
     "/LICENSE-APACHE",
+    "/NOTICE",
+    "/TRADEMARKS.md",
     "/README.md",
     "/include/**/*",
 ]

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+pdf_oxide
+Copyright (c) 2024-2026 Yury Fedoseev and the pdf_oxide project contributors
+
+This product is licensed under the terms of the MIT license OR the
+Apache License, Version 2.0, at your option. See LICENSE-MIT and
+LICENSE-APACHE for the full license texts.
+
+Copyright in the pdf_oxide code base is held by Yury Fedoseev; contributions are
+made under the project's Contributor License Agreement (see CLA.md) and/or the
+Developer Certificate of Origin (see CONTRIBUTING.md). Contributors retain
+ownership of their contributions and license them to the project.
+
+"pdf_oxide", the pdf_oxide name, and logo are trademarks of Yury Fedoseev and are
+not covered by the source-code license. See TRADEMARKS.md.
+
+Portions of this software incorporate third-party open-source components; their
+respective licenses are listed in the dependency manifests (Cargo.toml /
+Cargo.lock and the per-binding package manifests).

--- a/NOTICE
+++ b/NOTICE
@@ -1,17 +1,21 @@
-pdf_oxide
-Copyright (c) 2024-2026 Yury Fedoseev and the pdf_oxide project contributors
+PDFOxide
+Copyright (c) 2025-2026 Yury Fedoseev and the PDFOxide project contributors
+
+PDFOxide is the product; "pdf_oxide" is the name of its packages/crate.
 
 This product is licensed under the terms of the MIT license OR the
 Apache License, Version 2.0, at your option. See LICENSE-MIT and
 LICENSE-APACHE for the full license texts.
 
-Copyright in the pdf_oxide code base is held by Yury Fedoseev; contributions are
-made under the project's Contributor License Agreement (see CLA.md) and/or the
-Developer Certificate of Origin (see CONTRIBUTING.md). Contributors retain
-ownership of their contributions and license them to the project.
+Copyright in the PDFOxide code base is held by Yury Fedoseev and the project's
+contributors; contributions are made under the project's Contributor License
+Agreement (see CLA.md) and/or the Developer Certificate of Origin (see
+CONTRIBUTING.md), under which contributors retain ownership of their
+contributions and license them to the project.
 
-"pdf_oxide", the pdf_oxide name, and logo are trademarks of Yury Fedoseev and are
-not covered by the source-code license. See TRADEMARKS.md.
+"PDFOxide" (the product name) and "pdf_oxide" (the package name), together with
+any associated logo, are trademarks of Yury Fedoseev and are not covered by the
+source-code license. See TRADEMARKS.md.
 
 Portions of this software incorporate third-party open-source components; their
 respective licenses are listed in the dependency manifests (Cargo.toml /

--- a/README.md
+++ b/README.md
@@ -421,9 +421,13 @@ If it's useful to you, a star on GitHub genuinely helps. If something's broken o
 
 — Yury
 
-## License
+## License & trademark
 
-Dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) at your option. Unlike AGPL-licensed alternatives, PDFOxide can be used freely in any project — commercial or open-source — with no copyleft restrictions.
+The **code** is dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) at your option. Unlike AGPL-licensed alternatives, pdf_oxide can be used freely in any project — commercial or open-source — with no copyleft restrictions.
+
+The **name and brand** are not covered by the code license: **"pdf_oxide"**, the pdf_oxide name, and logo are trademarks of Yury Fedoseev. You may say your product "uses pdf_oxide"; please don't name a different or modified product "pdf_oxide". See [TRADEMARKS.md](TRADEMARKS.md).
+
+© 2024–2026 Yury Fedoseev and the pdf_oxide contributors. Contributions are accepted under the project's [DCO](CONTRIBUTING.md#commits-dco-and-review) and [CLA](CLA.md); contributors retain ownership of their work.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -425,9 +425,9 @@ If it's useful to you, a star on GitHub genuinely helps. If something's broken o
 
 The **code** is dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) at your option. Unlike AGPL-licensed alternatives, pdf_oxide can be used freely in any project — commercial or open-source — with no copyleft restrictions.
 
-The **name and brand** are not covered by the code license: **"pdf_oxide"**, the pdf_oxide name, and logo are trademarks of Yury Fedoseev. You may say your product "uses pdf_oxide"; please don't name a different or modified product "pdf_oxide". See [TRADEMARKS.md](TRADEMARKS.md).
+The **name and brand** are not covered by the code license: **"PDFOxide"** (the product name) and **"pdf_oxide"** (the package name), together with any associated logo, are trademarks of Yury Fedoseev. You may say your product "uses PDFOxide"; please don't name a different or modified product "PDFOxide" or "pdf_oxide". See [TRADEMARKS.md](TRADEMARKS.md).
 
-© 2024–2026 Yury Fedoseev and the pdf_oxide contributors. Contributions are accepted under the project's [DCO](CONTRIBUTING.md#commits-dco-and-review) and [CLA](CLA.md); contributors retain ownership of their work.
+© 2025–2026 Yury Fedoseev and the PDFOxide contributors. Contributions are accepted under the project's [DCO](CONTRIBUTING.md#commits-dco-and-review) and [CLA](CLA.md); contributors retain ownership of their work.
 
 ## Contributing
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,43 @@
+# pdf_oxide Trademark Policy
+
+**"pdf_oxide"**, the pdf_oxide name, and the pdf_oxide logo (the "Marks") are
+trademarks of Yury Fedoseev (the "Owner"). The **source code** is open source
+under `MIT OR Apache-2.0`; **the Marks are not.** Owning the code licence does
+not grant any right to use the Marks.
+
+This policy exists so users can always trust that something called "pdf_oxide"
+is the genuine project — the open-source licence covers the code, this policy
+covers the name and brand.
+
+## You may, without asking
+- State that your product **"uses pdf_oxide"**, is **"built on pdf_oxide"**, or is
+  **"compatible with pdf_oxide"** — accurate, descriptive references (nominative
+  use).
+- Use the Marks in **blog posts, talks, tutorials, and comparisons**, as long as
+  you don't imply endorsement or official status.
+- Redistribute **unmodified** official releases under their open-source licence
+  using the pdf_oxide name.
+
+## You may not, without written permission
+- Use the Marks (or a confusingly similar name/logo) as the name of **your own**
+  product, service, company, app, domain, or social/package-registry account.
+- Use the Marks in a way that suggests your product is **official, endorsed by, or
+  affiliated with** the pdf_oxide project when it is not.
+- Distribute a **modified** version of pdf_oxide under the pdf_oxide name (fork it
+  under a different name; you keep the code rights under the open-source licence,
+  but not the name).
+- Alter the logo, or use the Marks in a misleading, disparaging, or unlawful way.
+
+## Forks and derivatives
+The open-source licence lets you fork and modify the code freely. If you
+distribute a modified version, please give it a **different name** and make clear
+it is not the official pdf_oxide. You may still say it is *"a fork of pdf_oxide"*
+or *"derived from pdf_oxide"*.
+
+## Questions / permission
+For any use not clearly covered above, or to request permission, contact
+**yfedoseev@gmail.com**. We aim to be permissive for good-faith community use and
+strict only about uses that could confuse users about what the genuine project is.
+
+_This policy may be updated over time. It does not modify the terms of the
+open-source code licences (`MIT OR Apache-2.0`)._

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,38 +1,48 @@
-# pdf_oxide Trademark Policy
+# PDFOxide Trademark Policy
 
-**"pdf_oxide"**, the pdf_oxide name, and the pdf_oxide logo (the "Marks") are
-trademarks of Yury Fedoseev (the "Owner"). The **source code** is open source
-under `MIT OR Apache-2.0`; **the Marks are not.** Owning the code licence does
-not grant any right to use the Marks.
+**"PDFOxide"** (the product name), **"pdf_oxide"** (the package/crate name), and
+any associated PDFOxide logo (the "Marks") are trademarks of Yury Fedoseev (the
+"Owner"). Common casings and near-variants used on package registries (e.g.
+`PdfOxide`, `pdfoxide`) are treated as the same Marks. The **source code** is
+open source under `MIT OR Apache-2.0`; **the Marks are not.** Owning the code
+license does not grant any right to use the Marks.
 
-This policy exists so users can always trust that something called "pdf_oxide"
-is the genuine project — the open-source licence covers the code, this policy
-covers the name and brand.
+This policy exists so users can always trust that something called "PDFOxide" (or
+distributed as the `pdf_oxide` package) is the genuine project — the open-source
+license covers the code, this policy covers the name and brand.
 
 ## You may, without asking
-- State that your product **"uses pdf_oxide"**, is **"built on pdf_oxide"**, or is
-  **"compatible with pdf_oxide"** — accurate, descriptive references (nominative
-  use).
+- State that your product **"uses PDFOxide"**, is **"built on PDFOxide"**, or is
+  **"compatible with PDFOxide"** — accurate, descriptive references (nominative
+  use). The same applies to the `pdf_oxide` package name.
 - Use the Marks in **blog posts, talks, tutorials, and comparisons**, as long as
   you don't imply endorsement or official status.
-- Redistribute **unmodified** official releases under their open-source licence
-  using the pdf_oxide name.
+- Redistribute **unmodified** official releases under their open-source license
+  using the PDFOxide / `pdf_oxide` name.
+- **Package and redistribute the software for a distribution or package manager**
+  (e.g. a Linux distro, Homebrew, conda-forge) under the `pdf_oxide` / PDFOxide
+  name, including the minimal patches needed to build, package, or security-fix
+  it for that platform — provided the result stays functionally equivalent to the
+  corresponding official release and you don't imply it is a different product.
+  Larger functional forks still need a new name.
 
 ## You may not, without written permission
 - Use the Marks (or a confusingly similar name/logo) as the name of **your own**
   product, service, company, app, domain, or social/package-registry account.
 - Use the Marks in a way that suggests your product is **official, endorsed by, or
-  affiliated with** the pdf_oxide project when it is not.
-- Distribute a **modified** version of pdf_oxide under the pdf_oxide name (fork it
-  under a different name; you keep the code rights under the open-source licence,
-  but not the name).
-- Alter the logo, or use the Marks in a misleading, disparaging, or unlawful way.
+  affiliated with** PDFOxide when it is not.
+- Distribute a **modified** version under the PDFOxide or `pdf_oxide` name (fork
+  it under a different name; you keep the code rights under the open-source
+  license, but not the name).
+- Alter the logo, or use the Marks in a way that is misleading, that falsely
+  implies endorsement or affiliation, or that is otherwise unlawful. (Accurate
+  criticism or comparison that names the Marks is fine.)
 
 ## Forks and derivatives
-The open-source licence lets you fork and modify the code freely. If you
+The open-source license lets you fork and modify the code freely. If you
 distribute a modified version, please give it a **different name** and make clear
-it is not the official pdf_oxide. You may still say it is *"a fork of pdf_oxide"*
-or *"derived from pdf_oxide"*.
+it is not the official PDFOxide. You may still say it is *"a fork of PDFOxide"* or
+*"derived from PDFOxide"*.
 
 ## Questions / permission
 For any use not clearly covered above, or to request permission, contact
@@ -40,4 +50,4 @@ For any use not clearly covered above, or to request permission, contact
 strict only about uses that could confuse users about what the genuine project is.
 
 _This policy may be updated over time. It does not modify the terms of the
-open-source code licences (`MIT OR Apache-2.0`)._
+open-source code licenses (`MIT OR Apache-2.0`)._


### PR DESCRIPTION
**Stacked on #901** (governance branch), so CONTRIBUTING stays coherent — GitHub retargets this to `main` once #901 merges.

Establishes the copyright/brand position for the two future moves you named: a **commercial layer on top** and a **possible acquisition by a competitor**. The engine stays MIT/Apache and no relicensing is telegraphed — this only *preserves the option* and *consolidates ownership* while you're still effectively solo (it gets harder every un-CLA'd commit).

## Recommendation this implements
Copyright *control* is what turns an acqui-hire into a strategic-premium deal, and brand is a fully-ownable acquirable asset regardless of the code licence.

- **`CLA.md`** — lightweight Contributor License Agreement (adapted from the **Apache ICLA v2.0**). A **licence, not an assignment**: contributors keep ownership and grant a broad copyright **+ patent** licence including the right to sub-licence/relicense future versions. This is the break-glass relicense lever + acquisition multiplier, held quietly.
- **`TRADEMARKS.md`** — asserts "pdf_oxide" name/logo as trademarks with a permissive nominative-use policy (users can say "uses pdf_oxide"; can't name a different product that). ClickHouse model: own the trademark even though the code is permissive.
- **`NOTICE`** — Apache-2.0 attribution consolidating copyright under Yury Fedoseev; added to the crate `include` so it ships with published artifacts.
- **CONTRIBUTING** — replaces "there is no CLA" with the CLA reference (DCO kept as the operative check until a CLA bot is enabled).
- **README** — a License & Trademark section + a `© 2024–2026 … ™` line where people actually look.

## ⚠️ Before this is "live" (needs you / counsel — not code)
- **Legal review of `CLA.md`** before you enforce it (it's Apache-ICLA-derived, but have a lawyer confirm for your situation).
- **Install a CLA bot** (e.g. cla-assistant) to record signatures on PRs — until then DCO remains the operative requirement (the docs say exactly this).
- **Register the trademark**, own the domains + npm/PyPI/crates orgs.
- **Form the entity** and consolidate copyright into it (clean single-owner chain = what due-diligence wants).

I am not a lawyer; this is standard-template scaffolding + positioning, not legal advice.

https://claude.ai/code/session_01QXMiKnxkmFs3tCQNz1vMc5