### PR TITLE
perf(search): cache a lightweight per-page index across search() calls

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -475,6 +475,14 @@ pub struct PdfDocument {
     /// the second from cache. Cleared by redaction (`erase_region` /
     /// `clear_erase_regions`), the only span-affecting mutation.
     page_spans_cache: Mutex<BoundedEntryCache<usize, std::sync::Arc<Vec<crate::layout::TextSpan>>>>,
+    /// Per-page lightweight search index (page text + span bounding boxes,
+    /// no fonts/glyph widths) built lazily by `search()`/`search_page()` and
+    /// reused across repeated calls on the same document. Unlike
+    /// `page_spans_cache` this is never size-bounded/evicted — search never
+    /// reads font/glyph data, so retaining every page's projection is far
+    /// cheaper than retaining every page's full `TextSpan`s would be.
+    /// Cleared alongside `page_spans_cache` wherever spans are invalidated.
+    search_index: Mutex<HashMap<usize, std::sync::Arc<crate::search::SearchPageIndex>>>,
     /// Per-page character cache for the unfiltered (`extract_chars`) result.
     /// `postprocess_spans` needs the same char sequence the public API returns,
     /// so without this every span extraction re-parses the content stream a
@@ -1107,6 +1115,7 @@ impl PdfDocument {
             erase_regions: Mutex::new(HashMap::new()),
             page_content_cache: Mutex::new(BoundedEntryCache::new(64)),
             page_spans_cache: Mutex::new(BoundedEntryCache::new(8)),
+            search_index: Mutex::new(HashMap::new()),
             page_chars_cache: Mutex::new(BoundedEntryCache::new(8)),
             running_artifact_signatures: Mutex::new(None),
             article_threads_cache: Mutex::new(None),
@@ -6509,6 +6518,7 @@ impl PdfDocument {
             .push(rect);
         // Redaction changes a page's spans; drop the span cache.
         self.page_spans_cache.lock_or_recover().clear();
+        self.search_index.lock_or_recover().clear();
         Ok(())
     }
 
@@ -6516,6 +6526,7 @@ impl PdfDocument {
     pub fn clear_erase_regions(&self, page_index: usize) -> Result<()> {
         self.erase_regions.lock_or_recover().remove(&page_index);
         self.page_spans_cache.lock_or_recover().clear();
+        self.search_index.lock_or_recover().clear();
         Ok(())
     }
 
@@ -11266,6 +11277,44 @@ impl PdfDocument {
             .lock_or_recover()
             .insert(page_index, std::sync::Arc::new(spans.clone()));
         Ok(spans)
+    }
+
+    /// Get (building and caching if needed) the lightweight search index for
+    /// one page. Backs `search()`/`search_page()` — see `search_index` field
+    /// docs for why this is a separate, unbounded cache from
+    /// `page_spans_cache`.
+    pub(crate) fn search_page_index(
+        &self,
+        page_index: usize,
+    ) -> Result<std::sync::Arc<crate::search::SearchPageIndex>> {
+        if let Some(cached) = self.search_index.lock_or_recover().get(&page_index) {
+            return Ok(std::sync::Arc::clone(cached));
+        }
+        let spans = self.extract_spans(page_index)?;
+        let index = std::sync::Arc::new(crate::search::SearchPageIndex::from_spans(&spans));
+        self.search_index
+            .lock_or_recover()
+            .insert(page_index, std::sync::Arc::clone(&index));
+        Ok(index)
+    }
+
+    /// Build the search index for every page up front.
+    ///
+    /// `search()` builds this lazily one page at a time as needed, so calling
+    /// this is optional — it exists for callers who want the first `search()`
+    /// call to be as fast as the rest, at the cost of paying full-document
+    /// extraction immediately instead of spread across the first sweep.
+    pub fn prepare_search(&self) -> Result<()> {
+        for page_index in 0..self.page_count()? {
+            self.search_page_index(page_index)?;
+        }
+        Ok(())
+    }
+
+    /// Drop the cached search index, if any, freeing its memory.
+    /// `search()`/`search_page()` will rebuild it lazily on next use.
+    pub fn clear_search_index(&self) {
+        self.search_index.lock_or_recover().clear();
     }
 
     fn extract_spans_filtered(
@@ -24467,6 +24516,72 @@ mod tests {
         );
 
         pdf
+    }
+
+    /// Repeated `search_page_index()` calls (what `search()`/`search_page()`
+    /// use internally) must reuse the cached index instead of re-extracting
+    /// and rebuilding it every time — the whole point of the search index
+    /// (issue: `search()` re-extracted the full document on every call).
+    /// Redaction (`erase_region`) changes a page's spans, so it must
+    /// invalidate the cached index the same way it already invalidates
+    /// `page_spans_cache`.
+    #[test]
+    fn search_index_reused_across_calls_and_invalidated_by_redaction() {
+        let content = b"BT /F1 12 Tf 1 0 0 1 72 700 Tm (Hello World) Tj ET";
+        let pdf = build_minimal_pdf_with_font(content);
+        let doc = PdfDocument::from_bytes(pdf).expect("open pdf");
+
+        let first = doc.search_page_index(0).expect("build search index");
+        let second = doc.search_page_index(0).expect("reuse search index");
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &second),
+            "a second search_page_index() call should hit the cache, not rebuild"
+        );
+
+        doc.erase_region(0, crate::geometry::Rect::new(0.0, 0.0, 10.0, 10.0))
+            .expect("erase_region");
+        let third = doc.search_page_index(0).expect("rebuild after redaction");
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &third),
+            "erase_region must invalidate the cached search index"
+        );
+    }
+
+    /// `clear_search_index()` is the caller-facing escape hatch for dropping
+    /// the (otherwise unbounded) search index to reclaim memory.
+    #[test]
+    fn clear_search_index_forces_rebuild() {
+        let content = b"BT /F1 12 Tf 1 0 0 1 72 700 Tm (Hello World) Tj ET";
+        let pdf = build_minimal_pdf_with_font(content);
+        let doc = PdfDocument::from_bytes(pdf).expect("open pdf");
+
+        let first = doc.search_page_index(0).expect("build search index");
+        doc.clear_search_index();
+        let second = doc.search_page_index(0).expect("rebuild after clear");
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &second),
+            "clear_search_index() should force the next call to rebuild"
+        );
+    }
+
+    /// `prepare_search()` must populate the index for every page so a
+    /// subsequent full-document `search()` sweep hits cache on every page,
+    /// not just the last few (the failure mode `search()`'s own bounded
+    /// `page_spans_cache` has for documents with more than 8 pages).
+    #[test]
+    fn prepare_search_populates_every_page() {
+        let pdf = build_multi_page_pdf(10);
+        let doc = PdfDocument::from_bytes(pdf).expect("open pdf");
+
+        doc.prepare_search().expect("prepare_search");
+        for page in 0..10 {
+            let a = doc.search_page_index(page).expect("indexed page");
+            let b = doc.search_page_index(page).expect("still cached");
+            assert!(
+                std::sync::Arc::ptr_eq(&a, &b),
+                "page {page} should already be cached by prepare_search()"
+            );
+        }
     }
 
     /// Regression test: a content stream with a degenerate CTM (`a == 0`)

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -31,4 +31,5 @@
 
 mod text_search;
 
+pub(crate) use text_search::SearchPageIndex;
 pub use text_search::{SearchOptions, SearchResult, TextSearcher};

--- a/src/search/text_search.rs
+++ b/src/search/text_search.rs
@@ -87,6 +87,31 @@ impl SearchOptions {
     }
 }
 
+/// Lightweight per-page search index: page text plus per-span bounding
+/// boxes, no font names or per-character widths.
+///
+/// `compute_match_bbox` only ever needs whole-span boxes, so search never
+/// touches the rest of a [`TextSpan`] — caching this projection instead of
+/// the full spans is cheap enough to retain for every page across repeated
+/// `search()` calls on the same document (see `PdfDocument::search_index`).
+pub(crate) struct SearchPageIndex {
+    full_text: String,
+    span_positions: Vec<(usize, usize, usize)>,
+    span_boxes: Vec<Rect>,
+}
+
+impl SearchPageIndex {
+    pub(crate) fn from_spans(spans: &[TextSpan]) -> Self {
+        let (full_text, span_positions) = TextSearcher::build_text_with_positions(spans);
+        let span_boxes = spans.iter().map(|s| s.bbox).collect();
+        Self {
+            full_text,
+            span_positions,
+            span_boxes,
+        }
+    }
+}
+
 /// Text searcher for PDF documents.
 pub struct TextSearcher;
 
@@ -141,21 +166,20 @@ impl TextSearcher {
         regex: &Regex,
         options: &SearchOptions,
     ) -> Result<Vec<SearchResult>> {
-        // Extract text spans from the page using the document's built-in method
-        let spans = doc.extract_spans(page)?;
-
-        // Build a concatenated text and track span positions
-        let (full_text, span_positions) = Self::build_text_with_positions(&spans);
+        // Reuse the page's cached search index (page text + span boxes) if a
+        // prior search() built it, instead of re-extracting the page.
+        let index = doc.search_page_index(page)?;
 
         let mut results = Vec::new();
 
-        for mat in regex.find_iter(&full_text) {
+        for mat in regex.find_iter(&index.full_text) {
             let start = mat.start();
             let end = mat.end();
             let matched_text = mat.as_str().to_string();
 
             // Find the spans that contain this match
-            let (bbox, span_boxes) = Self::compute_match_bbox(start, end, &spans, &span_positions);
+            let (bbox, span_boxes) =
+                Self::compute_match_bbox(start, end, &index.span_boxes, &index.span_positions);
 
             results.push(SearchResult {
                 page,
@@ -220,31 +244,31 @@ impl TextSearcher {
     fn compute_match_bbox(
         match_start: usize,
         match_end: usize,
-        spans: &[TextSpan],
+        span_boxes: &[Rect],
         span_positions: &[(usize, usize, usize)],
     ) -> (Rect, Vec<Rect>) {
-        let mut span_boxes = Vec::new();
+        let mut matched_boxes = Vec::new();
         let mut combined_bbox: Option<Rect> = None;
 
         for &(span_start, span_end, span_idx) in span_positions {
             // Check if this span overlaps with the match
             if span_start < match_end && span_end > match_start {
-                let span = &spans[span_idx];
+                let bbox = span_boxes[span_idx];
 
                 // For simplicity, use the whole span's bbox
                 // A more sophisticated implementation would compute character-level boxes
-                span_boxes.push(span.bbox);
+                matched_boxes.push(bbox);
 
-                if let Some(ref mut bbox) = combined_bbox {
+                if let Some(ref mut combined) = combined_bbox {
                     // Expand bbox to include this span
-                    *bbox = bbox.union(&span.bbox);
+                    *combined = combined.union(&bbox);
                 } else {
-                    combined_bbox = Some(span.bbox);
+                    combined_bbox = Some(bbox);
                 }
             }
         }
 
-        (combined_bbox.unwrap_or_else(|| Rect::new(0.0, 0.0, 0.0, 0.0)), span_boxes)
+        (combined_bbox.unwrap_or_else(|| Rect::new(0.0, 0.0, 0.0, 0.0)), matched_boxes)
     }
 }
 


### PR DESCRIPTION
## Summary

`search()`/`search_page()` re-extracted and re-postprocessed every page's full `TextSpan`s on every call, funneled through `PdfDocument::extract_spans()` whose `page_spans_cache` is bounded to 8 entries — far smaller than a typical document, so a full-document search evicts what it just built and gains nothing from repeated calls or multi-pattern scans (~5s/call on a 2,124-page PDF, ~45s/call on 13,234 pages, no faster on repeat).

`compute_match_bbox` only ever reads whole-span bounding boxes — never fonts or per-character widths — so search doesn't need a page's full `TextSpan`s retained at all. This adds `PdfDocument::search_page_index()`: an *unbounded* per-page cache of just `(page text, span positions, span bounding boxes)`, much lighter per page than `page_spans_cache`'s full spans, built lazily on first use and reused on every later `search()`/`search_page()` call on the same document. It's invalidated at the same two sites that already clear `page_spans_cache` (`erase_region` / `clear_erase_regions` — the only span-affecting mutation).

Also adds, matching the issue's proposed API:
- `prepare_search()` — build the whole-document index up front instead of paying the cost spread across the first sweep.
- `clear_search_index()` — drop the cache to reclaim memory, since retention is otherwise unbounded for the document's lifetime.

All bindings (Python, WASM, the `Pdf` builder API) route through the same `TextSearcher::search`/`search_page`, so this fixes every language, not just Rust core. `search()`'s return value is unchanged — same `SearchResult`s, just computed from a cached projection instead of full spans on every call.

Deferred (per the issue's own "separately..." note): a lighter search-specific extraction path that skips `stamp_char_x_offsets`. That would fork the extraction pipeline itself and needs its own regression scrutiny — the caching fix here already turns the reported `O(searches × full extraction)` into `O(1 extraction + searches × regex)`, which is the actual complaint.

Closes #936

## Test plan

- [x] 3 new regression tests in `src/document.rs` asserting the cache is actually hit (`Arc::ptr_eq`) across repeated `search_page_index()` calls, invalidated by `erase_region`, dropped by `clear_search_index()`, and fully populated by `prepare_search()` across all pages
- [x] All 15 existing tests in `tests/test_search.rs` pass unchanged
- [x] Full default `cargo test`: 5777 lib tests + integration suite green — the only failure (`fix_535_cmap_miss_recovers_text`, an external-fixture-dependent CMap-fallback test in `tests/v054_empirical_repros.rs`, unrelated code path) reproduces identically on unmodified `main`, confirmed via a clean checkout before this change
- [x] `cargo check --features rendering` clean
- [x] `cargo check --no-default-features --features fips,icc` clean
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean
- No corpus sweep run: this change adds a caching layer around `extract_spans()`'s existing output and does not touch any extraction/layout/rendering heuristic — `search()`'s output is unchanged, only its cost on repeated calls

Claude-Session: https://claude.ai/code/session_01AK7dp19EhiWR8NK3So1FVa