### PR TITLE
docs: add Notable Users section to README (verified links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,19 @@ cargo build --release --lib
 - **PDF generation** — Create invoices, reports, certificates, and templated documents programmatically
 - **PyMuPDF alternative** — MIT licensed, 5× faster, no AGPL restrictions
 
+## Notable Users
+
+Projects using PDFOxide in production (verified against their public dependency manifests):
+
+- **[RAGFlow](https://github.com/infiniflow/ragflow)** (85k★) — one of the most popular open-source RAG engines; PDFOxide is the primary PDF engine in its `deepdoc` parsing pipeline ([go.mod](https://github.com/infiniflow/ragflow/blob/main/go.mod))
+- **[AFFiNE](https://github.com/toeverything/AFFiNE)** (70k★) — open-source Notion/Miro alternative; powers document extraction via AFFiNE's own [`doc_extractor`](https://crates.io/crates/doc_extractor) crate ([Cargo.toml](https://github.com/toeverything/AFFiNE/blob/canary/Cargo.toml), [doc_extractor's own dependency on PDFOxide](https://crates.io/crates/doc_extractor/0.1.1/dependencies))
+- **[grok-build](https://github.com/xai-org/grok-build)** (19k★) — xAI's coding-agent TUI; uses PDFOxide's rendering feature to read PDFs in a repo ([Cargo.toml](https://github.com/xai-org/grok-build/blob/main/Cargo.toml))
+- **[Xberg](https://github.com/xberg-io/xberg)** (formerly kreuzberg, 8.7k★) — polyglot document-intelligence framework; PDFOxide is its architectural PDF engine ([Cargo.toml](https://github.com/xberg-io/xberg/blob/main/Cargo.toml))
+- **[create-context-graph](https://github.com/neo4j-labs/create-context-graph)** (Neo4j Labs) — GraphRAG context-builder; PDFOxide is its primary PDF parser ([pyproject.toml](https://github.com/neo4j-labs/create-context-graph/blob/main/pyproject.toml))
+- **[arXiv submission-tools](https://github.com/arXiv/submission-tools)** — arXiv.org's own PDF validation and LaTeX-to-PDF submission pipeline ([pdf_profile/pyproject.toml](https://github.com/arXiv/submission-tools/blob/master/pdf_profile/pyproject.toml))
+
+Using PDFOxide in production? [Open an issue](https://github.com/yfedoseev/pdf_oxide/issues/new) to be added here.
+
 ## Why I built this
 
 I needed PyMuPDF's speed without its AGPL license, and I needed it in more than one language. Nothing existed that ticked all three boxes — fast, MIT, multi-language — so I wrote it. The Rust core is what does the real work; the bindings for Python, Go, JS/TS, C#, and WASM are thin shells around the same code, so a bug fix in one lands in all of them. It now passes 100% of the veraPDF + Mozilla pdf.js + DARPA SafeDocs test corpora (3,830 PDFs) on every platform I've tested.


### PR DESCRIPTION
## Summary
Supersedes #905. That PR's test plan had two unchecked items ("links resolve", "renders correctly") — this PR does the actual verification and fixes what didn't hold up:

- Re-checked every claim against the live manifest (not just at PR-authoring time): RAGFlow's `go.mod`, grok-build's/Xberg's/create-context-graph's `Cargo.toml`/`pyproject.toml` all directly pin `pdf_oxide`/`pdf-oxide` — confirmed as-is.
- **AFFiNE**: its own `Cargo.toml` only pins `doc_extractor`, not `pdf_oxide` directly — the pdf_oxide dependency lives one hop away, inside `doc_extractor`'s own manifest (published separately to crates.io). Added a second proof link to `doc_extractor`'s crates.io dependency listing so the full chain to `pdf_oxide` is verifiable, not just asserted.
- **arXiv submission-tools**: had no manifest link at all in #905 (the only bullet missing one). Confirmed the claim is true — `pdf-oxide>=0.3.61` is declared in `pdf_profile/pyproject.toml` — and added that link. Note the repo's default branch is `master`, not `main`.

## Test plan
- [x] Every linked URL resolves (checked via GitHub API + raw content fetch)
- [x] Every manifest was fetched and grepped to confirm it actually declares a `pdf_oxide`/`pdf-oxide` dependency (not just linked on trust)
- [x] `cargo check -p pdf_oxide --lib` passes (README-only change, but confirmed the workspace still builds)

Closes #905