### PR TITLE
fix: OCR-feature CCITT diagnostic tests use fax 0.2's u16 decode_g4 API

### DIFF
--- a/tests/test_ccitt_decoder_diagnosis.rs
+++ b/tests/test_ccitt_decoder_diagnosis.rs
@@ -80,17 +80,16 @@ mod ccitt_decoder_diagnosis {
     fn test_fax_decoder_directly(data: &[u8], width: u32, height: u32, img_idx: usize) {
         use fax::decoder;
 
-        let width_u16 = width as u16;
-        let height_opt = Some(height as u16);
+        let height_opt = Some(height);
 
-        println!("  - Width: {}, Height: {}", width_u16, height_opt.unwrap_or(0));
+        println!("  - Width: {}, Height: {}", width, height_opt.unwrap_or(0));
         println!("  - Input data size: {} bytes", data.len());
 
         // Test 1: Standard Group 4 with default parameters
         println!("\n  Test 1: Standard Group 4 decode");
         let mut output = Vec::new();
         let bytes_iter = data.iter().copied();
-        let result = decoder::decode_g4(bytes_iter, width_u16, height_opt, |line| {
+        let result = decoder::decode_g4(bytes_iter, width, height_opt, |line| {
             // Count transitions to see if decoder is being called
             output.extend_from_slice(&line);
         });

--- a/tests/test_ccitt_edge_cases.rs
+++ b/tests/test_ccitt_edge_cases.rs
@@ -61,8 +61,8 @@ mod ccitt_edge_cases {
                             println!("\n  Testing fax decoder with leading zeros stripped:");
                             test_fax_decoder_on_data(
                                 &pixels[leading_zeros..],
-                                image.width() as u16,
-                                Some(image.height() as u16),
+                                image.width(),
+                                Some(image.height()),
                                 &format!("Image {} (zeros stripped)", idx),
                             );
                         } else {
@@ -77,7 +77,7 @@ mod ccitt_edge_cases {
         }
     }
 
-    fn test_fax_decoder_on_data(data: &[u8], width: u16, height: Option<u16>, _label: &str) {
+    fn test_fax_decoder_on_data(data: &[u8], width: u32, height: Option<u32>, _label: &str) {
         use fax::decoder;
 
         let mut output_count = 0;


### PR DESCRIPTION
## Summary

`fax` was bumped to 0.3 (`Cargo.toml` already pins `fax = "0.3"`), which changed `decode_g4`'s `width`/`height` parameters from `u16`/`Option<u16>` to `u32`/`Option<u32>`. Production code (`src/extractors/ccitt_bilevel.rs`) was updated for this at the time, but two `ocr`-feature-gated diagnostic test files — `tests/test_ccitt_edge_cases.rs` and `tests/test_ccitt_decoder_diagnosis.rs` — still truncated to `u16` before calling `decode_g4`, which no longer compiles against `fax` 0.3's signature.

Neither `cargo test` (default features) nor the `rendering` / `fips,icc` combos compile these files, since they're gated behind the `ocr` feature — that's why this went unnoticed until building with `--features rendering,barcodes,signatures,ocr`, which is exactly the combo the reporter used from the pre-commit hook recommended in `CONTRIBUTING.md`.

Fix: drop the stale `u16` truncation in both test files and pass the already-`u32` width/height straight through, matching what `ccitt_bilevel.rs` already does.

Closes #945

## Test plan

- [x] `cargo check --all-targets --features rendering,barcodes,signatures,ocr` — the reporter's exact repro command — now compiles clean (was: `error[E0308]`)
- [x] `cargo clippy --all-targets --features rendering,barcodes,signatures,ocr -- -D warnings` clean
- [x] `cargo fmt --check` clean
- No behavior change: both files are print-only diagnostic scaffolding gated on an external `scanned_samples/pride_prejudice.pdf` fixture not present in CI, so this is purely a compile-error fix with no functional/regression surface

Claude-Session: https://claude.ai/code/session_01AK7dp19EhiWR8NK3So1FVa