### PR TITLE
perf(images): encode embedded PNGs with adaptive filtering, not NoFilter

### DIFF
--- a/src/extractors/images.rs
+++ b/src/extractors/images.rs
@@ -380,8 +380,17 @@ impl PdfImage {
         use std::io::Cursor;
 
         let mut buffer = Cursor::new(Vec::new());
-        let encoder =
-            PngEncoder::new_with_quality(&mut buffer, CompressionType::Fast, FilterType::NoFilter);
+        // `Adaptive` per-scanline filtering (Sub/Up/Average/Paeth) is where PNG's
+        // deflate win actually comes from on photographic / scanned content; with
+        // `NoFilter` deflate cannot exploit smooth gradients and the stream stays
+        // near-raw. This is purely a container-size choice - the decoded pixels
+        // are byte-identical either way (PNG is lossless) - so it trades a little
+        // encode CPU for large size reductions (measured ~40x on flat scans).
+        let encoder = PngEncoder::new_with_quality(
+            &mut buffer,
+            CompressionType::Default,
+            FilterType::Adaptive,
+        );
 
         match &self.data {
             ImageData::Raw { pixels, format } => {


### PR DESCRIPTION
## Problem

`PdfImage::to_png_bytes()` encodes every non-JPEG image (Flate / CCITT / JBIG2 / JPX) with:

```rust
PngEncoder::new_with_quality(&mut buffer, CompressionType::Fast, FilterType::NoFilter)
```

`FilterType::NoFilter` disables PNG's per-scanline Sub/Up/Average/Paeth filtering — the exact step that lets deflate compress smooth / scanned content — so the stream stays near-raw. A full-page scanned background that the source PDF stores in ~110 KB (FlateDecode) re-encodes at ~4.4 MB (~40×). Any consumer that inlines these images (e.g. base64 data URIs in an HTML export) inherits the blow-up; on a sample of image-heavy documents this alone accounted for hundreds of MB.

## Fix

Switch to `CompressionType::Default` + `FilterType::Adaptive`. This is purely a container-size choice — **the decoded pixels are byte-identical either way (PNG is lossless)** — trading a little encode CPU for large size reductions.

## Measured

Over a sample of image-heavy documents, total inlined output **2200 MB → 928 MB (0.42×)**; individual flat-scan docs up to **83× smaller**; pixel-fidelity and text metrics byte-identical (max delta 0.0000). The re-encode cost is per-image-decode, not per-render.

Full gate on this branch off `main`: `cargo test --lib` (5750 passed), `cargo test --doc` (141 passed), `cargo clippy --lib` clean, `cargo fmt --check` clean.