### PR TITLE
chore(deps): bump office_oxide 0.1.7 → 0.1.8 [HELD: awaiting crates.io release]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "office_oxide"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7150eeae2b40a6926717058d0575ee2f48a36806725376a2ff6b2e69b61c88e9"
+checksum = "317c254cebe5b87c74a0fbd84e889d51ec0c4db885fa5aca98700ad85fd9ec5f"
 dependencies = [
  "atoi_simd",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ qrcode = { version = "0.14", optional = true }
 barcoders = { version = "2.0", optional = true, features = ["image"] }
 
 # Office document creation and export via office_oxide (always required)
-office_oxide = { version = "0.1.7", default-features = false }
+office_oxide = { version = "0.1.8", default-features = false }
 x509-tsp = { version = "0.1", optional = true }
 ureq = { version = "3", default-features = false, features = ["rustls"], optional = true }
 cmpv2 = { version = "0.2", optional = true }


### PR DESCRIPTION
**Draft / held.** Bumps the office_oxide requirement to 0.1.8.

office_oxide 0.1.8 is **merged to office_oxide main but not yet published to crates.io**, so this can't build/pass CI yet — kept as a draft on purpose.

### Flip-live steps (when 0.1.8 publishes)
1. `cargo update -p office_oxide --precise 0.1.8` (regenerate Cargo.lock — currently still 0.1.7).
2. `cargo check` to confirm it resolves and compiles.
3. `git push`, mark ready, then add to the merge queue **before the governance PRs (#901/#902/#903)**.

Kept as a pure crates.io version bump (not a git dep) so pdf_oxide stays crates.io-publishable.

https://claude.ai/code/session_01VfT1dvLWaMNh4SpaXV8kcp