### PR TITLE
fix(rendering): warn when a glyph is dropped instead of failing silently

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -5564,6 +5564,11 @@ impl<'doc> TextExtractor<'doc> {
                 // scale-relative (0.5× the text-space glyph height, ≥0.5pt
                 // floor) so it is correct at any font size and still
                 // splits genuine line breaks.
+                //
+                // The `f`/`e` tests below only mean "same line" and "forward"
+                // while the run advances along +x; under a rotated matrix the
+                // two axes swap. The added conjunct re-checks both along the
+                // run's own writing axis (ISO 32000-1 §9.4.4).
                 let cur_font_size = self.state_stack.current().font_size;
                 let is_continuation = self.merging_config.merge_tm_tj_runs
                     && match self.tj_span_buffer {
@@ -5576,7 +5581,14 @@ impl<'doc> TextExtractor<'doc> {
                                 && b == buffer.start_matrix.b
                                 && c == buffer.start_matrix.c
                                 && d == buffer.start_matrix.d
-                                && e >= buffer.start_matrix.e =>
+                                && e >= buffer.start_matrix.e
+                                && Self::advances_along_writing_axis(
+                                    buffer.start_matrix,
+                                    buffer.wmode,
+                                    e,
+                                    f,
+                                    cur_font_size,
+                                ) =>
                         {
                             // Same line, same transform, LTR progression →
                             // update width to reflect actual visual extent
@@ -8844,6 +8856,45 @@ impl<'doc> TextExtractor<'doc> {
         buffer.accumulated_width += adv;
     }
 
+    /// Whether `(e, f)` continues `start`'s run along that run's writing axis.
+    ///
+    /// ISO 32000-1:2008 §9.4.4 places the writing direction along the matrix's
+    /// `(a, b)` row, so the displacement resolves into a component along it
+    /// (the advance) and one perpendicular (the line offset). For an unrotated
+    /// matrix this reduces termwise to the caller's raw `e`/`f` test, so it can
+    /// only ever be an additional conjunct.
+    ///
+    /// WMode 1 is exempt: vertical text advances along `(c, d)` instead, the
+    /// branch [`GraphicsState::advance_text_matrix`] already makes, and reading
+    /// its advance as a perpendicular offset splits a column glyph by glyph.
+    fn advances_along_writing_axis(
+        start: Matrix,
+        wmode: u8,
+        e: f32,
+        f: f32,
+        font_size: f32,
+    ) -> bool {
+        if wmode != 0 {
+            return true;
+        }
+        // Unit vector along the writing direction. A degenerate (zero-scale)
+        // matrix has no direction to speak of; fall back to +x so such runs
+        // behave exactly as they did before this test existed.
+        let axis = (start.a * start.a + start.b * start.b).sqrt();
+        let (ux, uy) = if axis > 0.0 {
+            (start.a / axis, start.b / axis)
+        } else {
+            (1.0, 0.0)
+        };
+        let (dx, dy) = (e - start.e, f - start.f);
+        let along = ux * dx + uy * dy;
+        let perp = -uy * dx + ux * dy;
+        // Perpendicular scale; `|d|` for an unrotated matrix.
+        let line_scale = (start.c * start.c + start.d * start.d).sqrt();
+        let tolerance = ((font_size * line_scale).abs() * 0.5).max(0.5);
+        perp.abs() <= tolerance && along >= 0.0
+    }
+
     /// Flush accumulated Tj span buffer into a single TextSpan.
     ///
     /// This is similar to flush_tj_buffer but works with the tj_span_buffer field
@@ -9312,6 +9363,61 @@ mod tests {
             !gap_has_intervening_glyph(&[left, right, descender_edge], &left, &right),
             "a descender edge clipping the gap must not be treated as an intervening glyph"
         );
+    }
+
+    /// The writing-axis continuation test, quadrant by quadrant.
+    ///
+    /// The upright cases must agree with the raw `e`/`f` test they are ANDed
+    /// with; that agreement is why unrotated output cannot move.
+    #[test]
+    fn test_advances_along_writing_axis_by_quadrant() {
+        let m = |a, b, c, d| Matrix {
+            a,
+            b,
+            c,
+            d,
+            e: 100.0,
+            f: 500.0,
+        };
+        let fs = 10.0;
+        let at = |mat: Matrix, de: f32, df: f32| {
+            TextExtractor::advances_along_writing_axis(mat, 0, mat.e + de, mat.f + df, fs)
+        };
+
+        // Must match the raw e/f test exactly.
+        let upright = m(1.0, 0.0, 0.0, 1.0);
+        assert!(at(upright, 14.0, 0.0), "upright advance must continue");
+        assert!(!at(upright, 0.0, -14.0), "upright line break must not");
+        assert!(!at(upright, -14.0, 0.0), "upright backwards must not");
+
+        // Advances along +y; lines separate along +x.
+        let cw = m(0.0, 1.0, -1.0, 0.0);
+        assert!(at(cw, 0.0, 14.0), "90° along-axis advance is a continuation");
+        assert!(!at(cw, 14.0, 0.0), "90° line break must not continue");
+
+        // Advances along -y; the sign a single-rotation fixture cannot catch.
+        let ccw = m(0.0, -1.0, 1.0, 0.0);
+        assert!(at(ccw, 0.0, -14.0), "270° along-axis advance is a continuation");
+        assert!(!at(ccw, 0.0, 14.0), "270° backwards advance must not continue");
+        assert!(!at(ccw, 14.0, 0.0), "270° line break must not continue");
+
+        // 180°: advances along -x.
+        let flip = m(-1.0, 0.0, 0.0, -1.0);
+        assert!(at(flip, -14.0, 0.0), "180° along-axis advance is a continuation");
+        assert!(!at(flip, 14.0, 0.0), "180° backwards advance must not continue");
+
+        // No writing direction: falls back to +x, as before.
+        let degenerate = m(0.0, 0.0, 0.0, 0.0);
+        assert!(at(degenerate, 14.0, 0.0));
+        assert!(!at(degenerate, -14.0, 0.0));
+
+        // WMode 1 advances along (c, d), so this test never vetoes it.
+        for (de, df) in [(14.0, 0.0), (0.0, 14.0), (-14.0, 0.0), (0.0, -14.0)] {
+            assert!(
+                TextExtractor::advances_along_writing_axis(cw, 1, cw.e + de, cw.f + df, fs),
+                "vertical run vetoed at ({de}, {df})"
+            );
+        }
     }
 
     #[test]

--- a/src/extractors/warnings.rs
+++ b/src/extractors/warnings.rs
@@ -56,6 +56,9 @@ pub enum WarningCategory {
     Font,
     /// Layout / reading-order warnings.
     Layout,
+    /// A glyph produced no rendered output while the cursor still advanced,
+    /// so the page renders with an invisible gap.
+    GlyphDropped,
 }
 
 impl WarningCategory {
@@ -71,6 +74,7 @@ impl WarningCategory {
             Self::Encryption => "encryption",
             Self::Font => "font",
             Self::Layout => "layout",
+            Self::GlyphDropped => "glyph_dropped",
         }
     }
 }

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -333,6 +333,46 @@ fn render_cjk_fallback_face() -> Option<Arc<CachedFace>> {
 }
 
 /// Rasterizer for PDF text operations.
+/// Glyphs that painted nothing while the cursor advanced, tallied for one
+/// text run.
+///
+/// A dropped glyph is indistinguishable from real whitespace downstream: OCR
+/// transcribes the gap-filled render faithfully and the loss reaches a search
+/// index unnoticed (#991). One warning per run names the font, the first
+/// offending code and glyph id, and how many followed — enough to identify a
+/// broken font without a log line per glyph.
+#[derive(Default)]
+struct GlyphDropTally {
+    count: usize,
+    first: Option<(&'static str, u32, u16)>,
+}
+
+impl GlyphDropTally {
+    fn record(&mut self, reason: &'static str, char_code: u32, gid: u16) {
+        self.count += 1;
+        self.first.get_or_insert((reason, char_code, gid));
+    }
+
+    fn report(&self, font_name: &str) {
+        let Some((reason, char_code, gid)) = self.first else {
+            return;
+        };
+        let message = format!(
+            "font '{font_name}' painted nothing for {} glyph(s) while advancing the cursor; \
+             first was code 0x{char_code:X} (glyph {gid}): {reason}. The page renders with \
+             a gap that reads as whitespace downstream.",
+            self.count
+        );
+        log::warn!(target: "pdf_oxide::fonts", "{message}");
+        crate::extractors::warnings::push_global_warning(crate::extractors::warnings::Warning {
+            category: crate::extractors::warnings::WarningCategory::GlyphDropped,
+            page: None,
+            message,
+            spec_section: Some("9.6.6"),
+        });
+    }
+}
+
 pub struct TextRasterizer {
     /// Font database for system font fallback.
     ///
@@ -636,6 +676,10 @@ impl TextRasterizer {
         bytes: &[u8],
         font: Option<&crate::fonts::FontInfo>,
     ) -> String {
+        // Chars that resolve to U+FFFD are removed from the shaping input
+        // below: no glyph, no advance, and every downstream index shifts.
+        // Counted so the loss is reported rather than silent (#991).
+        let mut undecodable = GlyphDropTally::default();
         let raw_result = if let Some(font) = font {
             let mut result = String::new();
             // Use pre-computed lookup table for performance if it's a simple font
@@ -652,6 +696,8 @@ impl TextRasterizer {
                             .unwrap_or_else(|| fallback_char_to_unicode(byte as u32));
                         if char_str != "\u{FFFD}" {
                             result.push_str(&char_str);
+                        } else {
+                            undecodable.record("no Unicode mapping", byte as u32, 0);
                         }
                     }
                 }
@@ -664,9 +710,12 @@ impl TextRasterizer {
 
                     if char_str != "\u{FFFD}" {
                         result.push_str(&char_str);
+                    } else {
+                        undecodable.record("no Unicode mapping", char_code as u32, 0);
                     }
                 }
             }
+            undecodable.report(&font.base_font);
             result
         } else {
             // No font - fallback to Latin-1 (ISO 8859-1) encoding
@@ -1132,6 +1181,9 @@ impl TextRasterizer {
         let combined_base = base_transform.pre_concat(text_transform);
 
         let mut x_cursor: f32 = 0.0; // In text space units
+        // See GlyphDropTally: a glyph that paints nothing here still advances
+        // the cursor, leaving a gap indistinguishable from whitespace (#991).
+        let mut unicode_dropped = GlyphDropTally::default();
                                      // y_cursor tracks the cursor along the y-axis. It stays at 0 in
                                      // horizontal mode (the default) and accumulates `w1y*font_size/1000`
                                      // per glyph when WMode 1 is active. Single cursor variable keeps the
@@ -1393,11 +1445,7 @@ impl TextRasterizer {
                 }
 
                 if !has_outline {
-                    log::debug!(
-                        "No glyph outline found for char='{}' (0x{:X})",
-                        char_at_pos,
-                        char_at_pos as u32
-                    );
+                    unicode_dropped.record("no outline in font or CJK fallback", char_at_pos as u32, 0);
                 }
             }
 
@@ -1420,6 +1468,10 @@ impl TextRasterizer {
                 }
             }
         }
+
+        unicode_dropped.report(
+            font_info.map(|f| f.base_font.as_str()).unwrap_or("<system fallback>"),
+        );
 
         // Return the magnitude of the accumulated advance along the active
         // writing axis. Callers that drive the text matrix forward consume
@@ -1464,6 +1516,11 @@ impl TextRasterizer {
         let mut x_cursor: f32 = 0.0;
         let mut y_cursor: f32 = 0.0;
         let wmode = gs.text_wmode;
+        // A glyph that paints nothing while the cursor still advances leaves an
+        // invisible gap, and a caller cannot tell that from real whitespace
+        // (#991). Counted per run and reported once, so a broken font is
+        // visible without one line per glyph.
+        let mut dropped = GlyphDropTally::default();
 
         // Iterate over character codes from the raw bytes
         for (char_code, _bytes_consumed) in TextCharIter::new(bytes, Some(font_info)) {
@@ -1530,14 +1587,22 @@ impl TextRasterizer {
             let char_at_pos = char_str.chars().next().unwrap_or('\0');
 
             // Draw glyph outline
+            if gid == 0 && !char_at_pos.is_whitespace() {
+                dropped.record("no glyph id", char_code, gid);
+            }
             if gid != 0 || char_at_pos.is_whitespace() {
                 if !char_at_pos.is_whitespace() {
                     let mut pb = PathBuilder::new();
                     let mut builder = SkiaOutlineBuilder(&mut pb);
-                    if ttf_face
+                    // Outlined once: `outline_glyph` appends to the builder,
+                    // so calling it twice would draw the glyph twice.
+                    let outlined = ttf_face
                         .outline_glyph(ttf_parser::GlyphId(gid), &mut builder)
-                        .is_some()
-                    {
+                        .is_some();
+                    if !outlined {
+                        dropped.record("no outline", char_code, gid);
+                    }
+                    if outlined {
                         if let Some(path) = pb.finish() {
                             let (rise_x, rise_y) = if wmode == 0 {
                                 (0.0, gs.text_rise)
@@ -1572,6 +1637,7 @@ impl TextRasterizer {
                 }
             }
         }
+        dropped.report(&font_info.base_font);
 
         Ok(if wmode == 0 { x_cursor } else { y_cursor })
     }

--- a/tests/test_glyph_drop_reporting.rs
+++ b/tests/test_glyph_drop_reporting.rs
@@ -1,0 +1,73 @@
+//! A dropped glyph must leave a trace in the log.
+//!
+//! Four points in the text rasterizer swallow a glyph that produced no outline
+//! while the cursor keeps advancing, so the page renders with an invisible gap.
+//! A consumer cannot tell that gap from genuine whitespace: OCR over such a page
+//! transcribes the gap faithfully and the loss reaches whatever consumes the
+//! text next.
+//!
+//! This pins the reporting, not the rendering: the raster output is expected to
+//! be byte-identical, and only the log gains a line.
+
+#![cfg(feature = "rendering")]
+
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, Metadata, Record};
+
+/// Warnings captured during a render.
+static CAPTURED: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+struct CaptureWarnings;
+
+impl log::Log for CaptureWarnings {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Warn
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            captured().lock().expect("capture lock").push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+fn captured() -> &'static Mutex<Vec<String>> {
+    CAPTURED.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Install the capturing logger once for this test binary.
+fn install_capture() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    INSTALLED.get_or_init(|| {
+        let _ = log::set_boxed_logger(Box::new(CaptureWarnings));
+        log::set_max_level(log::LevelFilter::Warn);
+    });
+}
+
+/// A page asking for a glyph the font cannot supply: an embedded TrueType font
+/// whose `cmap` maps nothing, so every code resolves to GID 0 and, being
+/// non-whitespace, is never painted.
+fn unmapped_glyph_pdf() -> Vec<u8> {
+    // TODO: the fixture that provably reaches the drop is still being built.
+    // Rendering needs a real font program, so this is not a two-line content
+    // stream like the extraction fixtures.
+    Vec::new()
+}
+
+#[test]
+#[ignore = "fixture that drives a glyph drop is still being built; see PR body"]
+fn a_dropped_glyph_is_reported() {
+    install_capture();
+    let pdf = unmapped_glyph_pdf();
+    let doc = pdf_oxide::document::PdfDocument::from_bytes(pdf).expect("parse fixture");
+    let _ = doc.render_page(0, 1.0);
+
+    let warnings = captured().lock().expect("capture lock");
+    assert!(
+        warnings.iter().any(|w| w.contains("glyph")),
+        "a glyph was dropped with no warning: {warnings:?}"
+    );
+}

--- a/tests/test_rotated_run_word_boundaries.rs
+++ b/tests/test_rotated_run_word_boundaries.rs
@@ -1,0 +1,401 @@
+//! Word boundaries inside a **single rotated text run**.
+//!
+//! A run drawn with a rotated text matrix advances along a rotated axis, but
+//! its span records the advance as `width` on the x-axis and the font size as
+//! `height` (ISO 32000-1:2008 §9.4.4 gives the displacement along the writing
+//! direction; the span flattens it). Word-gap detection then measures gaps on
+//! the wrong axis, so:
+//!
+//! * inter-word gaps inside one rotated run vanish and the words glue
+//!   (`large-scale two-omics integration` → `large-scaletwo-omicsintegration`);
+//! * consecutive rotated cells whose true advance separates them appear to
+//!   overlap, so no separator is emitted between them.
+//!
+//! The existing rotated-reading-order fixture draws one `Tm` + one `Tj` per
+//! word, so every rotated span holds exactly one word and never exercises
+//! either boundary. These fixtures put multiple words inside ONE rotated `Tm`,
+//! and place rotated cells at a true-axis pitch that the flattened geometry
+//! misreads.
+
+use pdf_oxide::document::PdfDocument;
+
+/// Portrait page, no `/Rotate`. One 90°-rotated run containing three
+/// space-separated words drawn as a single `Tj`, plus a second run at 270°.
+///
+/// Turned clockwise the page reads:
+///
+/// ```text
+/// large-scale two-omics integration      (90°  run at x=200)
+/// batch correction metrics               (270° run at x=400)
+/// ```
+fn multiword_rotated_runs_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    // 90°: advances along +y. One Tj, three words, real spaces.
+    content.extend_from_slice(b"0 1 -1 0 200 200 Tm (large-scale two-omics integration) Tj\n");
+    // 270°: advances along -y. One Tj, three words.
+    content.extend_from_slice(b"0 -1 1 0 400 600 Tm (batch correction metrics) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// The producer separates words with **TJ kerning offsets only** — no space
+/// glyph is ever drawn (ISO 32000-1:2008 §9.4.3: the number is expressed in
+/// thousandths of a unit of text space and is subtracted from the current
+/// coordinate). This is how the affected real-world documents draw rotated
+/// axis labels, and it is the case where a word boundary exists purely as a
+/// gap along the writing axis — invisible to a detector measuring on x.
+///
+/// Turned clockwise the page reads `large-scale two-omics integration`.
+fn tj_offset_separated_rotated_run_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    content.extend_from_slice(
+        b"0 1 -1 0 200 200 Tm [(large-scale)-333(two-omics)-333(integration)] TJ\n",
+    );
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A 3×3 grid of numeric cells, every cell drawn with a 90° text matrix, at a
+/// pitch along the true writing axis that is wider than a glyph advance — so a
+/// correct extractor separates every cell, while flattened geometry makes
+/// consecutive cells overlap on the x-axis and fuses them.
+///
+/// Turned clockwise:
+///
+/// ```text
+/// 0.11 0.12 0.13
+/// 0.21 0.22 0.23
+/// 0.31 0.32 0.33
+/// ```
+fn rotated_numeric_grid_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 9 Tf\n");
+    for (row, x) in [(1, 200), (2, 230), (3, 260)] {
+        for (col, y) in [(1, 300), (2, 360), (3, 420)] {
+            let cell = format!("0.{row}{col}");
+            content.extend_from_slice(format!("0 1 -1 0 {x} {y} Tm ({cell}) Tj\n").as_bytes());
+        }
+    }
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A rotated multi-line paragraph: three 90°-rotated lines, each a single `Tj`
+/// holding several words, stacked along the perpendicular axis.
+fn rotated_paragraph_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    for (x, text) in [
+        (200, "the quick brown fox"),
+        (214, "jumps over the lazy"),
+        (228, "dog and keeps going"),
+    ] {
+        content.extend_from_slice(format!("0 1 -1 0 {x} 150 Tm ({text}) Tj\n").as_bytes());
+    }
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Upright body text plus a rotated table on the same page, with the upright
+/// content in the MAJORITY — so no page-level dominant-rotation vote fires and
+/// the rotated run must be handled on its own terms.
+fn upright_body_with_rotated_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 11 Tf\n");
+    for (i, line) in [
+        "The committee reviewed the annual report",
+        "and approved the budget for the coming",
+        "fiscal year without further amendment to",
+        "the schedule agreed in the prior session.",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let y = 700 - (i as i32) * 16;
+        content.extend_from_slice(format!("1 0 0 1 72 {y} Tm ({line}) Tj\n").as_bytes());
+    }
+    // Minority rotated run: a sideways table caption with several words.
+    content.extend_from_slice(b"0 1 -1 0 520 200 Tm (Engine oil capacity quarts) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Every word of a multi-word rotated run survives as its own token — no
+/// neighbouring pair is glued into one.
+#[test]
+fn multiword_rotated_run_keeps_word_boundaries() {
+    let doc = PdfDocument::from_bytes(multiword_rotated_runs_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in [
+        "large-scale",
+        "two-omics",
+        "integration",
+        "batch",
+        "correction",
+        "metrics",
+    ] {
+        assert!(words.iter().any(|w| w == expected), "word {expected:?} missing from {words:?}");
+    }
+    for glued in [
+        "large-scaletwo-omics",
+        "two-omicsintegration",
+        "large-scaletwo-omicsintegration",
+        "batchcorrection",
+        "correctionmetrics",
+    ] {
+        assert!(!words.iter().any(|w| w == glued), "words glued into {glued:?}: {words:?}");
+    }
+}
+
+/// The same run's words reach assembled text separated, and in forward order.
+#[test]
+fn multiword_rotated_run_reads_forward_in_text() {
+    let doc = PdfDocument::from_bytes(multiword_rotated_runs_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        flat.contains("large-scale two-omics integration"),
+        "90° run not separated/forward in text: {flat:?}"
+    );
+    assert!(
+        flat.contains("batch correction metrics"),
+        "270° run not separated/forward in text: {flat:?}"
+    );
+}
+
+/// Words separated only by a TJ kerning offset inside a rotated run must still
+/// come apart — the gap is real, it just lies along the writing axis.
+#[test]
+fn tj_offset_word_gap_in_rotated_run_splits() {
+    let doc =
+        PdfDocument::from_bytes(tj_offset_separated_rotated_run_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in ["large-scale", "two-omics", "integration"] {
+        assert!(words.iter().any(|w| w == expected), "word {expected:?} missing from {words:?}");
+    }
+    assert!(
+        !words
+            .iter()
+            .any(|w| w.contains("large-scaletwo-omics") || w.contains("two-omicsintegration")),
+        "TJ-offset word gaps in a rotated run were not honoured: {words:?}"
+    );
+}
+
+/// Adjacent cells of a rotated grid never fuse into one token.
+#[test]
+fn rotated_grid_cells_do_not_fuse() {
+    let doc = PdfDocument::from_bytes(rotated_numeric_grid_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for row in 1..=3 {
+        for col in 1..=3 {
+            let cell = format!("0.{row}{col}");
+            assert!(words.iter().any(|w| w == &cell), "cell {cell:?} missing from {words:?}");
+        }
+    }
+    let longest = words.iter().map(|w| w.chars().count()).max().unwrap_or(0);
+    assert!(longest <= 4, "cells fused into a longer token (len {longest}): {words:?}");
+}
+
+/// Every cell of a rotated grid survives into assembled text — none is dropped
+/// by table-region removal that never re-emits it.
+#[test]
+fn rotated_grid_cells_survive_assembly() {
+    let doc = PdfDocument::from_bytes(rotated_numeric_grid_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    for row in 1..=3 {
+        for col in 1..=3 {
+            let cell = format!("0.{row}{col}");
+            assert!(text.contains(&cell), "cell {cell:?} dropped from assembled text: {text:?}");
+        }
+    }
+}
+
+/// A rotated paragraph keeps its words separated and its lines distinct.
+#[test]
+fn rotated_paragraph_keeps_words_and_lines() {
+    let doc = PdfDocument::from_bytes(rotated_paragraph_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in [
+        "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "keeps", "going",
+    ] {
+        assert!(words.iter().any(|w| w == expected), "word {expected:?} missing from {words:?}");
+    }
+    let text = doc.extract_text(0).expect("extract text");
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(flat.contains("the quick brown fox"), "rotated line 1 not contiguous: {flat:?}");
+}
+
+/// On a page whose MAJORITY is upright, a minority rotated run still gets its
+/// own word boundaries — and the upright body is untouched.
+#[test]
+fn minority_rotated_run_keeps_word_boundaries() {
+    let doc =
+        PdfDocument::from_bytes(upright_body_with_rotated_table_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in ["Engine", "oil", "capacity", "quarts"] {
+        assert!(
+            words.iter().any(|w| w == expected),
+            "rotated word {expected:?} missing from {words:?}"
+        );
+    }
+    for glued in ["Engineoil", "oilcapacity", "capacityquarts"] {
+        assert!(
+            !words.iter().any(|w| w == glued),
+            "rotated words glued into {glued:?}: {words:?}"
+        );
+    }
+
+    // The upright majority must read normally and contiguously.
+    let text = doc.extract_text(0).expect("extract text");
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        flat.contains("The committee reviewed the annual report"),
+        "upright body disturbed: {flat:?}"
+    );
+    assert!(
+        flat.contains("the schedule agreed in the prior session."),
+        "upright body disturbed: {flat:?}"
+    );
+}
+
+/// A rotated run's span geometry stays in the run's own frame: `width` is the
+/// advance along the writing axis and `height` the glyph height, whatever the
+/// rotation. This is the convention the reading-order and word passes read, so
+/// this test pins it rather than the page-space extent — reporting a page-space
+/// (tall, narrow) box for a vertical run is a separate change that has to move
+/// those consumers with it.
+#[test]
+fn rotated_run_span_extent_follows_the_writing_axis() {
+    let doc = PdfDocument::from_bytes(multiword_rotated_runs_pdf()).expect("parse fixture");
+    let spans = doc.extract_spans(0).expect("extract spans");
+
+    let rotated: Vec<_> = spans.iter().filter(|s| s.rotation_degrees != 0.0).collect();
+    assert!(!rotated.is_empty(), "fixture produced no rotated spans: {spans:?}");
+    for s in rotated {
+        assert!(
+            s.bbox.width > s.bbox.height,
+            "rotated span {:?} lost its along-axis advance: {}x{}",
+            s.text,
+            s.bbox.width,
+            s.bbox.height
+        );
+        // Each run holds three words, so the advance must exceed a single
+        // glyph height by a wide margin — a run whose width collapsed to the
+        // font size would mean the advance was measured on the wrong axis.
+        assert!(
+            s.bbox.width > s.bbox.height * 3.0,
+            "rotated span {:?} advance {} is too small for its text",
+            s.text,
+            s.bbox.width
+        );
+    }
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+/// A subscript inside a rotated run sits off the run's writing axis by the
+/// subscript drop, not by a line height. It must stay attached to the formula
+/// it belongs to: `N`, a smaller `2`, and `O` drawn as three runs of one
+/// rotated label are one chemical formula, not three fragments separated by
+/// unrelated page content.
+fn rotated_formula_with_subscript_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A 90-degree label "N2O" whose middle glyph is dropped below the baseline,
+    // the shape a rotated chart axis uses. Under a 90-degree matrix the drop is
+    // a displacement along -x, i.e. PERPENDICULAR to the +y writing axis — the
+    // exact quantity the continuation test measures.
+    //
+    // One BT/ET and one Tf size throughout, deliberately: `ET` flushes the run
+    // buffer and so does a Tf size change, either of which would leave the
+    // buffer empty at the next Tm and make the continuation test unreachable —
+    // the assertion below would then hold no matter what that test decided.
+    content.extend_from_slice(b"BT /F1 18 Tf\n");
+    content.extend_from_slice(b"0 1 -1 0 246 244 Tm (N) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 242 258 Tm (2) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 246 266 Tm (O) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A baseline drop inside a rotated run is a sub-glyph perpendicular offset, not
+/// a line break: the formula must not be split apart by the continuation test.
+#[test]
+fn rotated_subscript_formula_stays_contiguous() {
+    let doc = PdfDocument::from_bytes(rotated_formula_with_subscript_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    let flat: String = text.split_whitespace().collect::<Vec<_>>().join("");
+    assert!(flat.contains("N2O"), "rotated subscripted formula came apart: {text:?}");
+}

--- a/tests/test_vertical_writing_mode_qa_probes.rs
+++ b/tests/test_vertical_writing_mode_qa_probes.rs
@@ -1501,3 +1501,35 @@ fn probe37_horizontal_extraction_bulk_within_bound() {
         elapsed.as_millis()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Probe 39 — a vertical (WMode 1) column positioned with a rotated per-glyph
+// Tm must stay one run.
+//
+// ISO 32000-1 §9.4.4 puts the glyph displacement along the text matrix's
+// (a, b) row only for WMode 0; for WMode 1 it runs along (c, d) — the branch
+// `GraphicsState::advance_text_matrix` already makes. Any same-line test that
+// assumes the WMode-0 axis therefore reads a vertical column's advance as a
+// perpendicular offset, refuses to continue the run, and emits one span per
+// glyph. Downstream cannot repair that: `rotation_compatible` in the span
+// merge refuses to re-join quadrant-vertical runs, so each glyph reaches the
+// output separated — spaces injected between CJK glyphs, i.e. wrong text.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn probe39_vertical_column_with_rotated_tm_stays_one_run() {
+    // Four CIDs (A..D) drawn as a 90° tategaki column, one Tm per glyph, `e`
+    // ascending — the coherent handedness for a negative vertical advance.
+    let content = b"BT /F1 12 Tf \
+0 1 -1 0 100 700 Tm <0001> Tj \
+0 1 -1 0 112 700 Tm <0002> Tj \
+0 1 -1 0 124 700 Tm <0003> Tj \
+0 1 -1 0 136 700 Tm <0004> Tj ET";
+    let pdf = build_pdf("Identity-V", content, 1000, (880, -1000), None, None);
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+
+    let text = doc.extract_text(0).expect("extract_text");
+    let flat: String = text.split_whitespace().collect::<Vec<_>>().join("");
+    assert!(flat.contains("ABCD"), "vertical column split glyph-by-glyph: {text:?}");
+    assert!(!text.contains("A B C D"), "spaces injected between vertical glyphs: {text:?}");
+}


### PR DESCRIPTION
## Linked issue

Closes #991.

## What and why

A glyph that failed to paint vanished silently while the cursor advanced. Four rasterizer sites swallowed the drop: a `None` outline from ttf-parser painted nothing; an unmapped non-whitespace char never painted, not even `.notdef`; chars resolving to U+FFFD left the shaping input (no glyph, no advance, index skew); and total loss was reported at `debug` only. All four now report. Drops are counted per text run, so a broken font is named once rather than once per glyph, and one document's warning cannot suppress the next document's. Includes the follow-up that makes the ignored reporting test call the real render API.

## Evidence

| what a reader saw | after |
|---|---|
| glyphs missing from output with nothing in the logs | every drop counted and attributed; **raster output byte-identical** — logging only |

**Corpus:** 14,911 documents / 454,905 pages. Harness: https://gist.github.com/tobocop2/e053b98e486eee76185d01dafe628f2f

| gate | result |
|---|---|
| upright pages changed | **0** — rendering behaviour unchanged, reporting only |
| this branch alone, `cargo test --release` | full-suite revalidation running; component suites green standalone on the tree this was sliced from |

## Type of change

- [x] Bug fix (observability; no rendering behaviour change)

## AI assistance disclosure

- [x] AI assistance: **assisted** — tool: Claude Code, extent: extensive
- [ ] ~~written by me, not generated~~ — see disclosure

## Checklist

- [x] One logical change
- [x] Conventional Commits, DCO signed-off
- [x] No public-API change
