### PR TITLE
Release v0.3.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,47 @@
 
 All notable changes to PDFOxide are documented here.
 
-## [Unreleased]
+## [0.3.75] - 2026-07-23
+
+> Rendering-accuracy and extraction-fidelity release. DeviceCMYK now renders through measured process inks; page rotation (including `/Rotate 270` and negative values) and Separation/DeviceN tint transforms are honoured; inline images and CMYK/CCITT image decoding are corrected; Form-XObject text no longer goes missing; Tagged PDFs can be read in structure order; and a large text-extraction performance pass lands, alongside a dependency modernization (rustybuzz→harfrust, office_oxide 0.1.8).
+
+### Added
+
+- **`ReadingOrder::Structure`** — order a Tagged PDF by a pre-order traversal of its `/StructTreeRoot` (ISO 32000-1 §14.8.2.3), fixing table and complex-layout order where a geometric XY-cut guesses; falls back to `ColumnAware` when the structure tree is absent or not trustworthy (#877).
+- **Mapping provenance** — `extract_spans` reports which ISO 32000-1 §9.10.2 tier (ToUnicode / encoding / heuristic) produced each span's text, surfaced across all bindings (#893).
+- **`extract_spans_filtered_with_reading_order`** — reading-order extraction combined with optional-content (OCG) and ink-coverage filtering (#883).
+- **Type 0 (sampled) and Type 3 (stitching) tint-transform evaluation** in the renderer for Separation/DeviceN colours (#849).
+- **CJK vertical-writing running header/footer detection** — recognizes folios in the left/right side bands on tategaki pages (#889).
+- `resolve_named_destination` is now public (#881); a `remove_artifacts` markdown-conversion example (#845).
 
 ### Fixed
+
+**Rendering**
+
+- **DeviceCMYK rendered via the naive `1−(C+K)` additive clamp** — now converts through measured SWOP-style process inks across every composite / vector / text / image path, so `0 0 0 1 k` black renders `#231F20` and process cyan renders `#00ADEF` instead of over-saturated additive values (#861).
+- **`/Rotate 270` rendered MIRRORED rather than rotated**; negative `/Rotate` values were mishandled (`%` instead of `rem_euclid`); real `/Rotate` and indirect Separation alternates are now resolved correctly (#862, #848, #854).
+
+**Text extraction**
+
+- **Form-XObject (`Do`) text went missing when stray operands preceded the name** — a dropped/malformed `cm` left dangling numeric operands, so `Do` read `operands[0]` (a stray number) and resolved to an empty name; it now reads the operand *immediately preceding* the operator per ISO 32000-1 §7.8.2 (#914).
+- **Pages were lost when `/Count`-based page counting returned 0** — now recovered by walking the page tree (#909).
+- **Inline images (`BI`/`ID`/`EI`) were parsed but never decoded** — `/Subtype` is now supplied and the Table 92 abbreviated keys/values expanded (#863).
+- Unique `/PlacedPDF` bodies are kept instead of suppressed (#896); spans entirely outside the MediaBox are dropped from `extract_spans_with_reading_order` (#894); the top-level fill colour set before `BT` is preserved (`scn`/`cs`/`rg` no longer dropped) (#857).
+- Running-header/footer detection now requires position-consistency before removing repeated text as chrome, and recognizes non-Latin folio digits (#888, #887).
+
+**Images**
+
+- `/Decode [1 0]` is honoured for 1-bit CCITT/DeviceGray images (#856); the jpeg-decoder Adobe inversion is undone for CMYK JPEGs (#855).
+
+**Recovery / parsing**
+
+- A truncated file that lost its own Catalog is recovered by rebuilding one from the surviving pages (#890); a file padded after `%%EOF` is no longer rejected outright as 0 pages (#875).
+
+**Fonts**
+
+- The referenced `/Encoding /Differences` is folded into the font identity hash, and subset choice in `extract_embedded_fonts` is made deterministic (#878, #853).
+
+**Writer**
 
 - **Coloured text on a registered embedded font rendered black — `FluentPageBuilder::inline_color` (and any `TextStyle.color`) was silently dropped for embedded fonts** — `PdfWriter::add_element` routed embedded-font text through the deliberately colour-agnostic `add_embedded_text` (the HTML painter sets and resets the fill colour around its own calls) without ever emitting the element's fill colour, so no `rg` operator reached the content stream and the glyphs painted in whatever fill colour was last set (default black). The base-14 path (`add_text_content`) always emits `rg` from `style.color`; the embedded path now matches it by emitting `fill_color` before the glyph run. No restore is needed — every text element sets its own colour, mirroring the base-14 branch's "always set explicitly" contract.
 
@@ -12,9 +50,22 @@ All notable changes to PDFOxide are documented here.
 
 - **`extract_words` / `extract_text` spent most of their time re-deriving per-glyph facts that cannot change (#882)** — text extraction asked each font for its weight and slant once per *glyph*, inside the show-text loop. Both answers are name-derived: the weight lowercases the base font name (allocating) and runs up to a dozen substring searches, and the slant lowercases it again for two more — so a 13,234-page document repeated ~14 substring scans and 2 allocations 48.7M times for a value fixed at font-load. A sampling profile put `str::contains` and friends at ~38% of all samples. The Standard-14 width lookup had the same shape, re-stripping the subset prefix and re-scanning the 15-name table per glyph purely to choose a width table. Both are now resolved once per font and memoized, mirroring the existing byte-width-table memo. Alongside: `postprocess_spans` rescanned every glyph on the page per span to find its baseline (O(spans × chars) — now a bracketed y-sorted index); the page's characters were re-parsed for span post-processing and re-copied on every access (now cached and shared); the word and line paths materialized every glyph twice; article threads — a document-wide parse that walks the whole page tree — were re-parsed *per page*; the glyph dedup rebuilt the whole array to drop a handful; and the word-merge loop re-derived RTL-ness from an accumulating buffer, costing O(k²) characters per merge chain (the exact blow-up the backtrack guard above it exists to prevent). Measured on the reporter's PDFs: `extract_words` 156.9s → ~121s and `extract_spans` 88.7s → ~54s on a 13,234-page document; `extract_text` 6.03s → 3.94s on a 2,124-page one. Output is byte-identical — verified across a 419-PDF corpus for `extract_spans`/`extract_chars`/`extract_words`/`extract_text_lines` (including geometry and per-glyph x-offsets) and for text/markdown/HTML.
 
+### Changed / Dependencies
+
+- **Text shaping migrated from `rustybuzz` to `harfrust`** (#899); `fax` 0.2 → 0.3 (#873); the `ttf-parser` migration decision for RUSTSEC-2026-0192 is documented (#900).
+- `office_oxide` bumped to 0.1.8 (#904, #932). A combined dependency roundup (crates + CI actions + Go), plus routine crate and CI-action bumps (#931, #907, #898, #872, #869, #870, #871, #864, #865, #866, #867, #868, #874, #891).
+- Test/CI stability: the flaky `structured_warnings` round-trip test is fixed (#912); misc test guards and binding-format fixes (#846, #897, #880).
+
+### Contributors
+
+The majority of this release was contributed by **@ajbufort** — rendering (`/Rotate` handling and Separation/DeviceN tint transforms #848, #849, #854, #862; DeviceCMYK process inks #861), image decode (#855, #856), text extraction (#857, #863, #894, #896, #909), fonts (#853, #878), recovery/parsing (#875, #890), and reading-order / span filtering (#877, #881, #883). Additional fixes from **@norbusan** (#911) and **@ultrasaurus** (#845, #846). Thank you!
+
 Issues reported by:
 
-- **@ankursri494** — #882 (`extract_words`/`extract_text` slower than `extract_spans` on large PDFs)
+- **@ankursri494** — #882 (`extract_words`/`extract_text` far slower than `extract_spans` on large PDFs)
+- **@tobocop2** — #876 (signal to callers when a page's text cannot be extracted)
+- **@ultrasaurus** — #879 (`remove_footers` removed real content on IRS forms)
+- **@norbusan** — #913 (text inside a Form XObject missing from extraction)
 
 ## [0.3.74] - 2026-07-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.74"
+version = "0.3.75"
 dependencies = [
  "aes",
  "aws-lc-rs",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.74"
+version = "0.3.75"
 dependencies = [
  "clap",
  "is-terminal",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_jni"
-version = "0.3.74"
+version = "0.3.75"
 dependencies = [
  "jni",
  "pdf_oxide",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.74"
+version = "0.3.75"
 dependencies = [
  "pdf_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.74"
+version = "0.3.75"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85

--- a/clojure/deps.edn
+++ b/clojure/deps.edn
@@ -4,7 +4,7 @@
 ;; Java NativeLoader resolves the JNI cdylib via the `fyi.oxide.pdf.lib.path`
 ;; system property (pointed at the freshly built libpdf_oxide_jni below).
 {:paths ["src"]
- :deps {fyi.oxide/pdf-oxide {:mvn/version "0.3.74"}}
+ :deps {fyi.oxide/pdf-oxide {:mvn/version "0.3.75"}}
  :aliases
  {:test
   {:extra-paths ["test"]

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(pdf_oxide_cpp VERSION 0.3.74 LANGUAGES CXX)
+project(pdf_oxide_cpp VERSION 0.3.75 LANGUAGES CXX)
 
 # Idiomatic C++17 RAII bindings over the pdf_oxide C ABI (header-only wrapper).
 #

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.74</Version>
+    <Version>0.3.75</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_oxide
 description: The fastest Dart/Flutter PDF library — 5× faster than the industry leaders, 100% pass rate on 3,830 PDFs. Text, Markdown & HTML extraction plus PDF creation via dart:ffi.
-version: 0.3.74
+version: 0.3.75
 repository: https://github.com/yfedoseev/pdf_oxide
 homepage: https://github.com/yfedoseev/pdf_oxide
 issue_tracker: https://github.com/yfedoseev/pdf_oxide/issues

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule PdfOxide.MixProject do
   def project do
     [
       app: :pdf_oxide,
-      version: "0.3.74",
+      version: "0.3.75",
       elixir: "~> 1.15",
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -52,7 +52,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion = "0.3.74"
+	fallbackVersion = "0.3.75"
 	BaseURL         = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	// cacheSubdir lives under os.UserCacheDir() — XDG_CACHE_HOME on Linux,
 	// ~/Library/Caches on macOS (Time-Machine-excluded), %LocalAppData% on

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
                                namespace verification under oxide.fyi)
   artifactId:  pdf-oxide      (the Maven artifact; matches the
                                package fyi.oxide.pdf)
-  version:     0.3.74         (lockstep with Cargo workspace /
+  version:     0.3.75         (lockstep with Cargo workspace /
                                js/package.json / .csproj /
                                pyproject.toml — release-preflight
                                from v0.3.51 #515 enforces parity)
@@ -33,7 +33,7 @@
 
     <groupId>fyi.oxide</groupId>
     <artifactId>pdf-oxide</artifactId>
-    <version>0.3.74</version>
+    <version>0.3.75</version>
     <packaging>jar</packaging>
 
     <name>pdf_oxide — Java binding</name>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/yfedoseev/pdf_oxide.git</connection>
         <developerConnection>scm:git:git@github.com:yfedoseev/pdf_oxide.git</developerConnection>
         <url>https://github.com/yfedoseev/pdf_oxide</url>
-        <tag>v0.3.74</tag>
+        <tag>v0.3.75</tag>
     </scm>
 
     <issueManagement>

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.74",
+  "version": "0.3.75",
   "type": "module",
   "description": "The fastest Node.js PDF library — 0.8ms mean, 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs. Prebuilt native bindings, no build toolchain: text extraction, Markdown/HTML conversion, PDF creation and editing.",
   "main": "lib/index.js",

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "PdfOxide"
 uuid = "b0c1d2e3-4f56-47a8-9b0c-1d2e3f4a5b6c"
 authors = ["Yury Fedoseev <yfedoseev@gmail.com>"]
-version = "0.3.74"
+version = "0.3.75"
 
 [compat]
 Aqua = "0.8"

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "fyi.oxide"
-version = "0.3.74"
+version = "0.3.75"
 
 repositories {
     // mavenLocal first so a freshly `mvn install`-ed Java artifact (dev/CI)
@@ -40,7 +40,7 @@ detekt {
 dependencies {
     // The Java binding owns the JNI bridge; we re-export its types (api scope)
     // so Kotlin callers `import fyi.oxide.pdf.*` and get them transitively.
-    api("fyi.oxide:pdf-oxide:0.3.74")
+    api("fyi.oxide:pdf-oxide:0.3.75")
     testImplementation(kotlin("test"))
 }
 

--- a/objc/PdfOxide.podspec
+++ b/objc/PdfOxide.podspec
@@ -14,7 +14,7 @@
 # rule is added here — that wiring is intentionally left to the release tooling).
 Pod::Spec.new do |spec|
   spec.name         = 'PdfOxide'
-  spec.version      = '0.3.74'
+  spec.version      = '0.3.75'
   spec.summary      = 'The fastest Objective-C PDF library — 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs.'
   spec.description  = <<-DESC
     Objective-C bindings over the pdf_oxide C ABI. NSObject wrappers (POXDocument,

--- a/objc/include/POXPdfOxide.h
+++ b/objc/include/POXPdfOxide.h
@@ -9,7 +9,7 @@
 
 /// Binding version, kept in lock-step with the workspace crate by
 /// scripts/sync_version.py (the single source of truth is Cargo.toml).
-#define POX_PDF_OXIDE_VERSION "0.3.74"
+#define POX_PDF_OXIDE_VERSION "0.3.75"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.74"
+version = "0.3.75"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -34,7 +34,7 @@ workspace = true
 ocr = ["pdf_oxide/ocr"]
 
 [dependencies]
-pdf_oxide = { version = "0.3.74", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.75", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_jni/Cargo.toml
+++ b/pdf_oxide_jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_jni"
-version = "0.3.74"
+version = "0.3.75"
 edition = "2021"
 description = "JNI bindings for pdf_oxide — native Java binding, the 8th surface alongside Python/Go/JS/C#/WASM/CLI/MCP. Loaded by the fyi.oxide:pdf-oxide Maven artifact."
 license = "MIT OR Apache-2.0"
@@ -93,7 +93,7 @@ jni = "0.22"
 # opt-in FIPS 140-3 build) — those two are compile-time mutually
 # exclusive (pdf_oxide enforces via compile_error!). We always
 # enable `icc` for ICC-based colour management.
-pdf_oxide = { version = "0.3.74", path = "..", default-features = false, features = ["icc"] }
+pdf_oxide = { version = "0.3.75", path = "..", default-features = false, features = ["icc"] }
 
 # JSON envelope for the v0.3.51 AutoExtractor rich-result path. The
 # Java side gets the PageExtraction / DocumentExtraction as a JSON

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.74"
+version = "0.3.75"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.74", path = ".." }
+pdf_oxide = { version = "0.3.75", path = ".." }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/php/scripts/download-native-lib.php
+++ b/php/scripts/download-native-lib.php
@@ -37,7 +37,7 @@ declare(strict_types=1);
  *   - Set `PDF_OXIDE_NATIVE_VERSION=vX.Y.Z` to pin a specific release.
  */
 
-const PACKAGE_VERSION_DEFAULT = 'v0.3.74';
+const PACKAGE_VERSION_DEFAULT = 'v0.3.75';
 const RELEASE_BASE_URL = 'https://github.com/yfedoseev/pdf_oxide/releases/download';
 // Path is relative to the package root (parent-of-php in the new
 // root-composer.json layout); see comment on $packageRoot below.
@@ -253,12 +253,12 @@ function downloadFile(string $url, string $dest): bool
         'http' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.74',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.75',
         ],
         'https' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.74',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.75',
         ],
     ]);
     $data = @file_get_contents($url, false, $ctx);

--- a/php/src/Pdf.php
+++ b/php/src/Pdf.php
@@ -152,7 +152,7 @@ final class Pdf
      * pdf_oxide library version. Kept in sync with `Cargo.toml` by the
      * release tooling (see `docs/releases/RELEASE_PROCESS.md`).
      */
-    public const VERSION = '0.3.74';
+    public const VERSION = '0.3.75';
 
     /** Whether OCR-model prefetch + cache are available on this build. */
     public static function prefetchAvailable(): bool

--- a/php/tests/Integration/CoreParityTest.php
+++ b/php/tests/Integration/CoreParityTest.php
@@ -92,6 +92,6 @@ final class CoreParityTest extends IntegrationTestCase
 
     public function testVersionConstant(): void
     {
-        $this->assertSame('0.3.74', Pdf::VERSION);
+        $this->assertSame('0.3.75', Pdf::VERSION);
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.74"
+version = "0.3.75"
 description = "The fastest Python PDF library — 0.8ms mean, 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs. Text extraction, Markdown/HTML conversion, PDF creation and editing."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_core_parity.py
+++ b/python/tests/test_core_parity.py
@@ -82,4 +82,4 @@ def test_open_error():
 
 
 def test_version():
-    assert pdf_oxide.VERSION == "0.3.74"
+    assert pdf_oxide.VERSION == "0.3.75"

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pdfoxide
 Type: Package
 Title: Fast PDF Text, Markdown and HTML Extraction (pdf_oxide)
-Version: 0.3.74
+Version: 0.3.75
 Authors@R: person("Yury", "Fedoseev", email = "yfedoseev@gmail.com", role = c("aut", "cre"))
 Author: Yury Fedoseev [aut, cre]
 Maintainer: Yury Fedoseev <yfedoseev@gmail.com>

--- a/ruby/lib/pdf_oxide/version.rb
+++ b/ruby/lib/pdf_oxide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PdfOxide
-  VERSION = '0.3.74'
+  VERSION = '0.3.75'
 end

--- a/ruby/spec/cdylib_smoke_spec.rb
+++ b/ruby/spec/cdylib_smoke_spec.rb
@@ -11,7 +11,7 @@ require 'tmpdir'
 RSpec.describe 'libpdf_oxide cdylib smoke' do
   it 'loads the gem with the expected version' do
     expect(defined?(PdfOxide)).to eq('constant')
-    expect(PdfOxide::VERSION).to eq('0.3.74')
+    expect(PdfOxide::VERSION).to eq('0.3.75')
   end
 
   it 'exposes every public-API class' do

--- a/ruby/spec/core_parity_spec.rb
+++ b/ruby/spec/core_parity_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'core parity (Ruby)' do
     expect { PdfOxide::PdfDocument.open('/no/such/file/does/not/exist.pdf') }.to raise_error(StandardError)
   end
 
-  it 'exposes version 0.3.74' do
-    expect(PdfOxide::VERSION).to eq('0.3.74')
+  it 'exposes version 0.3.75' do
+    expect(PdfOxide::VERSION).to eq('0.3.75')
   end
 end

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -4,7 +4,7 @@
 // (Optional -> Option, java.util.List -> Seq, Using on AutoCloseable handles).
 ThisBuild / organization := "fyi.oxide"
 ThisBuild / organizationName := "PDF Oxide"
-ThisBuild / version := "0.3.74"
+ThisBuild / version := "0.3.75"
 ThisBuild / scalaVersion := "3.3.4"
 
 // scalafix needs SemanticDB. On Scala 3 it's emitted by the compiler itself
@@ -37,7 +37,7 @@ lazy val root = (project in file("."))
     description := "Idiomatic Scala 3 bindings for pdf_oxide — a thin facade over the fyi.oxide:pdf-oxide Java binding (JNI).",
     resolvers += Resolver.mavenLocal, // resolve the locally-installed Java artifact during dev/CI
     libraryDependencies ++= Seq(
-      "fyi.oxide" % "pdf-oxide" % "0.3.74",
+      "fyi.oxide" % "pdf-oxide" % "0.3.75",
       "org.scalatest" %% "scalatest" % "3.2.19" % Test
     ),
     // The Java NativeLoader resolves the JNI cdylib via this property; override

--- a/tests/core_parity.rs
+++ b/tests/core_parity.rs
@@ -93,5 +93,5 @@ fn open_error() {
 
 #[test]
 fn version() {
-    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.74");
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.75");
 }

--- a/uv.lock
+++ b/uv.lock
@@ -2254,7 +2254,7 @@ wheels = [
 
 [[package]]
 name = "pdf-oxide"
-version = "0.3.74"
+version = "0.3.75"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.74",
+  "version": "0.3.75",
   "description": "The fastest WebAssembly PDF library — 0.8ms mean, 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs. Zero-dependency for Node.js, browsers, and edge runtimes: text extraction, Markdown/HTML conversion, search, form filling, creation, and editing.",
   "license": "MIT OR Apache-2.0",
   "repository": {

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pdf_oxide,
-    .version = "0.3.74",
+    .version = "0.3.75",
     .fingerprint = 0x991319f35cdc7f8a,
     .minimum_zig_version = "0.15.0",
     .paths = .{


### PR DESCRIPTION
Release prep for **v0.3.75** (target tag date 2026-07-23).

- Version bumped 0.3.74 → 0.3.75 across all bindings via `sync_version.py` (+ Cargo.lock), consistency verified.
- CHANGELOG `[0.3.75] - 2026-07-23` covering the rendering-accuracy / extraction-fidelity fixes, the text-extraction performance pass, and dependency modernization (rustybuzz→harfrust, office_oxide 0.1.8), with community contributor credits.
- Extraction regression vs v0.3.74 (419-corpus, text/md/html): **2/419 changed, both improvements, 0 regressions, 0 new crashes** (issue11124 scanned-page OCR marker; arxiv_math subscript recovery — both confirmed against poppler).

Merging this to main precedes tagging `v0.3.75`.

https://claude.ai/code/session_01VfT1dvLWaMNh4SpaXV8kcp