### PR TITLE
fix(965): remove_footers should persist when saving a file

### DIFF
--- a/src/editor/document_editor.rs
+++ b/src/editor/document_editor.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides the DocumentEditor type for modifying PDF documents.
 
+use crate::cache::MutexExt;
 use crate::document::PdfDocument;
 use crate::editor::form_fields::FormFieldWrapper;
 use crate::editor::resource_manager::ResourceManager;
@@ -480,8 +481,19 @@ pub struct DocumentEditor {
     modified_annotations: HashMap<usize, Vec<crate::editor::dom::AnnotationWrapper>>,
     /// Modified page properties (rotation, boxes)
     modified_page_props: HashMap<usize, ModifiedPageProps>,
-    /// Erase regions per page (whiteout overlays)
+    /// Erase regions per page (whiteout overlays). Populated by the public
+    /// `erase_region`/`erase_regions` API (cosmetic-only, by contract — see
+    /// their doc comments) AND, for any rect also present in
+    /// `inherited_erase_regions`, as the default/fallback rendering for a
+    /// region inherited via `from_document` until/unless save-time
+    /// destructive redaction removes it.
     erase_regions: HashMap<usize, Vec<[f32; 4]>>,
+    /// Regions inherited via `from_document` (see its doc comment) that
+    /// save-time destructive redaction should attempt to actually remove.
+    /// Kept separate from `erase_regions` so a direct caller of the public
+    /// `erase_region`/`erase_regions` API — which is documented as
+    /// cosmetic-only — is never silently upgraded to real content removal.
+    inherited_erase_regions: HashMap<usize, Vec<[f32; 4]>>,
     /// Pages where annotations should be flattened
     flatten_annotations_pages: std::collections::HashSet<usize>,
     /// Pages where redactions should be applied
@@ -509,6 +521,10 @@ pub struct DocumentEditor {
     remove_acroform: bool,
     /// Warnings collected during form flattening (e.g. widgets with no /AP stream)
     flatten_warnings: Vec<String>,
+    /// Structured warnings collected during editing/save (distinct from
+    /// `flatten_warnings`, which predates this and is a `&[String]`
+    /// form-flattening-only log — see [`Self::structured_warnings`]).
+    structured_warnings: Vec<crate::extractors::warnings::Warning>,
     /// Embedded files to add to the document
     embedded_files: Vec<crate::writer::EmbeddedFile>,
     /// Modified or new form fields (field name → wrapper)
@@ -628,6 +644,7 @@ impl DocumentEditor {
             modified_annotations: HashMap::new(),
             modified_page_props: HashMap::new(),
             erase_regions: HashMap::new(),
+            inherited_erase_regions: HashMap::new(),
             flatten_annotations_pages: std::collections::HashSet::new(),
             apply_redactions_pages: std::collections::HashSet::new(),
             redaction_regions: HashMap::new(),
@@ -637,6 +654,7 @@ impl DocumentEditor {
             flatten_forms_pages: std::collections::HashSet::new(),
             remove_acroform: false,
             flatten_warnings: Vec::new(),
+            structured_warnings: Vec::new(),
             embedded_files: Vec::new(),
             modified_form_fields: HashMap::new(),
             deleted_form_fields: HashSet::new(),
@@ -646,10 +664,38 @@ impl DocumentEditor {
     }
 
     /// Open a PDF document for editing from an existing PdfDocument object.
+    ///
+    /// Any regions already staged via `source.erase_region()` (e.g. by
+    /// `remove_headers`/`remove_footers`/`remove_artifacts`) are carried
+    /// over so they aren't silently lost — see [`Self::save_to_bytes`] for
+    /// how they're actually applied. This step is a plain data copy, so it
+    /// cannot fail: staging a region never makes `from_document` itself
+    /// fallible, even for a page whose redaction will later be refused.
     pub fn from_document(mut source: PdfDocument) -> Result<Self> {
         let page_count = source.page_count()?;
         let next_id = Self::find_max_object_id(&source) + 1;
         let page_order: Vec<i32> = (0..page_count as i32).collect();
+
+        // Capture staged erase regions before `source` moves into `Self`.
+        // Populate BOTH fields: `erase_regions` so the region renders as its
+        // existing cosmetic overlay by default (same as any other overlay
+        // entry) until/unless save-time redaction removes it, and
+        // `inherited_erase_regions` as the marker that this particular
+        // region — unlike one a caller adds directly via the public
+        // `erase_region`/`erase_regions` API — is eligible for that
+        // destructive upgrade at save time.
+        let inherited: HashMap<usize, Vec<[f32; 4]>> = source
+            .erase_regions
+            .lock_or_recover()
+            .iter()
+            .map(|(&page, rects)| {
+                let converted = rects
+                    .iter()
+                    .map(|r| [r.x, r.y, r.x + r.width, r.y + r.height])
+                    .collect();
+                (page, converted)
+            })
+            .collect();
 
         Ok(Self {
             source,
@@ -667,7 +713,8 @@ impl DocumentEditor {
             structure_modified: false,
             modified_annotations: HashMap::new(),
             modified_page_props: HashMap::new(),
-            erase_regions: HashMap::new(),
+            erase_regions: inherited.clone(),
+            inherited_erase_regions: inherited,
             flatten_annotations_pages: std::collections::HashSet::new(),
             apply_redactions_pages: std::collections::HashSet::new(),
             redaction_regions: HashMap::new(),
@@ -677,6 +724,7 @@ impl DocumentEditor {
             flatten_forms_pages: std::collections::HashSet::new(),
             remove_acroform: false,
             flatten_warnings: Vec::new(),
+            structured_warnings: Vec::new(),
             embedded_files: Vec::new(),
             modified_form_fields: HashMap::new(),
             deleted_form_fields: HashSet::new(),
@@ -712,6 +760,7 @@ impl DocumentEditor {
             modified_annotations: HashMap::new(),
             modified_page_props: HashMap::new(),
             erase_regions: HashMap::new(),
+            inherited_erase_regions: HashMap::new(),
             flatten_annotations_pages: std::collections::HashSet::new(),
             apply_redactions_pages: std::collections::HashSet::new(),
             redaction_regions: HashMap::new(),
@@ -721,6 +770,7 @@ impl DocumentEditor {
             flatten_forms_pages: std::collections::HashSet::new(),
             remove_acroform: false,
             flatten_warnings: Vec::new(),
+            structured_warnings: Vec::new(),
             embedded_files: Vec::new(),
             modified_form_fields: HashMap::new(),
             deleted_form_fields: HashSet::new(),
@@ -1888,6 +1938,74 @@ impl DocumentEditor {
         // silently produces a structurally valid but unreadable PDF.
         if self.source.is_encrypted() && !self.source.is_authenticated() {
             return Err(Error::EncryptedPdf);
+        }
+
+        // Apply any regions inherited via `from_document`, now as real,
+        // destructive redactions. If a page's redaction is refused, leave
+        // that page's cosmetic overlay in place as a fallback, other errors
+        // still fail the save.
+        if !self.inherited_erase_regions.is_empty() {
+            let staged: Vec<(usize, Vec<[f32; 4]>)> = self
+                .inherited_erase_regions
+                .iter()
+                .map(|(&page, rects)| (page, rects.clone()))
+                .collect();
+            let redact_opts = crate::redaction::RedactionOptions {
+                draw_overlay_when_no_ic: false,
+                ..crate::redaction::RedactionOptions::default()
+            };
+            for (source_page, rects) in staged {
+                let entry = self.redaction_regions.entry(source_page).or_default();
+                let before_len = entry.len();
+                for rect in &rects {
+                    entry.push(crate::redaction::RedactionRegion::from_rect(
+                        rect[0], rect[1], rect[2], rect[3], None,
+                    ));
+                }
+                let was_already_queued = self.apply_redactions_pages.contains(&source_page);
+                self.apply_redactions_pages.insert(source_page);
+
+                match self.apply_redactions_destructive_for_page(source_page, &redact_opts) {
+                    Ok(_) => {
+                        // Removal succeeded — drop exactly these rects from
+                        // the cosmetic-overlay field, leaving any rect a
+                        // caller added directly via the public
+                        // `erase_region`/`erase_regions` API untouched.
+                        if let Some(v) = self.erase_regions.get_mut(&source_page) {
+                            v.retain(|r| !rects.contains(r));
+                            if v.is_empty() {
+                                self.erase_regions.remove(&source_page);
+                            }
+                        }
+                    },
+                    Err(Error::Unsupported(reason)) => {
+                        // Refused. Undo exactly what this step added,
+                        // any caller-supplied redaction_regions/
+                        // apply_redactions_pages state is untouched, and
+                        // keep the cosmetic overlay as the fallback.
+                        if let Some(v) = self.redaction_regions.get_mut(&source_page) {
+                            v.truncate(before_len);
+                            if v.is_empty() {
+                                self.redaction_regions.remove(&source_page);
+                            }
+                        }
+                        if !was_already_queued {
+                            self.apply_redactions_pages.remove(&source_page);
+                        }
+                        self.structured_warnings.push(crate::extractors::warnings::Warning {
+                            category:
+                                crate::extractors::warnings::WarningCategory::RedactionOverlayFallback,
+                            page: Some(source_page),
+                            message: format!(
+                                "staged erasure could not be applied as a destructive \
+                                 redaction, falling back to a cosmetic overlay: {reason}"
+                            ),
+                            spec_section: None,
+                        });
+                    },
+                    Err(e) => return Err(e),
+                }
+            }
         }
 
         /// Compress a stream object with FlateDecode if it has no filter yet.
@@ -4943,6 +5061,13 @@ impl DocumentEditor {
     /// could not have one generated — flattening it produces a blank rectangle.
     pub fn flatten_warnings(&self) -> &[String] {
         &self.flatten_warnings
+    }
+
+    /// Structured warnings collected during editing/save
+    /// Distinct from [`Self::flatten_warnings`],
+    /// which predates this and only covers form flattening.
+    pub fn structured_warnings(&self) -> &[crate::extractors::warnings::Warning] {
+        &self.structured_warnings
     }
 
     /// Rebuild an AcroForm dict containing only root fields that still have at

--- a/src/extractors/warnings.rs
+++ b/src/extractors/warnings.rs
@@ -60,6 +60,11 @@ pub enum WarningCategory {
     /// A glyph produced no rendered output while the cursor still advanced,
     /// so the page renders with an invisible gap.
     GlyphDropped,
+    /// A staged erasure region could not be applied as a real, destructive
+    /// redaction (e.g. an unsupported composite font) and fell back to a
+    /// cosmetic overlay instead — the underlying content is still present
+    /// and extractable in the saved file.
+    RedactionOverlayFallback,
 }
 
 impl WarningCategory {
@@ -76,6 +81,7 @@ impl WarningCategory {
             Self::Font => "font",
             Self::Layout => "layout",
             Self::GlyphDropped => "glyph_dropped",
+            Self::RedactionOverlayFallback => "redaction_overlay_fallback",
         }
     }
 }

--- a/tests/erase_persistence_save_path.rs
+++ b/tests/erase_persistence_save_path.rs
@@ -1,0 +1,317 @@
+//! #965: erasure staged on a `PdfDocument` (via `erase_region`,
+//! `remove_headers`/`remove_footers`/`remove_artifacts`) must survive a
+//! `DocumentEditor` save. Checking the in-memory editor state after save
+//! proves nothing about the bytes actually written, so every assertion
+//! here re-parses the saved output before checking it.
+//!
+//! Design invariants under test:
+//! - `DocumentEditor::from_document` only carries staged regions across; it
+//!   never performs content-stream rewriting itself, so it cannot fail in
+//!   any new way just because regions are staged — even on a page whose
+//!   redaction will later be refused.
+//! - Actual removal happens during save. Where it can be done safely, the
+//!   saved file has the region genuinely gone (not just visually covered).
+//! - Where removal can't be done safely, save still succeeds: the region
+//!   falls back to a visual overlay and a structured warning is recorded
+//!   rather than the save silently doing nothing or hard-erroring.
+
+use pdf_oxide::editor::DocumentEditor;
+use pdf_oxide::extractors::warnings::WarningCategory;
+use pdf_oxide::geometry::Rect;
+use pdf_oxide::PdfDocument;
+
+struct Run {
+    x: f32,
+    y: f32,
+    text: &'static str,
+    codes: &'static [u16],
+}
+
+/// Minimal Type0 PDF using the given predefined CMap name (`Identity-H` or
+/// `Identity-V`). Each glyph advances 12pt (W=1000 at 12 Tf); `/ToUnicode`
+/// maps every CID to its scalar so the run is extractable either way.
+fn type0_pdf(encoding: &str, runs: &[Run]) -> Vec<u8> {
+    let mut content = String::new();
+    for r in runs {
+        let hex: String = r.codes.iter().map(|c| format!("{c:04X}")).collect();
+        content.push_str(&format!("BT /F1 12 Tf 1 0 0 1 {:.1} {:.1} Tm <{hex}> Tj ET\n", r.x, r.y));
+    }
+    let mut pairs: Vec<(u16, char)> = Vec::new();
+    for r in runs {
+        for (code, ch) in r.codes.iter().zip(r.text.chars()) {
+            pairs.push((*code, ch));
+        }
+    }
+    let mut bf = String::new();
+    for (code, ch) in &pairs {
+        bf.push_str(&format!("<{code:04X}> <{:04X}>\n", *ch as u32));
+    }
+    let tounicode = format!(
+        "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n\
+         /CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n\
+         1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+         {} beginbfchar\n{}endbfchar\nendcmap\nCMapName currentdict /CMap defineresource pop\nend\nend",
+        pairs.len(),
+        bf
+    );
+    let mut w = String::new();
+    for (code, _) in &pairs {
+        w.push_str(&format!("{code} [1000] "));
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = [0usize; 9];
+    buf.extend_from_slice(b"%PDF-1.7\n");
+    let mut obj = |buf: &mut Vec<u8>, id: usize, body: String| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    obj(&mut buf, 1, "<< /Type /Catalog /Pages 2 0 R >>".into());
+    obj(&mut buf, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into());
+    obj(
+        &mut buf,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .into(),
+    );
+    obj(
+        &mut buf,
+        4,
+        format!("<< /Length {} >>\nstream\n{content}endstream", content.len()),
+    );
+    obj(
+        &mut buf,
+        5,
+        format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /IDFix /Encoding /{encoding} \
+             /DescendantFonts [6 0 R] /ToUnicode 7 0 R >>"
+        ),
+    );
+    obj(
+        &mut buf,
+        6,
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /IDFix \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             /FontDescriptor 8 0 R /DW 1000 /W [ {w}] /CIDToGIDMap /Identity >>"
+        ),
+    );
+    obj(
+        &mut buf,
+        7,
+        format!("<< /Length {} >>\nstream\n{tounicode}\nendstream", tounicode.len() + 1),
+    );
+    obj(
+        &mut buf,
+        8,
+        "<< /Type /FontDescriptor /FontName /IDFix /Flags 4 \
+         /FontBBox [0 -200 1000 800] /ItalicAngle 0 /Ascent 800 /Descent -200 \
+         /CapHeight 700 /StemV 80 >>"
+            .into(),
+    );
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 9\n0000000000 65535 f \n");
+    for id in 1..=8 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 9 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+fn body_and_footer_runs() -> Vec<Run> {
+    vec![
+        Run {
+            x: 100.0,
+            y: 700.0,
+            text: "BODY",
+            codes: &[1, 2, 3, 4],
+        },
+        Run {
+            x: 100.0,
+            y: 40.0,
+            text: "FOOTER",
+            codes: &[5, 6, 7, 8, 9, 10],
+        },
+    ]
+}
+
+/// `from_document` must stay infallible with staged erasures even on a page
+/// whose redaction will later be refused (Identity-V — vertical writing,
+/// not decodable by the box-based redaction engine, ISO 32000-1 §9.7.5.2).
+/// Construction only copies region data; it never runs the fallible
+/// content-stream rewrite, so nothing about the region's later fate can
+/// make this call fail.
+#[test]
+fn from_document_stays_infallible_when_page_redaction_will_be_refused() {
+    let runs = body_and_footer_runs();
+    let src = type0_pdf("Identity-V", &runs);
+    let doc = PdfDocument::from_bytes(src).expect("open source document");
+    doc.erase_region(
+        0,
+        Rect {
+            x: 90.0,
+            y: 30.0,
+            width: 200.0,
+            height: 20.0,
+        },
+    )
+    .expect("stage erasure");
+
+    let editor = DocumentEditor::from_document(doc);
+    assert!(
+        editor.is_ok(),
+        "from_document must not fail just because a staged region will later \
+         be refused at save time: {:?}",
+        editor.err()
+    );
+}
+
+/// Staged erasure that redaction *can* handle safely must be genuinely gone
+/// from the saved bytes — not merely absent from the in-memory editor.
+/// Re-parses the saved output rather than trusting anything checked before
+/// save. Also asserts the untouched body text is not collateral damage.
+#[test]
+fn erasure_on_redactable_page_is_gone_after_save_and_reparse() {
+    let runs = body_and_footer_runs();
+    let src = type0_pdf("Identity-H", &runs);
+    let doc = PdfDocument::from_bytes(src).expect("open source document");
+    // Footer run sits on baseline y=40; box covers just that run.
+    doc.erase_region(
+        0,
+        Rect {
+            x: 90.0,
+            y: 30.0,
+            width: 200.0,
+            height: 20.0,
+        },
+    )
+    .expect("stage erasure");
+
+    let mut editor = DocumentEditor::from_document(doc).expect("from_document");
+    let saved = editor.save_to_bytes().expect("save_to_bytes");
+
+    let reopened = PdfDocument::from_bytes(saved).expect("reopen saved bytes");
+    let text = reopened
+        .extract_text(0)
+        .expect("extract_text on reopened doc");
+
+    assert!(!text.contains("FOOTER"), "footer must be gone from saved bytes, got: {text:?}");
+    assert!(text.contains("BODY"), "body text must survive, got: {text:?}");
+}
+
+/// Where safe removal is refused (Identity-V), save must still succeed —
+/// falling back to a visual overlay rather than erroring the whole save —
+/// and must record a structured warning so the caller can detect the
+/// degraded case instead of silently getting a file that still extracts
+/// the "removed" text.
+#[test]
+fn save_falls_back_to_overlay_and_warns_when_page_redaction_is_refused() {
+    let runs = body_and_footer_runs();
+    let src = type0_pdf("Identity-V", &runs);
+    let doc = PdfDocument::from_bytes(src).expect("open source document");
+    doc.erase_region(
+        0,
+        Rect {
+            x: 90.0,
+            y: 30.0,
+            width: 200.0,
+            height: 20.0,
+        },
+    )
+    .expect("stage erasure");
+
+    let mut editor = DocumentEditor::from_document(doc).expect("from_document");
+    let saved = editor.save_to_bytes();
+    assert!(
+        saved.is_ok(),
+        "save must succeed even when a page's redaction is refused \
+         (degrade to overlay, never hard-fail the whole save): {:?}",
+        saved.err()
+    );
+
+    let warnings = editor.structured_warnings();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.category == WarningCategory::RedactionOverlayFallback),
+        "expected a RedactionOverlayFallback warning when redaction is \
+         refused and the page falls back to a cosmetic overlay, got: {warnings:?}"
+    );
+}
+
+/// A region inherited via `from_document` and a region added directly by a
+/// caller via the public `erase_region` API, on the same page, must not be
+/// conflated in either direction: the inherited region is eligible for
+/// destructive removal at save time, but a direct `erase_region` call is
+/// documented as cosmetic-only and must stay that way even when the same
+/// page also has an inherited region that DOES get destructively removed.
+#[test]
+fn inherited_and_direct_erase_regions_on_same_page_are_handled_independently() {
+    let runs = vec![
+        Run {
+            x: 100.0,
+            y: 700.0,
+            text: "BODY",
+            codes: &[1, 2, 3, 4],
+        },
+        Run {
+            x: 100.0,
+            y: 40.0,
+            text: "FOOTER",
+            codes: &[5, 6, 7, 8, 9, 10],
+        },
+        Run {
+            x: 300.0,
+            y: 40.0,
+            text: "DIRECT",
+            codes: &[11, 12, 13, 14, 15, 16],
+        },
+    ];
+    let src = type0_pdf("Identity-H", &runs);
+    let doc = PdfDocument::from_bytes(src).expect("open source document");
+    // Stage the FOOTER region on the PdfDocument itself, as remove_footers
+    // would — this is what `from_document` inherits.
+    doc.erase_region(
+        0,
+        Rect {
+            x: 90.0,
+            y: 30.0,
+            width: 200.0,
+            height: 20.0,
+        },
+    )
+    .expect("stage erasure");
+
+    let mut editor = DocumentEditor::from_document(doc).expect("from_document");
+    // DIRECT region added AFTER from_document, via the public cosmetic-only
+    // API — distinct rect from the inherited one, same page.
+    editor
+        .erase_region(0, [290.0, 30.0, 420.0, 50.0])
+        .expect("direct erase_region");
+
+    let saved = editor.save_to_bytes().expect("save_to_bytes");
+
+    // The direct region must still render as a cosmetic overlay box.
+    assert!(
+        saved.windows(9).any(|w| w == b"1 1 1 rg\n"),
+        "direct erase_region call must still produce a cosmetic overlay"
+    );
+
+    let reopened = PdfDocument::from_bytes(saved).expect("reopen saved bytes");
+    let text = reopened
+        .extract_text(0)
+        .expect("extract_text on reopened doc");
+
+    assert!(
+        !text.contains("FOOTER"),
+        "inherited region must be genuinely gone, got: {text:?}"
+    );
+    assert!(text.contains("BODY"), "untouched body text must survive, got: {text:?}");
+    assert!(
+        text.contains("DIRECT"),
+        "a direct erase_region call must stay cosmetic-only — its text must \
+         still be extractable underneath the overlay, got: {text:?}"
+    );
+}

--- a/tools/probes/probe_erase_persistence.rs
+++ b/tools/probes/probe_erase_persistence.rs
@@ -1,0 +1,192 @@
+//! Probe for #965: exercises the actual `remove_artifacts` →
+//! `DocumentEditor::from_document` → `save_to_bytes` → reopen path that
+//! `corpus_sig` never touches (open + extract only). For each corpus PDF:
+//! run `remove_artifacts(threshold)`, and wherever it erased something,
+//! round-trip through `DocumentEditor::from_document(...).save_to_bytes()`,
+//! reopen, and check:
+//!
+//! - `from_document`/`save_to_bytes` don't error
+//! - the reopened file's page count matches
+//! - every page still extracts without panicking
+//! - erased text is actually gone from the reopened bytes, UNLESS a
+//!   `RedactionOverlayFallback` warning was recorded for that save — in
+//!   which case the erased text should still be PRESENT (confirming the
+//!   fallback degraded as designed, not silently no-opped)
+//!
+//! Not general user value (hardcoded corpus paths) — per `tools/probes/`
+//! convention, copy into `examples/` to build/run, delete the copy after.
+//!
+//! Usage: `probe_erase_persistence <dir1> [dir2 ...] [--threshold 0.8]`
+
+use pdf_oxide::editor::DocumentEditor;
+use pdf_oxide::extractors::warnings::WarningCategory;
+use pdf_oxide::PdfDocument;
+use std::path::PathBuf;
+
+fn find_pdfs(dirs: &[PathBuf]) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for dir in dirs {
+        visit(dir, &mut out);
+    }
+    out.sort();
+    out
+}
+
+fn visit(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if file_type.is_dir() || file_type.is_symlink() {
+            // `is_symlink` covers the `pdf-data` symlink in test_datasets/;
+            // recurse into it too (metadata() follows symlinks so this
+            // correctly distinguishes a symlinked dir from a symlinked file).
+            if path.metadata().map(|m| m.is_dir()).unwrap_or(false) {
+                visit(&path, out);
+                continue;
+            }
+        }
+        if path.extension().and_then(|e| e.to_str()) == Some("pdf") {
+            out.push(path);
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut dirs = Vec::new();
+    let mut threshold = 0.8f32;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--threshold" {
+            i += 1;
+            threshold = args[i].parse().expect("valid float threshold");
+        } else {
+            dirs.push(PathBuf::from(&args[i]));
+        }
+        i += 1;
+    }
+    if dirs.is_empty() {
+        eprintln!("usage: probe_erase_persistence <dir1> [dir2 ...] [--threshold 0.8]");
+        std::process::exit(2);
+    }
+
+    let pdfs = find_pdfs(&dirs);
+    println!("Found {} PDFs", pdfs.len());
+
+    let mut exercised = 0usize;
+    let mut errors = 0usize;
+    let mut mismatches = 0usize;
+
+    for path in &pdfs {
+        let name = path.display();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            check_one(path, threshold)
+        }));
+        match result {
+            Ok(Ok(Some(outcome))) => {
+                exercised += 1;
+                if !outcome.ok {
+                    mismatches += 1;
+                    println!("MISMATCH {name}: {}", outcome.detail);
+                }
+            },
+            Ok(Ok(None)) => {}, // nothing erased, not exercised
+            Ok(Err(e)) => {
+                errors += 1;
+                println!("ERROR {name}: {e}");
+            },
+            Err(_) => {
+                errors += 1;
+                println!("PANIC {name}");
+            },
+        }
+    }
+
+    println!(
+        "\n{} PDFs scanned, {} exercised the save path, {} errors, {} mismatches",
+        pdfs.len(),
+        exercised,
+        errors,
+        mismatches
+    );
+    if errors > 0 || mismatches > 0 {
+        std::process::exit(1);
+    }
+}
+
+struct Outcome {
+    ok: bool,
+    detail: String,
+}
+
+fn check_one(
+    path: &std::path::Path,
+    threshold: f32,
+) -> Result<Option<Outcome>, Box<dyn std::error::Error>> {
+    let bytes = std::fs::read(path)?;
+    let doc = PdfDocument::from_bytes(bytes)?;
+    let page_count_before = doc.page_count()?;
+
+    let removed = doc.remove_artifacts(threshold)?;
+    if removed == 0 {
+        return Ok(None);
+    }
+    let before_text = doc.extract_all_text()?;
+
+    let mut editor = DocumentEditor::from_document(doc)?;
+    let saved = editor.save_to_bytes()?;
+    let fallback_pages: std::collections::HashSet<Option<usize>> = editor
+        .structured_warnings()
+        .iter()
+        .filter(|w| w.category == WarningCategory::RedactionOverlayFallback)
+        .map(|w| w.page)
+        .collect();
+
+    let reopened = PdfDocument::from_bytes(saved)?;
+    let page_count_after = reopened.page_count()?;
+    if page_count_after != page_count_before {
+        return Ok(Some(Outcome {
+            ok: false,
+            detail: format!("page count {page_count_before} -> {page_count_after}"),
+        }));
+    }
+    for i in 0..page_count_after {
+        reopened.extract_text(i)?;
+    }
+    let after_text = reopened.extract_all_text()?;
+
+    // Coarse signal only (word-set overlap, not char-diff — see README's
+    // corpus-methodology note on why char-Levenshtein is the wrong tool):
+    // when no page fell back to overlay, removed content should not
+    // reappear; when a page did fall back, we can't assert word-for-word
+    // equality (the fallback is degraded-but-safe by design), just that
+    // the save didn't error and the page still extracts.
+    if fallback_pages.is_empty() {
+        let before_words: std::collections::HashSet<&str> = before_text.split_whitespace().collect();
+        let after_words: std::collections::HashSet<&str> = after_text.split_whitespace().collect();
+        let reappeared: Vec<&&str> = after_words.difference(&before_words).take(5).collect();
+        if !reappeared.is_empty() {
+            return Ok(Some(Outcome {
+                ok: false,
+                detail: format!(
+                    "no overlay-fallback warning recorded, but saved text has words \
+                     absent from the in-memory post-erasure text (sample: {reappeared:?})"
+                ),
+            }));
+        }
+    }
+
+    Ok(Some(Outcome {
+        ok: true,
+        detail: format!(
+            "removed={removed}, fallback_pages={}",
+            fallback_pages.len()
+        ),
+    }))
+}


### PR DESCRIPTION
remove_footers (and remove_headers / remove_artifacts) claim that spans were erased (and they are for to_markdown), the caller reasonably believes the header/footer is gone, and saves the file — and the output file was byte-for-byte unmodified with respect to that content.

Now whatever was removed in the PDFDocument is removed when DocumentEditor::from_document is called.

## Linked issue

Closes https://github.com/yfedoseev/pdf_oxide/issues/965

## What and why

Initially I just wanted to use it for testing.  Practically, it could be useful in a production pipeline where I will assemble PDFs from different sources into a book / website and want to use PDFDocument to_html or to_markdown to present each PDF as a webpage and then use DocumentEditor to decorate the header/footer in some unified way.

Fundamentally, it's just how I expected it to work.

## Type of change

- [X] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [X] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [X] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [X] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): ____
- [X] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Regression on real PDFs

This is a change of behavior.  Before (on main) you can remove_artifacts/footers/headers and that has no effect on the PDF written by DocumentEditor.  After the change, on this branch, artifacts will be removed.

This is in progress.

**Corpus I tested** Corpus: 31 PDFs total
* 20 IRS tax forms
* 10 personal-library documents
* 1 large real-world scan — warandpeace030164mbp.pdf, 725 pages, from archive.org

Format/source diversity: government forms (dense tables, form fields), academic/magazine layout (running headers/footers, multi-column), and a large OCR'd scan (noisy positioning) — three fairly different document-generation pipelines.

For this specific PR (persistence fix): only 6 of the 31 actually exercise the code path (had removed > 0 from remove_artifacts at threshold 0.8)

- [x] Ran `corpus_sig` and diffed my branch against **`main`** — no unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [x] Diffed my branch against the **latest release** (`v0.3.__`) — same.
- [ ] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** <!-- e.g. "3 docs changed, all the intended fix" -->
zero diff against main

**Diff summary vs latest release:** <!--  -->
zero diff against v0.3.77

## AI assistance disclosure

- [X] AI assistance:**assisted** — tool: Claude, extent: draft code and corpus testing
- [X] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [X] One logical change (no bundled refactor/perf/correctness).
- [X] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [ ] Public-API changes considered for semver (`semver-checks` will run).
