### PR TITLE
chore(release): v0.3.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to PDFOxide are documented here.
 
+## [0.3.76] - 2026-07-26
+
+> Redaction/editor persistence and rendering-accuracy release: DOM edits and `add_text()` overlays on source-loaded pages now survive `save()` without leaving dangling `/Contents` references; multi-input (DeviceN) Type 0 tint transforms, non-CCITT 1-bit images, and inline images render correctly; CCITT `/ImageMask` XObjects decode instead of misreading compressed data as raw stencil rows; spatial table-cell ownership is corrected at singleton-span and boundary cases; and repeated `search()` calls on the same document are no longer `O(searches × full extraction)`. The Java binding gains PDF/A conversion, completing coverage across every first-party language binding.
+
+### Added
+
+- **PDF/A conversion exposed in the Java binding**, with idiomatic Kotlin/Scala/Clojure facades (`PdfAConverter`, `ConversionResult`/`ConversionAction`/`ActionType`/`ConversionError` in `fyi.oxide.pdf.compliance`) — completes PDF/A conversion coverage across every first-party binding (#948).
+
+### Fixed
+
+**Editor / redaction persistence**
+
+- **`PdfDocument.save()` silently discarded DOM edits (`set_text()`, `remove_element()`, `erase_header()`/`erase_footer()`/`erase_artifacts()`) made to a page loaded from an existing PDF** — the overlay-merge path that reconciles DOM edits back into a page's `/Contents` on save had a defect that dropped the edit entirely; edits made via the DOM API now persist through `save()`/`save_page()` (#940).
+- **A page whose original `/Contents` was already a multi-entry array (ISO 32000-1 §7.7.3.3) kept a dangling reference to its other original streams after destructive redaction** — the merge step that replaces `/Contents` with the redacted stream assumed a single original stream at array position 0; it now replaces every original content reference, keeping only genuine overlay/addition streams. The same defect class was independently hit through two different triggers: `set_text()`/`remove_element()` on a page whose `/Contents` was already an array, and `add_text()` combined with `apply_redactions_destructive()` on the same page (#940, #941, #799).
+- **`add_text()` overlay font registered under the raw font name while the content stream emitted the `map_font_name()`-transformed name**, leaving a dangling `/Tf` resource for bold/italic overlays, generic family names (`Arial`, `sans-serif`), and Symbol/ZapfDingbats — registration now keys off the exact name the `Tf` operator emits, and `/Resources`/`/Resources/Font` are resolved through indirect references (common for pages loaded from existing documents) (#941).
+- **`save_page()` discarded overlay text staged by a prior `save_page()` call on the same page** — `overlay_additions` now accumulates across calls instead of being overwritten (#941).
+
+**Rendering**
+
+- **CCITT Group 3/4 `/ImageMask` XObjects were treated as raw stencil rows instead of decoded** — compressed fax data is now actually decompressed; `DecodeParms`/filter-chain handling, `K < 0` Group 4 semantics, and allocation on oversized/malformed input are also corrected (#935, #939).
+- **Separation/DeviceN colour spaces with a genuinely multi-channel (N>1) Type 0 (sampled) tint transform rendered black or dropped shapes entirely** — the sampled-function evaluator only ever handled a single input dimension, forwarding just the first `scn` operand and silently falling back to `gray = 1 − components[0]`; it now performs full N-dimensional multilinear interpolation across the sample grid (ISO 32000-1 §7.10.2's general algorithm, of which the prior 1-D case is the N=1 special case), gated by a `MAX_SAMPLED_FUNCTION_DIMS = 8` bound against a pathological `/Size` array (#849, #859).
+- **Non-CCITT 1-bit `/DeviceGray` images (uncompressed or `FlateDecode`) were force-fed through the CCITT decompressor and silently dropped when decompression failed** — the CCITT path is now gated on the XObject's filter actually being `CCITTFaxDecode`; the non-CCITT case is unpacked directly, folding `/Decode [1 0]` inversion the same way the CCITT path already does (#860).
+- **Inline images (`BI…ID…EI`) were parsed and classified as a paint operator but never actually painted** — the renderer's operator dispatch had no match arm for `Operator::InlineImage`; it now expands the abbreviated dictionary keys and routes through the same `render_image`/`render_image_mask` path used for `Do`-invoked image XObjects (#860).
+- **Spatial table-cell ownership misattributed text near cell boundaries** — stale per-glyph offsets outside a text span's bounding box are now rejected for singleton spans, and exact half-open internal grid intervals keep superscripts and boundary-adjacent text in their correct geometric cell; outer-edge tolerance near the table boundary is unchanged (#937, #938).
+
+### Performance
+
+- **Repeated `search()`/`search_page()` calls on the same document re-extracted and re-postprocessed every page's full spans on every call** — a multi-pattern scan over one document cost `O(searches × full extraction)` with no benefit from repetition, since the existing span cache is bounded to 8 entries. An unbounded, lighter-weight per-page search index (page text + span bounding boxes only, no font/glyph data) is now built lazily on first use and reused across calls; `prepare_search()`/`clear_search_index()` give callers control over eager population and memory reclamation. Measured: repeat `search()` calls on a 60-page document dropped from ~30ms to ~20-50µs per call after the first (#936).
+
+### Changed / Dependencies
+
+- Test/CI stability: two `ocr`-feature-gated CCITT diagnostic test files still called `fax` 0.2's `u16` `decode_g4` signature after the crate's 0.3 API bump (`u32`), breaking `cargo clippy --all-targets --features rendering,barcodes,signatures,ocr` — exactly the combo CONTRIBUTING.md's recommended pre-commit hook uses (#945).
+
+### Contributors
+
+Rendering fixes from **@Goldziher** — CCITT `/ImageMask` decoding (#935, #939) and spatial table-cell ownership (#937, #938). Redaction/overlay persistence from **@thomnico** — the `add_text()`/destructive-redaction interaction (#941, #799, superseding an earlier iteration). Thank you!
+
+Issues reported by:
+
+- **@lightedlogic** — #940 (`save()` doesn't persist DOM edits made via `set_text()`/`remove_element()`)
+- **@ankursri494** — #936 (repeated `search()` calls on the same document don't get faster)
+- **@ultrasaurus** — #945 (recommended pre-commit hook fails on `main`)
+- **@bfchiheb** — #947 (PDF/A conversion missing from the Java binding)
+
 ## [0.3.75] - 2026-07-23
 
 > Rendering-accuracy and extraction-fidelity release. DeviceCMYK now renders through measured process inks; page rotation (including `/Rotate 270` and negative values) and Separation/DeviceN tint transforms are honoured; inline images and CMYK/CCITT image decoding are corrected; Form-XObject text no longer goes missing; Tagged PDFs can be read in structure order; and a large text-extraction performance pass lands, alongside a dependency modernization (rustybuzz→harfrust, office_oxide 0.1.8).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "aes",
  "aws-lc-rs",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_cli"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "clap",
  "is-terminal",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_jni"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "jni",
  "pdf_oxide",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide_mcp"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "pdf_oxide",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ manual_checked_ops = "allow"
 
 [package]
 name = "pdf_oxide"
-version = "0.3.75"
+version = "0.3.76"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85

--- a/clojure/deps.edn
+++ b/clojure/deps.edn
@@ -4,7 +4,7 @@
 ;; Java NativeLoader resolves the JNI cdylib via the `fyi.oxide.pdf.lib.path`
 ;; system property (pointed at the freshly built libpdf_oxide_jni below).
 {:paths ["src"]
- :deps {fyi.oxide/pdf-oxide {:mvn/version "0.3.75"}}
+ :deps {fyi.oxide/pdf-oxide {:mvn/version "0.3.76"}}
  :aliases
  {:test
   {:extra-paths ["test"]

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(pdf_oxide_cpp VERSION 0.3.75 LANGUAGES CXX)
+project(pdf_oxide_cpp VERSION 0.3.76 LANGUAGES CXX)
 
 # Idiomatic C++17 RAII bindings over the pdf_oxide C ABI (header-only wrapper).
 #

--- a/csharp/PdfOxide/PdfOxide.csproj
+++ b/csharp/PdfOxide/PdfOxide.csproj
@@ -19,7 +19,7 @@
     <!-- NuGet Package Configuration -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>PdfOxide</PackageId>
-    <Version>0.3.75</Version>
+    <Version>0.3.76</Version>
     <Title>PdfOxide</Title>
     <Authors>pdf_oxide Contributors</Authors>
     <Company>pdf_oxide Project</Company>

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_oxide
 description: The fastest Dart/Flutter PDF library — 5× faster than the industry leaders, 100% pass rate on 3,830 PDFs. Text, Markdown & HTML extraction plus PDF creation via dart:ffi.
-version: 0.3.75
+version: 0.3.76
 repository: https://github.com/yfedoseev/pdf_oxide
 homepage: https://github.com/yfedoseev/pdf_oxide
 issue_tracker: https://github.com/yfedoseev/pdf_oxide/issues

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule PdfOxide.MixProject do
   def project do
     [
       app: :pdf_oxide,
-      version: "0.3.75",
+      version: "0.3.76",
       elixir: "~> 1.15",
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],

--- a/go/cmd/install/main.go
+++ b/go/cmd/install/main.go
@@ -52,7 +52,7 @@ const (
 	// taken from the build info and THIS constant is irrelevant. That's what
 	// lets `@latest` just work — each tagged release resolves to its own
 	// version automatically, without a sed step in release automation.
-	fallbackVersion = "0.3.75"
+	fallbackVersion = "0.3.76"
 	BaseURL         = "https://github.com/yfedoseev/pdf_oxide/releases/download"
 	// cacheSubdir lives under os.UserCacheDir() — XDG_CACHE_HOME on Linux,
 	// ~/Library/Caches on macOS (Time-Machine-excluded), %LocalAppData% on

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
                                namespace verification under oxide.fyi)
   artifactId:  pdf-oxide      (the Maven artifact; matches the
                                package fyi.oxide.pdf)
-  version:     0.3.75         (lockstep with Cargo workspace /
+  version:     0.3.76         (lockstep with Cargo workspace /
                                js/package.json / .csproj /
                                pyproject.toml — release-preflight
                                from v0.3.51 #515 enforces parity)
@@ -33,7 +33,7 @@
 
     <groupId>fyi.oxide</groupId>
     <artifactId>pdf-oxide</artifactId>
-    <version>0.3.75</version>
+    <version>0.3.76</version>
     <packaging>jar</packaging>
 
     <name>pdf_oxide — Java binding</name>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/yfedoseev/pdf_oxide.git</connection>
         <developerConnection>scm:git:git@github.com:yfedoseev/pdf_oxide.git</developerConnection>
         <url>https://github.com/yfedoseev/pdf_oxide</url>
-        <tag>v0.3.75</tag>
+        <tag>v0.3.76</tag>
     </scm>
 
     <issueManagement>

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide",
-  "version": "0.3.75",
+  "version": "0.3.76",
   "type": "module",
   "description": "The fastest Node.js PDF library — 0.8ms mean, 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs. Prebuilt native bindings, no build toolchain: text extraction, Markdown/HTML conversion, PDF creation and editing.",
   "main": "lib/index.js",

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "PdfOxide"
 uuid = "b0c1d2e3-4f56-47a8-9b0c-1d2e3f4a5b6c"
 authors = ["Yury Fedoseev <yfedoseev@gmail.com>"]
-version = "0.3.75"
+version = "0.3.76"
 
 [compat]
 Aqua = "0.8"

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "fyi.oxide"
-version = "0.3.75"
+version = "0.3.76"
 
 repositories {
     // mavenLocal first so a freshly `mvn install`-ed Java artifact (dev/CI)
@@ -40,7 +40,7 @@ detekt {
 dependencies {
     // The Java binding owns the JNI bridge; we re-export its types (api scope)
     // so Kotlin callers `import fyi.oxide.pdf.*` and get them transitively.
-    api("fyi.oxide:pdf-oxide:0.3.75")
+    api("fyi.oxide:pdf-oxide:0.3.76")
     testImplementation(kotlin("test"))
 }
 

--- a/objc/PdfOxide.podspec
+++ b/objc/PdfOxide.podspec
@@ -14,7 +14,7 @@
 # rule is added here — that wiring is intentionally left to the release tooling).
 Pod::Spec.new do |spec|
   spec.name         = 'PdfOxide'
-  spec.version      = '0.3.75'
+  spec.version      = '0.3.76'
   spec.summary      = 'The fastest Objective-C PDF library — 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs.'
   spec.description  = <<-DESC
     Objective-C bindings over the pdf_oxide C ABI. NSObject wrappers (POXDocument,

--- a/objc/include/POXPdfOxide.h
+++ b/objc/include/POXPdfOxide.h
@@ -9,7 +9,7 @@
 
 /// Binding version, kept in lock-step with the workspace crate by
 /// scripts/sync_version.py (the single source of truth is Cargo.toml).
-#define POX_PDF_OXIDE_VERSION "0.3.75"
+#define POX_PDF_OXIDE_VERSION "0.3.76"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/pdf_oxide_cli/Cargo.toml
+++ b/pdf_oxide_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_cli"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2021"
 description = "CLI for pdf-oxide — the fastest PDF toolkit. 22 commands: text extraction, PDF to markdown, search, merge, split, images, compress, encrypt, watermark, forms, and more."
 license = "MIT OR Apache-2.0"
@@ -34,7 +34,7 @@ workspace = true
 ocr = ["pdf_oxide/ocr"]
 
 [dependencies]
-pdf_oxide = { version = "0.3.75", path = "..", features = ["rendering", "logging"] }
+pdf_oxide = { version = "0.3.76", path = "..", features = ["rendering", "logging"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 serde_json = "1.0"

--- a/pdf_oxide_jni/Cargo.toml
+++ b/pdf_oxide_jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_jni"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2021"
 description = "JNI bindings for pdf_oxide — native Java binding, the 8th surface alongside Python/Go/JS/C#/WASM/CLI/MCP. Loaded by the fyi.oxide:pdf-oxide Maven artifact."
 license = "MIT OR Apache-2.0"
@@ -93,7 +93,7 @@ jni = "0.22"
 # opt-in FIPS 140-3 build) — those two are compile-time mutually
 # exclusive (pdf_oxide enforces via compile_error!). We always
 # enable `icc` for ICC-based colour management.
-pdf_oxide = { version = "0.3.75", path = "..", default-features = false, features = ["icc"] }
+pdf_oxide = { version = "0.3.76", path = "..", default-features = false, features = ["icc"] }
 
 # JSON envelope for the v0.3.51 AutoExtractor rich-result path. The
 # Java side gets the PageExtraction / DocumentExtraction as a JSON

--- a/pdf_oxide_mcp/Cargo.toml
+++ b/pdf_oxide_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdf_oxide_mcp"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2021"
 description = "MCP server for PDF extraction — gives Claude, Cursor, and AI assistants the ability to read PDFs locally. Text, markdown, and HTML output. Powered by pdf_oxide."
 license = "MIT OR Apache-2.0"
@@ -19,7 +19,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-pdf_oxide = { version = "0.3.75", path = ".." }
+pdf_oxide = { version = "0.3.76", path = ".." }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/php/scripts/download-native-lib.php
+++ b/php/scripts/download-native-lib.php
@@ -37,7 +37,7 @@ declare(strict_types=1);
  *   - Set `PDF_OXIDE_NATIVE_VERSION=vX.Y.Z` to pin a specific release.
  */
 
-const PACKAGE_VERSION_DEFAULT = 'v0.3.75';
+const PACKAGE_VERSION_DEFAULT = 'v0.3.76';
 const RELEASE_BASE_URL = 'https://github.com/yfedoseev/pdf_oxide/releases/download';
 // Path is relative to the package root (parent-of-php in the new
 // root-composer.json layout); see comment on $packageRoot below.
@@ -253,12 +253,12 @@ function downloadFile(string $url, string $dest): bool
         'http' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.75',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.76',
         ],
         'https' => [
             'follow_location' => 1,
             'timeout' => 60,
-            'user_agent' => 'pdf_oxide-php-installer/0.3.75',
+            'user_agent' => 'pdf_oxide-php-installer/0.3.76',
         ],
     ]);
     $data = @file_get_contents($url, false, $ctx);

--- a/php/src/Pdf.php
+++ b/php/src/Pdf.php
@@ -152,7 +152,7 @@ final class Pdf
      * pdf_oxide library version. Kept in sync with `Cargo.toml` by the
      * release tooling (see `docs/releases/RELEASE_PROCESS.md`).
      */
-    public const VERSION = '0.3.75';
+    public const VERSION = '0.3.76';
 
     /** Whether OCR-model prefetch + cache are available on this build. */
     public static function prefetchAvailable(): bool

--- a/php/tests/Integration/CoreParityTest.php
+++ b/php/tests/Integration/CoreParityTest.php
@@ -92,6 +92,6 @@ final class CoreParityTest extends IntegrationTestCase
 
     public function testVersionConstant(): void
     {
-        $this->assertSame('0.3.75', Pdf::VERSION);
+        $this->assertSame('0.3.76', Pdf::VERSION);
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pdf_oxide"
-version = "0.3.75"
+version = "0.3.76"
 description = "The fastest Python PDF library — 0.8ms mean, 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs. Text extraction, Markdown/HTML conversion, PDF creation and editing."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_core_parity.py
+++ b/python/tests/test_core_parity.py
@@ -82,4 +82,4 @@ def test_open_error():
 
 
 def test_version():
-    assert pdf_oxide.VERSION == "0.3.75"
+    assert pdf_oxide.VERSION == "0.3.76"

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pdfoxide
 Type: Package
 Title: Fast PDF Text, Markdown and HTML Extraction (pdf_oxide)
-Version: 0.3.75
+Version: 0.3.76
 Authors@R: person("Yury", "Fedoseev", email = "yfedoseev@gmail.com", role = c("aut", "cre"))
 Author: Yury Fedoseev [aut, cre]
 Maintainer: Yury Fedoseev <yfedoseev@gmail.com>

--- a/ruby/lib/pdf_oxide/version.rb
+++ b/ruby/lib/pdf_oxide/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PdfOxide
-  VERSION = '0.3.75'
+  VERSION = '0.3.76'
 end

--- a/ruby/spec/cdylib_smoke_spec.rb
+++ b/ruby/spec/cdylib_smoke_spec.rb
@@ -11,7 +11,7 @@ require 'tmpdir'
 RSpec.describe 'libpdf_oxide cdylib smoke' do
   it 'loads the gem with the expected version' do
     expect(defined?(PdfOxide)).to eq('constant')
-    expect(PdfOxide::VERSION).to eq('0.3.75')
+    expect(PdfOxide::VERSION).to eq('0.3.76')
   end
 
   it 'exposes every public-API class' do

--- a/ruby/spec/core_parity_spec.rb
+++ b/ruby/spec/core_parity_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'core parity (Ruby)' do
     expect { PdfOxide::PdfDocument.open('/no/such/file/does/not/exist.pdf') }.to raise_error(StandardError)
   end
 
-  it 'exposes version 0.3.75' do
-    expect(PdfOxide::VERSION).to eq('0.3.75')
+  it 'exposes version 0.3.76' do
+    expect(PdfOxide::VERSION).to eq('0.3.76')
   end
 end

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -4,7 +4,7 @@
 // (Optional -> Option, java.util.List -> Seq, Using on AutoCloseable handles).
 ThisBuild / organization := "fyi.oxide"
 ThisBuild / organizationName := "PDF Oxide"
-ThisBuild / version := "0.3.75"
+ThisBuild / version := "0.3.76"
 ThisBuild / scalaVersion := "3.3.4"
 
 // scalafix needs SemanticDB. On Scala 3 it's emitted by the compiler itself
@@ -37,7 +37,7 @@ lazy val root = (project in file("."))
     description := "Idiomatic Scala 3 bindings for pdf_oxide — a thin facade over the fyi.oxide:pdf-oxide Java binding (JNI).",
     resolvers += Resolver.mavenLocal, // resolve the locally-installed Java artifact during dev/CI
     libraryDependencies ++= Seq(
-      "fyi.oxide" % "pdf-oxide" % "0.3.75",
+      "fyi.oxide" % "pdf-oxide" % "0.3.76",
       "org.scalatest" %% "scalatest" % "3.2.19" % Test
     ),
     // The Java NativeLoader resolves the JNI cdylib via this property; override

--- a/tests/core_parity.rs
+++ b/tests/core_parity.rs
@@ -93,5 +93,5 @@ fn open_error() {
 
 #[test]
 fn version() {
-    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.75");
+    assert_eq!(env!("CARGO_PKG_VERSION"), "0.3.76");
 }

--- a/uv.lock
+++ b/uv.lock
@@ -2254,7 +2254,7 @@ wheels = [
 
 [[package]]
 name = "pdf-oxide"
-version = "0.3.75"
+version = "0.3.76"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/wasm-pkg/package.json
+++ b/wasm-pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-oxide-wasm",
-  "version": "0.3.75",
+  "version": "0.3.76",
   "description": "The fastest WebAssembly PDF library — 0.8ms mean, 5× faster than the industry leaders, 100% pass rate on 3,830 real-world PDFs. Zero-dependency for Node.js, browsers, and edge runtimes: text extraction, Markdown/HTML conversion, search, form filling, creation, and editing.",
   "license": "MIT OR Apache-2.0",
   "repository": {

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .pdf_oxide,
-    .version = "0.3.75",
+    .version = "0.3.76",
     .fingerprint = 0x991319f35cdc7f8a,
     .minimum_zig_version = "0.15.0",
     .paths = .{


### PR DESCRIPTION
## Summary

Version bump 0.3.75 → 0.3.76 across every workspace crate and language-binding manifest (Rust, Python, JS/WASM, Java/Kotlin/Scala/Clojure, C#, C++, Go, PHP, R, Ruby, Dart, Elixir, Zig, Objective-C, Julia), plus the core-parity test assertions that pin the version string, and a new CHANGELOG.md entry.

Covers everything merged to `main` since v0.3.75:

- **#940/#941** — `save()` no longer discards DOM edits or `add_text()` overlays made to source-loaded pages; multi-stream `/Contents` no longer left with a dangling reference after destructive redaction; overlay font registration and `save_page()` accumulation fixed (#942, #943 — thanks @thomnico)
- **#935/#937** — CCITT `/ImageMask` decoding and spatial table-cell ownership fixed (thanks @Goldziher)
- **#936** — repeated `search()` calls on the same document no longer re-extract the whole document every time (perf)
- **#859/#860** — multi-input DeviceN Type 0 tint transforms, non-CCITT 1-bit images, and inline images now render correctly
- **#945** — CI-hygiene fix for the recommended pre-commit hook (thanks @ultrasaurus for reporting)
- **#947** — PDF/A conversion exposed in the Java binding + Kotlin/Scala/Clojure facades (thanks @bfchiheb for the feature request)

Full details in [CHANGELOG.md](https://github.com/yfedoseev/pdf_oxide/blob/release/v0.3.76/CHANGELOG.md#0376---2026-07-26).

## Regression testing

Word-level Jaccard similarity comparison (text/markdown/html extraction) between v0.3.75 and this branch, across a 419-PDF corpus:

- **text**: 411/419 byte-identical
- **markdown**: 410/419 byte-identical
- **html**: 410/419 byte-identical

Every one of the ~9 changed cases traces to the #937 table/span cell-ownership fix and is a correctness improvement, not a regression — e.g. a country/flag table row that previously mis-paired "Indonesia" with the Vatican flag (🇻🇦) now correctly reads "Indonesia 🇮🇩", and a garbled Arabic paragraph (`وااللأسود مونر`) now extracts as grammatically correct text (`الأسود والنمور`). Zero word-fusions, zero dropped content, zero new garbling anywhere in the corpus.

## Test plan

- [x] `cargo check --workspace` clean, `Cargo.lock` regenerated
- [x] Version bumped consistently across all 30+ manifest files (verified no stray `0.3.75` references remain outside CHANGELOG.md history and two unrelated historical code comments)
- [x] 419-PDF word-Jaccard regression sweep — zero regressions, see above