### PR TITLE
chore(deps): bump office_oxide to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "office_oxide"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673fefe70a9e53a74d4e4b2797cbe9fc2d778cfc1734956727db9e5b7d809e98"
+checksum = "7150eeae2b40a6926717058d0575ee2f48a36806725376a2ff6b2e69b61c88e9"
 dependencies = [
  "atoi_simd",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ qrcode = { version = "0.14", optional = true }
 barcoders = { version = "2.0", optional = true, features = ["image"] }
 
 # Office document creation and export via office_oxide (always required)
-office_oxide = { version = "0.1.6", default-features = false }
+office_oxide = { version = "0.1.7", default-features = false }
 x509-tsp = { version = "0.1", optional = true }
 ureq = { version = "3", default-features = false, features = ["rustls"], optional = true }
 cmpv2 = { version = "0.2", optional = true }


### PR DESCRIPTION
## Summary
- Bump `office_oxide` dependency from 0.1.6 to 0.1.7 (latest release on crates.io)
- Update `Cargo.lock` accordingly

## Test plan
- [x] `cargo check -p pdf_oxide --lib` passes against office_oxide 0.1.7