### PR TITLE
fix(render): decode non-CCITT 1-bit images and paint inline images

### DIFF
--- a/julia/src/PdfOxide.jl
+++ b/julia/src/PdfOxide.jl
@@ -252,7 +252,7 @@ end
 
 """PDF version as `(major, minor)`."""
 function version(d::PdfDocument)
-    maj = Ref{UInt8}(0);
+    maj = Ref{UInt8}(0)
     min = Ref{UInt8}(0)
     ccall(
         (:pdf_document_get_version, LIB),
@@ -419,9 +419,9 @@ for (jl_fn, c_fn) in (
     (:_bbox_line, :pdf_oxide_line_get_bbox),
 )
     @eval function $jl_fn(list::Ptr{Cvoid}, index::Integer, op::String)
-        x = Ref{Float32}(0);
+        x = Ref{Float32}(0)
         y = Ref{Float32}(0)
-        w = Ref{Float32}(0);
+        w = Ref{Float32}(0)
         h = Ref{Float32}(0)
         code = Ref{Int32}(0)
         ccall(
@@ -754,9 +754,9 @@ for (jl_fn, c_fn) in (
     (:_bbox_search, :pdf_oxide_search_result_get_bbox),
 )
     @eval function $jl_fn(list::Ptr{Cvoid}, index::Integer, op::String)
-        x = Ref{Float32}(0);
+        x = Ref{Float32}(0)
         y = Ref{Float32}(0)
-        w = Ref{Float32}(0);
+        w = Ref{Float32}(0)
         h = Ref{Float32}(0)
         code = Ref{Int32}(0)
         ccall(
@@ -931,7 +931,7 @@ function embedded_images(d::PdfDocument, page::Integer)
             bpc = _i32_image_bpc(list, i, "embedded_images")
             fmt = _str_image_format(list, i, "embedded_images")
             cs = _str_image_colorspace(list, i, "embedded_images")
-            dlen = Ref{Int32}(0);
+            dlen = Ref{Int32}(0)
             dcode = Ref{Int32}(0)
             dptr = ccall(
                 (:pdf_oxide_image_get_data, LIB),
@@ -1129,7 +1129,7 @@ mutable struct RenderedImage
             ccall((:pdf_rendered_image_free, LIB), Cvoid, (Ptr{Cvoid},), h)
             throw(PdfOxideError(hcode[], "render"))
         end
-        dlen = Ref{Int32}(0);
+        dlen = Ref{Int32}(0)
         dcode = Ref{Int32}(0)
         dptr = ccall(
             (:pdf_get_rendered_image_data, LIB),
@@ -1300,7 +1300,7 @@ end
 
 """Serialize the built PDF to a `Vector{UInt8}`."""
 function to_bytes(p::Pdf)
-    len = Ref{Int32}(0);
+    len = Ref{Int32}(0)
     code = Ref{Int32}(0)
     ptr = ccall(
         (:pdf_save_to_bytes, LIB),
@@ -6288,13 +6288,13 @@ function highlight_quad_point(
 )
     list = _open_annotations(d, page, "highlight_quad_point")
     try
-        x1 = Ref{Float32}(0);
+        x1 = Ref{Float32}(0)
         y1 = Ref{Float32}(0)
-        x2 = Ref{Float32}(0);
+        x2 = Ref{Float32}(0)
         y2 = Ref{Float32}(0)
-        x3 = Ref{Float32}(0);
+        x3 = Ref{Float32}(0)
         y3 = Ref{Float32}(0)
-        x4 = Ref{Float32}(0);
+        x4 = Ref{Float32}(0)
         y4 = Ref{Float32}(0)
         code = Ref{Int32}(0)
         ccall(
@@ -6409,9 +6409,9 @@ end
 
 """The `index`-th element's bounding box as a `Bbox`."""
 function element_rect(l::ElementList, index::Integer)
-    x = Ref{Float32}(0);
+    x = Ref{Float32}(0)
     y = Ref{Float32}(0)
-    w = Ref{Float32}(0);
+    w = Ref{Float32}(0)
     h = Ref{Float32}(0)
     code = Ref{Int32}(0)
     ccall(

--- a/src/extractors/images.rs
+++ b/src/extractors/images.rs
@@ -442,19 +442,51 @@ impl PdfImage {
             ImageData::Raw { pixels, format } => {
                 if self.bits_per_component == 1
                     && matches!(self.color_space, ColorSpace::DeviceGray)
+                    && self.ccitt_params.is_some()
                 {
-                    let params =
-                        self.ccitt_params
-                            .clone()
-                            .unwrap_or_else(|| crate::decoders::CcittParams {
-                                columns: self.width,
-                                rows: Some(self.height),
-                                ..Default::default()
-                            });
+                    // Only genuinely CCITT-filtered images reach here — see
+                    // `extract_image_from_xobject`, which sets `ccitt_params`
+                    // solely when the XObject's `/Filter` is CCITTFaxDecode.
+                    let Some(params) = self.ccitt_params.clone() else {
+                        unreachable!("guarded by ccitt_params.is_some() above")
+                    };
 
                     let decompressed = ccitt_bilevel::decompress_ccitt(pixels, &params)?;
                     let grayscale =
                         ccitt_bilevel::bilevel_to_grayscale(&decompressed, self.width, self.height);
+
+                    image::ImageBuffer::<image::Luma<u8>, Vec<u8>>::from_raw(
+                        self.width,
+                        self.height,
+                        grayscale,
+                    )
+                    .ok_or_else(|| Error::Decode("Invalid image dimensions".to_string()))
+                    .map(image::DynamicImage::ImageLuma8)
+                } else if self.bits_per_component == 1
+                    && matches!(self.color_space, ColorSpace::DeviceGray)
+                {
+                    // Non-CCITT 1-bit DeviceGray: the stream is already fully
+                    // decoded (Flate/LZW/ASCII/no filter) to raw packed bits,
+                    // one row per `ceil(width / 8)` bytes, MSB first. /Decode
+                    // inversion (if any) was already folded into the bits by
+                    // `extract_image_from_xobject`, so unpack with fixed
+                    // ISO 32000-1 §8.9.5.2 Table 90 default semantics: sample
+                    // bit 0 -> component 0.0 (black), bit 1 -> component 1.0
+                    // (white).
+                    let row_bytes = (self.width as usize).div_ceil(8);
+                    let mut grayscale =
+                        Vec::with_capacity(self.width as usize * self.height as usize);
+                    for row in 0..self.height as usize {
+                        let row_start = row * row_bytes;
+                        for col in 0..self.width as usize {
+                            let byte_idx = row_start + col / 8;
+                            let bit = pixels
+                                .get(byte_idx)
+                                .map(|b| (b >> (7 - (col % 8))) & 1)
+                                .unwrap_or(1);
+                            grayscale.push(if bit == 0 { 0x00 } else { 0xFF });
+                        }
+                    }
 
                     image::ImageBuffer::<image::Luma<u8>, Vec<u8>>::from_raw(
                         self.width,
@@ -844,6 +876,10 @@ pub fn extract_image_from_xobject(
         .iter()
         .any(|n| n.eq_ignore_ascii_case("JPXDecode"));
 
+    let is_ccitt = filter_names
+        .iter()
+        .any(|n| n.eq_ignore_ascii_case("CCITTFaxDecode"));
+
     let data = if is_jbig2 {
         decode_jbig2_image(xobject, obj_ref, dict, doc, width, height)?
     } else if is_jpx {
@@ -903,6 +939,18 @@ pub fn extract_image_from_xobject(
                     .chunks_exact(2)
                     .map(|sample| reduce_16_to_8(sample[0], sample[1]))
                     .collect()
+            } else if bits_per_component == 1
+                && color_space == ColorSpace::DeviceGray
+                && !is_ccitt
+                && decode_array_inverts_1bpc(dict.get("Decode"))
+            {
+                // Fold a non-default /Decode [1 0] into the packed bits here,
+                // the same way the CCITT branch below folds it into
+                // `black_is_1`, so `to_dynamic_image` can unpack with fixed
+                // (non-inverted) bit semantics regardless of /Decode. Flipping
+                // every bit of a 1-bpp buffer is a plain byte-wise NOT; the
+                // unused row-padding bits get flipped too but are never read.
+                decoded_data.iter().map(|b| !b).collect()
             } else {
                 decoded_data
             };
@@ -938,7 +986,7 @@ pub fn extract_image_from_xobject(
     }
     image.set_rendering_intent(rendering_intent);
 
-    if bits_per_component == 1 && image.color_space == ColorSpace::DeviceGray {
+    if bits_per_component == 1 && image.color_space == ColorSpace::DeviceGray && is_ccitt {
         if let Some(mut ccitt_params) =
             crate::object::extract_ccitt_params_with_width(dict.get("DecodeParms"), Some(width))
         {
@@ -3545,5 +3593,110 @@ mod ccitt_decode_array_polarity_tests {
     fn decode_0_1_is_a_no_op() {
         let (white, black) = white_black_counts(&ccitt_xobject(Some([0, 1])));
         assert_eq!((white, black), white_black_counts(&ccitt_xobject(None)));
+    }
+}
+
+/// Regression coverage for the non-CCITT 1-bit `/DeviceGray` image path:
+/// a raw packed-bit image (no `/Filter`, or `/Filter /FlateDecode`) used
+/// to be unconditionally force-fed through the CCITT decompressor
+/// (`to_dynamic_image`'s single `bits_per_component == 1 &&
+/// DeviceGray` branch had no filter check), which fails to decode
+/// already-unpacked bits as if they were CCITT-compressed data and drops
+/// the image entirely. `/ImageMask` variants of the same filters were
+/// unaffected (they go through the separate `render_image_mask` bit
+/// unpacker), which is why the bug only showed on plain (non-mask)
+/// images.
+#[cfg(test)]
+mod non_ccitt_1bpc_devicegray_tests {
+    use super::*;
+    use crate::object::Object;
+    use std::collections::HashMap;
+
+    /// 8x3 raw packed-bit image: rows 0-1 all-black, row 2 black with a
+    /// 2-pixel-wide white notch at columns 3-4 (mirrors the CCITT
+    /// polarity tests' pattern for an easy visual cross-check). Under the
+    /// default `/Decode [0 1]`, sample bit 0 -> black, bit 1 -> white.
+    fn black_majority_rows() -> [u8; 3] {
+        [0x00, 0x00, 0x18]
+    }
+
+    /// Build a minimal 1-bit `/DeviceGray` image XObject wrapping
+    /// `black_majority_rows`, either uncompressed or FlateDecode-filtered,
+    /// with an optional `/Decode` override.
+    fn devicegray_1bpc_xobject(flate: bool, decode: Option<[i64; 2]>) -> Object {
+        let raw: Vec<u8> = black_majority_rows().to_vec();
+        let (filter, data) = if flate {
+            use flate2::write::ZlibEncoder;
+            use flate2::Compression;
+            use std::io::Write;
+            let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(&raw).expect("flate-compress test bitmap");
+            (Some("FlateDecode"), encoder.finish().expect("finish flate stream"))
+        } else {
+            (None, raw)
+        };
+
+        let mut dict = HashMap::new();
+        dict.insert("Subtype".to_string(), Object::Name("Image".to_string()));
+        dict.insert("Width".to_string(), Object::Integer(8));
+        dict.insert("Height".to_string(), Object::Integer(3));
+        dict.insert("BitsPerComponent".to_string(), Object::Integer(1));
+        dict.insert("ColorSpace".to_string(), Object::Name("DeviceGray".to_string()));
+        if let Some(f) = filter {
+            dict.insert("Filter".to_string(), Object::Name(f.to_string()));
+        }
+        if let Some([lo, hi]) = decode {
+            dict.insert(
+                "Decode".to_string(),
+                Object::Array(vec![Object::Integer(lo), Object::Integer(hi)]),
+            );
+        }
+
+        Object::Stream {
+            dict,
+            data: bytes::Bytes::from(data),
+        }
+    }
+
+    fn white_black_counts(xobject: &Object) -> (u32, u32) {
+        let img = extract_image_from_xobject(None, xobject, None, None)
+            .expect("decode hand-built non-CCITT 1bpc test image");
+        let luma = img
+            .to_dynamic_image()
+            .expect("decode non-CCITT 1bpc test image pixels")
+            .into_luma8();
+        let white = luma.iter().filter(|&&v| v == 0xFF).count() as u32;
+        let black = luma.iter().filter(|&&v| v == 0x00).count() as u32;
+        (white, black)
+    }
+
+    /// Before the fix this failed outright (the CCITT decompressor
+    /// rejects raw packed bits as malformed input), not just mis-decoded.
+    #[test]
+    fn uncompressed_1bpc_devicegray_decodes_without_ccitt() {
+        let (white, black) = white_black_counts(&devicegray_1bpc_xobject(false, None));
+        assert_eq!(white + black, 24);
+        assert_eq!(black, 22, "22 of 24 pixels are black per the hand-built bitmap");
+        assert_eq!(white, 2, "the 2-pixel notch at row 2 cols 3-4 is white");
+    }
+
+    #[test]
+    fn flate_decoded_1bpc_devicegray_decodes_without_ccitt() {
+        let (white, black) = white_black_counts(&devicegray_1bpc_xobject(true, None));
+        assert_eq!(white + black, 24);
+        assert_eq!(black, 22);
+        assert_eq!(white, 2);
+    }
+
+    /// `/Decode [1 0]` inverts polarity for the non-CCITT path exactly
+    /// like it does for CCITT (ISO 32000-1 §8.9.5.2 Table 90) — the
+    /// bug's fallback path always produced a fully dropped image, so
+    /// there was no polarity to even get wrong before this fix.
+    #[test]
+    fn decode_1_0_inverts_polarity_on_non_ccitt_path() {
+        let (white, black) = white_black_counts(&devicegray_1bpc_xobject(true, Some([1, 0])));
+        assert_eq!(white + black, 24);
+        assert_eq!(white, 22, "polarity inverted: majority is now white");
+        assert_eq!(black, 2, "the notch is now the black pixels");
     }
 }

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -2929,6 +2929,44 @@ impl PageRenderer {
                     }
                 },
 
+                // Inline image (`BI ... ID <data> EI`) — §8.9.7. Unlike a
+                // `Do`-invoked image XObject, the pixel data sits directly in
+                // the content stream (no indirect object, so no encryption
+                // and no `/SMask` or `/Mask`, both of which the spec only
+                // allows as indirect references). Expand the abbreviated
+                // dictionary keys/values into the same shape
+                // `extract_image_from_xobject` expects, wrap it in a
+                // synthetic `Object::Stream`, and paint it through the same
+                // `render_image`/`render_image_mask` used for `Do` images.
+                Operator::InlineImage { dict, data } => {
+                    if excluded_layer_depth == 0 {
+                        let gs_clone = gs_stack.current().clone();
+                        let transform = combine_transforms(base_transform, &gs_clone.ctm);
+                        let clip = clip_stack.last().and_then(|c| c.as_ref());
+                        let expanded =
+                            crate::extractors::images::expand_inline_image_dict((**dict).clone());
+                        let is_image_mask = expanded
+                            .get("ImageMask")
+                            .map(|o| matches!(o, Object::Boolean(true)))
+                            .unwrap_or(false);
+                        let synthetic = Object::Stream {
+                            dict: expanded,
+                            data: bytes::Bytes::from(data.clone()),
+                        };
+                        if is_image_mask {
+                            if let Err(e) = self.render_image_mask(
+                                pixmap, &synthetic, None, transform, doc, clip, &gs_clone,
+                            ) {
+                                log::warn!("Skipping unrenderable inline ImageMask: {}", e);
+                            }
+                        } else if let Err(e) = self.render_image(
+                            pixmap, &synthetic, None, transform, doc, clip, None, None, &gs_clone,
+                        ) {
+                            log::warn!("Skipping unrenderable inline image: {}", e);
+                        }
+                    }
+                },
+
                 // Text positioning
                 Operator::Td { tx, ty } => {
                     if in_text_object {

--- a/tests/inline_image_rendering.rs
+++ b/tests/inline_image_rendering.rs
@@ -1,0 +1,132 @@
+//! Inline images (`BI` / `ID` / `EI`) must actually PAINT onto the page,
+//! not just be extractable via `PdfDocument::extract_images` (already
+//! covered by `tests/inline_image_decode.rs`). `Operator::InlineImage` was
+//! parsed and even classified as a paint operator for knockout-group
+//! segmentation, but the operator-execution `match` in
+//! `execute_operators` had no arm for it at all — inline images were
+//! silently dropped from the rendered page.
+
+#![cfg(feature = "rendering")]
+
+use pdf_oxide::rendering::{render_page, RenderOptions};
+use pdf_oxide::PdfDocument;
+
+/// One-page PDF whose whole page is covered by a single inline image with
+/// the given dictionary text and raw sample bytes.
+fn pdf_with_full_page_inline_image(dict: &str, samples: &[u8]) -> Vec<u8> {
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(b"q 200 0 0 200 0 0 cm\n");
+    content.extend_from_slice(format!("BI {dict} ID ").as_bytes());
+    content.extend_from_slice(samples);
+    content.extend_from_slice(b"\nEI\nQ\n");
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 5];
+    let obj = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, body: &str| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>",
+    );
+    off[4] = buf.len();
+    buf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    buf.extend_from_slice(&content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 5\n0000000000 65535 f \n");
+    for id in 1..=4 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+/// Render page 0 as raw RGBA and return the centre pixel.
+fn centre_pixel(pdf: Vec<u8>) -> [u8; 4] {
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let mut opts = RenderOptions::default();
+    opts.dpi = 72;
+    opts.format = pdf_oxide::rendering::ImageFormat::RawRgba8;
+    let img = render_page(&doc, 0, &opts).expect("render");
+    let (w, h) = (img.width as usize, img.height as usize);
+    let at = (h / 2 * w + w / 2) * 4;
+    [
+        img.data[at],
+        img.data[at + 1],
+        img.data[at + 2],
+        img.data[at + 3],
+    ]
+}
+
+#[test]
+fn inline_rgb_image_paints_onto_the_page() {
+    // 1x1 pure-green RGB inline image covering the whole page. Before the
+    // fix the page stayed the default white background — the operator was
+    // parsed and then dropped, not an error, so nothing indicated failure.
+    let green = [0x00u8, 0xFF, 0x00];
+    let pdf = pdf_with_full_page_inline_image("/W 1 /H 1 /CS /RGB /BPC 8", &green);
+    let [r, g, b, a] = centre_pixel(pdf);
+    assert!(
+        r < 40 && g > 200 && b < 40 && a > 200,
+        "expected the inline image's green to be painted, got rgba({r},{g},{b},{a}) \
+         — inline image not rendered?"
+    );
+}
+
+#[test]
+fn inline_image_mask_paints_with_current_fill_colour() {
+    // A 1x1 stencil mask, sample bit 0 (default /Decode [0 1], the mark
+    // colour) covering the whole page, filled with the current (blue) fill
+    // colour — mirrors how a `Do`-invoked /ImageMask XObject already
+    // behaves, which inline images must match.
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(b"0 0 1 rg\n"); // blue fill
+    content.extend_from_slice(b"q 200 0 0 200 0 0 cm\n");
+    content.extend_from_slice(b"BI /W 1 /H 1 /CS /G /BPC 1 /IM true ID ");
+    content.extend_from_slice(&[0x00u8]); // single bit 0 -> "paints" by default
+    content.extend_from_slice(b"\nEI\nQ\n");
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 5];
+    let obj = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, body: &str| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>",
+    );
+    off[4] = buf.len();
+    buf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    buf.extend_from_slice(&content);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 5\n0000000000 65535 f \n");
+    for id in 1..=4 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+
+    let [r, g, b, a] = centre_pixel(buf);
+    assert!(
+        r < 40 && g < 40 && b > 200 && a > 200,
+        "expected the inline image mask to paint the current blue fill, got rgba({r},{g},{b},{a}) \
+         — inline image mask not rendered?"
+    );
+}

--- a/tests/test_render_resolution_pipeline_qa_wave3.rs
+++ b/tests/test_render_resolution_pipeline_qa_wave3.rs
@@ -697,23 +697,16 @@ fn qa_standard_image_iccbased_n4_pass_through_paints_visible_ink() {
 // ===========================================================================
 // Probes 13-14 — Inline images (`BI ... ID ... EI`).
 //
-// Inline images are an entirely separate parse path. The wave-3 commit
-// only touches the `Operator::Do` arm; inline images flow through
-// `Operator::InlineImage` which the renderer DOES NOT IMPLEMENT —
-// `page_renderer.rs` has no `Operator::InlineImage` arm. So:
-//
-//   - inline images render as nothing (transparent / unchanged page);
-//   - inline ImageMasks therefore can't be filled via the pipeline
-//     (capability gap, not a regression).
-//
-// These probes PIN the current behaviour. If a future wave wires up
-// `Operator::InlineImage`, both should start failing — at which point
-// the new arm needs its own pipeline routing for `/IM true`.
+// Inline images are an entirely separate parse path from `Do`-invoked
+// XObjects. `Operator::InlineImage` now has its own dispatch arm in
+// `page_renderer.rs` that expands the abbreviated dictionary keys and
+// routes through the same `render_image`/`render_image_mask` functions
+// the `Do` arm uses, so both an inline ImageMask and a standard inline
+// image now paint correctly.
 // ===========================================================================
 
 /// Build a one-page PDF whose content stream is a literal byte slice
-/// (so callers can embed non-ASCII inline-image data). The renderer
-/// doesn't dispatch `Operator::InlineImage` today; this is a gap pin.
+/// (so callers can embed non-ASCII inline-image data).
 fn build_pdf_inline_image_bytes(content_ops: &[u8]) -> Vec<u8> {
     let mut buf: Vec<u8> = Vec::new();
     buf.extend_from_slice(b"%PDF-1.4\n");
@@ -743,16 +736,10 @@ fn build_pdf_inline_image_bytes(content_ops: &[u8]) -> Vec<u8> {
     buf
 }
 
-/// Probe 13 — Inline ImageMask via `BI ... ID ... EI`. Pin the current
-/// behaviour: the renderer does NOT dispatch `Operator::InlineImage`,
-/// so the page is blank.
-///
-/// If a future wave adds inline-image support, this test will fail —
-/// at which point the new arm needs its own pipeline routing for
-/// `/IM true` to match the `Do` arm's behaviour. Tracked as
-/// **WAVE-3-GAP-INLINE**.
+/// Probe 13 — Inline ImageMask via `BI ... ID ... EI` paints with the
+/// current fill colour, same as a `Do`-invoked ImageMask.
 #[test]
-fn qa_inline_image_mask_renderer_gap_pin() {
+fn qa_inline_image_mask_paints_with_current_fill_colour() {
     // Inline ImageMask: 1x1, /BPC 1, /IM true, one zero byte (opaque
     // under default Decode). Surround with a fill colour set first.
     //
@@ -766,25 +753,19 @@ fn qa_inline_image_mask_renderer_gap_pin() {
     let bytes = build_pdf_inline_image_bytes(&content);
     let doc = PdfDocument::from_bytes(bytes).expect("PDF parses");
     let on = render_with_pipeline(&doc, true);
-    // Pin the gap: the page must be all white. If a future wave wires
-    // up InlineImage rendering and forgets to route the fill through
-    // the pipeline, this stops being all-white at the centre and the
-    // pin fires.
     let (r, g, b, _a) = center_pixel(&on);
     assert_eq!(
         (r, g, b),
-        (255, 255, 255),
-        "inline ImageMask currently goes unrendered (renderer gap); \
-         WAVE-3-GAP-INLINE must remain until InlineImage is wired up"
+        (255, 0, 0),
+        "inline ImageMask must paint the current fill colour (red), got ({r}, {g}, {b})"
     );
 }
 
-/// Probe 14 — Inline standard (non-mask) image. Same gap: the renderer
-/// doesn't dispatch `Operator::InlineImage`. Pin all-white centre.
+/// Probe 14 — Inline standard (non-mask) image paints its own sample
+/// data, same as a `Do`-invoked standard image.
 #[test]
-fn qa_inline_standard_image_renderer_gap_pin() {
-    // 1x1 DeviceGray, BPC 8, single byte 0x80 → mid-grey. Without
-    // dispatch, the page is blank.
+fn qa_inline_standard_image_paints_sample_data() {
+    // 1x1 DeviceGray, BPC 8, single byte 0x80 → mid-grey.
     let mut content: Vec<u8> = Vec::new();
     content.extend_from_slice(b"q\n80 0 0 80 10 10 cm\n");
     content.extend_from_slice(b"BI /W 1 /H 1 /BPC 8 /CS /G ID ");
@@ -796,8 +777,8 @@ fn qa_inline_standard_image_renderer_gap_pin() {
     let (r, g, b, _a) = center_pixel(&on);
     assert_eq!(
         (r, g, b),
-        (255, 255, 255),
-        "inline standard image currently goes unrendered (renderer gap)"
+        (128, 128, 128),
+        "inline standard image must paint its own sample data (mid-grey), got ({r}, {g}, {b})"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #860.

Two independent bugs, both hiding parts of the same 1-bit-image test page (`images_1bit_grayscale.pdf`, a pdf.js self-labeling grid of 9 boxes — pdf_oxide rendered only 4).

**Bug 1 — non-CCITT 1-bit `/DeviceGray` images were force-fed through the CCITT decompressor.** `PdfImage::to_dynamic_image()` in `src/extractors/images.rs` had a single `bits_per_component == 1 && DeviceGray` branch with no filter check, so it routed *every* such image — including uncompressed (no `/Filter`) and `FlateDecode` ones — through `ccitt_bilevel::decompress_ccitt`. Those buffers are already fully decoded, packed 1-bpp samples, not CCITT-compressed data, so decompression failed and the image was silently dropped by the `?` in `render_image`. `/ImageMask` variants of the same filters were unaffected because they go through a separate direct bit-unpacker in `render_image_mask` — which is why the mask boxes on the test page always rendered fine while the plain-image boxes didn't.

Fix: gate the CCITT path on `self.ccitt_params.is_some()` (set only when the XObject's `/Filter` is really `CCITTFaxDecode`), and unpack the non-CCITT case directly (MSB-first, `ceil(width/8)` bytes per row), folding a `/Decode [1 0]` inversion into the bits the same way the CCITT path already folds `/BlackIs1`.

**Bug 2 — inline images never painted at all.** `Operator::InlineImage { dict, data }` is produced by the content-stream parser and is even classified as a paint operator by `is_paint_operator` (used for knockout-group segmentation) — but the actual operator-execution dispatch in `src/rendering/page_renderer.rs` had no match arm for it, so `BI...ID...EI` images (and inline image masks) were parsed and then silently dropped.

Fix: add a dispatch arm that expands the inline image's abbreviated dictionary keys via the existing `expand_inline_image_dict` helper, wraps the data in a synthetic stream object, and routes it through the same `render_image`/`render_image_mask` functions already used for `Do`-invoked image XObjects.

## Test plan
- [x] `cargo build --features rendering`, `cargo fmt --check`, `cargo clippy --features rendering -- -D warnings` — clean.
- [x] New unit tests (`src/extractors/images.rs`): `uncompressed_1bpc_devicegray_decodes_without_ccitt`, `flate_decoded_1bpc_devicegray_decodes_without_ccitt`, `decode_1_0_inverts_polarity_on_non_ccitt_path` — all pass, hand-built synthetic 8x3 bitmaps with known bit patterns.
- [x] New integration tests (`tests/inline_image_rendering.rs`): `inline_rgb_image_paints_onto_the_page`, `inline_image_mask_paints_with_current_fill_colour` — both pass.
- [x] Corpus regression: `corpus_sig` over the full local corpus (3530 PDFs) — zero-diff between `main` and this branch (expected: this tool measures text-extraction signatures, and this change is purely in the rendering/pixel path, so it's a negative-control confirmation rather than a direct exercise of the fix).
- [x] Visual verification against the real repro file (not committed — CONTRIBUTING.md fixture policy): before, 4 of 9 labeled boxes rendered; after, all 9 render, matching poppler's reference count from the issue.