### PR TITLE
fix(extract): keep words that the table grid does not re-emit

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -5790,14 +5790,14 @@ impl PdfDocument {
                 // table are already covered by the inline-table flush
                 // below, so we must NOT also preserve them in the flow
                 // span list (it would produce duplicate output).
-                let mut table_cell_texts: std::collections::HashSet<String> =
+                let mut table_cell_texts: std::collections::HashSet<&str> =
                     std::collections::HashSet::new();
                 for t in &tables {
                     for row in &t.rows {
                         for cell in &row.cells {
                             let trimmed = cell.text.trim();
                             if !trimmed.is_empty() {
-                                table_cell_texts.insert(trimmed.to_string());
+                                table_cell_texts.insert(trimmed);
                             }
                         }
                     }
@@ -5819,93 +5819,71 @@ impl PdfDocument {
                             .flat_map(|r| r.cells.iter().flat_map(|c| c.mcids.iter().copied()))
                     })
                     .collect();
-                // Flatten every cell bbox once and index it into coarse y-bands,
+                // Flatten every cell bbox once (with its trimmed text, so the
+                // ownership test below can tell an exact-text cell match from a
+                // fragment of a merged cell) and index it into coarse y-bands,
                 // so the per-span containment test below scans only the cells in
                 // the span's y-band instead of every cell on the page (was
                 // O(spans x cells) on untagged table pages). A cell that contains
                 // a span necessarily shares the span's y-band, so this is
                 // byte-identical to the full scan.
-                let cell_bboxes: Vec<crate::geometry::Rect> = tables
+                // Only tables with a bbox reach the inline flush below; a
+                // cell of an unflushed table renders nowhere and must not
+                // absorb anything.
+                let cell_bboxes: Vec<(crate::geometry::Rect, &str)> = tables
                     .iter()
+                    .filter(|t| t.bbox.is_some())
                     .flat_map(|t| {
-                        t.rows
-                            .iter()
-                            .flat_map(|r| r.cells.iter().filter_map(|c| c.bbox))
+                        t.rows.iter().flat_map(|r| {
+                            r.cells
+                                .iter()
+                                .filter_map(|c| c.bbox.map(|b| (b, c.text.trim())))
+                        })
                     })
                     .collect();
+                // Same-text cell lookup for the fallback path: a span that no
+                // cell bbox contains can still be absorbed by a cell whose
+                // exact text it carries, as long as that cell's budget is
+                // untouched.
+                let mut cell_text_index: std::collections::HashMap<&str, Vec<usize>> =
+                    std::collections::HashMap::new();
+                for (ci, (_, text)) in cell_bboxes.iter().enumerate() {
+                    if !text.is_empty() {
+                        cell_text_index.entry(text).or_default().push(ci);
+                    }
+                }
                 const CELL_Y_BIN: f32 = 18.0;
                 let cell_bin = |y: f32| (y / CELL_Y_BIN).floor() as i32;
                 let mut cell_y_index: std::collections::HashMap<i32, Vec<usize>> =
                     std::collections::HashMap::new();
-                for (ci, b) in cell_bboxes.iter().enumerate() {
+                for (ci, (b, _)) in cell_bboxes.iter().enumerate() {
                     for bin in cell_bin(b.y)..=cell_bin(b.y + b.height) {
                         cell_y_index.entry(bin).or_default().push(ci);
                     }
                 }
-                // Returns true when span should be removed from the flow because
-                // it is owned by a table cell (will be re-emitted by render_text).
-                let span_in_table = |s: &crate::layout::TextSpan| -> bool {
-                    if !table_cell_mcids.is_empty() {
-                        if let Some(mcid) = s.mcid {
-                            // Tagged PDF: MCID decides ownership precisely.
-                            return table_cell_mcids.contains(&mcid);
+                // Per-cell token budgets. `render_text()` emits each cell's
+                // text exactly once, so a cell can absorb dropped spans
+                // totalling at most its own token multiset. Bbox containment
+                // alone cannot decide a drop: a rowspan-merged cell's bbox can
+                // cover far more spans than its text was built from (a
+                // schedule column's tall cell covering hundreds of repeated
+                // marks while holding six lines of them), and an empty-text
+                // cell re-emits nothing at all (a value column without row
+                // rules becomes one tall empty cell whose bbox swallows every
+                // figure in the column). A span leaves the flow only by
+                // consuming its tokens from a covering cell's budget — the
+                // fragment-level form of the same rule the text fallback
+                // needs: membership cannot see multiplicity.
+                let mut cell_remaining: Vec<std::collections::HashMap<&str, usize>> = cell_bboxes
+                    .iter()
+                    .map(|(_, text)| {
+                        let mut m = std::collections::HashMap::new();
+                        for tok in text.split_whitespace() {
+                            *m.entry(tok).or_insert(0) += 1;
                         }
-                        // Tagged PDF but span has no MCID (widget/annotation):
-                        // keep in flow — better to duplicate than to silently drop.
-                        return false;
-                    }
-                    // Untagged PDF or no MCIDs in any cell: cell-bbox-based filter.
-                    // Using per-cell bboxes (rather than the coarser table bbox) prevents
-                    // dropping paragraph spans that lie inside the table's outer bounding
-                    // box but were not captured as table cells by the spatial detector.
-                    // Probe only the cells in the span's y-band (±1 bin guards the
-                    // containment tolerance). Equivalent to scanning every cell.
-                    let slo = cell_bin(s.bbox.y) - 1;
-                    let shi = cell_bin(s.bbox.y + s.bbox.height) + 1;
-                    let in_cell = (slo..=shi).any(|bin| {
-                        cell_y_index.get(&bin).is_some_and(|cands| {
-                            cands.iter().any(|&ci| {
-                                Self::contains_rect_with_tolerance(
-                                    &cell_bboxes[ci],
-                                    &s.bbox,
-                                    RETAIN_TOLERANCE,
-                                )
-                            })
-                        })
-                    });
-                    if in_cell {
-                        return true;
-                    }
-                    // Fallback: text-based match. The bbox check above uses
-                    // a tight 0.1pt tolerance and rejects spans whose font
-                    // ascent extends slightly above the cell's ink box (issue
-                    // 484: "FY 15 1st Q TTL" labels in JAL traffic table —
-                    // span height = font_size = 10.7pt, but cell bbox height
-                    // = 15.96pt covers two ink rows so the label glyphs reach
-                    // ~0.4pt above the cell's top edge). When a span's
-                    // trimmed text exactly matches some cell's text, the cell
-                    // already owns it — keeping it in flow would duplicate.
-                    let trimmed = s.text.trim();
-                    if trimmed.is_empty() {
-                        return false;
-                    }
-                    if !table_cell_texts.contains(trimmed) {
-                        return false;
-                    }
-                    // Require spatial proximity: the span must lie inside
-                    // some table's outer bbox so we don't drop body text that
-                    // coincidentally matches a cell's text elsewhere on the page.
-                    tables.iter().any(|t| {
-                        t.bbox.is_some_and(|tb| {
-                            let cx = s.bbox.x + s.bbox.width / 2.0;
-                            let cy = s.bbox.y + s.bbox.height / 2.0;
-                            cx >= tb.x - RETAIN_TOLERANCE
-                                && cx <= tb.x + tb.width + RETAIN_TOLERANCE
-                                && cy >= tb.y - RETAIN_TOLERANCE
-                                && cy <= tb.y + tb.height + RETAIN_TOLERANCE
-                        })
+                        m
                     })
-                };
+                    .collect();
 
                 let preserved_label_indices: std::collections::HashSet<usize> =
                     Self::identify_multi_row_labels(&spans)
@@ -5930,22 +5908,133 @@ impl PdfDocument {
                         })
                         .collect();
 
-                if preserved_label_indices.is_empty() {
-                    spans.retain(|s| !span_in_table(s));
-                } else {
-                    let kept: Vec<crate::layout::TextSpan> = spans
-                        .drain(..)
-                        .enumerate()
-                        .filter_map(|(i, s)| {
-                            if !span_in_table(&s) || preserved_label_indices.contains(&i) {
-                                Some(s)
+                // One pass covers both cases: with no preserved labels the
+                // index test is simply never true.
+                //
+                // A cell-covered span leaves the flow by consuming its tokens
+                // from the covering cell's budget. A text-fallback span
+                // (matching a cell's exact text without lying inside any cell
+                // — the ascent-overshoot geometry the fallback exists for)
+                // claims a same-text cell whose budget is still whole. Both
+                // paths draw on the SAME per-cell budgets, so a cell that
+                // absorbed its own spans cannot also be claimed from a
+                // distance: with split accounting, a page carrying one
+                // repeated label per row dropped three spans against two
+                // rendering cells.
+                //
+                // Once every cell that could absorb a text is spoken for,
+                // further spans matching it stay in the flow, because
+                // `render_text()` will not emit them again. Membership cannot
+                // see multiplicity. Spans no cell can absorb stay in the
+                // flow: better to duplicate than to silently drop.
+                let mut kept: Vec<crate::layout::TextSpan> = Vec::with_capacity(spans.len());
+                for (i, s) in spans.drain(..).enumerate() {
+                    if preserved_label_indices.contains(&i) {
+                        kept.push(s);
+                        continue;
+                    }
+                    if !table_cell_mcids.is_empty() {
+                        // Tagged PDF: MCID decides ownership precisely. A span
+                        // with no MCID (widget/annotation) stays in flow —
+                        // better to duplicate than to silently drop.
+                        if s.mcid.is_some_and(|m| table_cell_mcids.contains(&m)) {
+                            continue;
+                        }
+                        kept.push(s);
+                        continue;
+                    }
+                    // Inner scope: every borrow of `s.text` ends before the
+                    // span is moved into `kept`.
+                    let dropped = {
+                        let trimmed = s.text.trim();
+                        // A span rarely carries more than a few tokens; a
+                        // linear-scan Vec beats allocating a HashMap per span.
+                        let mut span_tokens: Vec<(&str, usize)> = Vec::new();
+                        for tok in trimmed.split_whitespace() {
+                            if let Some(entry) = span_tokens.iter_mut().find(|(t, _)| *t == tok) {
+                                entry.1 += 1;
                             } else {
-                                None
+                                span_tokens.push((tok, 1));
                             }
-                        })
-                        .collect();
-                    spans = kept;
+                        }
+                        // Probe only the cells in the span's y-band (±1 bin
+                        // guards the containment tolerance). Equivalent to
+                        // scanning every cell.
+                        let slo = cell_bin(s.bbox.y) - 1;
+                        let shi = cell_bin(s.bbox.y + s.bbox.height) + 1;
+                        let mut decided = false;
+                        'cells: for bin in slo..=shi {
+                            let Some(cands) = cell_y_index.get(&bin) else {
+                                continue;
+                            };
+                            for &ci in cands {
+                                let (cell_bbox, _) = &cell_bboxes[ci];
+                                if !Self::contains_rect_with_tolerance(
+                                    cell_bbox,
+                                    &s.bbox,
+                                    RETAIN_TOLERANCE,
+                                ) {
+                                    continue;
+                                }
+                                let remaining = &mut cell_remaining[ci];
+                                if span_tokens.iter().all(|(tok, n)| {
+                                    remaining.get::<str>(tok).copied().unwrap_or(0) >= *n
+                                }) {
+                                    for (tok, n) in &span_tokens {
+                                        if let Some(r) = remaining.get_mut::<str>(tok) {
+                                            *r -= n;
+                                        }
+                                    }
+                                    // Dropped: the cell re-emits it.
+                                    decided = true;
+                                    break 'cells;
+                                }
+                            }
+                        }
+                        // Fallback: text-based match. The bbox check above
+                        // uses a tight 0.1pt tolerance and rejects spans whose
+                        // font ascent extends slightly above the cell's ink
+                        // box (issue 484: "FY 15 1st Q TTL" labels in the JAL
+                        // traffic table). Require spatial proximity so body
+                        // text that coincidentally matches a cell's text
+                        // elsewhere on the page is not dropped.
+                        if !decided && !trimmed.is_empty() && cell_text_index.contains_key(trimmed)
+                        {
+                            let near_table = tables.iter().any(|t| {
+                                t.bbox.is_some_and(|tb| {
+                                    let cx = s.bbox.x + s.bbox.width / 2.0;
+                                    let cy = s.bbox.y + s.bbox.height / 2.0;
+                                    cx >= tb.x - RETAIN_TOLERANCE
+                                        && cx <= tb.x + tb.width + RETAIN_TOLERANCE
+                                        && cy >= tb.y - RETAIN_TOLERANCE
+                                        && cy <= tb.y + tb.height + RETAIN_TOLERANCE
+                                })
+                            });
+                            if near_table {
+                                for &ci in &cell_text_index[trimmed] {
+                                    let remaining = &mut cell_remaining[ci];
+                                    if span_tokens.iter().all(|(tok, n)| {
+                                        remaining.get::<str>(tok).copied().unwrap_or(0) >= *n
+                                    }) {
+                                        for (tok, n) in &span_tokens {
+                                            if let Some(r) = remaining.get_mut::<str>(tok) {
+                                                *r -= n;
+                                            }
+                                        }
+                                        // Dropped: this unclaimed cell re-emits it.
+                                        decided = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        decided
+                    };
+                    if !dropped {
+                        kept.push(s);
+                    }
                 }
+                spans = kept;
             }
 
             // Row-aware ordering: quantize Y into bands and sort band-

--- a/src/document.rs
+++ b/src/document.rs
@@ -5917,8 +5917,8 @@ impl PdfDocument {
                 // path keeps whole-token matching: it has no containment
                 // evidence, so fragments would let distant same-substring
                 // text vanish.
-                fn take_one<'a>(
-                    work: &mut std::collections::HashMap<&'a str, usize>,
+                fn take_one(
+                    work: &mut std::collections::HashMap<&str, usize>,
                     tok: &str,
                     allow_fragment: bool,
                 ) -> bool {
@@ -5957,8 +5957,8 @@ impl PdfDocument {
                 // text-fallback paths cannot drift apart — they must draw on
                 // the SAME accounting. All-or-nothing: a span either fits
                 // the cell's remaining budget whole or leaves it untouched.
-                fn try_consume<'a>(
-                    remaining: &mut std::collections::HashMap<&'a str, usize>,
+                fn try_consume(
+                    remaining: &mut std::collections::HashMap<&str, usize>,
                     span_tokens: &[(&str, usize)],
                     allow_fragment: bool,
                 ) -> bool {

--- a/src/document.rs
+++ b/src/document.rs
@@ -5811,34 +5811,37 @@ impl PdfDocument {
                 // by bbox alone would silently drop real content.
                 // Falls back to bbox-only filtering when no MCIDs are present
                 // (untagged PDFs or spatial-detection tables).
+                // Only tables with a bbox reach the inline flush below; a
+                // cell of an unflushed table renders nowhere and must not
+                // absorb anything — whether ownership is decided by MCID or
+                // by geometry.
                 let table_cell_mcids: HashSet<u32> = tables
                     .iter()
+                    .filter(|t| t.bbox.is_some())
                     .flat_map(|t| {
                         t.rows
                             .iter()
                             .flat_map(|r| r.cells.iter().flat_map(|c| c.mcids.iter().copied()))
                     })
                     .collect();
-                // Flatten every cell bbox once (with its trimmed text, so the
-                // ownership test below can tell an exact-text cell match from a
-                // fragment of a merged cell) and index it into coarse y-bands,
-                // so the per-span containment test below scans only the cells in
-                // the span's y-band instead of every cell on the page (was
-                // O(spans x cells) on untagged table pages). A cell that contains
-                // a span necessarily shares the span's y-band, so this is
+                // Flatten every flushed cell once (bbox plus the cell, whose
+                // text and member spans drive the ownership test below) and
+                // index it into coarse y-bands, so the per-span containment
+                // test below scans only the cells in the span's y-band
+                // instead of every cell on the page (was O(spans x cells) on
+                // untagged table pages). A cell that contains a span
+                // necessarily shares the span's y-band, so this is
                 // byte-identical to the full scan.
-                // Only tables with a bbox reach the inline flush below; a
-                // cell of an unflushed table renders nowhere and must not
-                // absorb anything.
-                let cell_bboxes: Vec<(crate::geometry::Rect, &str)> = tables
+                let flushed_cells: Vec<(
+                    crate::geometry::Rect,
+                    &crate::structure::table_extractor::TableCell,
+                )> = tables
                     .iter()
                     .filter(|t| t.bbox.is_some())
                     .flat_map(|t| {
-                        t.rows.iter().flat_map(|r| {
-                            r.cells
-                                .iter()
-                                .filter_map(|c| c.bbox.map(|b| (b, c.text.trim())))
-                        })
+                        t.rows
+                            .iter()
+                            .flat_map(|r| r.cells.iter().filter_map(|c| c.bbox.map(|b| (b, c))))
                     })
                     .collect();
                 // Same-text cell lookup for the fallback path: a span that no
@@ -5847,7 +5850,8 @@ impl PdfDocument {
                 // untouched.
                 let mut cell_text_index: std::collections::HashMap<&str, Vec<usize>> =
                     std::collections::HashMap::new();
-                for (ci, (_, text)) in cell_bboxes.iter().enumerate() {
+                for (ci, (_, c)) in flushed_cells.iter().enumerate() {
+                    let text = c.text.trim();
                     if !text.is_empty() {
                         cell_text_index.entry(text).or_default().push(ci);
                     }
@@ -5856,34 +5860,119 @@ impl PdfDocument {
                 let cell_bin = |y: f32| (y / CELL_Y_BIN).floor() as i32;
                 let mut cell_y_index: std::collections::HashMap<i32, Vec<usize>> =
                     std::collections::HashMap::new();
-                for (ci, (b, _)) in cell_bboxes.iter().enumerate() {
+                for (ci, (b, _)) in flushed_cells.iter().enumerate() {
                     for bin in cell_bin(b.y)..=cell_bin(b.y + b.height) {
                         cell_y_index.entry(bin).or_default().push(ci);
                     }
                 }
                 // Per-cell token budgets. `render_text()` emits each cell's
-                // text exactly once, so a cell can absorb dropped spans
-                // totalling at most its own token multiset. Bbox containment
-                // alone cannot decide a drop: a rowspan-merged cell's bbox can
-                // cover far more spans than its text was built from (a
-                // schedule column's tall cell covering hundreds of repeated
-                // marks while holding six lines of them), and an empty-text
-                // cell re-emits nothing at all (a value column without row
-                // rules becomes one tall empty cell whose bbox swallows every
-                // figure in the column). A span leaves the flow only by
-                // consuming its tokens from a covering cell's budget — the
-                // fragment-level form of the same rule the text fallback
-                // needs: membership cannot see multiplicity.
-                let mut cell_remaining: Vec<std::collections::HashMap<&str, usize>> = cell_bboxes
+                // content exactly once, so a cell can absorb dropped spans
+                // totalling at most the material it was built from. Bbox
+                // containment alone cannot decide a drop: a rowspan-merged
+                // cell's bbox can cover far more spans than its text was
+                // built from (a schedule column's tall cell covering
+                // hundreds of repeated marks while holding six lines of
+                // them), and an empty cell re-emits nothing at all (a value
+                // column without row rules becomes one tall empty cell whose
+                // bbox swallows every figure in the column). A span leaves
+                // the flow only by consuming its tokens from a covering
+                // cell's budget — the fragment-level form of the same rule
+                // the text fallback needs: membership cannot see
+                // multiplicity.
+                //
+                // Budgets are denominated in the cell's member-span tokens,
+                // not its rendered text: the cell builders rewrite text
+                // while joining spans (sub-em gaps and CJK/fullwidth pairs
+                // glue two spans with no separator, column-spanning decimals
+                // split "12.11" into "12 11"), so the rendered text is not a
+                // token superset of the spans the cell was built from. The
+                // member spans are, by construction — they are clones of the
+                // same flow spans this filter walks. A cell recorded without
+                // member spans falls back to its rendered text.
+                let mut cell_remaining: Vec<std::collections::HashMap<&str, usize>> = flushed_cells
                     .iter()
-                    .map(|(_, text)| {
+                    .map(|(_, c)| {
                         let mut m = std::collections::HashMap::new();
-                        for tok in text.split_whitespace() {
-                            *m.entry(tok).or_insert(0) += 1;
+                        if c.spans.is_empty() {
+                            for tok in c.text.split_whitespace() {
+                                *m.entry(tok).or_insert(0) += 1;
+                            }
+                        } else {
+                            for sp in &c.spans {
+                                for tok in sp.text.split_whitespace() {
+                                    *m.entry(tok).or_insert(0) += 1;
+                                }
+                            }
                         }
                         m
                     })
                     .collect();
+                // The detector runs on `extract_words` output, so a budget
+                // token can itself be a glued compound of several flow spans
+                // drawn with no gap ("12,3" + "45" -> "12,345"). A contained
+                // span may therefore consume a substring of one budget
+                // token; the unmatched remainder returns to the budget so
+                // the sibling fragments can follow. Absorption stays bounded
+                // by the material the cell was built from. The text-fallback
+                // path keeps whole-token matching: it has no containment
+                // evidence, so fragments would let distant same-substring
+                // text vanish.
+                fn take_one<'a>(
+                    work: &mut std::collections::HashMap<&'a str, usize>,
+                    tok: &str,
+                    allow_fragment: bool,
+                ) -> bool {
+                    if let Some(r) = work.get_mut(tok) {
+                        if *r > 0 {
+                            *r -= 1;
+                            return true;
+                        }
+                    }
+                    if !allow_fragment {
+                        return false;
+                    }
+                    // Shortest host wins: splits are deterministic (HashMap
+                    // iteration order is not) and minimal.
+                    let Some(host) = work
+                        .iter()
+                        .filter(|(k, n)| **n > 0 && k.len() > tok.len() && k.contains(tok))
+                        .map(|(k, _)| *k)
+                        .min_by_key(|k| (k.len(), *k))
+                    else {
+                        return false;
+                    };
+                    *work.get_mut(host).unwrap() -= 1;
+                    let start = host.find(tok).unwrap();
+                    let before = &host[..start];
+                    let after = &host[start + tok.len()..];
+                    if !before.is_empty() {
+                        *work.entry(before).or_insert(0) += 1;
+                    }
+                    if !after.is_empty() {
+                        *work.entry(after).or_insert(0) += 1;
+                    }
+                    true
+                }
+                // Test plus decrement, in one place so the containment and
+                // text-fallback paths cannot drift apart — they must draw on
+                // the SAME accounting. All-or-nothing: a span either fits
+                // the cell's remaining budget whole or leaves it untouched.
+                fn try_consume<'a>(
+                    remaining: &mut std::collections::HashMap<&'a str, usize>,
+                    span_tokens: &[(&str, usize)],
+                    allow_fragment: bool,
+                ) -> bool {
+                    let mut work = remaining.clone();
+                    for (tok, n) in span_tokens {
+                        for _ in 0..*n {
+                            if !take_one(&mut work, tok, allow_fragment) {
+                                return false;
+                            }
+                        }
+                    }
+                    *remaining = work;
+                    true
+                }
 
                 let preserved_label_indices: std::collections::HashSet<usize> =
                     Self::identify_multi_row_labels(&spans)
@@ -5968,7 +6057,7 @@ impl PdfDocument {
                                 continue;
                             };
                             for &ci in cands {
-                                let (cell_bbox, _) = &cell_bboxes[ci];
+                                let (cell_bbox, _) = &flushed_cells[ci];
                                 if !Self::contains_rect_with_tolerance(
                                     cell_bbox,
                                     &s.bbox,
@@ -5976,15 +6065,7 @@ impl PdfDocument {
                                 ) {
                                     continue;
                                 }
-                                let remaining = &mut cell_remaining[ci];
-                                if span_tokens.iter().all(|(tok, n)| {
-                                    remaining.get::<str>(tok).copied().unwrap_or(0) >= *n
-                                }) {
-                                    for (tok, n) in &span_tokens {
-                                        if let Some(r) = remaining.get_mut::<str>(tok) {
-                                            *r -= n;
-                                        }
-                                    }
+                                if try_consume(&mut cell_remaining[ci], &span_tokens, true) {
                                     // Dropped: the cell re-emits it.
                                     decided = true;
                                     break 'cells;
@@ -6012,15 +6093,7 @@ impl PdfDocument {
                             });
                             if near_table {
                                 for &ci in &cell_text_index[trimmed] {
-                                    let remaining = &mut cell_remaining[ci];
-                                    if span_tokens.iter().all(|(tok, n)| {
-                                        remaining.get::<str>(tok).copied().unwrap_or(0) >= *n
-                                    }) {
-                                        for (tok, n) in &span_tokens {
-                                            if let Some(r) = remaining.get_mut::<str>(tok) {
-                                                *r -= n;
-                                            }
-                                        }
+                                    if try_consume(&mut cell_remaining[ci], &span_tokens, false) {
                                         // Dropped: this unclaimed cell re-emits it.
                                         decided = true;
                                         break;

--- a/tests/test_table_repeated_cell_text.rs
+++ b/tests/test_table_repeated_cell_text.rs
@@ -83,14 +83,6 @@ fn table_extraction_does_not_delete_repeated_tokens() {
         !tables.is_empty(),
         "fixture produced no detected table; the comparison would be vacuous"
     );
-    for t in &tables {
-        eprintln!("fixture table bbox={:?}", t.bbox);
-        for r in &t.rows {
-            for c in &r.cells {
-                eprintln!("  cell {:?} bbox={:?}", c.text, c.bbox);
-            }
-        }
-    }
 
     let (a, b) = (token_counts(&with_tables), token_counts(&without));
     for (token, n_off) in &b {
@@ -266,6 +258,94 @@ fn table_extraction_keeps_values_in_unruled_columns() {
     }
 }
 
+/// A ruled table where two same-row spans sit closer than the sub-em space
+/// threshold (0.15 em): the table side glues them into one compound token
+/// ("12,3" + "45" -> "12,345"), so neither span's own text survives in the
+/// cell's budget material. Different fonts keep the two runs as separate
+/// FLOW spans (a span carries a single font), so each must be absorbed as a
+/// fragment of the glued token — verbatim token equality cannot.
+fn glued_cell_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A closed 2x2 grid: three horizontals, three verticals.
+    content.extend_from_slice(b"0.5 w\n");
+    for (x0, y0, x1, y1) in [
+        (100, 600, 100, 700),
+        (250, 600, 250, 700),
+        (400, 600, 400, 700),
+        (100, 700, 400, 700),
+        (100, 650, 400, 650),
+        (100, 600, 400, 600),
+    ] {
+        content.extend_from_slice(format!("{x0} {y0} m {x1} {y1} l S\n").as_bytes());
+    }
+    // "12,3" in Helvetica ends near x=129.5; "45" in Courier starts at
+    // x=130 — a sub-point gap, far below the 1.5pt space threshold at
+    // 10pt, so the cell builder joins them with no separator.
+    content.extend_from_slice(b"BT /F1 10 Tf 1 0 0 1 110 670 Tm (12,3) Tj ET\n");
+    content.extend_from_slice(b"BT /F2 10 Tf 1 0 0 1 130 670 Tm (45) Tj ET\n");
+    for (x, y, text) in [(260, 670, "Gamma"), (110, 620, "Delta"), (260, 620, "Epsilon")] {
+        content.extend_from_slice(
+            format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
+        );
+    }
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+fn nonspace_char_counts(text: &str) -> HashMap<char, usize> {
+    let mut counts = HashMap::new();
+    for c in text.chars().filter(|c| !c.is_whitespace()) {
+        *counts.entry(c).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// A span whose text the cell builder rewrote away (glued into a compound
+/// token) must still leave the flow: the cell re-emits its content, so
+/// keeping the span duplicates it. Token boundaries move when spans glue,
+/// so compare the non-whitespace character multiset — deletion and
+/// duplication both change it, reflow does not.
+#[test]
+fn table_extraction_absorbs_spans_glued_into_one_cell_token() {
+    let doc = PdfDocument::from_bytes(glued_cell_table_pdf()).expect("parse fixture");
+    let on = ConversionOptions {
+        extract_tables: true,
+        ..Default::default()
+    };
+    let off = ConversionOptions {
+        extract_tables: false,
+        ..Default::default()
+    };
+
+    let with_tables = doc.extract_text_with_options(0, &on).expect("tables on");
+    let without = doc.extract_text_with_options(0, &off).expect("tables off");
+
+    let tables = doc.extract_tables(0).unwrap_or_default();
+    assert!(
+        !tables.is_empty(),
+        "fixture produced no detected table; the comparison would be vacuous"
+    );
+    // The comparison below only pins the rewrite case if the table side
+    // actually glued the two runs into one compound token.
+    assert!(
+        tables
+            .iter()
+            .flat_map(|t| t.rows.iter())
+            .flat_map(|r| r.cells.iter())
+            .any(|c| c.text.split_whitespace().any(|t| t == "12,345")),
+        "no cell glued the two runs into one token; the rewrite case is not exercised"
+    );
+
+    let (a, b) = (
+        nonspace_char_counts(&with_tables),
+        nonspace_char_counts(&without),
+    );
+    assert_eq!(
+        a, b,
+        "tables on/off disagree on character content — a glued span was duplicated or \
+         deleted\n  off: {without:?}\n  on:  {with_tables:?}"
+    );
+}
+
 fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
     let mut pdf = b"%PDF-1.4\n".to_vec();
 
@@ -278,7 +358,9 @@ fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
     let off3 = pdf.len();
     pdf.extend_from_slice(b"3 0 obj\n<< ");
     pdf.extend_from_slice(page_extra);
-    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+    pdf.extend_from_slice(
+        b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R /F2 6 0 R >> >> >>\nendobj\n",
+    );
 
     let off4 = pdf.len();
     pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
@@ -290,8 +372,13 @@ fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
         b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
     );
 
+    let off6 = pdf.len();
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
     let xref_pos = pdf.len();
-    let offsets = [0usize, off1, off2, off3, off4, off5];
+    let offsets = [0usize, off1, off2, off3, off4, off5, off6];
     pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
     pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
     for &off in &offsets[1..] {

--- a/tests/test_table_repeated_cell_text.rs
+++ b/tests/test_table_repeated_cell_text.rs
@@ -1,0 +1,309 @@
+//! Table extraction must not delete words the grid does not re-emit,
+//!
+//! Spans inside a detected table were dropped whenever their trimmed text
+//! appeared in a `HashSet` of every cell's text. A set records THAT a text is
+//! a cell, never HOW MANY cells hold it, so when more spans matched than the
+//! grid re-emits, the surplus was deleted outright.
+//!
+//! The corpus scan that found this reported losses only ever on repeated
+//! tokens — `")(" 28->7`, `"+1" 8->3` — which is the shape this pins.
+
+use std::collections::HashMap;
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::document::PdfDocument;
+
+fn token_counts(text: &str) -> HashMap<&str, usize> {
+    let mut counts = HashMap::new();
+    for t in text.split_whitespace() {
+        *counts.entry(t).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// A ruled table whose cells repeat a value, plus the same value again below
+/// the grid but still inside the table's outer frame — the case where more
+/// spans match a cell text than the grid can re-emit.
+fn repeated_value_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A closed 2x2 grid between y=600 and y=700: three horizontals, three
+    // verticals.
+    content.extend_from_slice(b"0.5 w\n");
+    for (x0, y0, x1, y1) in [
+        (100, 600, 100, 700),
+        (250, 600, 250, 700),
+        (400, 600, 400, 700),
+        (100, 700, 400, 700),
+        (100, 650, 400, 650),
+        (100, 600, 400, 600),
+    ] {
+        content.extend_from_slice(format!("{x0} {y0} m {x1} {y1} l S\n").as_bytes());
+    }
+    // One BT/ET block per run: consecutive Tj inside one block merge into a
+    // single span and the fixture stops resembling real pages.
+    for (x, y, text) in [
+        (110, 670, "0.00"),
+        (260, 670, "0.00"),
+        (110, 620, "0.00"),
+        (260, 620, "Total"),
+        // Straddles the y=650 rule. The spatial detector adopts it as its own
+        // cell, so this does not reproduce the bbox-containment deletion
+        // (the un-ruled-column fixture below does); it pins the
+        // repeated-value invariant on a grid the detector reshapes.
+        (110, 646, "0.00"),
+    ] {
+        content.extend_from_slice(
+            format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
+        );
+    }
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Turning table extraction on must never emit a token fewer times than
+/// leaving it off. Reflow is fine; deletion is not.
+#[test]
+fn table_extraction_does_not_delete_repeated_tokens() {
+    let doc = PdfDocument::from_bytes(repeated_value_table_pdf()).expect("parse fixture");
+    let on = ConversionOptions {
+        extract_tables: true,
+        ..Default::default()
+    };
+    let off = ConversionOptions {
+        extract_tables: false,
+        ..Default::default()
+    };
+
+    let with_tables = doc.extract_text_with_options(0, &on).expect("tables on");
+    let without = doc.extract_text_with_options(0, &off).expect("tables off");
+
+    // The fixture must actually reach the table path, or this pins nothing —
+    // three previous attempts at this test failed exactly there.
+    let tables = doc.extract_tables(0).unwrap_or_default();
+    assert!(
+        !tables.is_empty(),
+        "fixture produced no detected table; the comparison would be vacuous"
+    );
+    for t in &tables {
+        eprintln!("fixture table bbox={:?}", t.bbox);
+        for r in &t.rows {
+            for c in &r.cells {
+                eprintln!("  cell {:?} bbox={:?}", c.text, c.bbox);
+            }
+        }
+    }
+
+    let (a, b) = (token_counts(&with_tables), token_counts(&without));
+    for (token, n_off) in &b {
+        let n_on = a.get(token).copied().unwrap_or(0);
+        assert!(
+            n_on >= *n_off,
+            "token {token:?} appears {n_off} times with tables off but only {n_on} times with \
+             tables on\n  off: {without:?}\n  on:  {with_tables:?}"
+        );
+    }
+}
+
+/// A ruled table where one cell's text is assembled from two separate spans.
+/// The cell re-emits both words, so neither span may stay in the flow — the
+/// multiplicity budget must not resurrect fragments of merged cells (a
+/// fragment's text is not a cell text, so it has no budget entry).
+fn merged_cell_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A closed 2x2 grid: three horizontals, three verticals.
+    content.extend_from_slice(b"0.5 w\n");
+    for (x0, y0, x1, y1) in [
+        (100, 600, 100, 700),
+        (250, 600, 250, 700),
+        (400, 600, 400, 700),
+        (100, 700, 400, 700),
+        (100, 650, 400, 650),
+        (100, 600, 400, 600),
+    ] {
+        content.extend_from_slice(format!("{x0} {y0} m {x1} {y1} l S\n").as_bytes());
+    }
+    // Top-left cell holds TWO spans; the other cells hold one each. One
+    // BT/ET block per run keeps the two fragments as separate spans — inside
+    // a single block they merge into one span equal to the cell text and the
+    // fragment case is never exercised.
+    for (x, y, text) in [
+        (110, 670, "Alpha"),
+        (160, 670, "Beta"),
+        (260, 670, "Gamma"),
+        (110, 620, "Delta"),
+        (260, 620, "Epsilon"),
+    ] {
+        content.extend_from_slice(
+            format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
+        );
+    }
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Turning table extraction on must neither delete tokens nor emit them twice:
+/// a span whose content the table re-emits as part of a merged cell has to
+/// leave the flow even though its own text never appears as a cell text.
+#[test]
+fn table_extraction_does_not_duplicate_merged_cell_fragments() {
+    let doc = PdfDocument::from_bytes(merged_cell_table_pdf()).expect("parse fixture");
+    let on = ConversionOptions {
+        extract_tables: true,
+        ..Default::default()
+    };
+    let off = ConversionOptions {
+        extract_tables: false,
+        ..Default::default()
+    };
+
+    let with_tables = doc.extract_text_with_options(0, &on).expect("tables on");
+    let without = doc.extract_text_with_options(0, &off).expect("tables off");
+
+    let tables = doc.extract_tables(0).unwrap_or_default();
+    assert!(
+        !tables.is_empty(),
+        "fixture produced no detected table; the comparison would be vacuous"
+    );
+    // The comparison below only pins the fragment case if some cell actually
+    // merged two spans into one text.
+    assert!(
+        tables
+            .iter()
+            .flat_map(|t| t.rows.iter())
+            .flat_map(|r| r.cells.iter())
+            .any(|c| c.text.split_whitespace().count() >= 2),
+        "no cell merged multiple spans; the fragment case is not exercised"
+    );
+
+    let (a, b) = (token_counts(&with_tables), token_counts(&without));
+    for (token, n_off) in &b {
+        let n_on = a.get(token).copied().unwrap_or(0);
+        assert!(
+            n_on >= *n_off,
+            "token {token:?} appears {n_off} times with tables off but only {n_on} times with \
+             tables on\n  off: {without:?}\n  on:  {with_tables:?}"
+        );
+        assert!(
+            n_on <= *n_off,
+            "token {token:?} appears {n_on} times with tables on but only {n_off} times with \
+             tables off — a merged-cell fragment stayed in the flow\n  off: {without:?}\n  on:  \
+             {with_tables:?}"
+        );
+    }
+}
+
+/// A ruled table transcribed from the failing financial-page geometry: the
+/// header band is ruled across every column, but below it only the left
+/// columns have row-separator rules. The detector merges each right-hand
+/// column into ONE tall cell for the whole body. Such a cell's text does not
+/// include every value its bbox covers, so dropping spans on bbox containment
+/// alone deletes the column's figures while the cell re-emits none of them.
+fn unruled_value_column_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"0.5 w\n");
+    let lines: [(i32, i32, i32, i32); 8] = [
+        // Verticals, full height.
+        (100, 600, 100, 700),
+        (250, 600, 250, 700),
+        (400, 600, 400, 700),
+        (460, 600, 460, 700),
+        // Header band and outer frame span every column...
+        (100, 700, 460, 700),
+        (100, 675, 460, 675),
+        (100, 600, 460, 600),
+        // ...but the interior row rule stops at the value column.
+        (100, 640, 400, 640),
+    ];
+    for (x0, y0, x1, y1) in lines {
+        content.extend_from_slice(format!("{x0} {y0} m {x1} {y1} l S\n").as_bytes());
+    }
+    for (fs, x, y, text) in [
+        (10, 110, 682, "Item"),
+        (10, 260, 682, "Qty"),
+        (10, 410, 682, "Net"),
+        (10, 110, 655, "alpha"),
+        (10, 260, 655, "10"),
+        (10, 110, 615, "beta"),
+        (10, 260, 615, "20"),
+        // Small figure inside the tall un-ruled value cell.
+        (6, 410, 646, "-1,004"),
+    ] {
+        content.extend_from_slice(
+            format!("BT /F1 {fs} Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
+        );
+    }
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A value covered only by a cell that does not carry its text must survive:
+/// that cell re-emits none of it, so dropping the span deletes real content.
+#[test]
+fn table_extraction_keeps_values_in_unruled_columns() {
+    let doc = PdfDocument::from_bytes(unruled_value_column_table_pdf()).expect("parse fixture");
+    let on = ConversionOptions {
+        extract_tables: true,
+        ..Default::default()
+    };
+    let off = ConversionOptions {
+        extract_tables: false,
+        ..Default::default()
+    };
+
+    let with_tables = doc.extract_text_with_options(0, &on).expect("tables on");
+    let without = doc.extract_text_with_options(0, &off).expect("tables off");
+
+    assert!(
+        !doc.extract_tables(0).unwrap_or_default().is_empty(),
+        "fixture produced no detected table; the comparison would be vacuous"
+    );
+
+    let (a, b) = (token_counts(&with_tables), token_counts(&without));
+    for (token, n_off) in &b {
+        let n_on = a.get(token).copied().unwrap_or(0);
+        assert!(
+            n_on >= *n_off,
+            "token {token:?} appears {n_off} times with tables off but only {n_on} times with \
+             tables on\n  off: {without:?}\n  on:  {with_tables:?}"
+        );
+    }
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{off:010} 00000 n\r\n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}

--- a/tests/test_table_repeated_cell_text.rs
+++ b/tests/test_table_repeated_cell_text.rs
@@ -283,7 +283,11 @@ fn glued_cell_table_pdf() -> Vec<u8> {
     // 10pt, so the cell builder joins them with no separator.
     content.extend_from_slice(b"BT /F1 10 Tf 1 0 0 1 110 670 Tm (12,3) Tj ET\n");
     content.extend_from_slice(b"BT /F2 10 Tf 1 0 0 1 130 670 Tm (45) Tj ET\n");
-    for (x, y, text) in [(260, 670, "Gamma"), (110, 620, "Delta"), (260, 620, "Epsilon")] {
+    for (x, y, text) in [
+        (260, 670, "Gamma"),
+        (110, 620, "Delta"),
+        (260, 620, "Epsilon"),
+    ] {
         content.extend_from_slice(
             format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
         );
@@ -335,10 +339,7 @@ fn table_extraction_absorbs_spans_glued_into_one_cell_token() {
         "no cell glued the two runs into one token; the rewrite case is not exercised"
     );
 
-    let (a, b) = (
-        nonspace_char_counts(&with_tables),
-        nonspace_char_counts(&without),
-    );
+    let (a, b) = (nonspace_char_counts(&with_tables), nonspace_char_counts(&without));
     assert_eq!(
         a, b,
         "tables on/off disagree on character content — a glued span was duplicated or \


### PR DESCRIPTION
## Linked issue

Closes #981.

## What and why

Turning table extraction on deleted words the grid never re-emitted. Three ownership checks overshot.

**Multiplicity.** Cell text was tracked as a `HashSet`. That records *that* a text is a cell, but never *how many* cells hold it. Repeated values lost their surplus. `")("` was emitted 7 times instead of 28.

**Containment.** A value column without row-separator rules became one tall empty-text cell. Its bbox swallowed every figure in the column. It re-emitted none of them.

**Double claims.** The containment path and the text-fallback path kept separate accounts. One cell could therefore be claimed twice. Three identical labels dropped against two rendering cells.

`render_text()` emits each cell's text exactly once. Ownership is now a per-cell token budget, drawn on by both paths. The budget is denominated in the cell's member spans. Filler cells with no members use rendered text instead, because builders glue sub-em gaps and split column-spanning decimals.

**Three rules follow.** A covered span leaves the flow only by consuming its tokens from a covering cell. A same-text span outside every cell claims a cell only while that cell's budget is whole. Spans no cell can absorb stay in the flow: duplication over silent deletion.

The new drop set is a strict subset of the old one by construction. No page can emit less content than before. This also enforces the documented unflushed-table invariant on the MCID branch, which previously held only on the bbox path.

**Rejected alternatives**, both measured on the full corpus. A multiplicity budget without ownership scoping fixed 4,243 pages but regressed 48, by resurrecting fragments of merged cells. Substring-containment ownership reintroduced deletion through rowspan-merged cells on 660 pages.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code**. No third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [ ] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): ____
- [ ] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents, ~470,000 pages. The mix is crawled government documents, conformance and renderer test suites, academic papers, Japanese vertical-writing texts, and synthetic malformed files.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [ ] Diffed my branch against the **latest release** (`v0.3.__`): same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

Not diffed against the latest release. The sweep was run against `main` only.

**Diff summary vs `main`.** Losing pages drop from **7,657** to **3,916**. Lost token instances drop from **78,019** to **17,995**.

The fix never emits fewer characters than `main` on any page. The one exception is 20 hyphens consumed by legitimate wrapped-word joins. On 40 pages the output duplicates a span the grid also renders: the deliberate trade.

Reference agreement (PyMuPDF / pypdf / pdfminer.six) was measured on a 1,500-page sample of changed pages. Word-Jaccard moves 0.8425 → **0.8467**. Recall moves 0.9160 → **0.9357**.

| Document | Pages | Demonstrates |
|---|---|---|
| [014094.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/014.zip) (014.zip) | 14 | base emits one figure per table row; fixed output restores the whole value columns |
| [031200.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/031.zip) (031.zip) | 13, 14 | flagged "token loss" is base emitting content twice ("Coronary Calci" twice in one line); fix emits once |
| [001644.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/001.zip) (001.zip) | 207 | the single blocker on an encrypted page is a 4-character whitespace delta; glyph text identical |
| [issue7454.pdf](https://raw.githubusercontent.com/mozilla/pdf.js/master/test/pdfs/issue7454.pdf) (pdf.js corpus) | 0 | known residual: a sub-em-split cell double-emits one line (base deletes it entirely) |

**Diff summary vs latest release:** not run.

## AI assistance disclosure

- [x] AI assistance: **none**, or **assisted**. Tool: Claude Code. Extent: corpus sweeps and differential analysis, drafting the patch and tests, and drafting this description; the diagnosis, the ownership design, and the accept/reject calls on alternatives are mine.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [ ] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [ ] Public-API changes considered for semver (`semver-checks` will run).

Commit subjects follow Conventional Commits, and every commit carries its `Signed-off-by` trailer.


