### PR TITLE
feat: expose PDF/A conversion in the Java binding (+ Kotlin/Scala/Clojure facades)

### DIFF
--- a/clojure/src/pdf_oxide/core.clj
+++ b/clojure/src/pdf_oxide/core.clj
@@ -6,7 +6,8 @@
 ;; `with-open` for deterministic cleanup.
 (ns pdf-oxide.core
   (:refer-clojure :exclude [chars]) ; pdf/chars (page glyphs) intentionally shadows clojure.core/chars
-  (:import [fyi.oxide.pdf Pdf PdfDocument PdfPage DocumentEditor AutoExtractor]
+  (:import [fyi.oxide.pdf Pdf PdfDocument PdfPage DocumentEditor AutoExtractor PdfAConverter]
+           [fyi.oxide.pdf.compliance PdfALevel]
            [java.util Optional]))
 
 (defn- opt->nil
@@ -78,6 +79,13 @@
 ;; ── Auto extraction ─────────────────────────────────────────────────────────
 (defn auto-extractor ^AutoExtractor [^PdfDocument doc] (AutoExtractor/of doc))
 (defn auto-text [^AutoExtractor ax] (.extractText ax))
+
+;; ── Compliance ────────────────────────────────────────────────────────────--
+(defn convert-to-pdf-a
+  "Convert `pdf-bytes` to the PDF/A conformance `level` (a fyi.oxide.pdf.compliance.PdfALevel
+  constant, e.g. PdfALevel/A_2B). Returns a ConversionResult."
+  ^fyi.oxide.pdf.compliance.ConversionResult [pdf-bytes ^PdfALevel level]
+  (PdfAConverter/convert pdf-bytes level))
 
 ;; ── Lifecycle (prefer `with-open`; these are escape hatches) ─────────────────
 (defn close [resource] (.close ^java.lang.AutoCloseable resource))

--- a/clojure/test/pdf_oxide/core_test.clj
+++ b/clojure/test/pdf_oxide/core_test.clj
@@ -5,7 +5,9 @@
 (ns pdf-oxide.core-test
   (:require [clojure.test :refer [deftest is]]
             [pdf-oxide.core :as pdf])
-  (:import [fyi.oxide.pdf.geometry BBox]))
+  (:import [fyi.oxide.pdf.geometry BBox]
+           [fyi.oxide.pdf.compliance PdfALevel]
+           [fyi.oxide.pdf.exception PdfUnsupportedException]))
 
 (defn sample-pdf ^bytes []
   (with-open [p (pdf/from-markdown "# Alpha Heading\n\nHello world from the Clojure facade. Beta gamma.\n")]
@@ -80,6 +82,15 @@
   (with-open [d (pdf/open (sample-pdf))]
     (let [t (pdf/auto-text (pdf/auto-extractor d))]
       (is (or (.contains t "Hello") (.contains t "Alpha"))))))
+
+(deftest convert-to-pdf-a-round-trip
+  (let [result (pdf/convert-to-pdf-a (sample-pdf) PdfALevel/A_2B)]
+    (is (> (count (.convertedPdf result)) 100))
+    (with-open [d (pdf/open (.convertedPdf result))]
+      (is (= 1 (pdf/page-count d))))))
+
+(deftest convert-to-pdf-a-rejects-pdf-a-4
+  (is (thrown? PdfUnsupportedException (pdf/convert-to-pdf-a (sample-pdf) PdfALevel/A_4))))
 
 (deftest explicit-close
   ;; `close` is the escape hatch for non-with-open usage.

--- a/java/src/main/java/fyi/oxide/pdf/PdfAConverter.java
+++ b/java/src/main/java/fyi/oxide/pdf/PdfAConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-2026 Yury Fedoseev and pdf_oxide contributors.
+ * Licensed under MIT OR Apache-2.0.
+ */
+package fyi.oxide.pdf;
+
+import fyi.oxide.pdf.compliance.ConversionResult;
+import fyi.oxide.pdf.compliance.PdfALevel;
+import fyi.oxide.pdf.exception.PdfUnsupportedException;
+import fyi.oxide.pdf.internal.NativeLoader;
+import java.util.Objects;
+
+/**
+ * Static bytes-in/bytes-out PDF/A converter, modeled on {@link PdfSigner}.
+ *
+ * <p>Wraps {@code pdf_oxide::compliance::convert_to_pdf_a}: embeds fonts,
+ * adds XMP metadata and an output intent, removes prohibited features
+ * (JavaScript, encryption), and flattens transparency where the target
+ * level requires it. The result carries the converted bytes plus an
+ * audit trail of what was changed ({@link ConversionResult#actions()})
+ * and what could not be fixed automatically
+ * ({@link ConversionResult#errors()}).
+ *
+ * <p>Only PDF/A-1/2/3 are supported; PDF/A-4 levels throw
+ * {@link PdfUnsupportedException} without touching native code.
+ */
+public final class PdfAConverter {
+
+    static {
+        NativeLoader.ensureLoaded();
+    }
+
+    private PdfAConverter() {
+        // Static-only.
+    }
+
+    /**
+     * Convert a PDF to the requested PDF/A conformance level.
+     *
+     * @throws PdfUnsupportedException for PDF/A-4 levels (pdf_oxide ships
+     *     PDF/A-1/2/3 only).
+     */
+    public static ConversionResult convert(byte[] pdf, PdfALevel level) {
+        Objects.requireNonNull(pdf, "pdf");
+        Objects.requireNonNull(level, "level");
+        if (level.ordinal() > PdfALevel.A_3U.ordinal()) {
+            throw new PdfUnsupportedException(
+                    "PdfAConverter.convert: " + level + " is not supported by pdf_oxide (PDF/A-1/2/3 only)");
+        }
+        return nativeConvert(pdf, level.ordinal(), level);
+    }
+
+    private static native ConversionResult nativeConvert(byte[] pdf, int levelOrdinal, PdfALevel level);
+}

--- a/java/src/main/java/fyi/oxide/pdf/compliance/ActionType.java
+++ b/java/src/main/java/fyi/oxide/pdf/compliance/ActionType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025-2026 Yury Fedoseev and pdf_oxide contributors.
+ * Licensed under MIT OR Apache-2.0.
+ */
+package fyi.oxide.pdf.compliance;
+
+/**
+ * Kind of remediation a {@link fyi.oxide.pdf.PdfAConverter} run performed on a document.
+ *
+ * <p>Declaration order matches the cdylib's {@code ActionType} enum
+ * (see {@code src/compliance/converter.rs}) so the JNI shim can build
+ * these directly from the Rust variant's discriminant.
+ */
+public enum ActionType {
+    /** Added XMP metadata where none was present. */
+    ADDED_XMP_METADATA,
+    /** Added PDF/A identification (part/conformance) to the XMP packet. */
+    ADDED_PDFA_IDENTIFICATION,
+    /** Embedded a font that was previously referenced but not embedded. */
+    EMBEDDED_FONT,
+    /** Added an output intent with an ICC profile. */
+    ADDED_OUTPUT_INTENT,
+    /** Removed JavaScript actions. */
+    REMOVED_JAVASCRIPT,
+    /** Removed encryption. */
+    REMOVED_ENCRYPTION,
+    /** Flattened transparency (required for PDF/A-1). */
+    FLATTENED_TRANSPARENCY,
+    /** Removed embedded files (required for PDF/A-1 and PDF/A-2). */
+    REMOVED_EMBEDDED_FILES,
+    /** Added a structure tree. */
+    ADDED_STRUCTURE,
+    /** Fixed an annotation missing its appearance stream. */
+    FIXED_ANNOTATION,
+    /** Added a document-level language specification. */
+    ADDED_LANGUAGE
+}

--- a/java/src/main/java/fyi/oxide/pdf/compliance/ConversionAction.java
+++ b/java/src/main/java/fyi/oxide/pdf/compliance/ConversionAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025-2026 Yury Fedoseev and pdf_oxide contributors.
+ * Licensed under MIT OR Apache-2.0.
+ */
+package fyi.oxide.pdf.compliance;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+/** A single remediation step taken by {@link fyi.oxide.pdf.PdfAConverter}. */
+public final class ConversionAction {
+    private final ActionType actionType;
+    private final String description;
+    private final @Nullable String fixedErrorCode;
+
+    public ConversionAction(ActionType actionType, String description, @Nullable String fixedErrorCode) {
+        this.actionType = Objects.requireNonNull(actionType, "actionType");
+        this.description = Objects.requireNonNull(description, "description");
+        this.fixedErrorCode = fixedErrorCode;
+    }
+
+    public ActionType actionType() {
+        return actionType;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    /** @return the error code (e.g. {@code "XMP-002"}) this action fixed, if any. */
+    public Optional<String> fixedErrorCode() {
+        return Optional.ofNullable(fixedErrorCode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ConversionAction)) return false;
+        ConversionAction a = (ConversionAction) o;
+        return actionType == a.actionType
+                && description.equals(a.description)
+                && Objects.equals(fixedErrorCode, a.fixedErrorCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(actionType, description, fixedErrorCode);
+    }
+
+    @Override
+    public String toString() {
+        return "ConversionAction[actionType=" + actionType + " description=" + description + "]";
+    }
+}

--- a/java/src/main/java/fyi/oxide/pdf/compliance/ConversionError.java
+++ b/java/src/main/java/fyi/oxide/pdf/compliance/ConversionError.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-2026 Yury Fedoseev and pdf_oxide contributors.
+ * Licensed under MIT OR Apache-2.0.
+ */
+package fyi.oxide.pdf.compliance;
+
+import java.util.Objects;
+
+/**
+ * A compliance error that {@link fyi.oxide.pdf.PdfAConverter} could not fix automatically.
+ *
+ * <p>{@link #errorCode()} is the same stable rule identifier surfaced by
+ * {@link ValidationViolation#ruleId()} (e.g. {@code "XMP-002"}).
+ */
+public final class ConversionError {
+    private final String errorCode;
+    private final String reason;
+
+    public ConversionError(String errorCode, String reason) {
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode");
+        this.reason = Objects.requireNonNull(reason, "reason");
+    }
+
+    public String errorCode() {
+        return errorCode;
+    }
+
+    public String reason() {
+        return reason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ConversionError)) return false;
+        ConversionError e = (ConversionError) o;
+        return errorCode.equals(e.errorCode) && reason.equals(e.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(errorCode, reason);
+    }
+
+    @Override
+    public String toString() {
+        return "ConversionError[errorCode=" + errorCode + " reason=" + reason + "]";
+    }
+}

--- a/java/src/main/java/fyi/oxide/pdf/compliance/ConversionResult.java
+++ b/java/src/main/java/fyi/oxide/pdf/compliance/ConversionResult.java
@@ -34,10 +34,9 @@ public final class ConversionResult {
         this.success = success;
         this.level = Objects.requireNonNull(level, "level");
         this.convertedPdf = Objects.requireNonNull(convertedPdf, "convertedPdf").clone();
-        this.actions = Collections.unmodifiableList(
-                new java.util.ArrayList<>(Objects.requireNonNull(actions, "actions")));
-        this.errors = Collections.unmodifiableList(
-                new java.util.ArrayList<>(Objects.requireNonNull(errors, "errors")));
+        this.actions =
+                Collections.unmodifiableList(new java.util.ArrayList<>(Objects.requireNonNull(actions, "actions")));
+        this.errors = Collections.unmodifiableList(new java.util.ArrayList<>(Objects.requireNonNull(errors, "errors")));
     }
 
     public boolean success() {

--- a/java/src/main/java/fyi/oxide/pdf/compliance/ConversionResult.java
+++ b/java/src/main/java/fyi/oxide/pdf/compliance/ConversionResult.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025-2026 Yury Fedoseev and pdf_oxide contributors.
+ * Licensed under MIT OR Apache-2.0.
+ */
+package fyi.oxide.pdf.compliance;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Result of a {@link fyi.oxide.pdf.PdfAConverter#convert(byte[], PdfALevel)} run.
+ *
+ * <p>{@link #success()} reflects whether the converted document met the
+ * requested {@link #level()}; {@link #convertedPdf()} holds the converted
+ * bytes regardless (best-effort output is still returned on partial
+ * success). {@link #actions()} is the audit trail of remediations applied;
+ * {@link #errors()} lists violations the converter could not fix
+ * automatically.
+ */
+public final class ConversionResult {
+    private final boolean success;
+    private final PdfALevel level;
+    private final byte[] convertedPdf;
+    private final List<ConversionAction> actions;
+    private final List<ConversionError> errors;
+
+    public ConversionResult(
+            boolean success,
+            PdfALevel level,
+            byte[] convertedPdf,
+            List<ConversionAction> actions,
+            List<ConversionError> errors) {
+        this.success = success;
+        this.level = Objects.requireNonNull(level, "level");
+        this.convertedPdf = Objects.requireNonNull(convertedPdf, "convertedPdf").clone();
+        this.actions = Collections.unmodifiableList(
+                new java.util.ArrayList<>(Objects.requireNonNull(actions, "actions")));
+        this.errors = Collections.unmodifiableList(
+                new java.util.ArrayList<>(Objects.requireNonNull(errors, "errors")));
+    }
+
+    public boolean success() {
+        return success;
+    }
+
+    public PdfALevel level() {
+        return level;
+    }
+
+    /** @return the converted PDF bytes (a defensive copy). */
+    public byte[] convertedPdf() {
+        return convertedPdf.clone();
+    }
+
+    public List<ConversionAction> actions() {
+        return actions;
+    }
+
+    public List<ConversionError> errors() {
+        return errors;
+    }
+
+    @Override
+    public String toString() {
+        return "ConversionResult[success=" + success
+                + " level=" + level
+                + " actions=" + actions.size()
+                + " errors=" + errors.size()
+                + "]";
+    }
+}

--- a/java/src/test/java/fyi/oxide/pdf/PdfAConverterTest.java
+++ b/java/src/test/java/fyi/oxide/pdf/PdfAConverterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025-2026 Yury Fedoseev and pdf_oxide contributors.
+ * Licensed under MIT OR Apache-2.0.
+ */
+package fyi.oxide.pdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fyi.oxide.pdf.compliance.ConversionResult;
+import fyi.oxide.pdf.compliance.PdfALevel;
+import fyi.oxide.pdf.exception.PdfUnsupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PdfAConverterTest {
+
+    private static Path fixturesDir;
+
+    @BeforeAll
+    static void resolveFixtures() {
+        fixturesDir = Paths.get("..")
+                .resolve("tests")
+                .resolve("fixtures")
+                .toAbsolutePath()
+                .normalize();
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+                Files.isDirectory(fixturesDir), "fixtures dir not present: " + fixturesDir);
+    }
+
+    private static Stream<PdfALevel> supportedLevels() {
+        return Stream.of(PdfALevel.A_1B, PdfALevel.A_2B, PdfALevel.A_2U, PdfALevel.A_3B);
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedLevels")
+    void convertProducesNonEmptyBytesForSupportedLevels(PdfALevel level) throws Exception {
+        byte[] source = Files.readAllBytes(fixturesDir.resolve("simple.pdf"));
+        ConversionResult result = PdfAConverter.convert(source, level);
+        assertThat(result).isNotNull();
+        assertThat(result.level()).isEqualTo(level);
+        assertThat(result.convertedPdf()).isNotEmpty();
+    }
+
+    @Test
+    void convertRecordsXmpMetadataAction() throws Exception {
+        byte[] source = Files.readAllBytes(fixturesDir.resolve("simple.pdf"));
+        ConversionResult result = PdfAConverter.convert(source, PdfALevel.A_1B);
+        // simple.pdf has no XMP packet, so conversion to any PDF/A level
+        // must add one; the converted bytes carry a /Metadata stream
+        // regardless of whether every other rule was satisfiable.
+        String convertedText = new String(result.convertedPdf(), java.nio.charset.StandardCharsets.ISO_8859_1);
+        assertThat(convertedText).contains("/Metadata");
+    }
+
+    @Test
+    void convertPreservesPageCount() throws Exception {
+        byte[] source = Files.readAllBytes(fixturesDir.resolve("simple.pdf"));
+        int originalPageCount;
+        try (PdfDocument doc = PdfDocument.open(source)) {
+            originalPageCount = doc.pageCount();
+        }
+        ConversionResult result = PdfAConverter.convert(source, PdfALevel.A_2B);
+        try (PdfDocument converted = PdfDocument.open(result.convertedPdf())) {
+            assertThat(converted.pageCount()).isEqualTo(originalPageCount);
+        }
+    }
+
+    @Test
+    void convertRejectsPdfA4Levels() throws Exception {
+        byte[] source = Files.readAllBytes(fixturesDir.resolve("simple.pdf"));
+        assertThatThrownBy(() -> PdfAConverter.convert(source, PdfALevel.A_4))
+                .isInstanceOf(PdfUnsupportedException.class);
+        assertThatThrownBy(() -> PdfAConverter.convert(source, PdfALevel.A_4E))
+                .isInstanceOf(PdfUnsupportedException.class);
+        assertThatThrownBy(() -> PdfAConverter.convert(source, PdfALevel.A_4F))
+                .isInstanceOf(PdfUnsupportedException.class);
+    }
+}

--- a/kotlin/src/main/kotlin/fyi/oxide/pdf/PdfOxide.kt
+++ b/kotlin/src/main/kotlin/fyi/oxide/pdf/PdfOxide.kt
@@ -15,6 +15,7 @@ package fyi.oxide.pdf
 
 import fyi.oxide.pdf.annotation.Annotation
 import fyi.oxide.pdf.auto.AutoResult
+import fyi.oxide.pdf.compliance.ConversionAction
 import fyi.oxide.pdf.compliance.ValidationViolation
 import fyi.oxide.pdf.form.FormField
 import fyi.oxide.pdf.geometry.BBox
@@ -59,6 +60,11 @@ fun AutoResult.htmlOrNull(): String? = html().orElse(null)
 
 /** Page index the violation applies to, or `null` for document-level rules. */
 fun ValidationViolation.pageIndexOrNull(): Int? = pageIndex().orElse(null)
+
+// ── ConversionAction (Optional -> nullable) ─────────────────────────────────
+
+/** The error code this action fixed, or `null` if it didn't fix a specific error. */
+fun ConversionAction.fixedErrorCodeOrNull(): String? = fixedErrorCode().orElse(null)
 
 // NB: the Java binding also defines DocumentInfo / XmpMetadata / SearchOptions
 // value types, but no API method currently produces or consumes them, so this

--- a/kotlin/src/test/kotlin/fyi/oxide/pdf/ApiCoverageTest.kt
+++ b/kotlin/src/test/kotlin/fyi/oxide/pdf/ApiCoverageTest.kt
@@ -6,6 +6,8 @@ package fyi.oxide.pdf
 
 import fyi.oxide.pdf.annotation.Annotation
 import fyi.oxide.pdf.annotation.AnnotationType
+import fyi.oxide.pdf.compliance.ActionType
+import fyi.oxide.pdf.compliance.PdfALevel
 import fyi.oxide.pdf.form.FormField
 import fyi.oxide.pdf.form.FormFieldType
 import fyi.oxide.pdf.geometry.BBox
@@ -80,6 +82,19 @@ class ApiCoverageTest {
         }
     }
 
+    @Test fun pdfAConverterRoundTrip() {
+        val result = PdfAConverter.convert(sampleBytes(), PdfALevel.A_2B)
+        assertTrue(result.convertedPdf().size > 100)
+        PdfDocument.open(result.convertedPdf()).use { doc -> assertEquals(1, doc.pageCount()) }
+    }
+
+    @Test fun pdfAConverterRejectsPdfA4() {
+        assertTrue(
+            runCatching { PdfAConverter.convert(sampleBytes(), PdfALevel.A_4) }
+                .exceptionOrNull() is fyi.oxide.pdf.exception.PdfUnsupportedException,
+        )
+    }
+
     @Test fun documentEditorRoundTrip() {
         DocumentEditor.open(sampleBytes()).use { ed ->
             assertTrue(ed.isOpen)
@@ -141,5 +156,16 @@ class ApiCoverageTest {
             fyi.oxide.pdf.compliance
                 .ValidationViolation("RULE-2", "desc", null)
         assertNull(docLevel.pageIndexOrNull())
+    }
+
+    @Test fun conversionActionOrNull() {
+        val withCode =
+            fyi.oxide.pdf.compliance
+                .ConversionAction(ActionType.EMBEDDED_FONT, "desc", "XMP-002")
+        assertEquals("XMP-002", withCode.fixedErrorCodeOrNull())
+        val bare =
+            fyi.oxide.pdf.compliance
+                .ConversionAction(ActionType.EMBEDDED_FONT, "desc", null)
+        assertNull(bare.fixedErrorCodeOrNull())
     }
 }

--- a/pdf_oxide_jni/src/conversion.rs
+++ b/pdf_oxide_jni/src/conversion.rs
@@ -1,0 +1,267 @@
+//! JNI surface for `fyi.oxide.pdf.PdfAConverter` — static bytes-in/
+//! bytes-out PDF/A conversion, wrapping
+//! `pdf_oxide::compliance::convert_to_pdf_a`.
+
+use jni::errors::{Error as JniError, ThrowRuntimeExAndDefault};
+use jni::jni_sig;
+use jni::objects::{JByteArray, JClass, JObject};
+use jni::strings::JNIString;
+use jni::sys::jint;
+use jni::EnvUnowned;
+use pdf_oxide::compliance::{convert_to_pdf_a, ActionType, ConversionResult, PdfALevel};
+use pdf_oxide::PdfDocument;
+
+use crate::error::throw_pdf;
+
+fn level_from_ordinal(ordinal: jint) -> Option<PdfALevel> {
+    match ordinal {
+        0 => Some(PdfALevel::A1b),
+        1 => Some(PdfALevel::A1a),
+        2 => Some(PdfALevel::A2b),
+        3 => Some(PdfALevel::A2a),
+        4 => Some(PdfALevel::A2u),
+        5 => Some(PdfALevel::A3b),
+        6 => Some(PdfALevel::A3a),
+        7 => Some(PdfALevel::A3u),
+        _ => None,
+    }
+}
+
+/// `Java_fyi_oxide_pdf_PdfAConverter_nativeConvert` — convert `pdf` to
+/// the PDF/A level identified by `level_ordinal`, returning a fully
+/// populated `fyi.oxide.pdf.compliance.ConversionResult`. `level` is
+/// the Java-side `PdfALevel` enum constant the caller already holds
+/// (the Java caller filters out PDF/A-4 before reaching here); it is
+/// embedded into the result unchanged rather than reconstructed from
+/// the ordinal.
+#[no_mangle]
+pub extern "system" fn Java_fyi_oxide_pdf_PdfAConverter_nativeConvert<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    pdf_bytes: JByteArray<'local>,
+    level_ordinal: jint,
+    level: JObject<'local>,
+) -> JObject<'local> {
+    env.with_env(|env| -> Result<JObject<'local>, JniError> {
+        let Some(pdf_level) = level_from_ordinal(level_ordinal) else {
+            let cls = JNIString::from("java/lang/IllegalArgumentException");
+            let msg = JNIString::from(format!("unknown PdfALevel ordinal {}", level_ordinal));
+            env.throw_new(&cls, &msg)?;
+            return Ok(JObject::null());
+        };
+
+        let pdf: Vec<u8> = env.convert_byte_array(&pdf_bytes)?;
+        let mut doc = match PdfDocument::from_bytes(pdf) {
+            Ok(d) => d,
+            Err(e) => {
+                throw_pdf(env, &e)?;
+                return Ok(JObject::null());
+            },
+        };
+
+        match convert_to_pdf_a(&mut doc, pdf_level) {
+            Ok(result) => build_conversion_result(env, &doc.source_bytes, &result, &level),
+            Err(e) => {
+                throw_pdf(env, &e)?;
+                Ok(JObject::null())
+            },
+        }
+    })
+    .resolve::<ThrowRuntimeExAndDefault>()
+}
+
+fn action_type_field<'local>(
+    env: &mut jni::Env<'local>,
+    class: &JClass<'local>,
+    name: &str,
+) -> Result<JObject<'local>, JniError> {
+    env.get_static_field(
+        class,
+        &JNIString::from(name),
+        jni_sig!("Lfyi/oxide/pdf/compliance/ActionType;"),
+    )?
+    .l()
+}
+
+fn build_conversion_result<'local>(
+    env: &mut jni::Env<'local>,
+    converted_pdf: &[u8],
+    result: &ConversionResult,
+    level: &JObject<'local>,
+) -> Result<JObject<'local>, JniError> {
+    let list_class = env.find_class(&JNIString::from("java/util/ArrayList"))?;
+    let list_ctor = env.get_method_id(&list_class, &JNIString::from("<init>"), jni_sig!("(I)V"))?;
+    let list_add =
+        env.get_method_id(&list_class, &JNIString::from("add"), jni_sig!("(Ljava/lang/Object;)Z"))?;
+
+    let action_type_class =
+        env.find_class(&JNIString::from("fyi/oxide/pdf/compliance/ActionType"))?;
+    let at_added_xmp_metadata = action_type_field(env, &action_type_class, "ADDED_XMP_METADATA")?;
+    let at_added_pdfa_identification =
+        action_type_field(env, &action_type_class, "ADDED_PDFA_IDENTIFICATION")?;
+    let at_embedded_font = action_type_field(env, &action_type_class, "EMBEDDED_FONT")?;
+    let at_added_output_intent = action_type_field(env, &action_type_class, "ADDED_OUTPUT_INTENT")?;
+    let at_removed_javascript = action_type_field(env, &action_type_class, "REMOVED_JAVASCRIPT")?;
+    let at_removed_encryption = action_type_field(env, &action_type_class, "REMOVED_ENCRYPTION")?;
+    let at_flattened_transparency =
+        action_type_field(env, &action_type_class, "FLATTENED_TRANSPARENCY")?;
+    let at_removed_embedded_files =
+        action_type_field(env, &action_type_class, "REMOVED_EMBEDDED_FILES")?;
+    let at_added_structure = action_type_field(env, &action_type_class, "ADDED_STRUCTURE")?;
+    let at_fixed_annotation = action_type_field(env, &action_type_class, "FIXED_ANNOTATION")?;
+    let at_added_language = action_type_field(env, &action_type_class, "ADDED_LANGUAGE")?;
+
+    let action_class =
+        env.find_class(&JNIString::from("fyi/oxide/pdf/compliance/ConversionAction"))?;
+    let action_ctor = env.get_method_id(
+        &action_class,
+        &JNIString::from("<init>"),
+        jni_sig!("(Lfyi/oxide/pdf/compliance/ActionType;Ljava/lang/String;Ljava/lang/String;)V"),
+    )?;
+
+    let error_class =
+        env.find_class(&JNIString::from("fyi/oxide/pdf/compliance/ConversionError"))?;
+    let error_ctor = env.get_method_id(
+        &error_class,
+        &JNIString::from("<init>"),
+        jni_sig!("(Ljava/lang/String;Ljava/lang/String;)V"),
+    )?;
+
+    let actions_list = unsafe {
+        env.new_object_unchecked(
+            &list_class,
+            list_ctor,
+            &[jni::sys::jvalue {
+                i: result.actions.len() as i32,
+            }],
+        )?
+    };
+    for action in &result.actions {
+        let action_type_obj = match action.action_type {
+            ActionType::AddedXmpMetadata => &at_added_xmp_metadata,
+            ActionType::AddedPdfaIdentification => &at_added_pdfa_identification,
+            ActionType::EmbeddedFont => &at_embedded_font,
+            ActionType::AddedOutputIntent => &at_added_output_intent,
+            ActionType::RemovedJavaScript => &at_removed_javascript,
+            ActionType::RemovedEncryption => &at_removed_encryption,
+            ActionType::FlattenedTransparency => &at_flattened_transparency,
+            ActionType::RemovedEmbeddedFiles => &at_removed_embedded_files,
+            ActionType::AddedStructure => &at_added_structure,
+            ActionType::FixedAnnotation => &at_fixed_annotation,
+            ActionType::AddedLanguage => &at_added_language,
+        };
+        let description = env.new_string(&action.description)?;
+        let fixed_error_code: JObject = match action.fixed_error {
+            Some(code) => env.new_string(code.to_string())?.into(),
+            None => JObject::null(),
+        };
+        let action_obj = unsafe {
+            env.new_object_unchecked(
+                &action_class,
+                action_ctor,
+                &[
+                    jni::sys::jvalue {
+                        l: action_type_obj.as_raw(),
+                    },
+                    jni::sys::jvalue {
+                        l: description.as_raw(),
+                    },
+                    jni::sys::jvalue {
+                        l: fixed_error_code.as_raw(),
+                    },
+                ],
+            )?
+        };
+        unsafe {
+            env.call_method_unchecked(
+                &actions_list,
+                list_add,
+                jni::signature::ReturnType::Primitive(jni::signature::Primitive::Boolean),
+                &[jni::sys::jvalue {
+                    l: action_obj.as_raw(),
+                }],
+            )?;
+        }
+    }
+
+    let errors_list = unsafe {
+        env.new_object_unchecked(
+            &list_class,
+            list_ctor,
+            &[jni::sys::jvalue {
+                i: result.errors.len() as i32,
+            }],
+        )?
+    };
+    for error in &result.errors {
+        let error_code = env.new_string(error.error_code.to_string())?;
+        let reason = env.new_string(&error.reason)?;
+        let error_obj = unsafe {
+            env.new_object_unchecked(
+                &error_class,
+                error_ctor,
+                &[
+                    jni::sys::jvalue {
+                        l: error_code.as_raw(),
+                    },
+                    jni::sys::jvalue { l: reason.as_raw() },
+                ],
+            )?
+        };
+        unsafe {
+            env.call_method_unchecked(
+                &errors_list,
+                list_add,
+                jni::signature::ReturnType::Primitive(jni::signature::Primitive::Boolean),
+                &[jni::sys::jvalue {
+                    l: error_obj.as_raw(),
+                }],
+            )?;
+        }
+    }
+
+    let converted_bytes = env.byte_array_from_slice(converted_pdf)?;
+
+    let result_class =
+        env.find_class(&JNIString::from("fyi/oxide/pdf/compliance/ConversionResult"))?;
+    let result_ctor = env.get_method_id(
+        &result_class,
+        &JNIString::from("<init>"),
+        jni_sig!("(ZLfyi/oxide/pdf/compliance/PdfALevel;[BLjava/util/List;Ljava/util/List;)V"),
+    )?;
+    let result_obj = unsafe {
+        env.new_object_unchecked(
+            &result_class,
+            result_ctor,
+            &[
+                jni::sys::jvalue {
+                    z: result.success as jni::sys::jboolean,
+                },
+                jni::sys::jvalue { l: level.as_raw() },
+                jni::sys::jvalue {
+                    l: converted_bytes.as_raw(),
+                },
+                jni::sys::jvalue {
+                    l: actions_list.as_raw(),
+                },
+                jni::sys::jvalue {
+                    l: errors_list.as_raw(),
+                },
+            ],
+        )?
+    };
+    Ok(result_obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordinal_maps_only_pdf_a_1_2_3_levels() {
+        assert_eq!(level_from_ordinal(0), Some(PdfALevel::A1b));
+        assert_eq!(level_from_ordinal(7), Some(PdfALevel::A3u));
+        assert_eq!(level_from_ordinal(8), None);
+        assert_eq!(level_from_ordinal(-1), None);
+    }
+}

--- a/pdf_oxide_jni/src/lib.rs
+++ b/pdf_oxide_jni/src/lib.rs
@@ -72,6 +72,7 @@ pub mod redaction;
 pub mod split;
 
 // ---- Phase 4 (security surface) ----
+pub mod conversion;
 pub mod policy;
 pub mod signatures_pades;
 pub mod validator;

--- a/scala/src/main/scala/fyi/oxide/pdf/PdfOxide.scala
+++ b/scala/src/main/scala/fyi/oxide/pdf/PdfOxide.scala
@@ -13,7 +13,12 @@ package fyi.oxide.pdf
 
 import fyi.oxide.pdf.annotation.Annotation
 import fyi.oxide.pdf.auto.AutoResult
-import fyi.oxide.pdf.compliance.{ConversionAction, ConversionError, ConversionResult, ValidationViolation}
+import fyi.oxide.pdf.compliance.{
+  ConversionAction,
+  ConversionError,
+  ConversionResult,
+  ValidationViolation
+}
 import fyi.oxide.pdf.form.FormField
 import fyi.oxide.pdf.image.ExtractedImage
 import fyi.oxide.pdf.search.SearchMatch

--- a/scala/src/main/scala/fyi/oxide/pdf/PdfOxide.scala
+++ b/scala/src/main/scala/fyi/oxide/pdf/PdfOxide.scala
@@ -13,7 +13,7 @@ package fyi.oxide.pdf
 
 import fyi.oxide.pdf.annotation.Annotation
 import fyi.oxide.pdf.auto.AutoResult
-import fyi.oxide.pdf.compliance.ValidationViolation
+import fyi.oxide.pdf.compliance.{ConversionAction, ConversionError, ConversionResult, ValidationViolation}
 import fyi.oxide.pdf.form.FormField
 import fyi.oxide.pdf.image.ExtractedImage
 import fyi.oxide.pdf.search.SearchMatch
@@ -62,6 +62,15 @@ extension (r: AutoResult)
 /** ValidationViolation: optional page index as `Option[Int]`. */
 extension (v: ValidationViolation)
   def pageIndexOption: Option[Int] = v.pageIndex.toOption.map(_.intValue)
+
+/** ConversionAction: optional fixed-error code as `Option[String]`. */
+extension (a: ConversionAction)
+  def fixedErrorCodeOption: Option[String] = a.fixedErrorCode.toOption
+
+/** ConversionResult: action/error audit trails as `Seq`. */
+extension (r: ConversionResult)
+  def actionsSeq: Seq[ConversionAction] = r.actions.asScala.toSeq
+  def errorsSeq: Seq[ConversionError] = r.errors.asScala.toSeq
 
 // NB: the Java binding also defines DocumentInfo / XmpMetadata / SearchOptions
 // value types, but no API method currently produces or consumes them, so this

--- a/scala/src/test/scala/fyi/oxide/pdf/ApiCoverageSpec.scala
+++ b/scala/src/test/scala/fyi/oxide/pdf/ApiCoverageSpec.scala
@@ -5,7 +5,8 @@
 package fyi.oxide.pdf
 
 import fyi.oxide.pdf.annotation.{Annotation, AnnotationType}
-import fyi.oxide.pdf.compliance.ValidationViolation
+import fyi.oxide.pdf.compliance.{ActionType, ConversionAction, PdfALevel, ValidationViolation}
+import fyi.oxide.pdf.exception.PdfUnsupportedException
 import fyi.oxide.pdf.form.{FormField, FormFieldType}
 import fyi.oxide.pdf.geometry.BBox
 import org.scalatest.funsuite.AnyFunSuite
@@ -55,6 +56,17 @@ class ApiCoverageSpec extends AnyFunSuite:
       assert(matches.nonEmpty)
       assert(matches.head.text.contains("Hello"))
 
+  test("PdfAConverter round-trip"):
+    val result = PdfAConverter.convert(samplePdf(), PdfALevel.A_2B)
+    assert(result.convertedPdf().length > 100)
+    Using.resource(PdfDocument.open(result.convertedPdf()))(doc => assert(doc.pageCount() == 1))
+    assert(result.actionsSeq != null) // List -> Seq
+    assert(result.errorsSeq != null)
+
+  test("PdfAConverter rejects PDF/A-4"):
+    assertThrows[PdfUnsupportedException]:
+      PdfAConverter.convert(samplePdf(), PdfALevel.A_4)
+
   test("render page"):
     Using.resource(PdfDocument.open(samplePdf())): doc =>
       assert(doc.render(0).length > 100)
@@ -103,3 +115,9 @@ class ApiCoverageSpec extends AnyFunSuite:
   test("ValidationViolation Option extension"):
     assert(ValidationViolation("RULE-1", "desc", 3).pageIndexOption.contains(3))
     assert(ValidationViolation("RULE-2", "desc", null).pageIndexOption.isEmpty)
+
+  test("ConversionAction Option extension"):
+    val withCode = ConversionAction(ActionType.EMBEDDED_FONT, "desc", "XMP-002")
+    assert(withCode.fixedErrorCodeOption.contains("XMP-002"))
+    val bare = ConversionAction(ActionType.EMBEDDED_FONT, "desc", null)
+    assert(bare.fixedErrorCodeOption.isEmpty)


### PR DESCRIPTION
## Summary

Closes #947.

- Adds a static bytes-in/bytes-out `PdfAConverter` to the Java binding, modeled on the existing `PdfSigner`, wrapping the already-implemented Rust core API `pdf_oxide::compliance::convert_to_pdf_a`. New value types `ConversionResult`, `ConversionAction`, `ActionType`, `ConversionError` in `fyi.oxide.pdf.compliance`.
- New JNI surface in `pdf_oxide_jni/src/conversion.rs` — builds the `ConversionResult` object graph directly on the Rust side, reusing the existing `throw_pdf` error-mapping and the same JNI object-construction pattern already used for forms/annotations.
- `PdfALevel.A_4`/`A_4E`/`A_4F` are rejected with `PdfUnsupportedException` in Java before any native call (pdf_oxide's core only supports PDF/A-1/2/3), consistent with how `PdfValidator` already handles those levels.
- Extends the three thin JVM facades to cover the new surface: Kotlin/Scala add `Optional`/`List` idiomatic adapters, Clojure adds a `convert-to-pdf-a` interop function. No native code in any of the three.

While scoping this, I audited every other language binding for PDF/A conversion coverage: Python (`src/python.rs`), WASM (`src/wasm.rs`), and all of Go/Ruby/PHP/C#/Node/C++/Swift/Dart/R/Julia/Zig/ObjC/Elixir already wrap `pdf_convert_to_pdf_a` idiomatically — Java (and its JVM-family facades) was the only gap.

## Test plan
- [x] `cargo build` / `fmt --check` / `clippy -D warnings` / `cargo test` for `pdf_oxide_jni` (default features and `--features full`) — clean.
- [x] Workspace `cargo build` (default features) unaffected.
- [x] Java: `mvn -P '!dev' test` — new `PdfAConverterTest` (7 tests: A_1B/A_2B/A_2U/A_3B conversion, XMP metadata action, page-count round-trip, PDF/A-4 rejection) plus regression pass on `PdfSignerTest`/`PdfValidatorTest`, all green.
- [x] Kotlin: `gradle test` — 15/15 passed.
- [x] Scala: `sbt test` — 15/15 passed.
- [x] Clojure: `clj -M:test` — 12/12 passed.
- No corpus regression sweep: new binding surface only, no extraction/rendering/layout/font-handling change (CONTRIBUTING.md's corpus-regression rule doesn't apply here).