### PR TITLE
fix(render): decode CCITT image masks

### DIFF
--- a/src/decoders/ccitt.rs
+++ b/src/decoders/ccitt.rs
@@ -13,7 +13,7 @@
 
 use crate::decoders::{CcittParams, StreamDecoder};
 use crate::error::{Error, Result};
-use crate::extractors::ccitt_bilevel::transitions_to_bytes;
+use crate::extractors::ccitt_bilevel::{append_transition_row, transitions_to_bytes};
 
 /// CCITTFaxDecode stream filter (pass-through).
 ///
@@ -64,9 +64,9 @@ pub fn decode(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
 
     let bytes_per_row = (width as usize).div_ceil(8);
     let mut reader = BitReader::new(data);
-    let mut reference: Vec<u16> = Vec::new(); // imaginary all-white line above row 0
-    let mut current: Vec<u16> = Vec::new();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes_per_row * params.rows.unwrap_or(0) as usize);
+    let mut reference = transition_buffer(width)?; // imaginary all-white line above row 0
+    let mut current = transition_buffer(width)?;
+    let mut out = packed_output_buffer(bytes_per_row, params.rows)?;
     let mut decoded_rows = 0usize;
     let mut byte_align = params.encoded_byte_align;
     let mut recovered = false;
@@ -97,6 +97,11 @@ pub fn decode(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
         current.clear();
         match decode_row_g4(&mut reader, &reference, width, &mut current) {
             RowStatus::EndOfBlock => break, // clean EOFB
+            RowStatus::AllocationFailed => {
+                return Err(Error::Decode(
+                    "Unable to grow CCITT row transition buffer".to_string(),
+                ));
+            },
             RowStatus::Error => {
                 if decoded_rows >= 1 {
                     recovered = true; // keep the rows we have; do NOT blank the page
@@ -105,7 +110,7 @@ pub fn decode(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
                 return Err(Error::Decode("CCITT: stream undecodable from first row".to_string()));
             },
             RowStatus::Ok => {
-                out.extend_from_slice(&transitions_to_bytes(&current, width as usize));
+                append_transition_row(&mut out, &current, width as usize)?;
                 std::mem::swap(&mut reference, &mut current);
                 decoded_rows += 1;
             },
@@ -114,8 +119,14 @@ pub fn decode(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
 
     // Pad missing trailing rows with white when the height is known.
     if let Some(h) = params.rows {
-        let white_row = vec![0u8; bytes_per_row];
+        let white_row = transitions_to_bytes::<u16>(&[], width as usize)?;
         while out.len() / bytes_per_row.max(1) < h as usize {
+            out.try_reserve(white_row.len()).map_err(|_| {
+                Error::Decode(format!(
+                    "Unable to grow CCITT output by {} padding bytes",
+                    white_row.len()
+                ))
+            })?;
             out.extend_from_slice(&white_row);
         }
     }
@@ -143,9 +154,9 @@ fn decode_g3(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
     let two_dimensional = params.k > 0;
     let bytes_per_row = (width as usize).div_ceil(8);
     let mut reader = BitReader::new(data);
-    let mut reference: Vec<u16> = Vec::new(); // imaginary all-white line above row 0
-    let mut current: Vec<u16> = Vec::new();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes_per_row * params.rows.unwrap_or(0) as usize);
+    let mut reference = transition_buffer(width)?; // imaginary all-white line above row 0
+    let mut current = transition_buffer(width)?;
+    let mut out = packed_output_buffer(bytes_per_row, params.rows)?;
     let mut decoded_rows = 0usize;
     let mut byte_align = params.encoded_byte_align;
     let mut recovered = false;
@@ -194,6 +205,11 @@ fn decode_g3(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
         };
         match status {
             RowStatus::EndOfBlock => break,
+            RowStatus::AllocationFailed => {
+                return Err(Error::Decode(
+                    "Unable to grow CCITT row transition buffer".to_string(),
+                ));
+            },
             RowStatus::Error => {
                 if decoded_rows >= 1 {
                     recovered = true; // keep decoded rows; do NOT blank the page
@@ -204,7 +220,7 @@ fn decode_g3(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
                 ));
             },
             RowStatus::Ok => {
-                out.extend_from_slice(&transitions_to_bytes(&current, width as usize));
+                append_transition_row(&mut out, &current, width as usize)?;
                 std::mem::swap(&mut reference, &mut current);
                 decoded_rows += 1;
             },
@@ -212,8 +228,14 @@ fn decode_g3(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
     }
 
     if let Some(h) = params.rows {
-        let white_row = vec![0u8; bytes_per_row];
+        let white_row = transitions_to_bytes::<u16>(&[], width as usize)?;
         while out.len() / bytes_per_row.max(1) < h as usize {
+            out.try_reserve(white_row.len()).map_err(|_| {
+                Error::Decode(format!(
+                    "Unable to grow CCITT output by {} padding bytes",
+                    white_row.len()
+                ))
+            })?;
             out.extend_from_slice(&white_row);
         }
     }
@@ -226,6 +248,31 @@ fn decode_g3(data: &[u8], params: &CcittParams) -> Result<CcittDecoded> {
         rows_decoded: decoded_rows,
         recovered_partial: recovered,
     })
+}
+
+fn packed_output_buffer(bytes_per_row: usize, rows: Option<u32>) -> Result<Vec<u8>> {
+    let Some(rows) = rows else {
+        return Ok(Vec::new());
+    };
+    let rows = usize::try_from(rows)
+        .map_err(|_| Error::Decode("CCITT row count exceeds platform limits".to_string()))?;
+    let capacity = bytes_per_row
+        .checked_mul(rows)
+        .ok_or_else(|| Error::Decode("CCITT packed output size overflow".to_string()))?;
+    let mut output = Vec::new();
+    output.try_reserve_exact(capacity).map_err(|_| {
+        Error::Decode(format!("Unable to allocate {capacity} bytes for CCITT packed output"))
+    })?;
+    Ok(output)
+}
+
+fn transition_buffer(width: u16) -> Result<Vec<u16>> {
+    let capacity = width as usize;
+    let mut transitions = Vec::new();
+    transitions.try_reserve_exact(capacity).map_err(|_| {
+        Error::Decode(format!("Unable to allocate {capacity} CCITT row transitions"))
+    })?;
+    Ok(transitions)
 }
 
 /// Decode one Group 3 1-D (Modified Huffman) row: runs alternate white→black
@@ -251,7 +298,9 @@ fn decode_row_g3_1d(reader: &mut BitReader, width: u16, current: &mut Vec<u16>) 
         if a1 >= width {
             break; // final run reaches the right edge; no trailing flip to push
         }
-        current.push(a1);
+        if !try_push_transition(current, a1) {
+            return RowStatus::AllocationFailed;
+        }
         a0 = a1;
         white = !white;
     }
@@ -483,6 +532,15 @@ enum RowStatus {
     Ok,
     EndOfBlock,
     Error,
+    AllocationFailed,
+}
+
+fn try_push_transition(transitions: &mut Vec<u16>, position: u16) -> bool {
+    if transitions.try_reserve(1).is_err() {
+        return false;
+    }
+    transitions.push(position);
+    true
 }
 
 /// Decode one G4 (T.6) row relative to `reference`, pushing color-flip column
@@ -522,8 +580,8 @@ fn decode_row_g4(
                     break; // malformed → end the line, keep what we have
                 }
                 let a1 = a1i as u16;
-                if a1 < width {
-                    current.push(a1);
+                if a1 < width && !try_push_transition(current, a1) {
+                    return RowStatus::AllocationFailed;
                 }
                 black = !black;
                 a0 = a1;
@@ -548,13 +606,15 @@ fn decode_row_g4(
                     Some(v) => v,
                     None => return RowStatus::Error,
                 };
-                if a1 < width {
-                    current.push(a1);
+                if a1 < width && !try_push_transition(current, a1) {
+                    return RowStatus::AllocationFailed;
                 }
                 if a2 >= width {
                     break;
                 }
-                current.push(a2);
+                if !try_push_transition(current, a2) {
+                    return RowStatus::AllocationFailed;
+                }
                 a0 = a2;
             },
             Mode::Extension => return RowStatus::Error,
@@ -706,6 +766,20 @@ mod tests {
         let d = p(params, "001 1000 11 1").unwrap();
         // pixels: white[0..3) black[3..5) white[5..8) ⇒ 0b00011000 = 0x18
         assert_eq!(d.data, vec![0b0001_1000]);
+    }
+
+    #[test]
+    fn g4_negative_k_with_unknown_rows_grows_output_fallibly() {
+        let params = CcittParams {
+            k: -2,
+            columns: 8,
+            rows: None,
+            ..Default::default()
+        };
+        let d = p(params, "001 1000 11 1 000000000001").unwrap();
+        assert_eq!(d.rows_decoded, 1);
+        assert_eq!(d.data, vec![0b0001_1000]);
+        assert!(!d.recovered_partial);
     }
 
     #[test]
@@ -889,5 +963,11 @@ mod tests {
         assert_eq!(g3.data, g4.data);
         // And it is not a degenerate all-white decode.
         assert!(g3.data.iter().any(|&b| b != 0));
+    }
+
+    #[test]
+    fn packed_output_buffer_rejects_size_overflow() {
+        let result = packed_output_buffer(usize::MAX, Some(2));
+        assert!(matches!(result, Err(Error::Decode(message)) if message.contains("size overflow")));
     }
 }

--- a/src/decoders/predictor.rs
+++ b/src/decoders/predictor.rs
@@ -73,7 +73,7 @@ impl DecodeParams {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CcittParams {
     /// Group indicator:
-    /// -1 = Group 4 (pure 2D, default)
+    ///  <0 = Group 4 (pure 2D)
     ///  0 = Group 3 (1-D)
     ///  >0 = Group 3 (2-D with specified K)
     pub k: i64,
@@ -110,9 +110,9 @@ impl Default for CcittParams {
 }
 
 impl CcittParams {
-    /// Check if this is Group 4 encoding (K = -1)
+    /// Check if this is Group 4 encoding (`K < 0`).
     pub fn is_group_4(&self) -> bool {
-        self.k == -1
+        self.k < 0
     }
 
     /// Check if this is Group 3 encoding
@@ -418,6 +418,16 @@ mod tests {
         assert_eq!(params.columns, 1);
         assert_eq!(params.colors, 1);
         assert_eq!(params.bits_per_component, 8);
+    }
+
+    #[test]
+    fn negative_k_values_select_group_4() {
+        let params = CcittParams {
+            k: -2,
+            ..Default::default()
+        };
+        assert!(params.is_group_4());
+        assert!(!params.is_group_3());
     }
 
     /// A producer may declare `/Predictor 12` and still write tag 0 (None)

--- a/src/extractors/ccitt_bilevel.rs
+++ b/src/extractors/ccitt_bilevel.rs
@@ -99,8 +99,20 @@ pub fn decompress_ccitt(data: &[u8], params: &CcittParams) -> Result<Vec<u8>> {
                 params.encoded_byte_align,
                 e
             );
-            let expected_bytes = params.rows.unwrap_or(1) as usize * (width as usize).div_ceil(8);
-            Ok(vec![0; expected_bytes.max((width as usize).div_ceil(8))])
+            let bytes_per_row = (width as usize).div_ceil(8);
+            let rows = usize::try_from(params.rows.unwrap_or(1)).map_err(|_| {
+                Error::Decode("CCITT row count exceeds platform limits".to_string())
+            })?;
+            let expected_bytes = rows
+                .checked_mul(bytes_per_row)
+                .ok_or_else(|| Error::Decode("CCITT fallback size overflow".to_string()))?;
+            let fallback_len = expected_bytes.max(bytes_per_row);
+            let mut fallback = Vec::new();
+            fallback.try_reserve_exact(fallback_len).map_err(|_| {
+                Error::Decode(format!("Unable to allocate {fallback_len} bytes for CCITT fallback"))
+            })?;
+            fallback.resize(fallback_len, 0);
+            Ok(fallback)
         },
     }
 }
@@ -140,11 +152,16 @@ fn decompress_with_fax(
     }
 
     // If that failed, try stripping leading zeros (common in some PDFs)
-    let trimmed_data = data
+    let first_nonzero = data
         .iter()
-        .skip_while(|b| **b == 0)
-        .copied()
-        .collect::<Vec<_>>();
+        .position(|byte| *byte != 0)
+        .unwrap_or(data.len());
+    let trimmed_len = data.len() - first_nonzero;
+    let mut trimmed_data = Vec::new();
+    trimmed_data.try_reserve_exact(trimmed_len).map_err(|_| {
+        Error::Decode(format!("Unable to allocate {trimmed_len} bytes for trimmed CCITT input"))
+    })?;
+    trimmed_data.extend_from_slice(&data[first_nonzero..]);
 
     if trimmed_data.len() < data.len() && !trimmed_data.is_empty() {
         log::debug!(
@@ -192,37 +209,65 @@ fn try_decode_with_fax(
 ) -> Result<Vec<u8>> {
     use fax::decoder;
 
-    let mut output_rows = Vec::new();
     let bytes_per_row = width.div_ceil(8);
+    let max_rows = height.map(|rows| rows as usize);
+    let mut output = Vec::new();
+    if let Some(rows) = max_rows {
+        let capacity = bytes_per_row
+            .checked_mul(rows)
+            .ok_or_else(|| Error::Decode("CCITT fax output size overflow".to_string()))?;
+        output.try_reserve_exact(capacity).map_err(|_| {
+            Error::Decode(format!("Unable to allocate {capacity} bytes for CCITT fax output"))
+        })?;
+    }
+    let mut rows_decoded = 0usize;
 
     // Use fax crate's decoder which is more lenient with malformed EOFB
     let bytes_iter = data.iter().copied();
 
     let success = if params.is_group_4() {
         log::debug!("Using Group 4 (T.6) decoder");
-        decoder::decode_g4(bytes_iter, width as u32, height, |transitions: &[u32]| {
-            // Convert run-length transitions to pixel bytes
-            let row_bytes = transitions_to_bytes(transitions, width);
-            output_rows.push(row_bytes);
-        })
+        let mut callback_error = None;
+        let success =
+            decoder::decode_g4(bytes_iter, width as u32, height, |transitions: &[u32]| {
+                if callback_error.is_none() && max_rows.is_none_or(|rows| rows_decoded < rows) {
+                    if let Err(error) = append_transition_row(&mut output, transitions, width) {
+                        callback_error = Some(error);
+                        return;
+                    }
+                    rows_decoded += 1;
+                }
+            });
+        if let Some(error) = callback_error {
+            return Err(error);
+        }
+        success
     } else {
         log::debug!("Using Group 3 (T.4) decoder");
         // Group 3 has a different signature - no width/height params in callback
-        decoder::decode_g3(bytes_iter, |transitions: &[u32]| {
-            // Convert run-length transitions to pixel bytes
-            let row_bytes = transitions_to_bytes(transitions, width);
-            output_rows.push(row_bytes);
-        })
+        let mut callback_error = None;
+        let success = decoder::decode_g3(bytes_iter, |transitions: &[u32]| {
+            if callback_error.is_none() && max_rows.is_none_or(|rows| rows_decoded < rows) {
+                if let Err(error) = append_transition_row(&mut output, transitions, width) {
+                    callback_error = Some(error);
+                    return;
+                }
+                rows_decoded += 1;
+            }
+        });
+        if let Some(error) = callback_error {
+            return Err(error);
+        }
+        success
     };
 
     // Check if decoder succeeded and returned data
-    if success.is_some() && !output_rows.is_empty() {
-        let output = output_rows.into_iter().flatten().collect::<Vec<u8>>();
+    if success.is_some() && !output.is_empty() {
         log::debug!(
             "CCITT decompression successful: {} bytes input -> {} bytes output ({} rows)",
             data.len(),
             output.len(),
-            output.len() / bytes_per_row
+            rows_decoded
         );
         Ok(output)
     } else if success.is_some() {
@@ -251,9 +296,13 @@ fn try_decode_with_fax(
 pub(crate) fn transitions_to_bytes<T: Copy + Into<u32>>(
     transitions: &[T],
     width: usize,
-) -> Vec<u8> {
+) -> Result<Vec<u8>> {
     let bytes_per_row = width.div_ceil(8);
-    let mut row_bytes = vec![0u8; bytes_per_row];
+    let mut row_bytes = Vec::new();
+    row_bytes.try_reserve_exact(bytes_per_row).map_err(|_| {
+        Error::Decode(format!("Unable to allocate {bytes_per_row} bytes for a CCITT row"))
+    })?;
+    row_bytes.resize(bytes_per_row, 0);
 
     let mut is_black = false; // Start with white
     let mut start_pos: usize = 0;
@@ -282,7 +331,20 @@ pub(crate) fn transitions_to_bytes<T: Copy + Into<u32>>(
         }
     }
 
-    row_bytes
+    Ok(row_bytes)
+}
+
+pub(crate) fn append_transition_row<T: Copy + Into<u32>>(
+    output: &mut Vec<u8>,
+    transitions: &[T],
+    width: usize,
+) -> Result<()> {
+    let row = transitions_to_bytes(transitions, width)?;
+    output.try_reserve(row.len()).map_err(|_| {
+        Error::Decode(format!("Unable to grow CCITT output by {} bytes", row.len()))
+    })?;
+    output.extend_from_slice(&row);
+    Ok(())
 }
 
 /// Decompresses CCITT Group 4 encoded data (legacy API for backwards compatibility).
@@ -398,11 +460,11 @@ mod tests {
         // Should produce: 0b00111001 = 57 (0x39)
         // Exercised for both transition scalars: the in-house decoder emits
         // u16, the fax crate (0.3+) emits u32, and both share this packer.
-        let row_u16 = transitions_to_bytes(&[2u16, 5, 7], 8);
+        let row_u16 = transitions_to_bytes(&[2u16, 5, 7], 8).expect("pack u16 row");
         assert_eq!(row_u16.len(), 1);
         assert_eq!(row_u16[0], 0b00111001);
 
-        let row_u32 = transitions_to_bytes(&[2u32, 5, 7], 8);
+        let row_u32 = transitions_to_bytes(&[2u32, 5, 7], 8).expect("pack u32 row");
         assert_eq!(row_u32, row_u16, "u32 and u16 transitions must pack identically");
     }
 
@@ -412,7 +474,7 @@ mod tests {
     fn test_transitions_to_bytes_beyond_u16() {
         let width = 70_000usize;
         // black run from 65_536 to 65_544 - a position that u16 could not hold
-        let row = transitions_to_bytes(&[65_536u32, 65_544], width);
+        let row = transitions_to_bytes(&[65_536u32, 65_544], width).expect("pack wide row");
         assert_eq!(row.len(), width.div_ceil(8));
         assert_eq!(row[65_536 / 8], 0xFF, "the 8 pixels at 65536.. must be black");
         assert!(row[..65_536 / 8].iter().all(|&b| b == 0), "everything before must stay white");

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -4349,6 +4349,191 @@ impl PageRenderer {
         Ok(())
     }
 
+    /// Return CCITT parameters for an ImageMask stream, if present.
+    ///
+    /// `/DecodeParms` arrays are positionally aligned with `/Filter`
+    /// arrays. CCITT must be the final filter: earlier ASCII/Flate wrappers
+    /// have already been removed by `decode_stream_with_encryption`, while a
+    /// later filter would incorrectly receive still-compressed fax data from
+    /// the stream decoder's intentional CCITT pass-through.
+    fn image_mask_ccitt_params(
+        dict: &HashMap<String, Object>,
+        width: u32,
+        height: u32,
+        doc: &PdfDocument,
+    ) -> Result<Option<crate::decoders::CcittParams>> {
+        let (ccitt_index, filter_count) = match dict.get("Filter") {
+            Some(Object::Name(name)) if Self::is_ccitt_filter(name) => (0, 1),
+            Some(Object::Array(filters)) => {
+                let Some(index) = filters
+                    .iter()
+                    .position(|filter| filter.as_name().is_some_and(Self::is_ccitt_filter))
+                else {
+                    return Ok(None);
+                };
+                (index, filters.len())
+            },
+            _ => return Ok(None),
+        };
+
+        if ccitt_index + 1 != filter_count {
+            return Err(Error::Image(
+                "CCITTFaxDecode must be the final ImageMask filter".to_string(),
+            ));
+        }
+        if width > u16::MAX as u32 {
+            return Err(Error::Image(format!(
+                "CCITT ImageMask width {width} exceeds decoder limit {}",
+                u16::MAX
+            )));
+        }
+
+        let resolved_params = dict
+            .get("DecodeParms")
+            .map(|params| {
+                let resolved = doc.resolve_object(params).map_err(|error| {
+                    Error::Image(format!("Unable to resolve CCITT ImageMask /DecodeParms: {error}"))
+                })?;
+                if params.as_reference().is_some() && matches!(&resolved, Object::Null) {
+                    return Err(Error::Image(
+                        "Unable to resolve CCITT ImageMask /DecodeParms: reference resolved to null"
+                            .to_string(),
+                    ));
+                }
+                Ok(resolved)
+            })
+            .transpose()?;
+        let selected_params = match resolved_params {
+            Some(Object::Array(params)) => params
+                .get(ccitt_index)
+                .map(|params| {
+                    let resolved = doc.resolve_object(params).map_err(|error| {
+                        Error::Image(format!(
+                            "Unable to resolve CCITT ImageMask /DecodeParms array entry: {error}"
+                        ))
+                    })?;
+                    if params.as_reference().is_some() && matches!(&resolved, Object::Null) {
+                        return Err(Error::Image(
+                            "Unable to resolve CCITT ImageMask /DecodeParms array entry: reference resolved to null"
+                                .to_string(),
+                        ));
+                    }
+                    Ok(resolved)
+                })
+                .transpose()?,
+            other => other,
+        };
+        let params_obj = selected_params.as_ref();
+        let params_dict = match params_obj {
+            None | Some(Object::Null) => None,
+            Some(params) => Some(params.as_dict().ok_or_else(|| {
+                Error::Image("CCITT ImageMask /DecodeParms must be a dictionary".to_string())
+            })?),
+        };
+        if params_dict
+            .and_then(|decode_params| decode_params.get("K"))
+            .is_some_and(|value| value.as_integer().is_none())
+        {
+            return Err(Error::Image(
+                "CCITT ImageMask /DecodeParms /K must be an integer".to_string(),
+            ));
+        }
+        Self::validate_ccitt_mask_dimension(params_dict, "Columns", width)?;
+        Self::validate_ccitt_mask_dimension(params_dict, "Rows", height)?;
+
+        let mut params = crate::object::extract_ccitt_params_with_width(params_obj, Some(width))
+            .unwrap_or_else(|| crate::decoders::CcittParams {
+                // ISO 32000-1 Table 11: absent /K defaults to Group 3 1-D.
+                k: 0,
+                columns: width,
+                rows: Some(height),
+                ..Default::default()
+            });
+        let has_explicit_k = params_obj
+            .and_then(Object::as_dict)
+            .is_some_and(|decode_params| decode_params.contains_key("K"));
+        if !has_explicit_k {
+            // The shared parser currently carries a historical Group 4
+            // default; enforce the PDF filter default at this renderer
+            // boundary without changing other image-extraction behaviour.
+            params.k = 0;
+        }
+        // Width and Height are authoritative for an Image XObject. Explicit
+        // mismatches were rejected above; normalise omitted values here.
+        params.columns = width;
+        params.rows = Some(height);
+        Ok(Some(params))
+    }
+
+    fn validate_ccitt_mask_dimension(
+        params: Option<&HashMap<String, Object>>,
+        key: &str,
+        expected: u32,
+    ) -> Result<()> {
+        let Some(value) = params.and_then(|decode_params| decode_params.get(key)) else {
+            return Ok(());
+        };
+        let integer = value.as_integer().ok_or_else(|| {
+            Error::Image(format!("CCITT ImageMask /DecodeParms /{key} must be an integer"))
+        })?;
+        let actual = u32::try_from(integer).map_err(|_| {
+            Error::Image(format!("CCITT ImageMask /DecodeParms /{key} must be positive"))
+        })?;
+        if actual == 0 {
+            return Err(Error::Image(format!(
+                "CCITT ImageMask /DecodeParms /{key} must be positive"
+            )));
+        }
+        if actual != expected {
+            return Err(Error::Image(format!(
+                "CCITT ImageMask /DecodeParms /{key} {actual} does not match image dimension {expected}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn is_ccitt_filter(name: &str) -> bool {
+        name.eq_ignore_ascii_case("CCITTFaxDecode") || name.eq_ignore_ascii_case("CCF")
+    }
+
+    fn image_mask_layout(
+        dict: &HashMap<String, Object>,
+    ) -> Result<(u32, u32, usize, usize, usize)> {
+        let dimension = |key: &str| -> Result<u32> {
+            let value = dict
+                .get(key)
+                .and_then(Object::as_integer)
+                .ok_or_else(|| Error::Image(format!("ImageMask missing /{key}")))?;
+            let dimension = u32::try_from(value)
+                .map_err(|_| Error::Image(format!("ImageMask /{key} must be positive")))?;
+            if dimension == 0 {
+                return Err(Error::Image(format!("ImageMask /{key} must be positive")));
+            }
+            Ok(dimension)
+        };
+
+        let width = dimension("Width")?;
+        let height = dimension("Height")?;
+        let width_usize = usize::try_from(width)
+            .map_err(|_| Error::Image("ImageMask /Width exceeds platform limits".to_string()))?;
+        let height_usize = usize::try_from(height)
+            .map_err(|_| Error::Image("ImageMask /Height exceeds platform limits".to_string()))?;
+        let pixel_count = width_usize
+            .checked_mul(height_usize)
+            .ok_or_else(|| Error::Image("ImageMask pixel count overflow".to_string()))?;
+        let rgba_len = pixel_count
+            .checked_mul(4)
+            .ok_or_else(|| Error::Image("ImageMask RGBA size overflow".to_string()))?;
+        let row_bytes = width_usize
+            .checked_add(7)
+            .ok_or_else(|| Error::Image("ImageMask row size overflow".to_string()))?
+            / 8;
+        let expected = row_bytes
+            .checked_mul(height_usize)
+            .ok_or_else(|| Error::Image("ImageMask packed size overflow".to_string()))?;
+        Ok((width, height, row_bytes, expected, rgba_len))
+    }
+
     /// Render an Image XObject with `/ImageMask true` — a 1-bit stencil
     /// painted with the current fill colour.
     ///
@@ -4361,13 +4546,10 @@ impl PageRenderer {
     /// routing that fill through the resolution pipeline, so this
     /// helper consumes whatever `gs` it is handed without re-resolving.
     ///
-    /// Only the minimum necessary to make the stencil paintable is
-    /// implemented here: 1-bit raw samples (no CCITT decode), default
-    /// and inverted `/Decode` polarities, bilinear/bicubic resampling
+    /// Supports raw 1-bit samples and CCITT Group 3/4 streams, default
+    /// and inverted `/Decode` polarities, and bilinear/bicubic resampling
     /// chosen by the image-space-to-user-space scale (matches
-    /// `render_image`). CCITT-compressed inline masks are out of scope
-    /// for wave 3 — they share the colour-resolution path and gain the
-    /// same pipeline routing as soon as their decode is added.
+    /// `render_image`).
     fn render_image_mask(
         &mut self,
         pixmap: &mut Pixmap,
@@ -4382,19 +4564,7 @@ impl PageRenderer {
             .as_dict()
             .ok_or_else(|| Error::Image("ImageMask XObject is not a stream".to_string()))?;
 
-        let width = dict
-            .get("Width")
-            .and_then(|o| o.as_integer())
-            .ok_or_else(|| Error::Image("ImageMask missing /Width".to_string()))?
-            as u32;
-        let height = dict
-            .get("Height")
-            .and_then(|o| o.as_integer())
-            .ok_or_else(|| Error::Image("ImageMask missing /Height".to_string()))?
-            as u32;
-        if width == 0 || height == 0 {
-            return Ok(());
-        }
+        let (width, height, row_bytes, expected, rgba_len) = Self::image_mask_layout(dict)?;
 
         // PDF §8.9.6.4: ImageMask BitsPerComponent must be 1 when present.
         // Some producers omit it; default to 1.
@@ -4406,8 +4576,8 @@ impl PageRenderer {
             return Err(Error::Image(format!("ImageMask requires BitsPerComponent 1, got {bpc}")));
         }
 
-        // /Decode array: [0 1] means bit 1 = opaque (default); [1 0]
-        // inverts. Other forms are spec-illegal for ImageMask.
+        // /Decode array: [0 1] means sample 0 paints (default); [1 0]
+        // means sample 1 paints. Other forms are spec-illegal for ImageMask.
         let invert = match dict.get("Decode") {
             Some(Object::Array(arr)) if arr.len() >= 2 => {
                 let first = match &arr[0] {
@@ -4420,11 +4590,25 @@ impl PageRenderer {
             _ => false,
         };
 
-        let raw = if let Some(r) = obj_ref {
+        let mut raw = if let Some(r) = obj_ref {
             doc.decode_stream_with_encryption(xobject, r)?
         } else {
             xobject.decode_stream_data()?
         };
+        if let Some(params) = Self::image_mask_ccitt_params(dict, width, height, doc)? {
+            raw = crate::extractors::ccitt_bilevel::decompress_ccitt(&raw, &params)?;
+
+            // The shared CCITT image decoder normalises packed rows to
+            // 0=white, 1=black. An ImageMask needs the actual PDF sample
+            // values instead: with the CCITT default `/BlackIs1 false`,
+            // 0 means black and 1 means white; `/BlackIs1 true` reverses
+            // that mapping. `decompress_ccitt` already applies BlackIs1
+            // while normalising, so one final inversion recovers the sample
+            // values consumed by the independent `/Decode` mapping below.
+            for byte in &mut raw {
+                *byte = !*byte;
+            }
+        }
 
         // Stencil pixels → premultiplied RGBA, applying the fill colour
         // to each opaque sample. Rows are packed MSB-first; each row is
@@ -4445,8 +4629,6 @@ impl PageRenderer {
             .round()
             .clamp(0.0, 255.0) as u8;
 
-        let row_bytes = (width as usize + 7) / 8;
-        let expected = row_bytes * height as usize;
         if raw.len() < expected {
             return Err(Error::Image(format!(
                 "ImageMask stream too short: {} bytes for {}x{} (expected {})",
@@ -4457,7 +4639,10 @@ impl PageRenderer {
             )));
         }
 
-        let mut rgba: Vec<u8> = vec![0u8; (width * height * 4) as usize];
+        let mut rgba = Vec::new();
+        rgba.try_reserve_exact(rgba_len)
+            .map_err(|_| Error::Image(format!("Unable to allocate {rgba_len} ImageMask bytes")))?;
+        rgba.resize(rgba_len, 0);
         for y in 0..height {
             let row_off = (y as usize) * row_bytes;
             for x in 0..width {
@@ -4466,7 +4651,7 @@ impl PageRenderer {
                 let bit = (raw[byte_idx] >> bit_idx) & 1 == 1;
                 let opaque = if invert { bit } else { !bit };
                 if opaque {
-                    let off = ((y * width + x) * 4) as usize;
+                    let off = ((y as usize * width as usize) + x as usize) * 4;
                     rgba[off] = pr;
                     rgba[off + 1] = pg;
                     rgba[off + 2] = pb;
@@ -9820,6 +10005,179 @@ fn intersect_with_inherited(
 mod tests {
     use super::*;
     use crate::object::Object;
+
+    fn pdf_doc_with_extra_object(extra: Option<&[u8]>) -> PdfDocument {
+        let mut pdf = b"%PDF-1.4\n".to_vec();
+        let mut offsets = Vec::new();
+        let mut append = |number: usize, body: &[u8]| {
+            offsets.push(pdf.len());
+            pdf.extend_from_slice(format!("{number} 0 obj\n").as_bytes());
+            pdf.extend_from_slice(body);
+            pdf.extend_from_slice(b"\nendobj\n");
+        };
+        append(1, b"<< /Type /Catalog /Pages 2 0 R >>");
+        append(2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        append(3, b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>");
+        if let Some(body) = extra {
+            append(4, body);
+        }
+        let xref = pdf.len();
+        let object_count = offsets.len() + 1;
+        pdf.extend_from_slice(format!("xref\n0 {object_count}\n0000000000 65535 f \n").as_bytes());
+        for offset in offsets {
+            pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+        }
+        pdf.extend_from_slice(
+            format!("trailer\n<< /Size {object_count} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n")
+                .as_bytes(),
+        );
+        PdfDocument::from_bytes(pdf).expect("open minimal PDF")
+    }
+
+    fn minimal_pdf_doc() -> PdfDocument {
+        pdf_doc_with_extra_object(None)
+    }
+
+    fn image_mask_dict(width: i64, height: i64) -> HashMap<String, Object> {
+        HashMap::from([
+            ("Width".to_string(), Object::Integer(width)),
+            ("Height".to_string(), Object::Integer(height)),
+        ])
+    }
+
+    fn ccitt_mask_dict(
+        width: i64,
+        height: i64,
+        columns: i64,
+        rows: i64,
+    ) -> HashMap<String, Object> {
+        let mut dict = image_mask_dict(width, height);
+        dict.insert("Filter".to_string(), Object::Name("CCITTFaxDecode".to_string()));
+        dict.insert(
+            "DecodeParms".to_string(),
+            Object::Dictionary(HashMap::from([
+                ("K".to_string(), Object::Integer(-1)),
+                ("Columns".to_string(), Object::Integer(columns)),
+                ("Rows".to_string(), Object::Integer(rows)),
+            ])),
+        );
+        dict
+    }
+
+    #[test]
+    fn image_mask_layout_rejects_non_positive_dimensions_before_allocation() {
+        let negative = PageRenderer::image_mask_layout(&image_mask_dict(-1, 1));
+        assert!(matches!(negative, Err(Error::Image(message)) if message.contains("positive")));
+
+        let zero = PageRenderer::image_mask_layout(&image_mask_dict(1, 0));
+        assert!(matches!(zero, Err(Error::Image(message)) if message.contains("positive")));
+    }
+
+    #[test]
+    fn image_mask_layout_accepts_large_valid_dimensions_without_allocating() {
+        let layout =
+            PageRenderer::image_mask_layout(&image_mask_dict(5_000, 4_000)).expect("valid layout");
+        assert_eq!(layout, (5_000, 4_000, 625, 2_500_000, 80_000_000));
+    }
+
+    #[test]
+    fn ccitt_image_mask_rejects_width_beyond_decoder_limit() {
+        let dict = ccitt_mask_dict(65_536, 1, 65_536, 1);
+        let doc = minimal_pdf_doc();
+        let result = PageRenderer::image_mask_ccitt_params(&dict, 65_536, 1, &doc);
+        assert!(matches!(result, Err(Error::Image(message)) if message.contains("decoder limit")));
+    }
+
+    #[test]
+    fn ccitt_image_mask_rejects_dimension_mismatches() {
+        let columns = ccitt_mask_dict(8, 1, 7, 1);
+        let doc = minimal_pdf_doc();
+        let result = PageRenderer::image_mask_ccitt_params(&columns, 8, 1, &doc);
+        assert!(matches!(result, Err(Error::Image(message)) if message.contains("/Columns 7")));
+
+        let rows = ccitt_mask_dict(8, 1, 8, 2);
+        let result = PageRenderer::image_mask_ccitt_params(&rows, 8, 1, &doc);
+        assert!(matches!(result, Err(Error::Image(message)) if message.contains("/Rows 2")));
+    }
+
+    #[test]
+    fn ccitt_image_mask_rejects_invalid_k_and_accepts_all_negative_k_values() {
+        let doc = minimal_pdf_doc();
+        let mut invalid = ccitt_mask_dict(8, 1, 8, 1);
+        let Some(Object::Dictionary(invalid_params)) = invalid.get_mut("DecodeParms") else {
+            panic!("decode parameters must be a dictionary");
+        };
+        invalid_params.insert("K".to_string(), Object::Name("invalid".to_string()));
+        let result = PageRenderer::image_mask_ccitt_params(&invalid, 8, 1, &doc);
+        assert!(
+            matches!(result, Err(Error::Image(message)) if message.contains("/K must be an integer"))
+        );
+
+        let mut negative = ccitt_mask_dict(8, 1, 8, 1);
+        let Some(Object::Dictionary(negative_params)) = negative.get_mut("DecodeParms") else {
+            panic!("decode parameters must be a dictionary");
+        };
+        negative_params.insert("K".to_string(), Object::Integer(-2));
+        let params = PageRenderer::image_mask_ccitt_params(&negative, 8, 1, &doc)
+            .expect("valid parameters")
+            .expect("CCITT parameters");
+        assert!(params.is_group_4());
+        assert_eq!(params.k, -2);
+    }
+
+    #[test]
+    fn ccitt_image_mask_rejects_dangling_and_wrong_type_decode_params_references() {
+        let mut dangling = ccitt_mask_dict(8, 1, 8, 1);
+        dangling.insert("DecodeParms".to_string(), Object::Reference(ObjectRef::new(99, 0)));
+        let error = PageRenderer::image_mask_ccitt_params(&dangling, 8, 1, &minimal_pdf_doc())
+            .expect_err("dangling reference must fail");
+        assert!(
+            matches!(&error, Error::Image(message) if message.contains("Unable to resolve")),
+            "unexpected dangling-reference error: {error:?}"
+        );
+
+        let mut dangling_array = ccitt_mask_dict(8, 1, 8, 1);
+        dangling_array.insert(
+            "Filter".to_string(),
+            Object::Array(vec![
+                Object::Name("ASCIIHexDecode".to_string()),
+                Object::Name("CCITTFaxDecode".to_string()),
+            ]),
+        );
+        dangling_array.insert(
+            "DecodeParms".to_string(),
+            Object::Array(vec![Object::Null, Object::Reference(ObjectRef::new(99, 0))]),
+        );
+        let error =
+            PageRenderer::image_mask_ccitt_params(&dangling_array, 8, 1, &minimal_pdf_doc())
+                .expect_err("dangling array entry must fail");
+        assert!(
+            matches!(&error, Error::Image(message) if message.contains("array entry")),
+            "unexpected dangling array-entry error: {error:?}"
+        );
+
+        let mut wrong_type = ccitt_mask_dict(8, 1, 8, 1);
+        wrong_type.insert("DecodeParms".to_string(), Object::Reference(ObjectRef::new(4, 0)));
+        let doc = pdf_doc_with_extra_object(Some(b"42"));
+        let result = PageRenderer::image_mask_ccitt_params(&wrong_type, 8, 1, &doc);
+        assert!(
+            matches!(result, Err(Error::Image(message)) if message.contains("must be a dictionary"))
+        );
+    }
+
+    #[test]
+    fn ccitt_image_mask_rejects_non_final_filter() {
+        let mut dict = ccitt_mask_dict(8, 1, 8, 1);
+        dict.insert(
+            "Filter".to_string(),
+            Object::Array(vec![
+                Object::Name("CCITTFaxDecode".to_string()),
+                Object::Name("ASCIIHexDecode".to_string()),
+            ]),
+        );
+        let result = PageRenderer::image_mask_ccitt_params(&dict, 8, 1, &minimal_pdf_doc());
+        assert!(matches!(result, Err(Error::Image(message)) if message.contains("final")));
+    }
 
     #[test]
     fn test_color_key_mask_range_logic() {

--- a/tests/test_ccitt_image_mask_rendering.rs
+++ b/tests/test_ccitt_image_mask_rendering.rs
@@ -1,0 +1,267 @@
+#![cfg(feature = "rendering")]
+
+use pdf_oxide::rendering::{render_page, RenderOptions};
+use pdf_oxide::PdfDocument;
+
+const CCITT_WHITE3_BLACK2_WHITE3: &[u8] = &[0x31, 0xC0];
+const CCITT_GROUP3_WHITE3_BLACK2_WHITE3: &[u8] = &[0x8E, 0x00];
+
+fn append_object(pdf: &mut Vec<u8>, offsets: &mut Vec<usize>, number: usize, body: &[u8]) {
+    offsets.push(pdf.len());
+    pdf.extend_from_slice(format!("{number} 0 obj\n").as_bytes());
+    pdf.extend_from_slice(body);
+    pdf.extend_from_slice(b"\nendobj\n");
+}
+
+fn build_pdf(
+    page_width: u32,
+    page_height: u32,
+    content: &[u8],
+    image: &[u8],
+    extra_objects: &[&[u8]],
+) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::new();
+
+    append_object(&mut pdf, &mut offsets, 1, b"<< /Type /Catalog /Pages 2 0 R >>");
+    append_object(&mut pdf, &mut offsets, 2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    append_object(
+        &mut pdf,
+        &mut offsets,
+        3,
+        format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {page_width} {page_height}] \
+             /Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>"
+        )
+        .as_bytes(),
+    );
+    append_object(
+        &mut pdf,
+        &mut offsets,
+        4,
+        format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content.len(),
+            String::from_utf8_lossy(content)
+        )
+        .as_bytes(),
+    );
+    append_object(&mut pdf, &mut offsets, 5, image);
+    for (index, body) in extra_objects.iter().enumerate() {
+        append_object(&mut pdf, &mut offsets, index + 6, body);
+    }
+
+    let xref = pdf.len();
+    let object_count = offsets.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {object_count}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!("trailer\n<< /Size {object_count} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n")
+            .as_bytes(),
+    );
+    pdf
+}
+
+fn build_image_mask_pdf(
+    black_is_one: bool,
+    inverted_decode: bool,
+    ascii_hex_wrapper: bool,
+    k: Option<i64>,
+) -> Vec<u8> {
+    let content = b"q 8 0 0 1 0 0 cm /Im0 Do Q";
+    let decode = if inverted_decode {
+        " /Decode [1 0]"
+    } else {
+        ""
+    };
+    let black = if black_is_one { " /BlackIs1 true" } else { "" };
+    let k_parameter = k.map_or_else(String::new, |value| format!(" /K {value}"));
+    let ccitt_stream = if k.is_none() {
+        CCITT_GROUP3_WHITE3_BLACK2_WHITE3
+    } else {
+        CCITT_WHITE3_BLACK2_WHITE3
+    };
+    let (filter, params, stream): (&str, String, Vec<u8>) = if ascii_hex_wrapper {
+        (
+            "[/ASCIIHexDecode /CCITTFaxDecode]",
+            format!("[null <<{k_parameter} /Columns 8 /Rows 1{black} >>]"),
+            b"31C0>".to_vec(),
+        )
+    } else {
+        (
+            "/CCITTFaxDecode",
+            format!("<<{k_parameter} /Columns 8 /Rows 1{black} >>"),
+            ccitt_stream.to_vec(),
+        )
+    };
+    let mut image = format!(
+        "<< /Type /XObject /Subtype /Image /Width 8 /Height 1 \
+         /BitsPerComponent 1 /ImageMask true /Filter {filter} \
+         /DecodeParms {params}{decode} /Length {} >>\nstream\n",
+        stream.len()
+    )
+    .into_bytes();
+    image.extend_from_slice(&stream);
+    image.extend_from_slice(b"\nendstream");
+    build_pdf(8, 1, content, &image, &[])
+}
+
+fn build_indirect_decode_params_pdf(array_entry: bool, params_object: &[u8]) -> Vec<u8> {
+    let content = b"q 8 0 0 1 0 0 cm /Im0 Do Q";
+    let (filter, decode_params, stream): (&str, &str, &[u8]) = if array_entry {
+        ("[/ASCIIHexDecode /CCITTFaxDecode]", "[null 6 0 R]", b"31C0>")
+    } else {
+        ("/CCITTFaxDecode", "6 0 R", CCITT_WHITE3_BLACK2_WHITE3)
+    };
+    let mut image = format!(
+        "<< /Type /XObject /Subtype /Image /Width 8 /Height 1 \
+         /BitsPerComponent 1 /ImageMask true /Filter {filter} \
+         /DecodeParms {decode_params} /Length {} >>\nstream\n",
+        stream.len()
+    )
+    .into_bytes();
+    image.extend_from_slice(stream);
+    image.extend_from_slice(b"\nendstream");
+    build_pdf(8, 1, content, &image, &[params_object])
+}
+
+fn push_bits(output: &mut Vec<u8>, bit_len: &mut usize, bits: u16, count: u8) {
+    for shift in (0..count).rev() {
+        if (*bit_len).is_multiple_of(8) {
+            output.push(0);
+        }
+        if bits & (1 << shift) != 0 {
+            let byte_index = *bit_len / 8;
+            output[byte_index] |= 1 << (7 - (*bit_len % 8));
+        }
+        *bit_len += 1;
+    }
+}
+
+fn repeated_black_run_group4(rows: u32) -> Vec<u8> {
+    let mut compressed = Vec::new();
+    let mut bit_len = 0usize;
+    // First row: horizontal; white run 3; black makeup 64 + terminating 0;
+    // then vertical-0 to the right edge. Each later identical row is three
+    // vertical-0 codes relative to the preceding row.
+    push_bits(&mut compressed, &mut bit_len, 0b001, 3);
+    push_bits(&mut compressed, &mut bit_len, 0b1000, 4);
+    push_bits(&mut compressed, &mut bit_len, 0b0000001111, 10);
+    push_bits(&mut compressed, &mut bit_len, 0b0000110111, 10);
+    push_bits(&mut compressed, &mut bit_len, 0b1, 1);
+    for _ in 1..rows {
+        push_bits(&mut compressed, &mut bit_len, 0b111, 3);
+    }
+    compressed
+}
+
+fn rendered_is_black(pdf: Vec<u8>) -> Vec<bool> {
+    let doc = PdfDocument::from_bytes(pdf).expect("open generated PDF");
+    let rendered =
+        render_page(&doc, 0, &RenderOptions::with_dpi(72).as_raw()).expect("render generated PDF");
+    assert_eq!((rendered.width, rendered.height), (8, 1));
+    rendered
+        .data
+        .chunks_exact(4)
+        .map(|pixel| pixel[0] < 128 && pixel[1] < 128 && pixel[2] < 128)
+        .collect()
+}
+
+#[test]
+fn ccitt_image_mask_renders_black_run_with_default_polarity() {
+    assert_eq!(
+        rendered_is_black(build_image_mask_pdf(false, false, false, Some(-1))),
+        [false, false, false, true, true, false, false, false]
+    );
+}
+
+#[test]
+fn black_is_one_and_decode_are_independent_polarity_controls() {
+    let inverse = [true, true, true, false, false, true, true, true];
+    assert_eq!(rendered_is_black(build_image_mask_pdf(true, false, false, Some(-1))), inverse);
+    assert_eq!(rendered_is_black(build_image_mask_pdf(false, true, false, Some(-1))), inverse);
+    assert_eq!(
+        rendered_is_black(build_image_mask_pdf(true, true, false, Some(-1))),
+        [false, false, false, true, true, false, false, false]
+    );
+}
+
+#[test]
+fn ccitt_filter_chain_uses_positionally_aligned_decode_params() {
+    assert_eq!(
+        rendered_is_black(build_image_mask_pdf(false, false, true, Some(-1))),
+        [false, false, false, true, true, false, false, false]
+    );
+}
+
+#[test]
+fn absent_k_uses_pdf_group3_one_dimensional_default() {
+    assert_eq!(
+        rendered_is_black(build_image_mask_pdf(false, false, false, None)),
+        [false, false, false, true, true, false, false, false]
+    );
+}
+
+#[test]
+fn all_negative_k_values_use_group4() {
+    assert_eq!(
+        rendered_is_black(build_image_mask_pdf(false, false, false, Some(-2))),
+        [false, false, false, true, true, false, false, false]
+    );
+}
+
+#[test]
+fn indirect_decode_params_and_array_entries_are_resolved() {
+    const PARAMS: &[u8] = b"<< /K -1 /Columns 8 /Rows 1 >>";
+    let expected = [false, false, false, true, true, false, false, false];
+    assert_eq!(rendered_is_black(build_indirect_decode_params_pdf(false, PARAMS)), expected);
+    assert_eq!(rendered_is_black(build_indirect_decode_params_pdf(true, PARAMS)), expected);
+}
+
+#[test]
+fn malformed_indirect_decode_params_are_skipped_without_panicking() {
+    assert_eq!(rendered_is_black(build_indirect_decode_params_pdf(false, b"42")), [false; 8]);
+    assert_eq!(rendered_is_black(build_indirect_decode_params_pdf(true, b"42")), [false; 8]);
+}
+
+#[test]
+fn german_sized_group4_mask_expands_and_paints_pixels() {
+    const WIDTH: u32 = 2016;
+    const HEIGHT: u32 = 2852;
+    let compressed = repeated_black_run_group4(HEIGHT);
+    let packed_size = (WIDTH as usize).div_ceil(8) * HEIGHT as usize;
+    assert!(
+        packed_size > compressed.len() * 500,
+        "fixture must exercise substantial CCITT expansion"
+    );
+
+    let mut image = format!(
+        "<< /Type /XObject /Subtype /Image /Width {WIDTH} /Height {HEIGHT} \
+         /BitsPerComponent 1 /ImageMask true /Filter /CCITTFaxDecode \
+         /DecodeParms << /K -1 /Columns {WIDTH} /Rows {HEIGHT} >> \
+         /Length {} >>\nstream\n",
+        compressed.len()
+    )
+    .into_bytes();
+    image.extend_from_slice(&compressed);
+    image.extend_from_slice(b"\nendstream");
+    let content = format!("q 0 1 0 rg {WIDTH} 0 0 {HEIGHT} 0 0 cm /Im0 Do Q");
+    let doc = PdfDocument::from_bytes(build_pdf(WIDTH, HEIGHT, content.as_bytes(), &image, &[]))
+        .expect("open PDF");
+    let mut options = RenderOptions::with_dpi(72);
+    options.background = Some([1.0, 0.0, 0.0, 1.0]);
+    let rendered = render_page(&doc, 0, &options.as_raw()).expect("render large mask");
+    assert_eq!((rendered.width, rendered.height), (WIDTH, HEIGHT));
+
+    let pixel = |x: u32, y: u32| {
+        let offset = ((y as usize * WIDTH as usize) + x as usize) * 4;
+        &rendered.data[offset..offset + 4]
+    };
+    let middle_row = HEIGHT / 2;
+    assert_eq!(pixel(20, middle_row), [0, 255, 0, 255]);
+    assert_eq!(pixel(200, middle_row), [255, 0, 0, 255]);
+    assert_eq!(pixel(20, HEIGHT - 2), [0, 255, 0, 255]);
+    assert_eq!(pixel(200, HEIGHT - 2), [255, 0, 0, 255]);
+}


### PR DESCRIPTION
Render CCITT Group 3/4 ImageMask XObjects instead of treating compressed fax data as raw stencil rows. This also aligns DecodeParms/filter handling, fixes K < 0 Group 4 semantics, and makes CCITT output growth fallible.

Adds polarity, filter-chain, indirect DecodeParms, malformed-input, allocation, and full-size 2016x2852 rendering regressions.

Coded using Codex

Closes #939