### PR TITLE
fix: read rotated pages the same way on every text surface

### DIFF
--- a/src/compliance/pdf_x/validator.rs
+++ b/src/compliance/pdf_x/validator.rs
@@ -687,7 +687,17 @@ impl PdfXValidator {
                 if let Ok(page_dict) = self.get_page_dict(document, page_num) {
                     if let Some(Object::Dictionary(resources)) = page_dict.get("Resources") {
                         if let Some(Object::Dictionary(colorspaces)) = resources.get("ColorSpace") {
-                            for (name, cs) in colorspaces {
+                            // Sorted by resource name: a PDF dictionary is a
+                            // `HashMap`, and this loop both pushes into the
+                            // emitted `color_spaces_found` list and reports
+                            // errors, so unsorted iteration randomizes a
+                            // compliance report's contents between runs.
+                            let mut cs_names: Vec<&String> = colorspaces.keys().collect();
+                            cs_names.sort();
+                            for name in cs_names {
+                                let Some(cs) = colorspaces.get(name) else {
+                                    continue;
+                                };
                                 let cs_name = self.get_colorspace_name(cs, document)?;
                                 result.stats.color_spaces_found.push(cs_name.clone());
 
@@ -736,7 +746,14 @@ impl PdfXValidator {
                         _ => continue,
                     };
 
-                    for (cs_name, cs_obj) in &colorspaces {
+                    // Sorted by resource name so the emitted error order is
+                    // stable; see the ColorSpace sweep above.
+                    let mut sorted_cs: Vec<&String> = colorspaces.keys().collect();
+                    sorted_cs.sort();
+                    for cs_name in sorted_cs {
+                        let Some(cs_obj) = colorspaces.get(cs_name) else {
+                            continue;
+                        };
                         let cs_type = self.get_colorspace_name(cs_obj, document)?;
 
                         // Device-dependent colors without output intent
@@ -782,7 +799,14 @@ impl PdfXValidator {
             if let Ok(page_dict) = self.get_page_dict(document, page_num) {
                 if let Some(Object::Dictionary(resources)) = page_dict.get("Resources") {
                     if let Some(Object::Dictionary(fonts)) = resources.get("Font") {
-                        for (name, font_ref) in fonts {
+                        // Sorted by resource name so the emitted error order is
+                        // stable; see the ColorSpace sweep above.
+                        let mut font_names: Vec<&String> = fonts.keys().collect();
+                        font_names.sort();
+                        for name in font_names {
+                            let Some(font_ref) = fonts.get(name) else {
+                                continue;
+                            };
                             result.stats.fonts_checked += 1;
 
                             let font_dict = match font_ref {

--- a/src/compliance/validators.rs
+++ b/src/compliance/validators.rs
@@ -153,7 +153,17 @@ pub fn validate_fonts(
             continue;
         };
 
-        for font_obj in fonts.values() {
+        // Sorted by resource name: a PDF dictionary is a `HashMap`, and
+        // `check_font_embedding` appends to the shared `result`, so unsorted
+        // iteration randomizes the order of reported violations between runs.
+        // The `seen` dedup below also makes WHICH duplicate reference is
+        // checked first depend on iteration order.
+        let mut font_names: Vec<&String> = fonts.keys().collect();
+        font_names.sort();
+        for font_name in font_names {
+            let Some(font_obj) = fonts.get(font_name) else {
+                continue;
+            };
             let (resolved, font_id) = match font_obj {
                 Object::Reference(r) => {
                     if !seen.insert(r.id) {

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -5478,16 +5478,16 @@ mod tests {
 
         let injected = last_region_injected(&ops);
         assert!(
-            injected
-                .iter()
-                .any(|op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.5).abs() < 1e-6)),
+            injected.iter().any(
+                |op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.5).abs() < 1e-6)
+            ),
             "inherited Tc not injected: {:?}",
             injected
         );
         assert!(
-            injected
-                .iter()
-                .any(|op| matches!(op, Operator::Tw { word_space } if (*word_space - 0.25).abs() < 1e-6)),
+            injected.iter().any(
+                |op| matches!(op, Operator::Tw { word_space } if (*word_space - 0.25).abs() < 1e-6)
+            ),
             "inherited Tw not injected: {:?}",
             injected
         );
@@ -5570,9 +5570,7 @@ mod tests {
 
         let injected = last_region_injected(&ops);
         assert!(
-            !injected
-                .iter()
-                .any(|op| matches!(op, Operator::Tc { .. })),
+            !injected.iter().any(|op| matches!(op, Operator::Tc { .. })),
             "Tc from a closed q/Q scope must not leak into a later region: {:?}",
             injected
         );

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -916,6 +916,7 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                             b: num_buf[num_count - 1],
                         });
                     }
+                    fill_space = None;
                     num_count = 0;
                 },
                 b"g" => {
@@ -924,6 +925,7 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                             gray: num_buf[num_count - 1],
                         });
                     }
+                    fill_space = None;
                     num_count = 0;
                 },
                 b"k" => {
@@ -935,6 +937,7 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                             k: num_buf[num_count - 1],
                         });
                     }
+                    fill_space = None;
                     num_count = 0;
                 },
                 b"cs" => {
@@ -947,17 +950,22 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     num_count = 0;
                 },
                 b"sc" => {
-                    if num_count >= 1 {
+                    // Operands are the TAIL of the rolling buffer, like every
+                    // other arm. More than 4 means a color space this replay
+                    // cannot represent (and the rotated buffer has lost the
+                    // leading operands) — inject nothing rather than a
+                    // truncated, plausible-looking wrong color.
+                    if (1..=4).contains(&num_count) {
                         fill_op = Some(Operator::SetFillColor {
-                            components: num_buf[..num_count.min(4)].to_vec(),
+                            components: num_buf[..num_count].to_vec(),
                         });
                     }
                     num_count = 0;
                 },
                 b"scn" => {
-                    if num_count >= 1 || last_name.is_some() {
+                    if (1..=4).contains(&num_count) || (num_count == 0 && last_name.is_some()) {
                         fill_op = Some(Operator::SetFillColorN {
-                            components: num_buf[..num_count.min(4)].to_vec(),
+                            components: num_buf[..num_count].to_vec(),
                             name: last_name.take().map(Box::new),
                         });
                     }
@@ -967,6 +975,10 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     num_count = 0;
                 },
             }
+            // A name operand belongs to the operator that follows it; once any
+            // operator has executed, a surviving `last_name` is stale. Without
+            // this, `/GS0 gs 0.5 scn` fabricated a pattern named GS0.
+            last_name = None;
             continue;
         }
 
@@ -5552,6 +5564,49 @@ mod tests {
                     if (*r - 0.2).abs() < 1e-6 && (*g - 0.4).abs() < 1e-6 && (*b - 0.6).abs() < 1e-6
             )),
             "inherited fill color not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_scn_does_not_inherit_stale_name() {
+        // `/GS0 gs 0.5 scn`: the name operand belongs to `gs`; the scanner
+        // must not hand it to `scn` as a pattern name.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET /GS0 gs 0.5 scn BT (X) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected.iter().any(
+                |op| matches!(op, Operator::SetFillColorN { name: Some(_), .. })
+            ),
+            "stale name fabricated a pattern: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_scn_with_too_many_operands_injects_nothing() {
+        // A 6-component scn (DeviceN) exceeds what the rolling buffer can
+        // faithfully replay; a truncated color would be plausible and wrong.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET 0.1 0.2 0.3 0.4 0.5 0.6 scn BT (X) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected.iter().any(|op| matches!(
+                op,
+                Operator::SetFillColor { .. } | Operator::SetFillColorN { .. }
+            )),
+            "truncated color injected: {:?}",
             injected
         );
     }

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -592,6 +592,43 @@ pub fn parse_content_stream_text_only(data: &[u8]) -> Result<Vec<Operator>> {
     Ok(operators)
 }
 
+/// Text-state parameters tracked by [`forward_scan_ctm`].
+///
+/// These persist across `BT`/`ET` (ISO 32000-1 §9.3.1 — only `Tm` resets at
+/// `BT`) and are saved/restored by `q`/`Q`, so a BT block may rely on a value
+/// set by an earlier block or between blocks. The prescan path parses each
+/// region in isolation inside a synthesized SaveState/RestoreState wrap, which
+/// would silently reset them; the scan tracks them so the region wrapper can
+/// re-inject the inherited values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PrescanTextState {
+    /// Character spacing (`Tc`).
+    char_spacing: f32,
+    /// Word spacing (`Tw`).
+    word_spacing: f32,
+    /// Horizontal scaling percentage (`Tz`).
+    horiz_scaling: f32,
+    /// Text leading (`TL`, and `TD`'s implicit `TL = -ty`).
+    leading: f32,
+    /// Text rise (`Ts`).
+    rise: f32,
+    /// Text rendering mode (`Tr`).
+    render_mode: u8,
+}
+
+impl Default for PrescanTextState {
+    fn default() -> Self {
+        PrescanTextState {
+            char_spacing: 0.0,
+            word_spacing: 0.0,
+            horiz_scaling: 100.0,
+            leading: 0.0,
+            rise: 0.0,
+            render_mode: 0,
+        }
+    }
+}
+
 /// Graphics state snapshot captured at a text position by [`forward_scan_ctm`].
 #[derive(Debug)]
 struct PrescanState {
@@ -599,13 +636,24 @@ struct PrescanState {
     ctm: (f32, f32, f32, f32, f32, f32),
     /// Current font name and size from the most recent `Tf` operator, if any.
     font: Option<(String, f32)>,
+    /// Persistent text-state parameters at this position.
+    text: PrescanTextState,
+    /// Fill color space set by `cs`, if any. Replayed before `fill_op` so the
+    /// components are interpreted in the right space.
+    fill_space: Option<String>,
+    /// Most recent fill-color operator (`rg`/`g`/`k`/`sc`/`scn`), if any.
+    /// Glyph color comes from the fill state, so losing this across region
+    /// boundaries turns colored text black (`chars_hash`-only sweep diffs).
+    fill_op: Option<Operator>,
 }
 
 /// Lightweight forward scan that tracks graphics state across the full content stream.
 ///
-/// Scans the stream recognizing only `q`, `Q`, `cm`, and `Tf` operators, skipping
-/// all path, color, and text operators. Records the accumulated CTM and font state
-/// at each position in `text_positions`.
+/// Scans the stream recognizing only `q`, `Q`, `cm`, `Tf`, and the persistent
+/// text-state operators (`Tc`, `Tw`, `Tz`, `TL`, `Ts`, `Tr`, plus `TD`'s
+/// implicit leading), skipping all path, color, and text-showing operators.
+/// Records the accumulated CTM, font, and text state at each position in
+/// `text_positions`.
 ///
 /// This is much cheaper than full parsing. Numeric operands are tracked in a
 /// rolling buffer so `cm` operands are always available when the operator is
@@ -631,8 +679,18 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
     // in ctm_stack to avoid String cloning on every q/Q.
     let mut font_table: Vec<(String, f32)> = Vec::new();
     let mut current_font_idx: Option<usize> = None;
-    let mut ctm_stack: Vec<(Matrix, Option<usize>)> = Vec::with_capacity(32);
+    #[allow(clippy::type_complexity)]
+    let mut ctm_stack: Vec<(
+        Matrix,
+        Option<usize>,
+        PrescanTextState,
+        Option<String>,
+        Option<Operator>,
+    )> = Vec::with_capacity(32);
     let mut ctm = Matrix::identity();
+    let mut text_state = PrescanTextState::default();
+    let mut fill_space: Option<String> = None;
+    let mut fill_op: Option<Operator> = None;
 
     // Rolling buffer of recent numeric operands (for cm's 6 floats)
     let mut num_buf: [f32; 6] = [0.0; 6];
@@ -652,6 +710,9 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
         .map(|_| PrescanState {
             ctm: (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
             font: None,
+            text: PrescanTextState::default(),
+            fill_space: None,
+            fill_op: None,
         })
         .collect();
 
@@ -665,6 +726,9 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
             results[orig_idx] = PrescanState {
                 ctm: (ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f),
                 font: current_font_idx.map(|idx| font_table[idx].clone()),
+                text: text_state,
+                fill_space: fill_space.clone(),
+                fill_op: fill_op.clone(),
             };
             next_tp_idx += 1;
         }
@@ -752,13 +816,24 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     continue;
                 },
                 b"q" => {
-                    ctm_stack.push((ctm, current_font_idx));
+                    ctm_stack.push((
+                        ctm,
+                        current_font_idx,
+                        text_state,
+                        fill_space.clone(),
+                        fill_op.clone(),
+                    ));
                     num_count = 0;
                 },
                 b"Q" => {
-                    if let Some((saved_ctm, saved_font_idx)) = ctm_stack.pop() {
+                    if let Some((saved_ctm, saved_font_idx, saved_text, saved_space, saved_fill)) =
+                        ctm_stack.pop()
+                    {
                         ctm = saved_ctm;
                         current_font_idx = saved_font_idx;
+                        text_state = saved_text;
+                        fill_space = saved_space;
+                        fill_op = saved_fill;
                     }
                     num_count = 0;
                 },
@@ -789,6 +864,104 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     }
                     num_count = 0;
                     last_name = None;
+                },
+                b"Tc" => {
+                    if num_count >= 1 {
+                        text_state.char_spacing = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Tw" => {
+                    if num_count >= 1 {
+                        text_state.word_spacing = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Tz" => {
+                    if num_count >= 1 {
+                        text_state.horiz_scaling = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"TL" => {
+                    if num_count >= 1 {
+                        text_state.leading = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Ts" => {
+                    if num_count >= 1 {
+                        text_state.rise = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Tr" => {
+                    if num_count >= 1 {
+                        text_state.render_mode = num_buf[num_count - 1] as u8;
+                    }
+                    num_count = 0;
+                },
+                b"TD" => {
+                    // `tx ty TD` also sets the leading to -ty (§9.4.2).
+                    if num_count >= 2 {
+                        text_state.leading = -num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"rg" => {
+                    if num_count >= 3 {
+                        fill_op = Some(Operator::SetFillRgb {
+                            r: num_buf[num_count - 3],
+                            g: num_buf[num_count - 2],
+                            b: num_buf[num_count - 1],
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"g" => {
+                    if num_count >= 1 {
+                        fill_op = Some(Operator::SetFillGray {
+                            gray: num_buf[num_count - 1],
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"k" => {
+                    if num_count >= 4 {
+                        fill_op = Some(Operator::SetFillCmyk {
+                            c: num_buf[num_count - 4],
+                            m: num_buf[num_count - 3],
+                            y: num_buf[num_count - 2],
+                            k: num_buf[num_count - 1],
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"cs" => {
+                    // `cs` resets the fill color to the space's initial value,
+                    // so any earlier color operator no longer applies.
+                    if let Some(name) = last_name.take() {
+                        fill_space = Some(name);
+                        fill_op = None;
+                    }
+                    num_count = 0;
+                },
+                b"sc" => {
+                    if num_count >= 1 {
+                        fill_op = Some(Operator::SetFillColor {
+                            components: num_buf[..num_count.min(4)].to_vec(),
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"scn" => {
+                    if num_count >= 1 || last_name.is_some() {
+                        fill_op = Some(Operator::SetFillColorN {
+                            components: num_buf[..num_count.min(4)].to_vec(),
+                            name: last_name.take().map(Box::new),
+                        });
+                    }
+                    num_count = 0;
                 },
                 _ => {
                     num_count = 0;
@@ -879,6 +1052,9 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
         results[orig_idx] = PrescanState {
             ctm: (ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f),
             font: current_font_idx.map(|idx| font_table[idx].clone()),
+            text: text_state,
+            fill_space: fill_space.clone(),
+            fill_op: fill_op.clone(),
         };
         next_tp_idx += 1;
     }
@@ -1272,6 +1448,16 @@ where
                         let (a, b, c, d, e, f) = state.ctm;
                         handler(Operator::SaveState)?;
                         handler(Operator::Cm { a, b, c, d, e, f })?;
+                        // Re-inject inherited fill color: glyph color reads the
+                        // fill state, which the region wrap would otherwise
+                        // reset to black. Space first so components are
+                        // interpreted in the right color space.
+                        if let Some(ref name) = state.fill_space {
+                            handler(Operator::SetFillColorSpace { name: name.clone() })?;
+                        }
+                        if let Some(ref op) = state.fill_op {
+                            handler(op.clone())?;
+                        }
                         // Inject font state if the forward scan tracked one.
                         // This handles BT blocks that inherit Tf from a prior
                         // scope instead of setting their own.
@@ -1279,6 +1465,41 @@ where
                             handler(Operator::Tf {
                                 font: font_name.clone(),
                                 size: font_size,
+                            })?;
+                        }
+                        // Re-inject inherited text state the same way. These
+                        // parameters persist across BT/ET, so a region may rely
+                        // on a value set by an earlier region — which the
+                        // SaveState/RestoreState wrap would otherwise reset.
+                        // Only non-default values are injected, keeping the
+                        // operator stream unchanged for the common case.
+                        let ts = &state.text;
+                        if ts.char_spacing != 0.0 {
+                            handler(Operator::Tc {
+                                char_space: ts.char_spacing,
+                            })?;
+                        }
+                        if ts.word_spacing != 0.0 {
+                            handler(Operator::Tw {
+                                word_space: ts.word_spacing,
+                            })?;
+                        }
+                        if ts.horiz_scaling != 100.0 {
+                            handler(Operator::Tz {
+                                scale: ts.horiz_scaling,
+                            })?;
+                        }
+                        if ts.leading != 0.0 {
+                            handler(Operator::TL {
+                                leading: ts.leading,
+                            })?;
+                        }
+                        if ts.rise != 0.0 {
+                            handler(Operator::Ts { rise: ts.rise })?;
+                        }
+                        if ts.render_mode != 0 {
+                            handler(Operator::Tr {
+                                render: ts.render_mode,
                             })?;
                         }
                         parse_region_text_only(&data[*start..*end], &mut handler)?;
@@ -5198,6 +5419,162 @@ mod tests {
             tf_ops.len() >= 2,
             "expected Tf for both BT blocks (explicit + inherited), got {}",
             tf_ops.len()
+        );
+    }
+
+    /// Build a stream with two BT regions separated by >256KB of path filler,
+    /// forcing the prescan's forward-scan path. `first_region` is the body of
+    /// the first BT block (state setters + show ops).
+    fn two_region_prescan_stream(first_region: &[u8]) -> Vec<u8> {
+        let mut cs = Vec::new();
+        cs.extend_from_slice(b"BT ");
+        cs.extend_from_slice(first_region);
+        cs.extend_from_slice(b" ET\n");
+        for i in 0..14000u32 {
+            let line = format!(
+                "{}.0 {}.0 m {}.0 {}.0 l n\n",
+                i % 500,
+                (i * 7) % 500,
+                (i * 3) % 500,
+                (i * 11) % 500
+            );
+            cs.extend_from_slice(line.as_bytes());
+        }
+        assert!(cs.len() > 256 * 1024, "stream must exceed 256KB prescan threshold");
+        cs.extend_from_slice(b"BT (B) Tj T* (C) Tj ET\n");
+        cs
+    }
+
+    /// The operators injected for the LAST region: everything between the
+    /// final SaveState and the final BeginText.
+    fn last_region_injected(ops: &[Operator]) -> &[Operator] {
+        let last_bt = ops
+            .iter()
+            .rposition(|op| matches!(op, Operator::BeginText))
+            .expect("no BeginText");
+        let save = ops[..last_bt]
+            .iter()
+            .rposition(|op| matches!(op, Operator::SaveState))
+            .expect("no SaveState before last BeginText");
+        &ops[save..last_bt]
+    }
+
+    #[test]
+    fn test_prescan_injects_inherited_text_state() {
+        // Tc, Tw, and the leading persist across BT/ET (ISO 32000-1 §9.3.1;
+        // only Tm resets at BT), so the second region legitimately runs with
+        // the first region's values. The prescan path parses each region in
+        // an isolated SaveState/RestoreState wrap; without reconstruction the
+        // second region's T* would step by zero leading and every advance
+        // would lose Tc — glyphs land on the wrong line, slightly compressed
+        // (govdocs_040_040921.pdf p22, govdocs_055_055555.pdf p23).
+        let cs = two_region_prescan_stream(b"/F1 10 Tf 0.5 Tc 0.25 Tw 0 -12 TD (A) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            injected
+                .iter()
+                .any(|op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.5).abs() < 1e-6)),
+            "inherited Tc not injected: {:?}",
+            injected
+        );
+        assert!(
+            injected
+                .iter()
+                .any(|op| matches!(op, Operator::Tw { word_space } if (*word_space - 0.25).abs() < 1e-6)),
+            "inherited Tw not injected: {:?}",
+            injected
+        );
+        assert!(
+            injected
+                .iter()
+                .any(|op| matches!(op, Operator::TL { leading } if (*leading - 12.0).abs() < 1e-6)),
+            "leading set via TD not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_does_not_inject_default_text_state() {
+        // A first region that never touches text state must not cause any
+        // text-state operator to be synthesized for the second region.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected.iter().any(|op| matches!(
+                op,
+                Operator::Tc { .. }
+                    | Operator::Tw { .. }
+                    | Operator::Tz { .. }
+                    | Operator::TL { .. }
+                    | Operator::Ts { .. }
+                    | Operator::Tr { .. }
+            )),
+            "default text state must not be injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_injects_inherited_fill_color() {
+        // Glyph color reads the fill state, which persists across BT/ET like
+        // the rest of the graphics state. A region relying on a color set
+        // before or in an earlier region must get it re-injected, or colored
+        // text silently turns black on the prescan path (the old vec parser
+        // preserved color operators, so this shows up as chars_hash-only
+        // sweep diffs).
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET 0.2 0.4 0.6 rg BT (X) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            injected.iter().any(|op| matches!(
+                op,
+                Operator::SetFillRgb { r, g, b }
+                    if (*r - 0.2).abs() < 1e-6 && (*g - 0.4).abs() < 1e-6 && (*b - 0.6).abs() < 1e-6
+            )),
+            "inherited fill color not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_text_state_respects_q_restore() {
+        // Text state set inside a q/Q scope is restored at Q, so it must not
+        // be injected into a region that begins after the Q.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET q 3 Tc BT (X) Tj ET Q BT (Y) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected
+                .iter()
+                .any(|op| matches!(op, Operator::Tc { .. })),
+            "Tc from a closed q/Q scope must not leak into a later region: {:?}",
+            injected
         );
     }
 

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -5581,9 +5581,9 @@ mod tests {
         .unwrap();
         let injected = last_region_injected(&ops);
         assert!(
-            !injected.iter().any(
-                |op| matches!(op, Operator::SetFillColorN { name: Some(_), .. })
-            ),
+            !injected
+                .iter()
+                .any(|op| matches!(op, Operator::SetFillColorN { name: Some(_), .. })),
             "stale name fabricated a pattern: {:?}",
             injected
         );
@@ -5593,7 +5593,8 @@ mod tests {
     fn test_prescan_scn_with_too_many_operands_injects_nothing() {
         // A 6-component scn (DeviceN) exceeds what the rolling buffer can
         // faithfully replay; a truncated color would be plausible and wrong.
-        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET 0.1 0.2 0.3 0.4 0.5 0.6 scn BT (X) Tj");
+        let cs =
+            two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET 0.1 0.2 0.3 0.4 0.5 0.6 scn BT (X) Tj");
         let mut ops = Vec::new();
         parse_and_execute_text_only(&cs, |op| {
             ops.push(op);

--- a/src/converters/docx_layout.rs
+++ b/src/converters/docx_layout.rs
@@ -984,11 +984,7 @@ mod heading_level_tests {
             );
         }
         for s in spans.iter().skip(3) {
-            assert_eq!(
-                s.heading_level, None,
-                "body-size span must not be a heading: {:?}",
-                s.text
-            );
+            assert_eq!(s.heading_level, None, "body-size span must not be a heading: {:?}", s.text);
         }
     }
 

--- a/src/converters/docx_layout.rs
+++ b/src/converters/docx_layout.rs
@@ -739,9 +739,14 @@ fn annotate_heading_levels(spans: &mut [crate::layout::text_block::TextSpan]) {
         let key = (s.font_size * 10.0).round() as i32;
         *buckets.entry(key).or_default() += 1;
     }
+    // Explicit tie-break, not `max_by_key`: it returns the LAST maximal
+    // element, and over a `HashMap` that is the per-process-randomized
+    // iteration order, so a page whose two font sizes carry equal span counts
+    // picked a different modal body size per process — which flips the
+    // heading/body ratio test below. Ties resolve to the smaller size.
     let body_size_tenth = buckets
         .iter()
-        .max_by_key(|(_, c)| *c)
+        .max_by(|(a_key, a_c), (b_key, b_c)| a_c.cmp(b_c).then_with(|| b_key.cmp(a_key)))
         .map(|(k, _)| *k)
         .unwrap_or(120);
     let body = (body_size_tenth as f32) / 10.0;
@@ -937,4 +942,67 @@ fn escape_xml(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod heading_level_tests {
+    use super::*;
+
+    fn span(text: &str, size: f32) -> TextSpan {
+        TextSpan {
+            text: text.to_string(),
+            font_size: size,
+            ..Default::default()
+        }
+    }
+
+    /// The modal-body-size histogram inside `annotate_heading_levels` ties
+    /// 3-to-3 between 10 pt and 20 pt. `max_by_key` over the backing
+    /// `HashMap` returned whichever bucket the per-process-randomized
+    /// iteration order visited last, so the body size — and therefore every
+    /// heading/body ratio — flapped between runs. The tie must resolve to the
+    /// SMALLER size (10 pt), which makes the 20 pt spans ratio-2.0 H1s. Had
+    /// it resolved to 20 pt, those same spans would be ratio-1.0 body text
+    /// and get no heading level at all.
+    #[test]
+    fn modal_body_size_tie_resolves_to_smaller_size() {
+        let mut spans = vec![
+            span("Chapter One", 20.0),
+            span("Chapter Two", 20.0),
+            span("Chapter Three", 20.0),
+            span("Some body text", 10.0),
+            span("More body text", 10.0),
+            span("Further body text", 10.0),
+        ];
+        annotate_heading_levels(&mut spans);
+        for s in spans.iter().take(3) {
+            assert_eq!(
+                s.heading_level,
+                Some(1),
+                "20 pt span against a 10 pt body must be an H1: {:?}",
+                s.text
+            );
+        }
+        for s in spans.iter().skip(3) {
+            assert_eq!(
+                s.heading_level, None,
+                "body-size span must not be a heading: {:?}",
+                s.text
+            );
+        }
+    }
+
+    /// The tie-break must not disturb the ordinary case: a clear modal size
+    /// stays the body size regardless of the tie direction.
+    #[test]
+    fn unique_modal_body_size_is_unaffected_by_tie_break() {
+        let mut spans = vec![
+            span("Chapter One", 20.0),
+            span("Some body text", 10.0),
+            span("More body text", 10.0),
+            span("Further body text", 10.0),
+        ];
+        annotate_heading_levels(&mut spans);
+        assert_eq!(spans[0].heading_level, Some(1));
+    }
 }

--- a/src/converters/pdf_to_ir.rs
+++ b/src/converters/pdf_to_ir.rs
@@ -1447,10 +1447,7 @@ mod merge_lines_tests {
         let mut lines: Vec<Vec<TextSpan>> = Vec::new();
         for i in 0..8 {
             let left_x = if i < 4 { 50.0 } else { 100.0 };
-            lines.push(vec![
-                span_at(left_x, 250.0 - left_x),
-                span_at(350.0, 200.0),
-            ]);
+            lines.push(vec![span_at(left_x, 250.0 - left_x), span_at(350.0, 200.0)]);
         }
         let layout = detect_columns(&lines, 612.0).expect("two-column layout expected");
         assert_eq!(

--- a/src/converters/pdf_to_ir.rs
+++ b/src/converters/pdf_to_ir.rs
@@ -1155,7 +1155,13 @@ fn detect_columns(all_lines: &[Vec<TextSpan>], page_w_pt: f32) -> Option<ColumnL
         for &x in xs {
             *bins.entry((x / BIN_PT).round() as i32).or_insert(0) += 1;
         }
-        let (&best_b, &best_n) = bins.iter().max_by_key(|(_, &n)| n)?;
+        // Explicit tie-break, not `max_by_key`: it returns the LAST maximal
+        // element, and over a `HashMap` that is the per-process-randomized
+        // iteration order, so two equally-populated bins picked a different
+        // column left-edge per process. Ties resolve to the smaller bin.
+        let (&best_b, &best_n) = bins
+            .iter()
+            .max_by(|(a_bin, a_n), (b_bin, b_n)| a_n.cmp(b_n).then_with(|| b_bin.cmp(a_bin)))?;
         Some((best_b as f32 * BIN_PT, best_n))
     };
 
@@ -1418,5 +1424,39 @@ mod merge_lines_tests {
     #[test]
     fn existing_whitespace_seam_unchanged() {
         assert_eq!(merged_text(&[line("hello "), line("world")]), "hello world");
+    }
+
+    /// The column-left histogram inside `detect_columns` ties 4-to-4 between
+    /// the x=50 and x=100 bins. `max_by_key` over the backing `HashMap`
+    /// returned whichever bin the per-process-randomized iteration order
+    /// visited last, so the derived column width flapped between runs. The
+    /// tie must resolve to the SMALLER bin (x=50), giving a 250 pt column
+    /// (5000 twips) rather than the 200 pt (4000 twips) the other bin yields.
+    #[test]
+    fn column_left_histogram_tie_resolves_to_smaller_bin() {
+        fn span_at(x: f32, w: f32) -> TextSpan {
+            TextSpan {
+                text: "x".to_string(),
+                bbox: crate::geometry::Rect::new(x, 0.0, w, 12.0),
+                ..Default::default()
+            }
+        }
+        // Eight two-column lines. Four start column 1 at x=50, four at x=100
+        // — an exact tie. Column 1 always ends at x=250; column 2 always
+        // starts at x=350, so the gutter and midline gates all pass.
+        let mut lines: Vec<Vec<TextSpan>> = Vec::new();
+        for i in 0..8 {
+            let left_x = if i < 4 { 50.0 } else { 100.0 };
+            lines.push(vec![
+                span_at(left_x, 250.0 - left_x),
+                span_at(350.0, 200.0),
+            ]);
+        }
+        let layout = detect_columns(&lines, 612.0).expect("two-column layout expected");
+        assert_eq!(
+            layout.column_widths_twips,
+            vec![5000, 5000],
+            "tie must resolve to the smaller column-left bin (x=50 → 250 pt columns)"
+        );
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -5966,9 +5966,7 @@ impl PdfDocument {
                         // linear-scan Vec beats allocating a HashMap per span.
                         let mut span_tokens: Vec<(&str, usize)> = Vec::new();
                         for tok in trimmed.split_whitespace() {
-                            if let Some(entry) =
-                                span_tokens.iter_mut().find(|(t, _)| *t == tok)
-                            {
+                            if let Some(entry) = span_tokens.iter_mut().find(|(t, _)| *t == tok) {
                                 entry.1 += 1;
                             } else {
                                 span_tokens.push((tok, 1));
@@ -6015,9 +6013,7 @@ impl PdfDocument {
                         // traffic table). Require spatial proximity so body
                         // text that coincidentally matches a cell's text
                         // elsewhere on the page is not dropped.
-                        if !decided
-                            && !trimmed.is_empty()
-                            && cell_text_index.contains_key(trimmed)
+                        if !decided && !trimmed.is_empty() && cell_text_index.contains_key(trimmed)
                         {
                             let near_table = tables.iter().any(|t| {
                                 t.bbox.is_some_and(|tb| {

--- a/src/document.rs
+++ b/src/document.rs
@@ -17127,7 +17127,14 @@ impl PdfDocument {
                 );
             }
         }
-        // One line per rotated run (contiguous words sharing the same span index).
+        // Rotated runs, grouped into lines. A run's own extents are recorded in
+        // its frame, so the offset BETWEEN lines is the coordinate the run does
+        // not advance along: x for a +-90 degree run, y for 180. Runs that share
+        // that offset are one visual line however many `Tm`s drew them — a
+        // rotated table row is typically one run per cell. Grouping by run alone
+        // returns one line per cell (#983); grouping without the rotation key
+        // fuses perpendicular columns into one line (#804).
+        let mut run_first_word: Vec<(usize, usize)> = Vec::new();
         let mut run_start = 0;
         while run_start < words.len() {
             match word_rot_run[run_start] {
@@ -17137,11 +17144,41 @@ impl PdfDocument {
                     while run_end < words.len() && word_rot_run[run_end] == Some(run_id) {
                         run_end += 1;
                     }
-                    lines.push(words[run_start..run_end].to_vec());
+                    run_first_word.push((run_start, run_end));
                     run_start = run_end;
                 },
             }
         }
+
+        // On a /Rotate page `postprocess_spans` rect-maps each span's bbox into
+        // the displayed frame but leaves `rotation_degrees` describing the
+        // pre-display one, so the bbox axes and the rotation no longer agree and
+        // the offset read below would be taken off the wrong axis.
+        let page_is_unrotated = self.get_page_rotation(page_index).unwrap_or(0) == 0;
+
+        let mut rotated_lines: Vec<(f32, f32, Vec<Word>)> = Vec::new();
+        for (start, end) in run_first_word {
+            let word = &words[start];
+            let rotation = spans[word_rot_run[start].expect("rotated run")].rotation_degrees;
+            // Only a quarter-turn run has its line offset on x; 180 degrees and
+            // free angles keep one line per run, as before. Widening past this
+            // merges runs that were never one line.
+            let quarter_turn = (rotation.abs() - 90.0).abs() < 0.5;
+            if !quarter_turn || !page_is_unrotated {
+                rotated_lines.push((rotation, f32::NAN, words[start..end].to_vec()));
+                continue;
+            }
+            let across = word.bbox.x;
+            let tolerance = word.bbox.height.max(1.0) * 0.5;
+            let existing = rotated_lines.iter_mut().find(|(rot, off, _)| {
+                (*rot - rotation).abs() < 0.5 && (*off - across).abs() <= tolerance
+            });
+            match existing {
+                Some((_, _, line)) => line.extend_from_slice(&words[start..end]),
+                None => rotated_lines.push((rotation, across, words[start..end].to_vec())),
+            }
+        }
+        lines.extend(rotated_lines.into_iter().map(|(_, _, line)| line));
         // Reading order: sort lines by the span sequence of their first word
         // (stable so intra-line order is preserved).
         lines.sort_by_key(|line| line.first().map(|w| w.sequence).unwrap_or(usize::MAX));

--- a/src/document.rs
+++ b/src/document.rs
@@ -5393,13 +5393,27 @@ impl PdfDocument {
         // portrait page): the row-major assembler groups lines
         // in the portrait frame and interleaves every rotated row. Assemble
         // such pages in their rotated reading frame instead.
-        let base_spans = match self.map_dominant_rotation_into_reading_frame(page_index, base_spans)
-        {
-            Ok(mapped) => mapped,
-            Err(original) => original,
-        };
+        let base_spans = self.spans_in_reading_frame(page_index, base_spans);
         let text = self.assemble_text_from_spans(page_index, base_spans, options)?;
         Ok(Self::apply_mixed_rtl_line_pass(text))
+    }
+
+    /// [`Self::map_dominant_rotation_into_reading_frame`] with the
+    /// mapped/unchanged distinction collapsed, for the call sites that only
+    /// want "spans as a reader sees them".
+    ///
+    /// Every text-producing surface goes through this. Applying the frame at
+    /// one call site made the same page read correctly through `extract_text`
+    /// and incorrectly through `to_markdown` / `to_html` / `to_plain_text`.
+    fn spans_in_reading_frame(
+        &self,
+        page_index: usize,
+        spans: Vec<crate::layout::TextSpan>,
+    ) -> Vec<crate::layout::TextSpan> {
+        match self.map_dominant_rotation_into_reading_frame(page_index, spans) {
+            Ok(mapped) => mapped,
+            Err(original) => original,
+        }
     }
 
     /// Map a dominant-rotation page's spans into their rotated reading
@@ -5491,6 +5505,7 @@ impl PdfDocument {
     ) -> Result<String> {
         let mut base_spans = self.extract_spans(page_index)?;
         base_spans.extend(extra);
+        let base_spans = self.spans_in_reading_frame(page_index, base_spans);
         let text = self.assemble_text_from_spans(page_index, base_spans, options)?;
         Ok(Self::apply_mixed_rtl_line_pass(text))
     }
@@ -15566,6 +15581,7 @@ impl PdfDocument {
         }
 
         let spans = self.extract_spans_filtered(page_index, excluded_layers, excluded_inks)?;
+        let spans = self.spans_in_reading_frame(page_index, spans);
         let options = crate::converters::ConversionOptions {
             extract_tables: true,
             ..Default::default()
@@ -15592,6 +15608,7 @@ impl PdfDocument {
         } else {
             self.extract_spans_filtered(page_index, excluded_layers, excluded_inks)?
         };
+        let spans = self.spans_in_reading_frame(page_index, spans);
         let options = crate::converters::ConversionOptions {
             extract_tables: true,
             include_region: Some((region, mode)),
@@ -20005,6 +20022,11 @@ impl PdfDocument {
             return Ok(vertical);
         }
 
+        // Same frame `extract_text` assembles in, applied at the same point:
+        // after the vertical-CJK check (which reads the rotation this clears)
+        // and before table detection (which consumes the geometry this maps).
+        let base_spans = self.spans_in_reading_frame(page_index, base_spans);
+
         // Two-column prose (#734) is content-balance-gated to reject real
         // tables, so when it fires suppress the text-only spatial table
         // fallback: a short-cell two-column body must read column-major as
@@ -20581,6 +20603,9 @@ impl PdfDocument {
             return Ok(format!("<p>{}</p>", escaped.trim()));
         }
 
+        // Same frame `extract_text` assembles in — see `to_markdown_inner`.
+        let base_spans = self.spans_in_reading_frame(page_index, base_spans);
+
         // Two-column prose (#734) is content-balance-gated to reject real
         // tables, so when it fires suppress the text-only spatial table
         // fallback: a short-cell two-column body must read column-major as
@@ -20822,11 +20847,12 @@ impl PdfDocument {
         // path below, so their output is byte-for-byte unchanged.
         if self.prefers_structure_reading_order() {
             let base_spans = self.extract_spans(page_index)?;
+            let base_spans = self.spans_in_reading_frame(page_index, base_spans);
             return self.assemble_text_from_spans(page_index, base_spans, options);
         }
 
         // Step 1: Extract raw spans (unchanged - this is the foundation)
-        let mut spans = self.extract_spans(page_index)?;
+        let mut spans = self.spans_in_reading_frame(page_index, self.extract_spans(page_index)?);
 
         // Step 1b: Merge widget annotation spans (form field values) if enabled
         if options.include_form_fields {

--- a/src/document.rs
+++ b/src/document.rs
@@ -5805,14 +5805,14 @@ impl PdfDocument {
                 // table are already covered by the inline-table flush
                 // below, so we must NOT also preserve them in the flow
                 // span list (it would produce duplicate output).
-                let mut table_cell_texts: std::collections::HashSet<String> =
+                let mut table_cell_texts: std::collections::HashSet<&str> =
                     std::collections::HashSet::new();
                 for t in &tables {
                     for row in &t.rows {
                         for cell in &row.cells {
                             let trimmed = cell.text.trim();
                             if !trimmed.is_empty() {
-                                table_cell_texts.insert(trimmed.to_string());
+                                table_cell_texts.insert(trimmed);
                             }
                         }
                     }
@@ -5834,93 +5834,71 @@ impl PdfDocument {
                             .flat_map(|r| r.cells.iter().flat_map(|c| c.mcids.iter().copied()))
                     })
                     .collect();
-                // Flatten every cell bbox once and index it into coarse y-bands,
+                // Flatten every cell bbox once (with its trimmed text, so the
+                // ownership test below can tell an exact-text cell match from a
+                // fragment of a merged cell) and index it into coarse y-bands,
                 // so the per-span containment test below scans only the cells in
                 // the span's y-band instead of every cell on the page (was
                 // O(spans x cells) on untagged table pages). A cell that contains
                 // a span necessarily shares the span's y-band, so this is
                 // byte-identical to the full scan.
-                let cell_bboxes: Vec<crate::geometry::Rect> = tables
+                // Only tables with a bbox reach the inline flush below; a
+                // cell of an unflushed table renders nowhere and must not
+                // absorb anything.
+                let cell_bboxes: Vec<(crate::geometry::Rect, &str)> = tables
                     .iter()
+                    .filter(|t| t.bbox.is_some())
                     .flat_map(|t| {
-                        t.rows
-                            .iter()
-                            .flat_map(|r| r.cells.iter().filter_map(|c| c.bbox))
+                        t.rows.iter().flat_map(|r| {
+                            r.cells
+                                .iter()
+                                .filter_map(|c| c.bbox.map(|b| (b, c.text.trim())))
+                        })
                     })
                     .collect();
+                // Same-text cell lookup for the fallback path: a span that no
+                // cell bbox contains can still be absorbed by a cell whose
+                // exact text it carries, as long as that cell's budget is
+                // untouched.
+                let mut cell_text_index: std::collections::HashMap<&str, Vec<usize>> =
+                    std::collections::HashMap::new();
+                for (ci, (_, text)) in cell_bboxes.iter().enumerate() {
+                    if !text.is_empty() {
+                        cell_text_index.entry(text).or_default().push(ci);
+                    }
+                }
                 const CELL_Y_BIN: f32 = 18.0;
                 let cell_bin = |y: f32| (y / CELL_Y_BIN).floor() as i32;
                 let mut cell_y_index: std::collections::HashMap<i32, Vec<usize>> =
                     std::collections::HashMap::new();
-                for (ci, b) in cell_bboxes.iter().enumerate() {
+                for (ci, (b, _)) in cell_bboxes.iter().enumerate() {
                     for bin in cell_bin(b.y)..=cell_bin(b.y + b.height) {
                         cell_y_index.entry(bin).or_default().push(ci);
                     }
                 }
-                // Returns true when span should be removed from the flow because
-                // it is owned by a table cell (will be re-emitted by render_text).
-                let span_in_table = |s: &crate::layout::TextSpan| -> bool {
-                    if !table_cell_mcids.is_empty() {
-                        if let Some(mcid) = s.mcid {
-                            // Tagged PDF: MCID decides ownership precisely.
-                            return table_cell_mcids.contains(&mcid);
+                // Per-cell token budgets. `render_text()` emits each cell's
+                // text exactly once, so a cell can absorb dropped spans
+                // totalling at most its own token multiset. Bbox containment
+                // alone cannot decide a drop: a rowspan-merged cell's bbox can
+                // cover far more spans than its text was built from (a
+                // schedule column's tall cell covering hundreds of repeated
+                // marks while holding six lines of them), and an empty-text
+                // cell re-emits nothing at all (a value column without row
+                // rules becomes one tall empty cell whose bbox swallows every
+                // figure in the column). A span leaves the flow only by
+                // consuming its tokens from a covering cell's budget — the
+                // fragment-level form of the same rule the text fallback
+                // needs: membership cannot see multiplicity.
+                let mut cell_remaining: Vec<std::collections::HashMap<&str, usize>> = cell_bboxes
+                    .iter()
+                    .map(|(_, text)| {
+                        let mut m = std::collections::HashMap::new();
+                        for tok in text.split_whitespace() {
+                            *m.entry(tok).or_insert(0) += 1;
                         }
-                        // Tagged PDF but span has no MCID (widget/annotation):
-                        // keep in flow — better to duplicate than to silently drop.
-                        return false;
-                    }
-                    // Untagged PDF or no MCIDs in any cell: cell-bbox-based filter.
-                    // Using per-cell bboxes (rather than the coarser table bbox) prevents
-                    // dropping paragraph spans that lie inside the table's outer bounding
-                    // box but were not captured as table cells by the spatial detector.
-                    // Probe only the cells in the span's y-band (±1 bin guards the
-                    // containment tolerance). Equivalent to scanning every cell.
-                    let slo = cell_bin(s.bbox.y) - 1;
-                    let shi = cell_bin(s.bbox.y + s.bbox.height) + 1;
-                    let in_cell = (slo..=shi).any(|bin| {
-                        cell_y_index.get(&bin).is_some_and(|cands| {
-                            cands.iter().any(|&ci| {
-                                Self::contains_rect_with_tolerance(
-                                    &cell_bboxes[ci],
-                                    &s.bbox,
-                                    RETAIN_TOLERANCE,
-                                )
-                            })
-                        })
-                    });
-                    if in_cell {
-                        return true;
-                    }
-                    // Fallback: text-based match. The bbox check above uses
-                    // a tight 0.1pt tolerance and rejects spans whose font
-                    // ascent extends slightly above the cell's ink box (issue
-                    // 484: "FY 15 1st Q TTL" labels in JAL traffic table —
-                    // span height = font_size = 10.7pt, but cell bbox height
-                    // = 15.96pt covers two ink rows so the label glyphs reach
-                    // ~0.4pt above the cell's top edge). When a span's
-                    // trimmed text exactly matches some cell's text, the cell
-                    // already owns it — keeping it in flow would duplicate.
-                    let trimmed = s.text.trim();
-                    if trimmed.is_empty() {
-                        return false;
-                    }
-                    if !table_cell_texts.contains(trimmed) {
-                        return false;
-                    }
-                    // Require spatial proximity: the span must lie inside
-                    // some table's outer bbox so we don't drop body text that
-                    // coincidentally matches a cell's text elsewhere on the page.
-                    tables.iter().any(|t| {
-                        t.bbox.is_some_and(|tb| {
-                            let cx = s.bbox.x + s.bbox.width / 2.0;
-                            let cy = s.bbox.y + s.bbox.height / 2.0;
-                            cx >= tb.x - RETAIN_TOLERANCE
-                                && cx <= tb.x + tb.width + RETAIN_TOLERANCE
-                                && cy >= tb.y - RETAIN_TOLERANCE
-                                && cy <= tb.y + tb.height + RETAIN_TOLERANCE
-                        })
+                        m
                     })
-                };
+                    .collect();
 
                 let preserved_label_indices: std::collections::HashSet<usize> =
                     Self::identify_multi_row_labels(&spans)
@@ -5945,22 +5923,137 @@ impl PdfDocument {
                         })
                         .collect();
 
-                if preserved_label_indices.is_empty() {
-                    spans.retain(|s| !span_in_table(s));
-                } else {
-                    let kept: Vec<crate::layout::TextSpan> = spans
-                        .drain(..)
-                        .enumerate()
-                        .filter_map(|(i, s)| {
-                            if !span_in_table(&s) || preserved_label_indices.contains(&i) {
-                                Some(s)
+                // One pass covers both cases: with no preserved labels the
+                // index test is simply never true.
+                //
+                // A cell-covered span leaves the flow by consuming its tokens
+                // from the covering cell's budget. A text-fallback span
+                // (matching a cell's exact text without lying inside any cell
+                // — the ascent-overshoot geometry the fallback exists for)
+                // claims a same-text cell whose budget is still whole. Both
+                // paths draw on the SAME per-cell budgets, so a cell that
+                // absorbed its own spans cannot also be claimed from a
+                // distance: with split accounting, a page carrying one
+                // repeated label per row dropped three spans against two
+                // rendering cells.
+                //
+                // Once every cell that could absorb a text is spoken for,
+                // further spans matching it stay in the flow, because
+                // `render_text()` will not emit them again. Membership cannot
+                // see multiplicity. Spans no cell can absorb stay in the
+                // flow: better to duplicate than to silently drop.
+                let mut kept: Vec<crate::layout::TextSpan> = Vec::with_capacity(spans.len());
+                for (i, s) in spans.drain(..).enumerate() {
+                    if preserved_label_indices.contains(&i) {
+                        kept.push(s);
+                        continue;
+                    }
+                    if !table_cell_mcids.is_empty() {
+                        // Tagged PDF: MCID decides ownership precisely. A span
+                        // with no MCID (widget/annotation) stays in flow —
+                        // better to duplicate than to silently drop.
+                        if s.mcid.is_some_and(|m| table_cell_mcids.contains(&m)) {
+                            continue;
+                        }
+                        kept.push(s);
+                        continue;
+                    }
+                    // Inner scope: every borrow of `s.text` ends before the
+                    // span is moved into `kept`.
+                    let dropped = {
+                        let trimmed = s.text.trim();
+                        // A span rarely carries more than a few tokens; a
+                        // linear-scan Vec beats allocating a HashMap per span.
+                        let mut span_tokens: Vec<(&str, usize)> = Vec::new();
+                        for tok in trimmed.split_whitespace() {
+                            if let Some(entry) =
+                                span_tokens.iter_mut().find(|(t, _)| *t == tok)
+                            {
+                                entry.1 += 1;
                             } else {
-                                None
+                                span_tokens.push((tok, 1));
                             }
-                        })
-                        .collect();
-                    spans = kept;
+                        }
+                        // Probe only the cells in the span's y-band (±1 bin
+                        // guards the containment tolerance). Equivalent to
+                        // scanning every cell.
+                        let slo = cell_bin(s.bbox.y) - 1;
+                        let shi = cell_bin(s.bbox.y + s.bbox.height) + 1;
+                        let mut decided = false;
+                        'cells: for bin in slo..=shi {
+                            let Some(cands) = cell_y_index.get(&bin) else {
+                                continue;
+                            };
+                            for &ci in cands {
+                                let (cell_bbox, _) = &cell_bboxes[ci];
+                                if !Self::contains_rect_with_tolerance(
+                                    cell_bbox,
+                                    &s.bbox,
+                                    RETAIN_TOLERANCE,
+                                ) {
+                                    continue;
+                                }
+                                let remaining = &mut cell_remaining[ci];
+                                if span_tokens.iter().all(|(tok, n)| {
+                                    remaining.get::<str>(tok).copied().unwrap_or(0) >= *n
+                                }) {
+                                    for (tok, n) in &span_tokens {
+                                        if let Some(r) = remaining.get_mut::<str>(tok) {
+                                            *r -= n;
+                                        }
+                                    }
+                                    // Dropped: the cell re-emits it.
+                                    decided = true;
+                                    break 'cells;
+                                }
+                            }
+                        }
+                        // Fallback: text-based match. The bbox check above
+                        // uses a tight 0.1pt tolerance and rejects spans whose
+                        // font ascent extends slightly above the cell's ink
+                        // box (issue 484: "FY 15 1st Q TTL" labels in the JAL
+                        // traffic table). Require spatial proximity so body
+                        // text that coincidentally matches a cell's text
+                        // elsewhere on the page is not dropped.
+                        if !decided
+                            && !trimmed.is_empty()
+                            && cell_text_index.contains_key(trimmed)
+                        {
+                            let near_table = tables.iter().any(|t| {
+                                t.bbox.is_some_and(|tb| {
+                                    let cx = s.bbox.x + s.bbox.width / 2.0;
+                                    let cy = s.bbox.y + s.bbox.height / 2.0;
+                                    cx >= tb.x - RETAIN_TOLERANCE
+                                        && cx <= tb.x + tb.width + RETAIN_TOLERANCE
+                                        && cy >= tb.y - RETAIN_TOLERANCE
+                                        && cy <= tb.y + tb.height + RETAIN_TOLERANCE
+                                })
+                            });
+                            if near_table {
+                                for &ci in &cell_text_index[trimmed] {
+                                    let remaining = &mut cell_remaining[ci];
+                                    if span_tokens.iter().all(|(tok, n)| {
+                                        remaining.get::<str>(tok).copied().unwrap_or(0) >= *n
+                                    }) {
+                                        for (tok, n) in &span_tokens {
+                                            if let Some(r) = remaining.get_mut::<str>(tok) {
+                                                *r -= n;
+                                            }
+                                        }
+                                        // Dropped: this unclaimed cell re-emits it.
+                                        decided = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        decided
+                    };
+                    if !dropped {
+                        kept.push(s);
+                    }
                 }
+                spans = kept;
             }
 
             // Row-aware ordering: quantize Y into bands and sort band-

--- a/src/document.rs
+++ b/src/document.rs
@@ -17174,6 +17174,20 @@ impl PdfDocument {
         let page_is_unrotated = self.get_page_rotation(page_index).unwrap_or(0) == 0;
 
         let mut rotated_lines: Vec<(f32, f32, Vec<Word>)> = Vec::new();
+        // Offsets of the quarter-turn lines, quantized to 1/100 pt, mapped to
+        // the indices of the lines carrying them. The match below used to scan
+        // every line built so far, which is O(runs^2) — and a rotated table,
+        // the exact page this grouping exists for, is where the run count
+        // climbs. The index answers the same question over a bounded range.
+        //
+        // Semantics are preserved exactly. A line's offset is frozen when it is
+        // created, and the winner is the FIRST such line in insertion order, so
+        // candidates are filtered by the original predicate and the smallest
+        // index wins. Merging neighbours instead would group differently:
+        // offsets 0, 3, 6 with tolerance 4 give {0,3},{6} under this rule but
+        // {0,3,6} under a chained merge.
+        let mut offset_index: std::collections::BTreeMap<i64, Vec<usize>> =
+            std::collections::BTreeMap::new();
         for (start, end) in run_first_word {
             let word = &words[start];
             let rotation = spans[word_rot_run[start].expect("rotated run")].rotation_degrees;
@@ -17187,12 +17201,27 @@ impl PdfDocument {
             }
             let across = word.bbox.x;
             let tolerance = word.bbox.height.max(1.0) * 0.5;
-            let existing = rotated_lines.iter_mut().find(|(rot, off, _)| {
-                (*rot - rotation).abs() < 0.5 && (*off - across).abs() <= tolerance
-            });
-            match existing {
-                Some((_, _, line)) => line.extend_from_slice(&words[start..end]),
-                None => rotated_lines.push((rotation, across, words[start..end].to_vec())),
+            let quantize = |v: f32| (f64::from(v) * 100.0).round() as i64;
+            // Widened by one step each way so a value sitting on a bucket edge
+            // cannot be missed by rounding.
+            let (lo, hi) = (quantize(across - tolerance) - 1, quantize(across + tolerance) + 1);
+            let winner = offset_index
+                .range(lo..=hi)
+                .flat_map(|(_, indices)| indices.iter().copied())
+                .filter(|&i| {
+                    let (rot, off, _) = &rotated_lines[i];
+                    (*rot - rotation).abs() < 0.5 && (*off - across).abs() <= tolerance
+                })
+                .min();
+            match winner {
+                Some(i) => rotated_lines[i].2.extend_from_slice(&words[start..end]),
+                None => {
+                    offset_index
+                        .entry(quantize(across))
+                        .or_default()
+                        .push(rotated_lines.len());
+                    rotated_lines.push((rotation, across, words[start..end].to_vec()));
+                },
             }
         }
         lines.extend(rotated_lines.into_iter().map(|(_, _, line)| line));

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -14,6 +14,10 @@ use crate::content::parse_and_execute_text_only;
 use crate::content::parse_content_stream;
 use crate::error::Result;
 use crate::extract_log_debug;
+use crate::fonts::unicode_decode::{
+    decode_text_to_unicode, fallback_char_to_unicode, strip_subset_prefix, DecodePolicy,
+    TextCharIter,
+};
 use crate::fonts::FontInfo;
 use crate::geometry::Rect;
 use crate::layout::{Color, FontWeight, TextChar, TextSpan};
@@ -2091,389 +2095,19 @@ impl TjBuffer {
         }
 
         // Slow path: Type0 (CID) fonts or no font — use full decode function
-        let unicode_text = decode_text_to_unicode(bytes, font);
+        let unicode_text = decode_text_to_unicode(
+            bytes,
+            font,
+            DecodePolicy {
+                preserve_unmapped: preserve_unmapped_glyphs(),
+                decompose_ligatures: false,
+            },
+            None,
+        );
         self.unicode.push_str(&unicode_text);
 
         Ok(())
     }
-}
-
-/// Fallback function to map common character codes to Unicode when ToUnicode CMap fails.
-///
-/// PDF Spec Compliance: ISO 32000-1:2008 Section 9.10.2
-/// This function implements Priority 6 (enhanced fallback) after the standard 5-tier
-/// encoding system (ToUnicode CMap, predefined encodings, Adobe Glyph List, etc.) fails.
-///
-/// Multi-tier fallback strategy:
-/// 1. Common punctuation and symbols (em dash, en dash, quotes, bullets)
-/// 2. Mathematical operators (∂, ∇, ∑, ∏, ∫, √, ∞, ≤, ≥, ≠)
-/// 3. Greek letters (α, β, γ, δ, θ, λ, μ, π, σ, ω - both cases)
-/// 4. Currency symbols (€, £, ¥, ¢)
-/// 5. Direct Unicode (if char_code is in valid Unicode range)
-/// 6. Private Use Area visual description (U+E000-U+F8FF)
-/// 7. Replacement character "?" as last resort
-///
-/// # Arguments
-/// * `char_code` - 16-bit character code that failed to decode via standard system
-///
-/// # Returns
-/// Best-effort Unicode string representation, or "?" if no mapping possible
-fn fallback_char_to_unicode(char_code: u32) -> String {
-    match char_code {
-        // ==================================================================================
-        // PRIORITY 1: Common Punctuation (most frequently failing)
-        // ==================================================================================
-        0x2014 => "—".to_string(),        // Em dash
-        0x2013 => "–".to_string(),        // En dash
-        0x2018 => "\u{2018}".to_string(), // Left single quotation mark (')
-        0x2019 => "\u{2019}".to_string(), // Right single quotation mark (')
-        0x201C => "\u{201C}".to_string(), // Left double quotation mark (")
-        0x201D => "\u{201D}".to_string(), // Right double quotation mark (")
-        0x2022 => "•".to_string(),        // Bullet
-        0x2026 => "…".to_string(),        // Horizontal ellipsis
-        0x00B0 => "°".to_string(),        // Degree sign
-
-        // ==================================================================================
-        // PRIORITY 2: Mathematical Operators (common in academic papers)
-        // ==================================================================================
-        0x00B1 => "±".to_string(), // Plus-minus sign
-        0x00D7 => "×".to_string(), // Multiplication sign
-        0x00F7 => "÷".to_string(), // Division sign
-        0x2202 => "∂".to_string(), // Partial differential
-        0x2207 => "∇".to_string(), // Nabla (del operator)
-        0x220F => "∏".to_string(), // N-ary product
-        0x2211 => "∑".to_string(), // N-ary summation
-        0x221A => "√".to_string(), // Square root
-        0x221E => "∞".to_string(), // Infinity
-        0x2260 => "≠".to_string(), // Not equal to
-        0x2261 => "≡".to_string(), // Identical to
-        0x2264 => "≤".to_string(), // Less-than or equal to
-        0x2265 => "≥".to_string(), // Greater-than or equal to
-        0x222B => "∫".to_string(), // Integral
-        0x2248 => "≈".to_string(), // Almost equal to
-        0x2282 => "⊂".to_string(), // Subset of
-        0x2283 => "⊃".to_string(), // Superset of
-        0x2286 => "⊆".to_string(), // Subset of or equal to
-        0x2287 => "⊇".to_string(), // Superset of or equal to
-        0x2208 => "∈".to_string(), // Element of
-        0x2209 => "∉".to_string(), // Not an element of
-        0x2200 => "∀".to_string(), // For all
-        0x2203 => "∃".to_string(), // There exists
-        0x2205 => "∅".to_string(), // Empty set
-        0x2227 => "∧".to_string(), // Logical and
-        0x2228 => "∨".to_string(), // Logical or
-        0x00AC => "¬".to_string(), // Not sign
-        0x2192 => "→".to_string(), // Rightwards arrow
-        0x2190 => "←".to_string(), // Leftwards arrow
-        0x2194 => "↔".to_string(), // Left right arrow
-        0x21D2 => "⇒".to_string(), // Rightwards double arrow
-        0x21D4 => "⇔".to_string(), // Left right double arrow
-
-        // ==================================================================================
-        // PRIORITY 3: Greek Letters (common in scientific/mathematical texts)
-        // ==================================================================================
-        // Lowercase Greek
-        0x03B1 => "α".to_string(), // Alpha
-        0x03B2 => "β".to_string(), // Beta
-        0x03B3 => "γ".to_string(), // Gamma
-        0x03B4 => "δ".to_string(), // Delta
-        0x03B5 => "ε".to_string(), // Epsilon
-        0x03B6 => "ζ".to_string(), // Zeta
-        0x03B7 => "η".to_string(), // Eta
-        0x03B8 => "θ".to_string(), // Theta
-        0x03B9 => "ι".to_string(), // Iota
-        0x03BA => "κ".to_string(), // Kappa
-        0x03BB => "λ".to_string(), // Lambda
-        0x03BC => "μ".to_string(), // Mu
-        0x03BD => "ν".to_string(), // Nu
-        0x03BE => "ξ".to_string(), // Xi
-        0x03BF => "ο".to_string(), // Omicron
-        0x03C0 => "π".to_string(), // Pi
-        0x03C1 => "ρ".to_string(), // Rho
-        0x03C2 => "ς".to_string(), // Final sigma
-        0x03C3 => "σ".to_string(), // Sigma
-        0x03C4 => "τ".to_string(), // Tau
-        0x03C5 => "υ".to_string(), // Upsilon
-        0x03C6 => "φ".to_string(), // Phi
-        0x03C7 => "χ".to_string(), // Chi
-        0x03C8 => "ψ".to_string(), // Psi
-        0x03C9 => "ω".to_string(), // Omega
-
-        // Uppercase Greek
-        0x0391 => "Α".to_string(), // Alpha
-        0x0392 => "Β".to_string(), // Beta
-        0x0393 => "Γ".to_string(), // Gamma
-        0x0394 => "Δ".to_string(), // Delta
-        0x0395 => "Ε".to_string(), // Epsilon
-        0x0396 => "Ζ".to_string(), // Zeta
-        0x0397 => "Η".to_string(), // Eta
-        0x0398 => "Θ".to_string(), // Theta
-        0x0399 => "Ι".to_string(), // Iota
-        0x039A => "Κ".to_string(), // Kappa
-        0x039B => "Λ".to_string(), // Lambda
-        0x039C => "Μ".to_string(), // Mu
-        0x039D => "Ν".to_string(), // Nu
-        0x039E => "Ξ".to_string(), // Xi
-        0x039F => "Ο".to_string(), // Omicron
-        0x03A0 => "Π".to_string(), // Pi
-        0x03A1 => "Ρ".to_string(), // Rho
-        0x03A3 => "Σ".to_string(), // Sigma
-        0x03A4 => "Τ".to_string(), // Tau
-        0x03A5 => "Υ".to_string(), // Upsilon
-        0x03A6 => "Φ".to_string(), // Phi
-        0x03A7 => "Χ".to_string(), // Chi
-        0x03A8 => "Ψ".to_string(), // Psi
-        0x03A9 => "Ω".to_string(), // Omega
-
-        // ==================================================================================
-        // PRIORITY 4: Currency Symbols
-        // ==================================================================================
-        0x20AC => "€".to_string(), // Euro
-        0x00A3 => "£".to_string(), // Pound sterling
-        0x00A5 => "¥".to_string(), // Yen
-        0x00A2 => "¢".to_string(), // Cent
-        0x20A3 => "₣".to_string(), // French franc
-        0x20A4 => "₤".to_string(), // Lira
-        0x20A9 => "₩".to_string(), // Won
-        0x20AA => "₪".to_string(), // New shekel
-        0x20AB => "₫".to_string(), // Dong
-        0x20B9 => "₹".to_string(), // Indian rupee
-
-        // ==================================================================================
-        // PRIORITY 5: Direct Unicode (for valid ranges)
-        // ==================================================================================
-        // Valid Unicode: BMP (0x0000-0xD7FF, 0xE000-0xFFFF) and supplementary planes
-        // Excludes surrogate pairs (0xD800-0xDFFF)
-        code => {
-            if let Some(ch) = char::from_u32(code) {
-                if (0xE000..=0xF8FF).contains(&code) {
-                    log::debug!("Private Use Area character: U+{:04X}", code);
-                }
-                ch.to_string()
-            } else {
-                log::warn!("Character code 0x{:04X} is not a valid Unicode code point", code);
-                "?".to_string()
-            }
-        },
-    }
-}
-
-/// Byte grouping mode for CID font character code decoding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ByteMode {
-    /// Single-byte codes (simple fonts, some predefined CMaps)
-    OneByte,
-    /// Always 2-byte codes (Identity-H/V, UCS2)
-    TwoByte,
-    /// Shift-JIS variable-width (1 or 2 bytes depending on lead byte)
-    ShiftJIS,
-}
-
-/// True when a Type0 font's `/Encoding` is a UTF-8 (variable-width) CMap —
-/// `Uni-Utf8-H` (embedded, pdf.js issue18117) or the Adobe predefined
-/// `UniGB-UTF8-H` / `UniCNS-UTF8-H` / `UniJIS-UTF8-H` / `UniKS-UTF8-H` family.
-/// Such codes are 1–4 bytes and must be segmented by UTF-8 lead-byte rules
-/// (see `decode_text_to_unicode`), not the fixed 1/2-byte `ByteMode`. Matching
-/// on the CMap name keeps the change isolated to these fonts. See #610.
-fn font_has_utf8_cmap(font: &FontInfo) -> bool {
-    if font.subtype != "Type0" {
-        return false;
-    }
-    if let crate::fonts::Encoding::Standard(name) = &font.encoding {
-        let lower = name.to_ascii_lowercase();
-        lower.contains("utf8") || lower.contains("utf-8")
-    } else {
-        false
-    }
-}
-
-/// Get byte grouping mode for a font (v0.3.14).
-fn get_byte_mode(font: Option<&FontInfo>) -> ByteMode {
-    if let Some(font) = font {
-        if font.subtype == "Type0" {
-            // If the ToUnicode CMap declares a 2-byte codespace range, always use
-            // TwoByte mode regardless of the encoding name. This handles CJK fonts
-            // whose /Encoding name is a custom CMap stream that doesn't match the
-            // well-known keyword patterns below (e.g. "H", "V", "UniCNS-H", …).
-            // See PDF Spec §9.7.5 — `begincodespacerange` is authoritative.
-            if let Some(ref lazy_cmap) = font.to_unicode {
-                if lazy_cmap.code_width() == 2 {
-                    return ByteMode::TwoByte;
-                }
-            }
-
-            match &font.encoding {
-                crate::fonts::Encoding::Identity => ByteMode::TwoByte,
-                crate::fonts::Encoding::Standard(name) => {
-                    if (name.contains("Identity") && !name.contains("OneByteIdentity"))
-                        || name.contains("UCS2")
-                        || name.contains("UTF16")
-                        // CORPUS-3: bare Adobe predefined horizontal/vertical CMaps
-                        // ("H"/"V", e.g. Adobe-Japan1-H) are 2-byte by definition;
-                        // without this they were read single-byte → CJK garbage
-                        // ("あいうえお" → "CACCCECGCI" on noembed-jis7).
-                        || name == "H"
-                        || name == "V"
-                    {
-                        ByteMode::TwoByte
-                    } else if name.contains("RKSJ") {
-                        ByteMode::ShiftJIS
-                    } else if name.contains("EUC")
-                        || name.contains("GBK")
-                        || name.contains("GBpc")
-                        || name.contains("GB-")
-                        || name.contains("CNS")
-                        || name.contains("B5")
-                        || name.contains("KSC")
-                        || name.contains("KSCms")
-                    {
-                        ByteMode::TwoByte
-                    } else {
-                        ByteMode::OneByte
-                    }
-                },
-                _ => ByteMode::OneByte,
-            }
-        } else {
-            ByteMode::OneByte
-        }
-    } else {
-        ByteMode::OneByte
-    }
-}
-
-/// Iterator over characters in a PDF string based on font encoding (v0.3.14).
-struct TextCharIter<'a> {
-    bytes: &'a [u8],
-    byte_mode: ByteMode,
-    index: usize,
-}
-
-impl<'a> TextCharIter<'a> {
-    fn new(bytes: &'a [u8], font: Option<&FontInfo>) -> Self {
-        Self {
-            bytes,
-            byte_mode: get_byte_mode(font),
-            index: 0,
-        }
-    }
-}
-
-impl<'a> Iterator for TextCharIter<'a> {
-    type Item = (u16, usize); // (char_code, bytes_consumed)
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.bytes.len() {
-            return None;
-        }
-
-        let (char_code, bytes_consumed) = match self.byte_mode {
-            ByteMode::TwoByte if self.index + 1 < self.bytes.len() => {
-                (((self.bytes[self.index] as u16) << 8) | (self.bytes[self.index + 1] as u16), 2)
-            },
-            ByteMode::ShiftJIS => {
-                let b = self.bytes[self.index];
-                let is_lead = (0x81..=0x9F).contains(&b) || (0xE0..=0xFC).contains(&b);
-                if is_lead && self.index + 1 < self.bytes.len() {
-                    (((b as u16) << 8) | (self.bytes[self.index + 1] as u16), 2)
-                } else {
-                    (b as u16, 1)
-                }
-            },
-            _ => (self.bytes[self.index] as u16, 1),
-        };
-
-        self.index += bytes_consumed;
-        Some((char_code, bytes_consumed))
-    }
-}
-
-fn decode_text_to_unicode(bytes: &[u8], font: Option<&FontInfo>) -> String {
-    let raw_result = if let Some(font) = font {
-        let mut result = String::new();
-        // Use pre-computed lookup table for performance if it's a simple font
-        if font.subtype != "Type0" {
-            let table = font.get_byte_to_char_table();
-            for &byte in bytes {
-                let c = table[byte as usize];
-                if c != '\0' {
-                    result.push(c);
-                } else {
-                    // Fallback: multi-char mapping or unmapped byte
-                    let char_str = font
-                        .char_to_unicode(byte as u32)
-                        .unwrap_or_else(|| fallback_char_to_unicode(byte as u32));
-                    if char_str != "\u{FFFD}" || preserve_unmapped_glyphs() {
-                        result.push_str(&char_str);
-                    }
-                }
-            }
-        } else if font_has_utf8_cmap(font) {
-            // Type0 font whose /Encoding is an embedded CMap with a UTF-8
-            // (variable-width) codespace — e.g. `Uni-Utf8-H` (pdf.js
-            // issue18117) and the Adobe predefined `Uni*-UTF8-H` family.
-            // Codes are 1–4 bytes segmented by UTF-8 lead-byte rules, which
-            // exceed the u16 of `TextCharIter`. Segment here into u32 codes
-            // and resolve via the (present) ToUnicode CMap, which is keyed by
-            // the same multi-byte codes. Isolated to UTF-8-CMap fonts: every
-            // other font keeps the path below unchanged. See #610.
-            let n = bytes.len();
-            let mut i = 0;
-            while i < n {
-                let lead = bytes[i];
-                let width = match lead {
-                    0x00..=0x7F => 1,
-                    0xC0..=0xDF => 2,
-                    0xE0..=0xEF => 3,
-                    0xF0..=0xF7 => 4,
-                    _ => 1, // invalid lead byte → consume one, avoids stalling
-                }
-                .min(n - i);
-                let mut code: u32 = 0;
-                for &b in &bytes[i..i + width] {
-                    code = (code << 8) | b as u32;
-                }
-                let char_str = font
-                    .char_to_unicode(code)
-                    .unwrap_or_else(|| fallback_char_to_unicode(code));
-                if char_str != "\u{FFFD}" || preserve_unmapped_glyphs() {
-                    result.push_str(&char_str);
-                }
-                i += width;
-            }
-        } else {
-            // Complex font: use unified iterator for robust multi-byte decoding
-            for (char_code, _) in TextCharIter::new(bytes, Some(font)) {
-                let char_str = font
-                    .char_to_unicode(char_code as u32)
-                    .unwrap_or_else(|| fallback_char_to_unicode(char_code as u32));
-
-                if char_str != "\u{FFFD}" || preserve_unmapped_glyphs() {
-                    result.push_str(&char_str);
-                }
-            }
-        }
-        result
-    } else {
-        // No font - fallback to Latin-1 (ISO 8859-1) encoding
-        // Per PDF Spec ISO 32000-1:2008, Section 9.6.6, Latin-1 maps bytes 0x00-0xFF
-        // directly to Unicode code points U+0000-U+00FF
-        log::warn!(
-            "⚠️  No font provided for {} bytes, using Latin-1 fallback (PDF spec compliant)",
-            bytes.len()
-        );
-        bytes.iter().map(|&b| char::from(b)).collect()
-    };
-
-    // Filter control characters from failed encoding resolution
-    // Keep: \t (0x09), \n (0x0A), \r (0x0D), and all printable chars (>= 0x20)
-    let mut filtered = String::with_capacity(raw_result.len());
-    for c in raw_result.chars() {
-        if c >= '\x20' || c == '\t' || c == '\n' || c == '\r' {
-            filtered.push(c);
-        }
-    }
-    filtered
 }
 
 /// Artifact type classification per PDF Spec Section 14.8.2.2
@@ -3629,45 +3263,8 @@ impl<'doc> TextExtractor<'doc> {
     /// When a CIDFontType2 Identity-H font has no truetype_cmap, borrow from
     /// another font on the same page with the same base font name (ignoring subset prefix).
     pub fn share_truetype_cmaps(&mut self) {
-        // Strip subset prefix (e.g., "QQPMQK+Impact" → "Impact")
-        fn strip_subset(name: &str) -> &str {
-            if name.len() > 7
-                && name.as_bytes()[6] == b'+'
-                && name[..6].chars().all(|c| c.is_ascii_uppercase())
-            {
-                &name[7..]
-            } else {
-                name
-            }
-        }
-
-        // First pass: collect the BEST available TrueType cmap for each stripped base font name.
-        // When multiple subset variants of the same font exist (e.g., ABCDEF+Arial, GHIJKL+Arial),
-        // pick the cmap with the most glyph mappings — it has the best Unicode coverage.
-        // On equal coverage, prefer the lexicographically smallest base_font name as a
-        // deterministic tie-breaker (HashMap iteration order is randomized per-process).
-        let mut best_cmaps: std::collections::HashMap<
-            String,
-            (crate::fonts::truetype_cmap::TrueTypeCMap, String),
-        > = std::collections::HashMap::new();
-        for font in self.fonts.values() {
-            if let Some(cmap) = font.truetype_cmap() {
-                let stripped = strip_subset(&font.base_font).to_string();
-                let dominated =
-                    best_cmaps
-                        .get(&stripped)
-                        .is_none_or(|(existing, existing_name)| {
-                            match cmap.len().cmp(&existing.len()) {
-                                std::cmp::Ordering::Greater => true,
-                                std::cmp::Ordering::Equal => font.base_font < *existing_name,
-                                std::cmp::Ordering::Less => false,
-                            }
-                        });
-                if dominated {
-                    best_cmaps.insert(stripped, (cmap.clone(), font.base_font.clone()));
-                }
-            }
-        }
+        let best_cmaps =
+            crate::fonts::unicode_decode::best_truetype_cmaps(self.fonts.values().map(|f| &**f));
 
         if best_cmaps.is_empty() {
             return;
@@ -3688,7 +3285,7 @@ impl<'doc> TextExtractor<'doc> {
                 continue;
             }
 
-            let stripped = strip_subset(&font_arc.base_font);
+            let stripped = strip_subset_prefix(&font_arc.base_font);
             if let Some((donor_cmap, _)) = best_cmaps.get(stripped) {
                 log::info!(
                     "Sharing TrueType cmap ({} entries) to '{}' (Identity-H, no embedded font)",
@@ -10743,7 +10340,7 @@ mod tests {
 
     #[test]
     fn test_decode_text_no_font_latin1() {
-        let result = decode_text_to_unicode(b"Hello", None);
+        let result = decode_text_to_unicode(b"Hello", None, DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
         assert_eq!(result, "Hello");
     }
 
@@ -10751,7 +10348,7 @@ mod tests {
     fn test_decode_text_no_font_high_bytes() {
         // Latin-1 high bytes should map to Unicode code points
         let bytes = vec![0xC0, 0xE9]; // A-grave, e-acute in Latin-1
-        let result = decode_text_to_unicode(&bytes, None);
+        let result = decode_text_to_unicode(&bytes, None, DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
         assert!(result.contains('\u{00C0}'), "Should contain A-grave");
         assert!(result.contains('\u{00E9}'), "Should contain e-acute");
     }
@@ -10760,7 +10357,7 @@ mod tests {
     fn test_decode_text_filters_control_chars() {
         // Control characters (except tab, newline, carriage return) should be filtered
         let bytes = vec![0x01, 0x02, 0x41, 0x09, 0x0A]; // ctrl chars, 'A', tab, newline
-        let result = decode_text_to_unicode(&bytes, None);
+        let result = decode_text_to_unicode(&bytes, None, DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
         assert!(result.contains('A'), "Should contain 'A'");
         assert!(result.contains('\t'), "Should keep tab");
         assert!(result.contains('\n'), "Should keep newline");
@@ -10770,7 +10367,7 @@ mod tests {
     #[test]
     fn test_decode_text_with_simple_font() {
         let font = create_test_font();
-        let result = decode_text_to_unicode(b"ABC", Some(&font));
+        let result = decode_text_to_unicode(b"ABC", Some(&font), DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
         // With WinAnsiEncoding, ASCII characters should map correctly
         assert!(result.contains('A') || !result.is_empty(), "Should decode something");
     }
@@ -14890,7 +14487,7 @@ mod tests {
     fn test_decode_text_simple_font_with_control_chars() {
         let font = create_test_font();
         let bytes = vec![0x01, 0x41, 0x09]; // ctrl char, 'A', tab
-        let result = decode_text_to_unicode(&bytes, Some(&font));
+        let result = decode_text_to_unicode(&bytes, Some(&font), DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
         // Should filter control chars but keep tab
         assert!(result.contains('\t') || result.contains('A'));
     }
@@ -14902,7 +14499,7 @@ mod tests {
         font.subtype = "Type0".to_string();
         font.encoding = crate::fonts::Encoding::Identity;
         let bytes = vec![0x41]; // Single byte for Type0 identity
-        let result = decode_text_to_unicode(&bytes, Some(&font));
+        let result = decode_text_to_unicode(&bytes, Some(&font), DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
         // Should hit trailing byte path
     }
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -10340,7 +10340,15 @@ mod tests {
 
     #[test]
     fn test_decode_text_no_font_latin1() {
-        let result = decode_text_to_unicode(b"Hello", None, DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
+        let result = decode_text_to_unicode(
+            b"Hello",
+            None,
+            DecodePolicy {
+                preserve_unmapped: preserve_unmapped_glyphs(),
+                decompose_ligatures: false,
+            },
+            None,
+        );
         assert_eq!(result, "Hello");
     }
 
@@ -10348,7 +10356,15 @@ mod tests {
     fn test_decode_text_no_font_high_bytes() {
         // Latin-1 high bytes should map to Unicode code points
         let bytes = vec![0xC0, 0xE9]; // A-grave, e-acute in Latin-1
-        let result = decode_text_to_unicode(&bytes, None, DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
+        let result = decode_text_to_unicode(
+            &bytes,
+            None,
+            DecodePolicy {
+                preserve_unmapped: preserve_unmapped_glyphs(),
+                decompose_ligatures: false,
+            },
+            None,
+        );
         assert!(result.contains('\u{00C0}'), "Should contain A-grave");
         assert!(result.contains('\u{00E9}'), "Should contain e-acute");
     }
@@ -10357,7 +10373,15 @@ mod tests {
     fn test_decode_text_filters_control_chars() {
         // Control characters (except tab, newline, carriage return) should be filtered
         let bytes = vec![0x01, 0x02, 0x41, 0x09, 0x0A]; // ctrl chars, 'A', tab, newline
-        let result = decode_text_to_unicode(&bytes, None, DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
+        let result = decode_text_to_unicode(
+            &bytes,
+            None,
+            DecodePolicy {
+                preserve_unmapped: preserve_unmapped_glyphs(),
+                decompose_ligatures: false,
+            },
+            None,
+        );
         assert!(result.contains('A'), "Should contain 'A'");
         assert!(result.contains('\t'), "Should keep tab");
         assert!(result.contains('\n'), "Should keep newline");
@@ -10367,7 +10391,15 @@ mod tests {
     #[test]
     fn test_decode_text_with_simple_font() {
         let font = create_test_font();
-        let result = decode_text_to_unicode(b"ABC", Some(&font), DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
+        let result = decode_text_to_unicode(
+            b"ABC",
+            Some(&font),
+            DecodePolicy {
+                preserve_unmapped: preserve_unmapped_glyphs(),
+                decompose_ligatures: false,
+            },
+            None,
+        );
         // With WinAnsiEncoding, ASCII characters should map correctly
         assert!(result.contains('A') || !result.is_empty(), "Should decode something");
     }
@@ -14487,7 +14519,15 @@ mod tests {
     fn test_decode_text_simple_font_with_control_chars() {
         let font = create_test_font();
         let bytes = vec![0x01, 0x41, 0x09]; // ctrl char, 'A', tab
-        let result = decode_text_to_unicode(&bytes, Some(&font), DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
+        let result = decode_text_to_unicode(
+            &bytes,
+            Some(&font),
+            DecodePolicy {
+                preserve_unmapped: preserve_unmapped_glyphs(),
+                decompose_ligatures: false,
+            },
+            None,
+        );
         // Should filter control chars but keep tab
         assert!(result.contains('\t') || result.contains('A'));
     }
@@ -14499,7 +14539,15 @@ mod tests {
         font.subtype = "Type0".to_string();
         font.encoding = crate::fonts::Encoding::Identity;
         let bytes = vec![0x41]; // Single byte for Type0 identity
-        let result = decode_text_to_unicode(&bytes, Some(&font), DecodePolicy { preserve_unmapped: preserve_unmapped_glyphs(), decompose_ligatures: false }, None);
+        let result = decode_text_to_unicode(
+            &bytes,
+            Some(&font),
+            DecodePolicy {
+                preserve_unmapped: preserve_unmapped_glyphs(),
+                decompose_ligatures: false,
+            },
+            None,
+        );
         // Should hit trailing byte path
     }
 

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -5564,6 +5564,11 @@ impl<'doc> TextExtractor<'doc> {
                 // scale-relative (0.5× the text-space glyph height, ≥0.5pt
                 // floor) so it is correct at any font size and still
                 // splits genuine line breaks.
+                //
+                // The `f`/`e` tests below only mean "same line" and "forward"
+                // while the run advances along +x; under a rotated matrix the
+                // two axes swap. The added conjunct re-checks both along the
+                // run's own writing axis (ISO 32000-1 §9.4.4).
                 let cur_font_size = self.state_stack.current().font_size;
                 let is_continuation = self.merging_config.merge_tm_tj_runs
                     && match self.tj_span_buffer {
@@ -5576,7 +5581,14 @@ impl<'doc> TextExtractor<'doc> {
                                 && b == buffer.start_matrix.b
                                 && c == buffer.start_matrix.c
                                 && d == buffer.start_matrix.d
-                                && e >= buffer.start_matrix.e =>
+                                && e >= buffer.start_matrix.e
+                                && Self::advances_along_writing_axis(
+                                    buffer.start_matrix,
+                                    buffer.wmode,
+                                    e,
+                                    f,
+                                    cur_font_size,
+                                ) =>
                         {
                             // Same line, same transform, LTR progression →
                             // update width to reflect actual visual extent
@@ -8844,6 +8856,45 @@ impl<'doc> TextExtractor<'doc> {
         buffer.accumulated_width += adv;
     }
 
+    /// Whether `(e, f)` continues `start`'s run along that run's writing axis.
+    ///
+    /// ISO 32000-1:2008 §9.4.4 places the writing direction along the matrix's
+    /// `(a, b)` row, so the displacement resolves into a component along it
+    /// (the advance) and one perpendicular (the line offset). For an unrotated
+    /// matrix this reduces termwise to the caller's raw `e`/`f` test, so it can
+    /// only ever be an additional conjunct.
+    ///
+    /// WMode 1 is exempt: vertical text advances along `(c, d)` instead, the
+    /// branch [`GraphicsState::advance_text_matrix`] already makes, and reading
+    /// its advance as a perpendicular offset splits a column glyph by glyph.
+    fn advances_along_writing_axis(
+        start: Matrix,
+        wmode: u8,
+        e: f32,
+        f: f32,
+        font_size: f32,
+    ) -> bool {
+        if wmode != 0 {
+            return true;
+        }
+        // Unit vector along the writing direction. A degenerate (zero-scale)
+        // matrix has no direction to speak of; fall back to +x so such runs
+        // behave exactly as they did before this test existed.
+        let axis = (start.a * start.a + start.b * start.b).sqrt();
+        let (ux, uy) = if axis > 0.0 {
+            (start.a / axis, start.b / axis)
+        } else {
+            (1.0, 0.0)
+        };
+        let (dx, dy) = (e - start.e, f - start.f);
+        let along = ux * dx + uy * dy;
+        let perp = -uy * dx + ux * dy;
+        // Perpendicular scale; `|d|` for an unrotated matrix.
+        let line_scale = (start.c * start.c + start.d * start.d).sqrt();
+        let tolerance = ((font_size * line_scale).abs() * 0.5).max(0.5);
+        perp.abs() <= tolerance && along >= 0.0
+    }
+
     /// Flush accumulated Tj span buffer into a single TextSpan.
     ///
     /// This is similar to flush_tj_buffer but works with the tj_span_buffer field
@@ -9312,6 +9363,61 @@ mod tests {
             !gap_has_intervening_glyph(&[left, right, descender_edge], &left, &right),
             "a descender edge clipping the gap must not be treated as an intervening glyph"
         );
+    }
+
+    /// The writing-axis continuation test, quadrant by quadrant.
+    ///
+    /// The upright cases must agree with the raw `e`/`f` test they are ANDed
+    /// with; that agreement is why unrotated output cannot move.
+    #[test]
+    fn test_advances_along_writing_axis_by_quadrant() {
+        let m = |a, b, c, d| Matrix {
+            a,
+            b,
+            c,
+            d,
+            e: 100.0,
+            f: 500.0,
+        };
+        let fs = 10.0;
+        let at = |mat: Matrix, de: f32, df: f32| {
+            TextExtractor::advances_along_writing_axis(mat, 0, mat.e + de, mat.f + df, fs)
+        };
+
+        // Must match the raw e/f test exactly.
+        let upright = m(1.0, 0.0, 0.0, 1.0);
+        assert!(at(upright, 14.0, 0.0), "upright advance must continue");
+        assert!(!at(upright, 0.0, -14.0), "upright line break must not");
+        assert!(!at(upright, -14.0, 0.0), "upright backwards must not");
+
+        // Advances along +y; lines separate along +x.
+        let cw = m(0.0, 1.0, -1.0, 0.0);
+        assert!(at(cw, 0.0, 14.0), "90° along-axis advance is a continuation");
+        assert!(!at(cw, 14.0, 0.0), "90° line break must not continue");
+
+        // Advances along -y; the sign a single-rotation fixture cannot catch.
+        let ccw = m(0.0, -1.0, 1.0, 0.0);
+        assert!(at(ccw, 0.0, -14.0), "270° along-axis advance is a continuation");
+        assert!(!at(ccw, 0.0, 14.0), "270° backwards advance must not continue");
+        assert!(!at(ccw, 14.0, 0.0), "270° line break must not continue");
+
+        // 180°: advances along -x.
+        let flip = m(-1.0, 0.0, 0.0, -1.0);
+        assert!(at(flip, -14.0, 0.0), "180° along-axis advance is a continuation");
+        assert!(!at(flip, 14.0, 0.0), "180° backwards advance must not continue");
+
+        // No writing direction: falls back to +x, as before.
+        let degenerate = m(0.0, 0.0, 0.0, 0.0);
+        assert!(at(degenerate, 14.0, 0.0));
+        assert!(!at(degenerate, -14.0, 0.0));
+
+        // WMode 1 advances along (c, d), so this test never vetoes it.
+        for (de, df) in [(14.0, 0.0), (0.0, 14.0), (-14.0, 0.0), (0.0, -14.0)] {
+            assert!(
+                TextExtractor::advances_along_writing_axis(cw, 1, cw.e + de, cw.f + df, fs),
+                "vertical run vetoed at ({de}, {df})"
+            );
+        }
     }
 
     #[test]

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -12,7 +12,6 @@ use crate::content::graphics_state::{GraphicsStateStack, Matrix};
 use crate::content::operators::{Operator, TextElement};
 use crate::content::parse_and_execute_text_only;
 use crate::content::parse_content_stream;
-use crate::content::parse_content_stream_text_only;
 use crate::error::Result;
 use crate::extract_log_debug;
 use crate::fonts::FontInfo;
@@ -3867,13 +3866,29 @@ impl<'doc> TextExtractor<'doc> {
         self.spans.clear(); // Ensure spans are clear so they don't poison xobject_spans_cache
         self.placed_pdf_keep = Self::placed_pdf_text_dominates(content_stream);
 
-        let operators = if self.excluded_inks.is_empty() {
-            parse_content_stream_text_only(content_stream)?
+        // Same parser as `extract_text_spans`. Character mode and span mode must
+        // differ only in how `execute_operator` handles the show-text operators,
+        // never in which operators reach it.
+        //
+        // This was the last caller of `parse_content_stream_text_only`, a second
+        // implementation of the same job that is not equivalent to
+        // `parse_and_execute_text_only` — they reconstruct the graphics state
+        // around a text region by different routes, so they can agree on every
+        // text operator (same BT blocks, same show operators, same operands)
+        // and still hand the extractor a different CTM. Counting operators does
+        // not detect that. On govdocs_003_003181.pdf page 4 it cost a
+        // 90°-rotated chart axis: all 2322 glyphs came back at rotation 0.
+        // Through this parser the page yields 2590 glyphs, 122 at 90°, matching
+        // the span path.
+        if self.excluded_inks.is_empty() {
+            parse_and_execute_text_only(content_stream, |op| self.execute_operator(op))?;
         } else {
-            parse_content_stream(content_stream)?
-        };
-        for op in operators {
-            self.execute_operator(op)?;
+            // Ink filtering requires color operators (cs, rg, g, k) which the
+            // text-only parser skips. Fall back to the full parser.
+            let operators = parse_content_stream(content_stream)?;
+            for op in operators {
+                self.execute_operator(op)?;
+            }
         }
 
         // BUG FIX #2: Sort characters by reading order (top-to-bottom, left-to-right)

--- a/src/extractors/warnings.rs
+++ b/src/extractors/warnings.rs
@@ -56,6 +56,9 @@ pub enum WarningCategory {
     Font,
     /// Layout / reading-order warnings.
     Layout,
+    /// A glyph produced no rendered output while the cursor still advanced,
+    /// so the page renders with an invisible gap.
+    GlyphDropped,
 }
 
 impl WarningCategory {
@@ -71,6 +74,7 @@ impl WarningCategory {
             Self::Encryption => "encryption",
             Self::Font => "font",
             Self::Layout => "layout",
+            Self::GlyphDropped => "glyph_dropped",
         }
     }
 }

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -39,6 +39,8 @@ pub mod truetype_cmap;
 pub mod truetype_parser;
 /// Type 1 font encoding parser for extracting built-in encoding from FontFile data.
 pub mod type1_encoding;
+/// The one glyph decoder shared by extraction and rendering.
+pub(crate) mod unicode_decode;
 /// System Unicode font fallback for office round-trip.
 pub mod unicode_fallback;
 

--- a/src/fonts/unicode_decode.rs
+++ b/src/fonts/unicode_decode.rs
@@ -44,6 +44,10 @@ impl GlyphDropTally {
         self.first.get_or_insert((reason, char_code, gid));
     }
 
+    /// Only the rasterizer reports (extraction's drops are policy-visible
+    /// via `preserve_unmapped`), so without the `rendering` feature this is
+    /// dead code by design.
+    #[cfg_attr(not(feature = "rendering"), allow(dead_code))]
     pub(crate) fn report(&self, font_name: &str) {
         let Some((reason, char_code, gid)) = self.first else {
             return;

--- a/src/fonts/unicode_decode.rs
+++ b/src/fonts/unicode_decode.rs
@@ -1,0 +1,510 @@
+//! The one glyph decoder shared by every text surface.
+//!
+//! `decode_text_to_unicode` and its helpers (`fallback_char_to_unicode`,
+//! `get_byte_mode`, `TextCharIter`) used to exist twice — an extraction copy
+//! in `extractors/text.rs` and a rendering copy in
+//! `rendering/text_rasterizer.rs` — and the copies drifted in both
+//! directions: UTF-8 codespace CMaps and `preserve_unmapped_glyphs` existed
+//! only in extraction; ligature decomposition and dropped-glyph accounting
+//! only in rendering. A Type0 font with a UTF-8 CMap extracted right and
+//! rendered garbage; a ligature rendered right and extracted lossy. This
+//! module is the union; the two genuine policy differences are expressed in
+//! [`DecodePolicy`], not by forking the decoder.
+
+use std::collections::HashMap;
+
+use crate::fonts::truetype_cmap::TrueTypeCMap;
+use crate::fonts::FontInfo;
+
+/// Per-surface decoding policy — the only intended differences between the
+/// extraction and rendering paths.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct DecodePolicy {
+    /// Keep U+FFFD for unmapped codes instead of dropping them.
+    /// Extraction honours the `preserve_unmapped_glyphs()` toggle; rendering
+    /// always drops (a U+FFFD has no glyph to paint).
+    pub preserve_unmapped: bool,
+    /// Expand presentation-form ligature code points (fi, fl, ffi, …) into
+    /// component letters. The rasterizer needs this so the shaper doesn't
+    /// drop the cluster (issue #331); extraction decomposes downstream in
+    /// `ligature_processor`, so it must stay off here or chars would change.
+    pub decompose_ligatures: bool,
+}
+
+/// Counts glyphs a decode dropped so the loss is reported, not silent (#991).
+#[derive(Debug, Default)]
+pub(crate) struct GlyphDropTally {
+    count: usize,
+    first: Option<(&'static str, u32, u16)>,
+}
+
+impl GlyphDropTally {
+    pub(crate) fn record(&mut self, reason: &'static str, char_code: u32, gid: u16) {
+        self.count += 1;
+        self.first.get_or_insert((reason, char_code, gid));
+    }
+
+    pub(crate) fn report(&self, font_name: &str) {
+        let Some((reason, char_code, gid)) = self.first else {
+            return;
+        };
+        let message = format!(
+            "font '{font_name}' painted nothing for {} glyph(s) while advancing the cursor; \
+             first was code 0x{char_code:X} (glyph {gid}): {reason}. The page renders with \
+             a gap that reads as whitespace downstream.",
+            self.count
+        );
+        log::warn!(target: "pdf_oxide::fonts", "{message}");
+        crate::extractors::warnings::push_global_warning(crate::extractors::warnings::Warning {
+            category: crate::extractors::warnings::WarningCategory::GlyphDropped,
+            page: None,
+            message,
+            spec_section: Some("9.6.6"),
+        });
+    }
+}
+
+
+/// Fallback function to map common character codes to Unicode when ToUnicode CMap fails.
+///
+/// PDF Spec Compliance: ISO 32000-1:2008 Section 9.10.2
+/// This function implements Priority 6 (enhanced fallback) after the standard 5-tier
+/// encoding system (ToUnicode CMap, predefined encodings, Adobe Glyph List, etc.) fails.
+///
+/// Multi-tier fallback strategy:
+/// 1. Common punctuation and symbols (em dash, en dash, quotes, bullets)
+/// 2. Mathematical operators (∂, ∇, ∑, ∏, ∫, √, ∞, ≤, ≥, ≠)
+/// 3. Greek letters (α, β, γ, δ, θ, λ, μ, π, σ, ω - both cases)
+/// 4. Currency symbols (€, £, ¥, ¢)
+/// 5. Direct Unicode (if char_code is in valid Unicode range)
+/// 6. Private Use Area visual description (U+E000-U+F8FF)
+/// 7. Replacement character "?" as last resort
+///
+/// # Arguments
+/// * `char_code` - 16-bit character code that failed to decode via standard system
+///
+/// # Returns
+/// Best-effort Unicode string representation, or "?" if no mapping possible
+pub(crate) fn fallback_char_to_unicode(char_code: u32) -> String {
+    match char_code {
+        // ==================================================================================
+        // PRIORITY 1: Common Punctuation (most frequently failing)
+        // ==================================================================================
+        0x2014 => "—".to_string(),        // Em dash
+        0x2013 => "–".to_string(),        // En dash
+        0x2018 => "\u{2018}".to_string(), // Left single quotation mark (')
+        0x2019 => "\u{2019}".to_string(), // Right single quotation mark (')
+        0x201C => "\u{201C}".to_string(), // Left double quotation mark (")
+        0x201D => "\u{201D}".to_string(), // Right double quotation mark (")
+        0x2022 => "•".to_string(),        // Bullet
+        0x2026 => "…".to_string(),        // Horizontal ellipsis
+        0x00B0 => "°".to_string(),        // Degree sign
+
+        // ==================================================================================
+        // PRIORITY 2: Mathematical Operators (common in academic papers)
+        // ==================================================================================
+        0x00B1 => "±".to_string(), // Plus-minus sign
+        0x00D7 => "×".to_string(), // Multiplication sign
+        0x00F7 => "÷".to_string(), // Division sign
+        0x2202 => "∂".to_string(), // Partial differential
+        0x2207 => "∇".to_string(), // Nabla (del operator)
+        0x220F => "∏".to_string(), // N-ary product
+        0x2211 => "∑".to_string(), // N-ary summation
+        0x221A => "√".to_string(), // Square root
+        0x221E => "∞".to_string(), // Infinity
+        0x2260 => "≠".to_string(), // Not equal to
+        0x2261 => "≡".to_string(), // Identical to
+        0x2264 => "≤".to_string(), // Less-than or equal to
+        0x2265 => "≥".to_string(), // Greater-than or equal to
+        0x222B => "∫".to_string(), // Integral
+        0x2248 => "≈".to_string(), // Almost equal to
+        0x2282 => "⊂".to_string(), // Subset of
+        0x2283 => "⊃".to_string(), // Superset of
+        0x2286 => "⊆".to_string(), // Subset of or equal to
+        0x2287 => "⊇".to_string(), // Superset of or equal to
+        0x2208 => "∈".to_string(), // Element of
+        0x2209 => "∉".to_string(), // Not an element of
+        0x2200 => "∀".to_string(), // For all
+        0x2203 => "∃".to_string(), // There exists
+        0x2205 => "∅".to_string(), // Empty set
+        0x2227 => "∧".to_string(), // Logical and
+        0x2228 => "∨".to_string(), // Logical or
+        0x00AC => "¬".to_string(), // Not sign
+        0x2192 => "→".to_string(), // Rightwards arrow
+        0x2190 => "←".to_string(), // Leftwards arrow
+        0x2194 => "↔".to_string(), // Left right arrow
+        0x21D2 => "⇒".to_string(), // Rightwards double arrow
+        0x21D4 => "⇔".to_string(), // Left right double arrow
+
+        // ==================================================================================
+        // PRIORITY 3: Greek Letters (common in scientific/mathematical texts)
+        // ==================================================================================
+        // Lowercase Greek
+        0x03B1 => "α".to_string(), // Alpha
+        0x03B2 => "β".to_string(), // Beta
+        0x03B3 => "γ".to_string(), // Gamma
+        0x03B4 => "δ".to_string(), // Delta
+        0x03B5 => "ε".to_string(), // Epsilon
+        0x03B6 => "ζ".to_string(), // Zeta
+        0x03B7 => "η".to_string(), // Eta
+        0x03B8 => "θ".to_string(), // Theta
+        0x03B9 => "ι".to_string(), // Iota
+        0x03BA => "κ".to_string(), // Kappa
+        0x03BB => "λ".to_string(), // Lambda
+        0x03BC => "μ".to_string(), // Mu
+        0x03BD => "ν".to_string(), // Nu
+        0x03BE => "ξ".to_string(), // Xi
+        0x03BF => "ο".to_string(), // Omicron
+        0x03C0 => "π".to_string(), // Pi
+        0x03C1 => "ρ".to_string(), // Rho
+        0x03C2 => "ς".to_string(), // Final sigma
+        0x03C3 => "σ".to_string(), // Sigma
+        0x03C4 => "τ".to_string(), // Tau
+        0x03C5 => "υ".to_string(), // Upsilon
+        0x03C6 => "φ".to_string(), // Phi
+        0x03C7 => "χ".to_string(), // Chi
+        0x03C8 => "ψ".to_string(), // Psi
+        0x03C9 => "ω".to_string(), // Omega
+
+        // Uppercase Greek
+        0x0391 => "Α".to_string(), // Alpha
+        0x0392 => "Β".to_string(), // Beta
+        0x0393 => "Γ".to_string(), // Gamma
+        0x0394 => "Δ".to_string(), // Delta
+        0x0395 => "Ε".to_string(), // Epsilon
+        0x0396 => "Ζ".to_string(), // Zeta
+        0x0397 => "Η".to_string(), // Eta
+        0x0398 => "Θ".to_string(), // Theta
+        0x0399 => "Ι".to_string(), // Iota
+        0x039A => "Κ".to_string(), // Kappa
+        0x039B => "Λ".to_string(), // Lambda
+        0x039C => "Μ".to_string(), // Mu
+        0x039D => "Ν".to_string(), // Nu
+        0x039E => "Ξ".to_string(), // Xi
+        0x039F => "Ο".to_string(), // Omicron
+        0x03A0 => "Π".to_string(), // Pi
+        0x03A1 => "Ρ".to_string(), // Rho
+        0x03A3 => "Σ".to_string(), // Sigma
+        0x03A4 => "Τ".to_string(), // Tau
+        0x03A5 => "Υ".to_string(), // Upsilon
+        0x03A6 => "Φ".to_string(), // Phi
+        0x03A7 => "Χ".to_string(), // Chi
+        0x03A8 => "Ψ".to_string(), // Psi
+        0x03A9 => "Ω".to_string(), // Omega
+
+        // ==================================================================================
+        // PRIORITY 4: Currency Symbols
+        // ==================================================================================
+        0x20AC => "€".to_string(), // Euro
+        0x00A3 => "£".to_string(), // Pound sterling
+        0x00A5 => "¥".to_string(), // Yen
+        0x00A2 => "¢".to_string(), // Cent
+        0x20A3 => "₣".to_string(), // French franc
+        0x20A4 => "₤".to_string(), // Lira
+        0x20A9 => "₩".to_string(), // Won
+        0x20AA => "₪".to_string(), // New shekel
+        0x20AB => "₫".to_string(), // Dong
+        0x20B9 => "₹".to_string(), // Indian rupee
+
+        // ==================================================================================
+        // PRIORITY 5: Direct Unicode (for valid ranges)
+        // ==================================================================================
+        // Valid Unicode: BMP (0x0000-0xD7FF, 0xE000-0xFFFF) and supplementary planes
+        // Excludes surrogate pairs (0xD800-0xDFFF)
+        code => {
+            if let Some(ch) = char::from_u32(code) {
+                if (0xE000..=0xF8FF).contains(&code) {
+                    log::debug!("Private Use Area character: U+{:04X}", code);
+                }
+                ch.to_string()
+            } else {
+                log::warn!("Character code 0x{:04X} is not a valid Unicode code point", code);
+                "?".to_string()
+            }
+        },
+    }
+}
+
+/// Byte grouping mode for CID font character code decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ByteMode {
+    /// Single-byte codes (simple fonts, some predefined CMaps)
+    OneByte,
+    /// Always 2-byte codes (Identity-H/V, UCS2)
+    TwoByte,
+    /// Shift-JIS variable-width (1 or 2 bytes depending on lead byte)
+    ShiftJIS,
+}
+
+/// True when a Type0 font's `/Encoding` is a UTF-8 (variable-width) CMap —
+/// `Uni-Utf8-H` (embedded, pdf.js issue18117) or the Adobe predefined
+/// `UniGB-UTF8-H` / `UniCNS-UTF8-H` / `UniJIS-UTF8-H` / `UniKS-UTF8-H` family.
+/// Such codes are 1–4 bytes and must be segmented by UTF-8 lead-byte rules
+/// (see `decode_text_to_unicode`), not the fixed 1/2-byte `ByteMode`. Matching
+/// on the CMap name keeps the change isolated to these fonts. See #610.
+pub(crate) fn font_has_utf8_cmap(font: &FontInfo) -> bool {
+    if font.subtype != "Type0" {
+        return false;
+    }
+    if let crate::fonts::Encoding::Standard(name) = &font.encoding {
+        let lower = name.to_ascii_lowercase();
+        lower.contains("utf8") || lower.contains("utf-8")
+    } else {
+        false
+    }
+}
+
+/// Get byte grouping mode for a font (v0.3.14).
+pub(crate) fn get_byte_mode(font: Option<&FontInfo>) -> ByteMode {
+    if let Some(font) = font {
+        if font.subtype == "Type0" {
+            // If the ToUnicode CMap declares a 2-byte codespace range, always use
+            // TwoByte mode regardless of the encoding name. This handles CJK fonts
+            // whose /Encoding name is a custom CMap stream that doesn't match the
+            // well-known keyword patterns below (e.g. "H", "V", "UniCNS-H", …).
+            // See PDF Spec §9.7.5 — `begincodespacerange` is authoritative.
+            if let Some(ref lazy_cmap) = font.to_unicode {
+                if lazy_cmap.code_width() == 2 {
+                    return ByteMode::TwoByte;
+                }
+            }
+
+            match &font.encoding {
+                crate::fonts::Encoding::Identity => ByteMode::TwoByte,
+                crate::fonts::Encoding::Standard(name) => {
+                    if (name.contains("Identity") && !name.contains("OneByteIdentity"))
+                        || name.contains("UCS2")
+                        || name.contains("UTF16")
+                        // CORPUS-3: bare Adobe predefined horizontal/vertical CMaps
+                        // ("H"/"V", e.g. Adobe-Japan1-H) are 2-byte by definition;
+                        // without this they were read single-byte → CJK garbage
+                        // ("あいうえお" → "CACCCECGCI" on noembed-jis7).
+                        || name == "H"
+                        || name == "V"
+                    {
+                        ByteMode::TwoByte
+                    } else if name.contains("RKSJ") {
+                        ByteMode::ShiftJIS
+                    } else if name.contains("EUC")
+                        || name.contains("GBK")
+                        || name.contains("GBpc")
+                        || name.contains("GB-")
+                        || name.contains("CNS")
+                        || name.contains("B5")
+                        || name.contains("KSC")
+                        || name.contains("KSCms")
+                    {
+                        ByteMode::TwoByte
+                    } else {
+                        ByteMode::OneByte
+                    }
+                },
+                _ => ByteMode::OneByte,
+            }
+        } else {
+            ByteMode::OneByte
+        }
+    } else {
+        ByteMode::OneByte
+    }
+}
+
+/// Iterator over characters in a PDF string based on font encoding (v0.3.14).
+pub(crate) struct TextCharIter<'a> {
+    bytes: &'a [u8],
+    byte_mode: ByteMode,
+    index: usize,
+}
+
+impl<'a> TextCharIter<'a> {
+    pub(crate) fn new(bytes: &'a [u8], font: Option<&FontInfo>) -> Self {
+        Self {
+            bytes,
+            byte_mode: get_byte_mode(font),
+            index: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for TextCharIter<'a> {
+    type Item = (u16, usize); // (char_code, bytes_consumed)
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.bytes.len() {
+            return None;
+        }
+
+        let (char_code, bytes_consumed) = match self.byte_mode {
+            ByteMode::TwoByte if self.index + 1 < self.bytes.len() => {
+                (((self.bytes[self.index] as u16) << 8) | (self.bytes[self.index + 1] as u16), 2)
+            },
+            ByteMode::ShiftJIS => {
+                let b = self.bytes[self.index];
+                let is_lead = (0x81..=0x9F).contains(&b) || (0xE0..=0xFC).contains(&b);
+                if is_lead && self.index + 1 < self.bytes.len() {
+                    (((b as u16) << 8) | (self.bytes[self.index + 1] as u16), 2)
+                } else {
+                    (b as u16, 1)
+                }
+            },
+            _ => (self.bytes[self.index] as u16, 1),
+        };
+
+        self.index += bytes_consumed;
+        Some((char_code, bytes_consumed))
+    }
+}
+
+pub(crate) fn decode_text_to_unicode(
+    bytes: &[u8],
+    font: Option<&FontInfo>,
+    policy: DecodePolicy,
+    mut drops: Option<&mut GlyphDropTally>,
+) -> String {
+    let raw_result = if let Some(font) = font {
+        let mut result = String::new();
+        // Use pre-computed lookup table for performance if it's a simple font
+        if font.subtype != "Type0" {
+            let table = font.get_byte_to_char_table();
+            for &byte in bytes {
+                let c = table[byte as usize];
+                if c != '\0' {
+                    result.push(c);
+                } else {
+                    // Fallback: multi-char mapping or unmapped byte
+                    let char_str = font
+                        .char_to_unicode(byte as u32)
+                        .unwrap_or_else(|| fallback_char_to_unicode(byte as u32));
+                    if char_str != "\u{FFFD}" || policy.preserve_unmapped {
+                        result.push_str(&char_str);
+                    } else if let Some(tally) = drops.as_deref_mut() {
+                        tally.record("no Unicode mapping", byte as u32, 0);
+                    }
+                }
+            }
+        } else if font_has_utf8_cmap(font) {
+            // Type0 font whose /Encoding is an embedded CMap with a UTF-8
+            // (variable-width) codespace — e.g. `Uni-Utf8-H` (pdf.js
+            // issue18117) and the Adobe predefined `Uni*-UTF8-H` family.
+            // Codes are 1–4 bytes segmented by UTF-8 lead-byte rules, which
+            // exceed the u16 of `TextCharIter`. Segment here into u32 codes
+            // and resolve via the (present) ToUnicode CMap, which is keyed by
+            // the same multi-byte codes. Isolated to UTF-8-CMap fonts: every
+            // other font keeps the path below unchanged. See #610.
+            let n = bytes.len();
+            let mut i = 0;
+            while i < n {
+                let lead = bytes[i];
+                let width = match lead {
+                    0x00..=0x7F => 1,
+                    0xC0..=0xDF => 2,
+                    0xE0..=0xEF => 3,
+                    0xF0..=0xF7 => 4,
+                    _ => 1, // invalid lead byte → consume one, avoids stalling
+                }
+                .min(n - i);
+                let mut code: u32 = 0;
+                for &b in &bytes[i..i + width] {
+                    code = (code << 8) | b as u32;
+                }
+                let char_str = font
+                    .char_to_unicode(code)
+                    .unwrap_or_else(|| fallback_char_to_unicode(code));
+                if char_str != "\u{FFFD}" || policy.preserve_unmapped {
+                    result.push_str(&char_str);
+                } else if let Some(tally) = drops.as_deref_mut() {
+                    tally.record("no Unicode mapping", code, 0);
+                }
+                i += width;
+            }
+        } else {
+            // Complex font: use unified iterator for robust multi-byte decoding
+            for (char_code, _) in TextCharIter::new(bytes, Some(font)) {
+                let char_str = font
+                    .char_to_unicode(char_code as u32)
+                    .unwrap_or_else(|| fallback_char_to_unicode(char_code as u32));
+
+                if char_str != "\u{FFFD}" || policy.preserve_unmapped {
+                    result.push_str(&char_str);
+                } else if let Some(tally) = drops.as_deref_mut() {
+                    tally.record("no Unicode mapping", char_code as u32, 0);
+                }
+            }
+        }
+        result
+    } else {
+        // No font - fallback to Latin-1 (ISO 8859-1) encoding
+        // Per PDF Spec ISO 32000-1:2008, Section 9.6.6, Latin-1 maps bytes 0x00-0xFF
+        // directly to Unicode code points U+0000-U+00FF
+        log::warn!(
+            "⚠️  No font provided for {} bytes, using Latin-1 fallback (PDF spec compliant)",
+            bytes.len()
+        );
+        bytes.iter().map(|&b| char::from(b)).collect()
+    };
+
+    // Filter control characters from failed encoding resolution
+    // Keep: \t (0x09), \n (0x0A), \r (0x0D), and all printable chars (>= 0x20)
+    let mut filtered = String::with_capacity(raw_result.len());
+    for c in raw_result.chars() {
+        if c < '\x20' && c != '\t' && c != '\n' && c != '\r' {
+            continue;
+        }
+        if policy.decompose_ligatures {
+            if let Some(components) = crate::text::ligature_processor::get_ligature_components(c) {
+                filtered.push_str(components);
+                continue;
+            }
+        }
+        filtered.push(c);
+    }
+    filtered
+}
+
+
+/// Strip a subset-tag prefix from a base font name
+/// (e.g., `"QQPMQK+Impact"` → `"Impact"`). Only the spec-shaped form —
+/// six uppercase letters and a `+` — is treated as a tag, so fonts whose
+/// real name contains `+` are left alone.
+pub(crate) fn strip_subset_prefix(name: &str) -> &str {
+    if name.len() > 7
+        && name.as_bytes()[6] == b'+'
+        && name[..6].chars().all(|c| c.is_ascii_uppercase())
+    {
+        &name[7..]
+    } else {
+        name
+    }
+}
+
+/// The best available TrueType cmap for each stripped base font name.
+///
+/// When multiple subset variants of the same font exist (`ABCDEF+Arial`,
+/// `GHIJKL+Arial`), pick the cmap with the most glyph mappings — it has the
+/// best Unicode coverage. On equal coverage, prefer the lexicographically
+/// smallest `base_font` as a deterministic tie-breaker (HashMap iteration
+/// order is randomized per-process). Callers donate these cmaps to
+/// Identity-H fonts that lack one; the write loop stays at the call site
+/// because the two font tables store `FontInfo` differently (`Arc` vs
+/// owned).
+pub(crate) fn best_truetype_cmaps<'a>(
+    fonts: impl Iterator<Item = &'a FontInfo>,
+) -> HashMap<String, (TrueTypeCMap, String)> {
+    let mut best: HashMap<String, (TrueTypeCMap, String)> = HashMap::new();
+    for font in fonts {
+        if let Some(cmap) = font.truetype_cmap() {
+            let stripped = strip_subset_prefix(&font.base_font).to_string();
+            let dominated = best
+                .get(&stripped)
+                .is_none_or(|(existing, existing_name)| match cmap.len().cmp(&existing.len()) {
+                    std::cmp::Ordering::Greater => true,
+                    std::cmp::Ordering::Equal => font.base_font < *existing_name,
+                    std::cmp::Ordering::Less => false,
+                });
+            if dominated {
+                best.insert(stripped, (cmap.clone(), font.base_font.clone()));
+            }
+        }
+    }
+    best
+}

--- a/src/fonts/unicode_decode.rs
+++ b/src/fonts/unicode_decode.rs
@@ -64,7 +64,6 @@ impl GlyphDropTally {
     }
 }
 
-
 /// Fallback function to map common character codes to Unicode when ToUnicode CMap fails.
 ///
 /// PDF Spec Compliance: ISO 32000-1:2008 Section 9.10.2
@@ -460,7 +459,6 @@ pub(crate) fn decode_text_to_unicode(
     }
     filtered
 }
-
 
 /// Strip a subset-tag prefix from a base font name
 /// (e.g., `"QQPMQK+Impact"` → `"Impact"`). Only the spec-shaped form —

--- a/src/layout/font_stats.rs
+++ b/src/layout/font_stats.rs
@@ -88,17 +88,40 @@ impl PageFontStats {
             return Self::default();
         }
 
+        // Both modes are picked with an explicit tie-break, NOT `max_by_key`.
+        // `max_by_key` returns the LAST maximal element, and over a `HashMap`
+        // "last" is whichever bucket the per-process-randomized iteration order
+        // happens to visit last. When the top two buckets carry the SAME
+        // character count — two font sizes each covering half the page, a page
+        // set in two fonts of equal mass — the winner was a coin flip per
+        // process, so `dominant_em` and `body_font_name` differed between runs
+        // of the same binary on the same page. `dominant_em` then feeds the
+        // column-shape gate in `is_multi_column_page` (`cluster_gap`), which
+        // selects the reading-order branch in `assemble_text_from_spans`, so
+        // the flip reordered the whole page's extracted text.
+        //
+        // Ties resolve to the SMALLER size bucket and the lexicographically
+        // smaller font name. Smaller-wins is the conservative direction for the
+        // size: `dominant_em` is meant to be the BODY em, headings are the
+        // larger size, and a tighter `cluster_gap` makes the multi-column gate
+        // stricter rather than looser. Same idiom as the mode pick in
+        // `crate::pipeline::converters` and the cmap pick in
+        // `crate::extractors::text`.
         let dominant_em = {
             let (bucket, _) = size_buckets
                 .iter()
-                .max_by_key(|(_, &count)| count)
+                .max_by(|(a_bucket, a_count), (b_bucket, b_count)| {
+                    a_count.cmp(b_count).then_with(|| b_bucket.cmp(a_bucket))
+                })
                 .expect("size_buckets non-empty checked above");
             (*bucket as f32) / 4.0
         };
 
         let body_font_name = font_buckets
             .iter()
-            .max_by_key(|(_, &count)| count)
+            .max_by(|(a_name, a_count), (b_name, b_count)| {
+                a_count.cmp(b_count).then_with(|| b_name.cmp(a_name))
+            })
             .map(|(name, _)| (*name).to_string())
             .unwrap_or_default();
 
@@ -232,6 +255,68 @@ mod tests {
             "expected ~6.0, got {}",
             stats.dominant_char_width
         );
+    }
+
+    // A tie in the size histogram must resolve to the SMALLER bucket, every
+    // run. Both sizes carry exactly 50 characters, so `max_by_key` over the
+    // backing `HashMap` would return whichever bucket the per-process-
+    // randomized iteration order visited last — this test failed roughly half
+    // the time before the explicit tie-break.
+    #[test]
+    fn size_histogram_tie_resolves_to_smaller_bucket() {
+        let mut spans = Vec::new();
+        let mut y = 720.0;
+        for _ in 0..10 {
+            spans.push(span("abcde", 72.0, y, "Helvetica", 10.0));
+            y -= 12.0;
+        }
+        for _ in 0..10 {
+            spans.push(span("abcde", 300.0, y, "Helvetica", 14.0));
+            y -= 16.0;
+        }
+        let stats = PageFontStats::from_spans(&spans);
+        assert_eq!(
+            stats.dominant_em, 10.0,
+            "50 chars at 10 pt vs 50 chars at 14 pt must resolve to the smaller em"
+        );
+    }
+
+    // Same defect on the font histogram: equal character mass in two fonts
+    // must resolve to the lexicographically smaller name.
+    #[test]
+    fn font_histogram_tie_resolves_to_lexicographically_smaller_name() {
+        let mut spans = Vec::new();
+        let mut y = 720.0;
+        for _ in 0..10 {
+            spans.push(span("abcde", 72.0, y, "Helvetica", 12.0));
+            spans.push(span("vwxyz", 300.0, y, "Arial", 12.0));
+            y -= 14.4;
+        }
+        let stats = PageFontStats::from_spans(&spans);
+        assert_eq!(
+            stats.body_font_name, "Arial",
+            "equal character mass in two fonts must resolve to the smaller name"
+        );
+    }
+
+    // The tie-break must not disturb the ordinary case: a clear winner is
+    // still the clear winner, whichever side of the tie-break it sits on.
+    #[test]
+    fn unique_mode_is_unaffected_by_tie_break_direction() {
+        let mut spans = Vec::new();
+        let mut y = 720.0;
+        // Larger size holds strictly more character mass, so it must win even
+        // though ties resolve toward the smaller bucket.
+        for _ in 0..4 {
+            spans.push(span("ab", 72.0, y, "Helvetica", 9.0));
+            y -= 11.0;
+        }
+        for _ in 0..10 {
+            spans.push(span("abcdefghij", 300.0, y, "Helvetica", 18.0));
+            y -= 21.0;
+        }
+        let stats = PageFontStats::from_spans(&spans);
+        assert_eq!(stats.dominant_em, 18.0);
     }
 
     #[test]

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -212,6 +212,47 @@ impl Default for TextSpan {
 }
 
 impl TextSpan {
+    /// Where the run physically sits on the page.
+    ///
+    /// [`Self::bbox`] carries the run's own extents: `width` is the advance
+    /// along the writing axis and `height` the font size, whatever the
+    /// rotation. That is the right frame for measuring the text, and it is the
+    /// frame every existing consumer already reads, so it is left alone — but
+    /// it means a run drawn with `Tm [0 1 -1 0]` reports a wide, short box for
+    /// text that is physically tall and narrow.
+    ///
+    /// This rotates those extents about the run origin into page space. At
+    /// `rotation_degrees == 0` it returns `bbox` unchanged, so upright pages
+    /// cannot move; free angles get the axis-aligned hull of the rotated box.
+    ///
+    /// Mirrors [`crate::elements::Path::rendered_bbox`]: a derived accessor
+    /// rather than a second stored rectangle that could drift out of sync.
+    pub fn page_bbox(&self) -> Rect {
+        if self.rotation_degrees == 0.0 {
+            return self.bbox;
+        }
+        let theta = self.rotation_degrees.to_radians();
+        let (sin, cos) = theta.sin_cos();
+        // Writing axis and the across-line axis, the same pair the assembler
+        // resolves displacements onto (ISO 32000-1 §9.4.4).
+        let (ux, uy) = (cos, sin);
+        let (vx, vy) = (-sin, cos);
+        let (w, h) = (self.bbox.width, self.bbox.height);
+        let corners = [
+            (0.0, 0.0),
+            (w, 0.0),
+            (0.0, h),
+            (w, h),
+        ]
+        .map(|(a, b)| (self.bbox.x + a * ux + b * vx, self.bbox.y + a * uy + b * vy));
+
+        let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
+        let max_x = corners.iter().map(|c| c.0).fold(f32::NEG_INFINITY, f32::max);
+        let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
+        let max_y = corners.iter().map(|c| c.1).fold(f32::NEG_INFINITY, f32::max);
+        Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
+    }
+
     /// Decompose the span into individual characters.
     pub fn to_chars(&self) -> Vec<TextChar> {
         let char_count = self.text.chars().count();

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -225,7 +225,7 @@ impl TextSpan {
     /// `rotation_degrees == 0` it returns `bbox` unchanged, so upright pages
     /// cannot move; free angles get the axis-aligned hull of the rotated box.
     ///
-    /// Mirrors [`crate::elements::Path::rendered_bbox`]: a derived accessor
+    /// Mirrors [`crate::elements::PathContent::rendered_bbox`]: a derived accessor
     /// rather than a second stored rectangle that could drift out of sync.
     pub fn page_bbox(&self) -> Rect {
         if self.rotation_degrees == 0.0 {

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -780,9 +780,16 @@ impl TextBlock {
         for c in &chars {
             *font_counts.entry(c.font_name.clone()).or_insert(0) += 1;
         }
+        // Explicit tie-break, not `max_by_key`: it returns the LAST maximal
+        // element, and over a `HashMap` that is the per-process-randomized
+        // iteration order. A block whose two fonts carry the same character
+        // count would otherwise pick a different dominant font per process.
+        // Ties resolve to the lexicographically smaller font name.
         let dominant_font = font_counts
             .iter()
-            .max_by_key(|(_, count)| *count)
+            .max_by(|(a_font, a_count), (b_font, b_count)| {
+                a_count.cmp(b_count).then_with(|| b_font.cmp(a_font))
+            })
             .map(|(font, _)| font.clone())
             .unwrap_or_default();
 
@@ -922,6 +929,49 @@ mod tests {
             descent: -0.35 * 12.0,
             matrix: None,
         }
+    }
+
+    // A block whose two fonts carry equal character counts must resolve to the
+    // lexicographically smaller name, every run. `max_by_key` over the backing
+    // `HashMap` returned whichever entry the per-process-randomized iteration
+    // order visited last, so this assertion failed roughly half the time before
+    // the explicit tie-break.
+    #[test]
+    fn dominant_font_tie_resolves_to_lexicographically_smaller_name() {
+        let mut chars = Vec::new();
+        for (i, c) in "abcd".chars().enumerate() {
+            let mut ch = mock_char(c, i as f32 * 10.0, 0.0);
+            ch.font_name = "Times".to_string();
+            chars.push(ch);
+        }
+        for (i, c) in "efgh".chars().enumerate() {
+            let mut ch = mock_char(c, 40.0 + i as f32 * 10.0, 0.0);
+            ch.font_name = "Courier".to_string();
+            chars.push(ch);
+        }
+        let block = TextBlock::from_chars(chars);
+        assert_eq!(
+            block.dominant_font, "Courier",
+            "4 chars of Times vs 4 of Courier must resolve to the smaller name"
+        );
+    }
+
+    // The tie-break must not disturb the ordinary case.
+    #[test]
+    fn dominant_font_unique_winner_is_unaffected_by_tie_break() {
+        let mut chars = Vec::new();
+        for (i, c) in "abcdef".chars().enumerate() {
+            let mut ch = mock_char(c, i as f32 * 10.0, 0.0);
+            ch.font_name = "Times".to_string();
+            chars.push(ch);
+        }
+        for (i, c) in "gh".chars().enumerate() {
+            let mut ch = mock_char(c, 60.0 + i as f32 * 10.0, 0.0);
+            ch.font_name = "Courier".to_string();
+            chars.push(ch);
+        }
+        let block = TextBlock::from_chars(chars);
+        assert_eq!(block.dominant_font, "Times");
     }
 
     #[test]

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -238,18 +238,19 @@ impl TextSpan {
         let (ux, uy) = (cos, sin);
         let (vx, vy) = (-sin, cos);
         let (w, h) = (self.bbox.width, self.bbox.height);
-        let corners = [
-            (0.0, 0.0),
-            (w, 0.0),
-            (0.0, h),
-            (w, h),
-        ]
-        .map(|(a, b)| (self.bbox.x + a * ux + b * vx, self.bbox.y + a * uy + b * vy));
+        let corners = [(0.0, 0.0), (w, 0.0), (0.0, h), (w, h)]
+            .map(|(a, b)| (self.bbox.x + a * ux + b * vx, self.bbox.y + a * uy + b * vy));
 
         let min_x = corners.iter().map(|c| c.0).fold(f32::INFINITY, f32::min);
-        let max_x = corners.iter().map(|c| c.0).fold(f32::NEG_INFINITY, f32::max);
+        let max_x = corners
+            .iter()
+            .map(|c| c.0)
+            .fold(f32::NEG_INFINITY, f32::max);
         let min_y = corners.iter().map(|c| c.1).fold(f32::INFINITY, f32::min);
-        let max_y = corners.iter().map(|c| c.1).fold(f32::NEG_INFINITY, f32::max);
+        let max_y = corners
+            .iter()
+            .map(|c| c.1)
+            .fold(f32::NEG_INFINITY, f32::max);
         Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
     }
 

--- a/src/redaction/serialize.rs
+++ b/src/redaction/serialize.rs
@@ -309,10 +309,18 @@ pub(crate) fn serialize_operator(output: &mut Vec<u8>, op: &Operator) {
         // Inline image (BI…ID…EI)
         Operator::InlineImage { dict, data } => {
             output.extend_from_slice(b"BI\n");
-            for (key, value) in dict.iter() {
-                output.extend_from_slice(format!("/{} ", key).as_bytes());
-                serialize_object(output, value);
-                output.push(b'\n');
+            // Sorted for the same reason as `Object::Dictionary` below: the
+            // inline-image dictionary is a `HashMap`, and every inline image
+            // carries several keys (/W /H /BPC /CS at minimum), so unsorted
+            // emission randomizes the content stream's bytes every run.
+            let mut keys: Vec<_> = dict.keys().collect();
+            keys.sort();
+            for key in keys {
+                if let Some(value) = dict.get(key) {
+                    output.extend_from_slice(format!("/{} ", key).as_bytes());
+                    serialize_object(output, value);
+                    output.push(b'\n');
+                }
             }
             output.extend_from_slice(b"ID ");
             output.extend_from_slice(data);
@@ -356,9 +364,20 @@ pub(crate) fn serialize_object(output: &mut Vec<u8>, obj: &Object) {
         },
         Object::Dictionary(dict) => {
             output.extend_from_slice(b"<<");
-            for (key, value) in dict {
-                output.extend_from_slice(format!("/{} ", key).as_bytes());
-                serialize_object(output, value);
+            // Sort keys for deterministic output. `Object::Dictionary` is a
+            // `HashMap`, so iterating it directly emits the entries in the
+            // per-process-randomized order and the redacted PDF's bytes differ
+            // between runs of the same binary on the same input. Unlike a
+            // tie-break this is unconditional: any dictionary with two or more
+            // keys reorders. Same fix as `writer::ObjectSerializer`, which
+            // already sorts for this reason.
+            let mut keys: Vec<_> = dict.keys().collect();
+            keys.sort();
+            for key in keys {
+                if let Some(value) = dict.get(key) {
+                    output.extend_from_slice(format!("/{} ", key).as_bytes());
+                    serialize_object(output, value);
+                }
             }
             output.extend_from_slice(b">>");
         },
@@ -482,5 +501,54 @@ mod tests {
         );
         serialize_operator(&mut out, &Operator::RestoreState);
         assert_eq!(s(&out), "q\n1.000000 0.000000 0.000000 1.000000 10.000000 20.000000 cm\nQ\n");
+    }
+
+    /// A dictionary with several keys must serialize in sorted key order every
+    /// run. `Object::Dictionary` is a `HashMap`, so emitting its entries in
+    /// iteration order put the redacted PDF's bytes at the mercy of the
+    /// per-process hash seed — this assertion failed on most runs before the
+    /// keys were sorted. Unlike a tie-break the defect is unconditional: two
+    /// or more keys is enough.
+    #[test]
+    fn dictionary_serializes_in_sorted_key_order() {
+        let mut dict = std::collections::HashMap::new();
+        dict.insert("Zebra".to_string(), Object::Integer(3));
+        dict.insert("Alpha".to_string(), Object::Integer(1));
+        dict.insert("Middle".to_string(), Object::Integer(2));
+        let mut out = Vec::new();
+        serialize_object(&mut out, &Object::Dictionary(dict));
+        assert_eq!(s(&out), "<</Alpha 1/Middle 2/Zebra 3>>");
+    }
+
+    /// A single-key dictionary is unaffected by the sort — the ordinary case
+    /// must serialize exactly as before.
+    #[test]
+    fn single_key_dictionary_is_unaffected_by_sorting() {
+        let mut dict = std::collections::HashMap::new();
+        dict.insert("Only".to_string(), Object::Name("Value".to_string()));
+        let mut out = Vec::new();
+        serialize_object(&mut out, &Object::Dictionary(dict));
+        assert_eq!(s(&out), "<</Only /Value>>");
+    }
+
+    /// The inline-image dictionary is emitted through a separate loop and
+    /// needs the same guarantee: every inline image carries several keys, so
+    /// unsorted emission randomized the content stream on essentially every
+    /// image.
+    #[test]
+    fn inline_image_dictionary_serializes_in_sorted_key_order() {
+        let mut dict = std::collections::HashMap::new();
+        dict.insert("W".to_string(), Object::Integer(2));
+        dict.insert("BPC".to_string(), Object::Integer(8));
+        dict.insert("H".to_string(), Object::Integer(1));
+        let mut out = Vec::new();
+        serialize_operator(
+            &mut out,
+            &Operator::InlineImage {
+                dict: Box::new(dict),
+                data: b"ab".to_vec(),
+            },
+        );
+        assert_eq!(s(&out), "BI\n/BPC 8\n/H 1\n/W 2\nID ab\nEI\n");
     }
 }

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -675,31 +675,23 @@ impl PageRenderer {
     }
 
     /// Share TrueType cmap tables between fonts with matching base font names.
+    ///
+    /// Donor selection lives in `fonts::unicode_decode::best_truetype_cmaps`,
+    /// shared with the extraction path: best coverage wins, deterministic
+    /// tie-break, strict subset-prefix stripping. Only the write loop is
+    /// local, because this table stores fonts behind a `OnceLock` cmap slot.
     fn share_truetype_cmaps(&mut self) {
-        let mut base_font_to_cmap = HashMap::new();
-
-        // First pass: collect available cmaps
-        for font in self.fonts.values() {
-            if let Some(cmap) = font.truetype_cmap() {
-                // Get base font name without subset prefix (e.g. ABCDEF+Arial -> Arial)
-                let base_name = if let Some(plus_idx) = font.base_font.find('+') {
-                    &font.base_font[plus_idx + 1..]
-                } else {
-                    &font.base_font
-                };
-                base_font_to_cmap.insert(base_name.to_string(), cmap.clone());
-            }
+        let best_cmaps =
+            crate::fonts::unicode_decode::best_truetype_cmaps(self.fonts.values().map(|f| &**f));
+        if best_cmaps.is_empty() {
+            return;
         }
 
-        // Second pass: apply cmaps to fonts missing them
         for font in self.fonts.values() {
             if font.subtype == "Type0" && font.truetype_cmap().is_none() {
-                let base_name = if let Some(plus_idx) = font.base_font.find('+') {
-                    &font.base_font[plus_idx + 1..]
-                } else {
-                    &font.base_font
-                };
-                if let Some(shared_cmap) = base_font_to_cmap.get(base_name) {
+                let base_name =
+                    crate::fonts::unicode_decode::strip_subset_prefix(&font.base_font);
+                if let Some((shared_cmap, _)) = best_cmaps.get(base_name) {
                     font.truetype_cmap.set(Some(shared_cmap.clone())).ok();
                 }
             }

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -689,8 +689,7 @@ impl PageRenderer {
 
         for font in self.fonts.values() {
             if font.subtype == "Type0" && font.truetype_cmap().is_none() {
-                let base_name =
-                    crate::fonts::unicode_decode::strip_subset_prefix(&font.base_font);
+                let base_name = crate::fonts::unicode_decode::strip_subset_prefix(&font.base_font);
                 if let Some((shared_cmap, _)) = best_cmaps.get(base_name) {
                     font.truetype_cmap.set(Some(shared_cmap.clone())).ok();
                 }

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -1500,7 +1500,7 @@ impl TextRasterizer {
 
             // Draw glyph outline
             if gid == 0 && !char_at_pos.is_whitespace() {
-                dropped.record("no glyph id", char_code, gid);
+                dropped.record("no glyph id", u32::from(char_code), gid);
             }
             if gid != 0 || char_at_pos.is_whitespace() {
                 if !char_at_pos.is_whitespace() {
@@ -1512,7 +1512,7 @@ impl TextRasterizer {
                         .outline_glyph(ttf_parser::GlyphId(gid), &mut builder)
                         .is_some();
                     if !outlined {
-                        dropped.record("no outline", char_code, gid);
+                        dropped.record("no outline", u32::from(char_code), gid);
                     }
                     if outlined {
                         if let Some(path) = pb.finish() {

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -13,9 +13,9 @@
 use super::create_fill_paint;
 use crate::content::operators::TextElement;
 use crate::content::GraphicsState;
-use crate::fonts::unicode_decode::{DecodePolicy, GlyphDropTally, TextCharIter};
 use crate::document::PdfDocument;
 use crate::error::{Error, Result};
+use crate::fonts::unicode_decode::{DecodePolicy, GlyphDropTally, TextCharIter};
 use crate::object::Object;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -332,7 +332,6 @@ fn render_cjk_fallback_face() -> Option<Arc<CachedFace>> {
         })
         .clone()
 }
-
 
 pub struct TextRasterizer {
     /// Font database for system font fallback.
@@ -1093,15 +1092,15 @@ impl TextRasterizer {
         let combined_base = base_transform.pre_concat(text_transform);
 
         let mut x_cursor: f32 = 0.0; // In text space units
-        // See GlyphDropTally: a glyph that paints nothing here still advances
-        // the cursor, leaving a gap indistinguishable from whitespace (#991).
+                                     // See GlyphDropTally: a glyph that paints nothing here still advances
+                                     // the cursor, leaving a gap indistinguishable from whitespace (#991).
         let mut unicode_dropped = GlyphDropTally::default();
-                                     // y_cursor tracks the cursor along the y-axis. It stays at 0 in
-                                     // horizontal mode (the default) and accumulates `w1y*font_size/1000`
-                                     // per glyph when WMode 1 is active. Single cursor variable keeps the
-                                     // hot loop simple — the branch on `gs.text_wmode` only flips which
-                                     // axis receives the advance and how the glyph is positioned
-                                     // relative to its horizontal origin.
+        // y_cursor tracks the cursor along the y-axis. It stays at 0 in
+        // horizontal mode (the default) and accumulates `w1y*font_size/1000`
+        // per glyph when WMode 1 is active. Single cursor variable keeps the
+        // hot loop simple — the branch on `gs.text_wmode` only flips which
+        // axis receives the advance and how the glyph is positioned
+        // relative to its horizontal origin.
         let mut y_cursor: f32 = 0.0;
         let mut last_fallback_cluster: Option<usize> = None;
         let wmode = gs.text_wmode;
@@ -1357,7 +1356,11 @@ impl TextRasterizer {
                 }
 
                 if !has_outline {
-                    unicode_dropped.record("no outline in font or CJK fallback", char_at_pos as u32, 0);
+                    unicode_dropped.record(
+                        "no outline in font or CJK fallback",
+                        char_at_pos as u32,
+                        0,
+                    );
                 }
             }
 
@@ -1382,7 +1385,9 @@ impl TextRasterizer {
         }
 
         unicode_dropped.report(
-            font_info.map(|f| f.base_font.as_str()).unwrap_or("<system fallback>"),
+            font_info
+                .map(|f| f.base_font.as_str())
+                .unwrap_or("<system fallback>"),
         );
 
         // Return the magnitude of the accumulated advance along the active
@@ -1824,7 +1829,6 @@ impl TextRasterizer {
         Ok(x_cursor * h_scale)
     }
 }
-
 
 impl Default for TextRasterizer {
     fn default() -> Self {

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -13,6 +13,7 @@
 use super::create_fill_paint;
 use crate::content::operators::TextElement;
 use crate::content::GraphicsState;
+use crate::fonts::unicode_decode::{DecodePolicy, GlyphDropTally, TextCharIter};
 use crate::document::PdfDocument;
 use crate::error::{Error, Result};
 use crate::object::Object;
@@ -332,46 +333,6 @@ fn render_cjk_fallback_face() -> Option<Arc<CachedFace>> {
         .clone()
 }
 
-/// Rasterizer for PDF text operations.
-/// Glyphs that painted nothing while the cursor advanced, tallied for one
-/// text run.
-///
-/// A dropped glyph is indistinguishable from real whitespace downstream: OCR
-/// transcribes the gap-filled render faithfully and the loss reaches a search
-/// index unnoticed (#991). One warning per run names the font, the first
-/// offending code and glyph id, and how many followed — enough to identify a
-/// broken font without a log line per glyph.
-#[derive(Default)]
-struct GlyphDropTally {
-    count: usize,
-    first: Option<(&'static str, u32, u16)>,
-}
-
-impl GlyphDropTally {
-    fn record(&mut self, reason: &'static str, char_code: u32, gid: u16) {
-        self.count += 1;
-        self.first.get_or_insert((reason, char_code, gid));
-    }
-
-    fn report(&self, font_name: &str) {
-        let Some((reason, char_code, gid)) = self.first else {
-            return;
-        };
-        let message = format!(
-            "font '{font_name}' painted nothing for {} glyph(s) while advancing the cursor; \
-             first was code 0x{char_code:X} (glyph {gid}): {reason}. The page renders with \
-             a gap that reads as whitespace downstream.",
-            self.count
-        );
-        log::warn!(target: "pdf_oxide::fonts", "{message}");
-        crate::extractors::warnings::push_global_warning(crate::extractors::warnings::Warning {
-            category: crate::extractors::warnings::WarningCategory::GlyphDropped,
-            page: None,
-            message,
-            spec_section: Some("9.6.6"),
-        });
-    }
-}
 
 pub struct TextRasterizer {
     /// Font database for system font fallback.
@@ -671,80 +632,31 @@ impl TextRasterizer {
     }
 
     /// Decode raw PDF text bytes to a Unicode string based on font type.
+    ///
+    /// Delegates to the shared decoder with the rasterizer policy: unmapped
+    /// codes are dropped (a U+FFFD has no glyph to paint) but counted so the
+    /// loss is reported rather than silent (#991), and presentation-form
+    /// ligature code points are decomposed so the shaper passes the cluster
+    /// through instead of dropping it (#331).
     fn decode_text_to_unicode(
         &self,
         bytes: &[u8],
         font: Option<&crate::fonts::FontInfo>,
     ) -> String {
-        // Chars that resolve to U+FFFD are removed from the shaping input
-        // below: no glyph, no advance, and every downstream index shifts.
-        // Counted so the loss is reported rather than silent (#991).
         let mut undecodable = GlyphDropTally::default();
-        let raw_result = if let Some(font) = font {
-            let mut result = String::new();
-            // Use pre-computed lookup table for performance if it's a simple font
-            if font.subtype != "Type0" {
-                let table = font.get_byte_to_char_table();
-                for &byte in bytes {
-                    let c = table[byte as usize];
-                    if c != '\0' {
-                        result.push(c);
-                    } else {
-                        // Fallback: multi-char mapping or unmapped byte
-                        let char_str = font
-                            .char_to_unicode(byte as u32)
-                            .unwrap_or_else(|| fallback_char_to_unicode(byte as u32));
-                        if char_str != "\u{FFFD}" {
-                            result.push_str(&char_str);
-                        } else {
-                            undecodable.record("no Unicode mapping", byte as u32, 0);
-                        }
-                    }
-                }
-            } else {
-                // Complex font: use unified iterator for robust multi-byte decoding
-                for (char_code, _) in TextCharIter::new(bytes, Some(font)) {
-                    let char_str = font
-                        .char_to_unicode(char_code as u32)
-                        .unwrap_or_else(|| fallback_char_to_unicode(char_code as u32));
-
-                    if char_str != "\u{FFFD}" {
-                        result.push_str(&char_str);
-                    } else {
-                        undecodable.record("no Unicode mapping", char_code as u32, 0);
-                    }
-                }
-            }
+        let result = crate::fonts::unicode_decode::decode_text_to_unicode(
+            bytes,
+            font,
+            DecodePolicy {
+                preserve_unmapped: false,
+                decompose_ligatures: true,
+            },
+            Some(&mut undecodable),
+        );
+        if let Some(font) = font {
             undecodable.report(&font.base_font);
-            result
-        } else {
-            // No font - fallback to Latin-1 (ISO 8859-1) encoding
-            bytes.iter().map(|&b| char::from(b)).collect()
-        };
-
-        // Filter control characters from failed encoding resolution,
-        // and expand presentation-form ligature code points (fi, fl, ffi,
-        // ffl, st, ct, …) into their component letters so the shaper
-        // passes the cluster through as ordinary glyphs instead of
-        // dropping it or producing a lone box. `extract_text` already
-        // does this on the extraction path via
-        // `ligature_processor::get_ligature_components`; without the
-        // same decomposition on the render path, words like
-        // "Efficient" rasterize as "Effi  ert" because the shaper can't
-        // resolve the ligature cluster against the fallback system
-        // font. See issue #331 (R2).
-        let mut filtered = String::with_capacity(raw_result.len());
-        for c in raw_result.chars() {
-            if c < '\x20' && c != '\t' && c != '\n' && c != '\r' {
-                continue;
-            }
-            if let Some(components) = crate::text::ligature_processor::get_ligature_components(c) {
-                filtered.push_str(components);
-            } else {
-                filtered.push(c);
-            }
         }
-        filtered
+        result
     }
 
     /// Measure-only: compute the horizontal advance of a Tj text string
@@ -1913,135 +1825,6 @@ impl TextRasterizer {
     }
 }
 
-/// Byte grouping mode for CID font character code decoding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ByteMode {
-    /// Single-byte codes (simple fonts, some predefined CMaps)
-    OneByte,
-    /// Always 2-byte codes (Identity-H/V, UCS2)
-    TwoByte,
-    /// Shift-JIS variable-width (1 or 2 bytes depending on lead byte)
-    ShiftJIS,
-}
-
-/// Get byte grouping mode for a font.
-fn get_byte_mode(font: Option<&crate::fonts::FontInfo>) -> ByteMode {
-    if let Some(font) = font {
-        if font.subtype == "Type0" {
-            match &font.encoding {
-                crate::fonts::Encoding::Identity => ByteMode::TwoByte,
-                crate::fonts::Encoding::Standard(name) => {
-                    if (name.contains("Identity") && !name.contains("OneByteIdentity"))
-                        || name.contains("UCS2")
-                        || name.contains("UTF16")
-                    {
-                        ByteMode::TwoByte
-                    } else if name.contains("RKSJ") {
-                        ByteMode::ShiftJIS
-                    } else if name.contains("EUC")
-                        || name.contains("GBK")
-                        || name.contains("GBpc")
-                        || name.contains("GB-")
-                        || name.contains("CNS")
-                        || name.contains("B5")
-                        || name.contains("KSC")
-                        || name.contains("KSCms")
-                    {
-                        ByteMode::TwoByte
-                    } else {
-                        ByteMode::OneByte
-                    }
-                },
-                _ => ByteMode::OneByte,
-            }
-        } else {
-            ByteMode::OneByte
-        }
-    } else {
-        ByteMode::OneByte
-    }
-}
-
-/// Iterator over characters in a PDF string based on font encoding.
-struct TextCharIter<'a> {
-    bytes: &'a [u8],
-    byte_mode: ByteMode,
-    index: usize,
-}
-
-impl<'a> TextCharIter<'a> {
-    fn new(bytes: &'a [u8], font: Option<&crate::fonts::FontInfo>) -> Self {
-        Self {
-            bytes,
-            byte_mode: get_byte_mode(font),
-            index: 0,
-        }
-    }
-}
-
-impl<'a> Iterator for TextCharIter<'a> {
-    type Item = (u16, usize); // (char_code, bytes_consumed)
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.bytes.len() {
-            return None;
-        }
-
-        let (char_code, bytes_consumed) = match self.byte_mode {
-            ByteMode::TwoByte if self.index + 1 < self.bytes.len() => {
-                (((self.bytes[self.index] as u16) << 8) | (self.bytes[self.index + 1] as u16), 2)
-            },
-            ByteMode::ShiftJIS => {
-                let b = self.bytes[self.index];
-                let is_lead = (0x81..=0x9F).contains(&b) || (0xE0..=0xFC).contains(&b);
-                if is_lead && self.index + 1 < self.bytes.len() {
-                    (((b as u16) << 8) | (self.bytes[self.index + 1] as u16), 2)
-                } else {
-                    (b as u16, 1)
-                }
-            },
-            _ => (self.bytes[self.index] as u16, 1),
-        };
-
-        self.index += bytes_consumed;
-        Some((char_code, bytes_consumed))
-    }
-}
-
-/// Fallback function to map common character codes to Unicode when ToUnicode CMap fails.
-fn fallback_char_to_unicode(char_code: u32) -> String {
-    match char_code {
-        0x2014 => "—".to_string(),
-        0x2013 => "–".to_string(),
-        0x2018 => "\u{2018}".to_string(),
-        0x2019 => "\u{2019}".to_string(),
-        0x201C => "\u{201C}".to_string(),
-        0x201D => "\u{201D}".to_string(),
-        0x2022 => "•".to_string(),
-        0x2026 => "…".to_string(),
-        0x00B0 => "°".to_string(),
-        0x00B1 => "±".to_string(),
-        0x00D7 => "×".to_string(),
-        0x00F7 => "÷".to_string(),
-        0x2202 => "∂".to_string(),
-        0x2207 => "∇".to_string(),
-        0x220F => "∏".to_string(),
-        0x2211 => "∑".to_string(),
-        0x221A => "√".to_string(),
-        0x221E => "∞".to_string(),
-        0x2260 => "≠".to_string(),
-        0x2261 => "≡".to_string(),
-        0x2264 => "≤".to_string(),
-        0x2265 => "≥".to_string(),
-        code => {
-            if let Some(ch) = char::from_u32(code) {
-                ch.to_string()
-            } else {
-                "\u{FFFD}".to_string()
-            }
-        },
-    }
-}
 
 impl Default for TextRasterizer {
     fn default() -> Self {

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -333,6 +333,46 @@ fn render_cjk_fallback_face() -> Option<Arc<CachedFace>> {
 }
 
 /// Rasterizer for PDF text operations.
+/// Glyphs that painted nothing while the cursor advanced, tallied for one
+/// text run.
+///
+/// A dropped glyph is indistinguishable from real whitespace downstream: OCR
+/// transcribes the gap-filled render faithfully and the loss reaches a search
+/// index unnoticed (#991). One warning per run names the font, the first
+/// offending code and glyph id, and how many followed — enough to identify a
+/// broken font without a log line per glyph.
+#[derive(Default)]
+struct GlyphDropTally {
+    count: usize,
+    first: Option<(&'static str, u32, u16)>,
+}
+
+impl GlyphDropTally {
+    fn record(&mut self, reason: &'static str, char_code: u32, gid: u16) {
+        self.count += 1;
+        self.first.get_or_insert((reason, char_code, gid));
+    }
+
+    fn report(&self, font_name: &str) {
+        let Some((reason, char_code, gid)) = self.first else {
+            return;
+        };
+        let message = format!(
+            "font '{font_name}' painted nothing for {} glyph(s) while advancing the cursor; \
+             first was code 0x{char_code:X} (glyph {gid}): {reason}. The page renders with \
+             a gap that reads as whitespace downstream.",
+            self.count
+        );
+        log::warn!(target: "pdf_oxide::fonts", "{message}");
+        crate::extractors::warnings::push_global_warning(crate::extractors::warnings::Warning {
+            category: crate::extractors::warnings::WarningCategory::GlyphDropped,
+            page: None,
+            message,
+            spec_section: Some("9.6.6"),
+        });
+    }
+}
+
 pub struct TextRasterizer {
     /// Font database for system font fallback.
     ///
@@ -636,6 +676,10 @@ impl TextRasterizer {
         bytes: &[u8],
         font: Option<&crate::fonts::FontInfo>,
     ) -> String {
+        // Chars that resolve to U+FFFD are removed from the shaping input
+        // below: no glyph, no advance, and every downstream index shifts.
+        // Counted so the loss is reported rather than silent (#991).
+        let mut undecodable = GlyphDropTally::default();
         let raw_result = if let Some(font) = font {
             let mut result = String::new();
             // Use pre-computed lookup table for performance if it's a simple font
@@ -652,6 +696,8 @@ impl TextRasterizer {
                             .unwrap_or_else(|| fallback_char_to_unicode(byte as u32));
                         if char_str != "\u{FFFD}" {
                             result.push_str(&char_str);
+                        } else {
+                            undecodable.record("no Unicode mapping", byte as u32, 0);
                         }
                     }
                 }
@@ -664,9 +710,12 @@ impl TextRasterizer {
 
                     if char_str != "\u{FFFD}" {
                         result.push_str(&char_str);
+                    } else {
+                        undecodable.record("no Unicode mapping", char_code as u32, 0);
                     }
                 }
             }
+            undecodable.report(&font.base_font);
             result
         } else {
             // No font - fallback to Latin-1 (ISO 8859-1) encoding
@@ -1132,6 +1181,9 @@ impl TextRasterizer {
         let combined_base = base_transform.pre_concat(text_transform);
 
         let mut x_cursor: f32 = 0.0; // In text space units
+        // See GlyphDropTally: a glyph that paints nothing here still advances
+        // the cursor, leaving a gap indistinguishable from whitespace (#991).
+        let mut unicode_dropped = GlyphDropTally::default();
                                      // y_cursor tracks the cursor along the y-axis. It stays at 0 in
                                      // horizontal mode (the default) and accumulates `w1y*font_size/1000`
                                      // per glyph when WMode 1 is active. Single cursor variable keeps the
@@ -1393,11 +1445,7 @@ impl TextRasterizer {
                 }
 
                 if !has_outline {
-                    log::debug!(
-                        "No glyph outline found for char='{}' (0x{:X})",
-                        char_at_pos,
-                        char_at_pos as u32
-                    );
+                    unicode_dropped.record("no outline in font or CJK fallback", char_at_pos as u32, 0);
                 }
             }
 
@@ -1420,6 +1468,10 @@ impl TextRasterizer {
                 }
             }
         }
+
+        unicode_dropped.report(
+            font_info.map(|f| f.base_font.as_str()).unwrap_or("<system fallback>"),
+        );
 
         // Return the magnitude of the accumulated advance along the active
         // writing axis. Callers that drive the text matrix forward consume
@@ -1464,6 +1516,11 @@ impl TextRasterizer {
         let mut x_cursor: f32 = 0.0;
         let mut y_cursor: f32 = 0.0;
         let wmode = gs.text_wmode;
+        // A glyph that paints nothing while the cursor still advances leaves an
+        // invisible gap, and a caller cannot tell that from real whitespace
+        // (#991). Counted per run and reported once, so a broken font is
+        // visible without one line per glyph.
+        let mut dropped = GlyphDropTally::default();
 
         // Iterate over character codes from the raw bytes
         for (char_code, _bytes_consumed) in TextCharIter::new(bytes, Some(font_info)) {
@@ -1530,14 +1587,22 @@ impl TextRasterizer {
             let char_at_pos = char_str.chars().next().unwrap_or('\0');
 
             // Draw glyph outline
+            if gid == 0 && !char_at_pos.is_whitespace() {
+                dropped.record("no glyph id", char_code, gid);
+            }
             if gid != 0 || char_at_pos.is_whitespace() {
                 if !char_at_pos.is_whitespace() {
                     let mut pb = PathBuilder::new();
                     let mut builder = SkiaOutlineBuilder(&mut pb);
-                    if ttf_face
+                    // Outlined once: `outline_glyph` appends to the builder,
+                    // so calling it twice would draw the glyph twice.
+                    let outlined = ttf_face
                         .outline_glyph(ttf_parser::GlyphId(gid), &mut builder)
-                        .is_some()
-                    {
+                        .is_some();
+                    if !outlined {
+                        dropped.record("no outline", char_code, gid);
+                    }
+                    if outlined {
                         if let Some(path) = pb.finish() {
                             let (rise_x, rise_y) = if wmode == 0 {
                                 (0.0, gs.text_rise)
@@ -1572,6 +1637,7 @@ impl TextRasterizer {
                 }
             }
         }
+        dropped.report(&font_info.base_font);
 
         Ok(if wmode == 0 { x_cursor } else { y_cursor })
     }

--- a/src/structure/spatial_table_detector.rs
+++ b/src/structure/spatial_table_detector.rs
@@ -3581,17 +3581,33 @@ fn detect_tables_from_horizontal_rules(
             }
         }
     }
-    let mut families: HashMap<usize, Vec<&Edge>> = HashMap::new();
+    // Keyed by union-find root in a BTreeMap, not a HashMap: HashMap iteration
+    // order is randomized per process, and the sort below cannot recover from
+    // that on its own. Families are grouped by X-RANGE COHERENCE, so `coord`
+    // (the Y of a horizontal rule) is not unique across families — two rule
+    // families side by side, or a decorative border sharing a table's top-rule
+    // Y, tie on `a[0].coord`. `sort_by` is stable, so a tie leaves the input
+    // order intact, and with a HashMap that input order is per-process random:
+    // the two families then emit their tables in a different order each run,
+    // which reorders the rendered table blocks in the assembled page text.
+    // The BTreeMap makes the collected order deterministic; the root tiebreak
+    // makes the emitted order a total order over the families, so it depends
+    // only on page geometry and edge input order. Each family's `Vec` is pushed
+    // in ascending `wide` index order, so `a[0]` is still the family's first
+    // rule and non-tied pages sort exactly as before (byte-identical).
+    let mut families: std::collections::BTreeMap<usize, Vec<&Edge>> =
+        std::collections::BTreeMap::new();
     for (i, e) in wide.iter().enumerate() {
         families.entry(uf.find(i)).or_default().push(e);
     }
-    // Deterministic family order (HashMap iteration is randomized).
-    let mut families: Vec<Vec<&Edge>> = families.into_values().collect();
-    families.sort_by(|a, b| crate::utils::safe_float_cmp(a[0].coord, b[0].coord));
+    let mut families: Vec<(usize, Vec<&Edge>)> = families.into_iter().collect();
+    families.sort_by(|(root_a, a), (root_b, b)| {
+        crate::utils::safe_float_cmp(a[0].coord, b[0].coord).then_with(|| root_a.cmp(root_b))
+    });
 
     let mut tables = Vec::new();
 
-    for family in &families {
+    for (_root, family) in &families {
         // Cluster this family's edges by Y-coordinate (snap within Y_SNAP).
         let mut y_coords: Vec<f32> = Vec::new();
         for e in family {

--- a/tests/test_glyph_drop_reporting.rs
+++ b/tests/test_glyph_drop_reporting.rs
@@ -27,7 +27,10 @@ impl log::Log for CaptureWarnings {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            captured().lock().expect("capture lock").push(record.args().to_string());
+            captured()
+                .lock()
+                .expect("capture lock")
+                .push(record.args().to_string());
         }
     }
 

--- a/tests/test_glyph_drop_reporting.rs
+++ b/tests/test_glyph_drop_reporting.rs
@@ -1,0 +1,73 @@
+//! A dropped glyph must leave a trace in the log.
+//!
+//! Four points in the text rasterizer swallow a glyph that produced no outline
+//! while the cursor keeps advancing, so the page renders with an invisible gap.
+//! A consumer cannot tell that gap from genuine whitespace: OCR over such a page
+//! transcribes the gap faithfully and the loss reaches whatever consumes the
+//! text next.
+//!
+//! This pins the reporting, not the rendering: the raster output is expected to
+//! be byte-identical, and only the log gains a line.
+
+#![cfg(feature = "rendering")]
+
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, Metadata, Record};
+
+/// Warnings captured during a render.
+static CAPTURED: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+struct CaptureWarnings;
+
+impl log::Log for CaptureWarnings {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Warn
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            captured().lock().expect("capture lock").push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+fn captured() -> &'static Mutex<Vec<String>> {
+    CAPTURED.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Install the capturing logger once for this test binary.
+fn install_capture() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    INSTALLED.get_or_init(|| {
+        let _ = log::set_boxed_logger(Box::new(CaptureWarnings));
+        log::set_max_level(log::LevelFilter::Warn);
+    });
+}
+
+/// A page asking for a glyph the font cannot supply: an embedded TrueType font
+/// whose `cmap` maps nothing, so every code resolves to GID 0 and, being
+/// non-whitespace, is never painted.
+fn unmapped_glyph_pdf() -> Vec<u8> {
+    // TODO: the fixture that provably reaches the drop is still being built.
+    // Rendering needs a real font program, so this is not a two-line content
+    // stream like the extraction fixtures.
+    Vec::new()
+}
+
+#[test]
+#[ignore = "fixture that drives a glyph drop is still being built; see PR body"]
+fn a_dropped_glyph_is_reported() {
+    install_capture();
+    let pdf = unmapped_glyph_pdf();
+    let doc = pdf_oxide::document::PdfDocument::from_bytes(pdf).expect("parse fixture");
+    let _ = doc.render_page(0, 1.0);
+
+    let warnings = captured().lock().expect("capture lock");
+    assert!(
+        warnings.iter().any(|w| w.contains("glyph")),
+        "a glyph was dropped with no warning: {warnings:?}"
+    );
+}

--- a/tests/test_glyph_drop_reporting.rs
+++ b/tests/test_glyph_drop_reporting.rs
@@ -63,7 +63,8 @@ fn a_dropped_glyph_is_reported() {
     install_capture();
     let pdf = unmapped_glyph_pdf();
     let doc = pdf_oxide::document::PdfDocument::from_bytes(pdf).expect("parse fixture");
-    let _ = doc.render_page(0, 1.0);
+    let opts = pdf_oxide::rendering::RenderOptions::default();
+    let _ = pdf_oxide::rendering::render_page(&doc, 0, &opts);
 
     let warnings = captured().lock().expect("capture lock");
     assert!(

--- a/tests/test_rotated_converter_parity.rs
+++ b/tests/test_rotated_converter_parity.rs
@@ -63,7 +63,9 @@ fn converters_read_a_rotated_page_in_the_same_order_as_extract_text() {
 
     // The fixture must reach the framed path, or the comparison is vacuous.
     assert!(
-        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        from_text
+            .windows(3)
+            .any(|w| w == ["Engine", "oil", "capacity"]),
         "extract_text did not assemble the rotated page: {from_text:?}"
     );
 
@@ -82,13 +84,12 @@ fn html_reads_a_rotated_page_in_the_same_order_as_extract_text() {
     let from_html = reading_order(&strip_tags(&doc.to_html(0, &options).expect("to_html")));
 
     assert!(
-        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        from_text
+            .windows(3)
+            .any(|w| w == ["Engine", "oil", "capacity"]),
         "extract_text did not assemble the rotated page: {from_text:?}"
     );
-    assert_eq!(
-        from_text, from_html,
-        "extract_text and to_html disagree on a rotated page"
-    );
+    assert_eq!(from_text, from_html, "extract_text and to_html disagree on a rotated page");
 }
 
 #[test]
@@ -100,7 +101,9 @@ fn plain_text_reads_a_rotated_page_in_the_same_order_as_extract_text() {
     let from_plain = reading_order(&doc.to_plain_text(0, &options).expect("to_plain_text"));
 
     assert!(
-        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        from_text
+            .windows(3)
+            .any(|w| w == ["Engine", "oil", "capacity"]),
         "extract_text did not assemble the rotated page: {from_text:?}"
     );
     assert_eq!(
@@ -127,7 +130,9 @@ fn filtered_text_reads_a_rotated_page_in_the_same_order_as_extract_text() {
     let from_filtered = reading_order(&filtered);
 
     assert!(
-        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        from_text
+            .windows(3)
+            .any(|w| w == ["Engine", "oil", "capacity"]),
         "extract_text did not assemble the rotated page: {from_text:?}"
     );
     assert_eq!(

--- a/tests/test_rotated_converter_parity.rs
+++ b/tests/test_rotated_converter_parity.rs
@@ -1,0 +1,213 @@
+//! Every text-producing surface must read a rotated page the same way.
+//!
+//! The rotated reading frame is applied at one call site, inside
+//! `extract_text`. `to_markdown` and `to_html` assemble the same page in raw
+//! page space, so the same document extracts correctly through one surface and
+//! incorrectly through the other.
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::document::PdfDocument;
+
+/// A page whose text is predominantly rotated: three 90° lines, so the
+/// dominant-rotation vote fires and `extract_text` assembles in the frame.
+fn rotated_page_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    for (x, text) in [
+        (200, "Engine oil capacity"),
+        (214, "six point zero quarts"),
+        (228, "Motorcraft synthetic blend"),
+    ] {
+        content.extend_from_slice(format!("0 1 -1 0 {x} 150 Tm ({text}) Tj\n").as_bytes());
+    }
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Remove HTML tags before tokenizing. `reading_order` trims non-alphanumerics
+/// from a token's EDGES, which cannot clear a tag: `<p>Engine` trims the `<`,
+/// then stops at the alphanumeric `p`, leaving `p>Engine`. Tags have to go
+/// before tokenizing, not after.
+fn strip_tags(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut depth = 0usize;
+    for c in html.chars() {
+        match c {
+            '<' => depth += 1,
+            '>' => {
+                depth = depth.saturating_sub(1);
+                out.push(' ');
+            },
+            _ if depth == 0 => out.push(c),
+            _ => {},
+        }
+    }
+    out
+}
+
+/// Strip markup and whitespace so only the reading order is compared.
+fn reading_order(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
+        .filter(|w| !w.is_empty())
+        .collect()
+}
+
+#[test]
+fn converters_read_a_rotated_page_in_the_same_order_as_extract_text() {
+    let doc = PdfDocument::from_bytes(rotated_page_pdf()).expect("parse fixture");
+    let options = ConversionOptions::default();
+
+    let from_text = reading_order(&doc.extract_text(0).expect("extract text"));
+    let from_markdown = reading_order(&doc.to_markdown(0, &options).expect("to_markdown"));
+
+    // The fixture must reach the framed path, or the comparison is vacuous.
+    assert!(
+        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        "extract_text did not assemble the rotated page: {from_text:?}"
+    );
+
+    assert_eq!(
+        from_text, from_markdown,
+        "extract_text and to_markdown disagree on a rotated page"
+    );
+}
+
+#[test]
+fn html_reads_a_rotated_page_in_the_same_order_as_extract_text() {
+    let doc = PdfDocument::from_bytes(rotated_page_pdf()).expect("parse fixture");
+    let options = ConversionOptions::default();
+
+    let from_text = reading_order(&doc.extract_text(0).expect("extract text"));
+    let from_html = reading_order(&strip_tags(&doc.to_html(0, &options).expect("to_html")));
+
+    assert!(
+        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        "extract_text did not assemble the rotated page: {from_text:?}"
+    );
+    assert_eq!(
+        from_text, from_html,
+        "extract_text and to_html disagree on a rotated page"
+    );
+}
+
+#[test]
+fn plain_text_reads_a_rotated_page_in_the_same_order_as_extract_text() {
+    let doc = PdfDocument::from_bytes(rotated_page_pdf()).expect("parse fixture");
+    let options = ConversionOptions::default();
+
+    let from_text = reading_order(&doc.extract_text(0).expect("extract text"));
+    let from_plain = reading_order(&doc.to_plain_text(0, &options).expect("to_plain_text"));
+
+    assert!(
+        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        "extract_text did not assemble the rotated page: {from_text:?}"
+    );
+    assert_eq!(
+        from_text, from_plain,
+        "extract_text and to_plain_text disagree on a rotated page"
+    );
+}
+
+/// The layer/ink-filtered surface assembles from its own span source, so it
+/// needs the frame applied there too — with no filters it must equal
+/// `extract_text`, and with a filter that excludes nothing it still must.
+#[test]
+fn filtered_text_reads_a_rotated_page_in_the_same_order_as_extract_text() {
+    use std::collections::HashSet;
+
+    let doc = PdfDocument::from_bytes(rotated_page_pdf()).expect("parse fixture");
+
+    let from_text = reading_order(&doc.extract_text(0).expect("extract text"));
+    let mut inks = HashSet::new();
+    inks.insert("NoSuchInkOnThisPage".to_string());
+    let filtered = doc
+        .extract_text_filtered(0, HashSet::new(), inks)
+        .expect("extract_text_filtered");
+    let from_filtered = reading_order(&filtered);
+
+    assert!(
+        from_text.windows(3).any(|w| w == ["Engine", "oil", "capacity"]),
+        "extract_text did not assemble the rotated page: {from_text:?}"
+    );
+    assert_eq!(
+        from_text, from_filtered,
+        "extract_text and extract_text_filtered disagree on a rotated page"
+    );
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+/// A subscript inside a rotated run sits off the run's writing axis by the
+/// subscript drop, not by a line height. It must stay attached to the formula
+/// it belongs to: `N`, a smaller `2`, and `O` drawn as three runs of one
+/// rotated label are one chemical formula, not three fragments separated by
+/// unrelated page content.
+fn rotated_formula_with_subscript_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A 90-degree label "N2O" whose middle glyph is dropped below the baseline,
+    // the shape a rotated chart axis uses. Under a 90-degree matrix the drop is
+    // a displacement along -x, i.e. PERPENDICULAR to the +y writing axis — the
+    // exact quantity the continuation test measures.
+    //
+    // One BT/ET and one Tf size throughout, deliberately: `ET` flushes the run
+    // buffer and so does a Tf size change, either of which would leave the
+    // buffer empty at the next Tm and make the continuation test unreachable —
+    // the assertion below would then hold no matter what that test decided.
+    content.extend_from_slice(b"BT /F1 18 Tf\n");
+    content.extend_from_slice(b"0 1 -1 0 246 244 Tm (N) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 242 258 Tm (2) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 246 266 Tm (O) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A baseline drop inside a rotated run is a sub-glyph perpendicular offset, not
+/// a line break: the formula must not be split apart by the continuation test.
+#[test]
+fn rotated_subscript_formula_stays_contiguous() {
+    let doc = PdfDocument::from_bytes(rotated_formula_with_subscript_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    let flat: String = text.split_whitespace().collect::<Vec<_>>().join("");
+    assert!(flat.contains("N2O"), "rotated subscripted formula came apart: {text:?}");
+}

--- a/tests/test_rotated_line_grouping.rs
+++ b/tests/test_rotated_line_grouping.rs
@@ -1,0 +1,129 @@
+//! A rotated line must group into one `TextLine`, not one line per word.
+//!
+//! `extract_text_lines` bands words by y. A rotated run advances along y, so
+//! every word of one visual line lands in its own band and the page comes back
+//! as one-word lines. `extract_text` does not have this problem — it assembles
+//! rotated pages in their own frame — so the two surfaces disagree about the
+//! same page.
+
+use pdf_oxide::document::PdfDocument;
+
+/// One 90°-rotated line whose words are each positioned by their own `Tm`, the
+/// way a rotated table row or chart axis is typically drawn. All four share a
+/// perpendicular offset (x) and advance along the writing axis (y), so they are
+/// one visual line drawn as four runs.
+fn rotated_line_of_separate_runs_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    for (y, word) in [(150, "the"), (190, "quick"), (240, "brown"), (300, "fox")] {
+        content.extend_from_slice(format!("0 1 -1 0 200 {y} Tm ({word}) Tj\n").as_bytes());
+    }
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+#[test]
+fn a_rotated_line_drawn_as_separate_runs_groups_into_one_line() {
+    let doc = PdfDocument::from_bytes(rotated_line_of_separate_runs_pdf()).expect("parse fixture");
+    let words = doc.extract_words(0).expect("extract words");
+    let lines = doc.extract_text_lines(0).expect("extract lines");
+
+    // The fixture must be rotated and must reach line grouping as several runs,
+    // or the assertion below proves nothing.
+    assert!(
+        doc.extract_chars(0)
+            .expect("extract chars")
+            .iter()
+            .any(|c| (c.rotation_degrees - 90.0).abs() < 0.5),
+        "fixture produced no rotated glyphs"
+    );
+    assert!(
+        doc.extract_spans(0).expect("extract spans").len() >= 4,
+        "fixture collapsed into fewer runs than it draws"
+    );
+
+    assert_eq!(
+        lines.len(),
+        1,
+        "one visual line came back as {} lines: {:?}",
+        lines.len(),
+        lines.iter().map(|l| l.text.trim()).collect::<Vec<_>>()
+    );
+    assert_eq!(words.len(), 4, "expected 4 words, got {}", words.len());
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+/// A subscript inside a rotated run sits off the run's writing axis by the
+/// subscript drop, not by a line height. It must stay attached to the formula
+/// it belongs to: `N`, a smaller `2`, and `O` drawn as three runs of one
+/// rotated label are one chemical formula, not three fragments separated by
+/// unrelated page content.
+fn rotated_formula_with_subscript_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A 90-degree label "N2O" whose middle glyph is dropped below the baseline,
+    // the shape a rotated chart axis uses. Under a 90-degree matrix the drop is
+    // a displacement along -x, i.e. PERPENDICULAR to the +y writing axis — the
+    // exact quantity the continuation test measures.
+    //
+    // One BT/ET and one Tf size throughout, deliberately: `ET` flushes the run
+    // buffer and so does a Tf size change, either of which would leave the
+    // buffer empty at the next Tm and make the continuation test unreachable —
+    // the assertion below would then hold no matter what that test decided.
+    content.extend_from_slice(b"BT /F1 18 Tf\n");
+    content.extend_from_slice(b"0 1 -1 0 246 244 Tm (N) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 242 258 Tm (2) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 246 266 Tm (O) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A baseline drop inside a rotated run is a sub-glyph perpendicular offset, not
+/// a line break: the formula must not be split apart by the continuation test.
+#[test]
+fn rotated_subscript_formula_stays_contiguous() {
+    let doc = PdfDocument::from_bytes(rotated_formula_with_subscript_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    let flat: String = text.split_whitespace().collect::<Vec<_>>().join("");
+    assert!(flat.contains("N2O"), "rotated subscripted formula came apart: {text:?}");
+}

--- a/tests/test_rotated_run_word_boundaries.rs
+++ b/tests/test_rotated_run_word_boundaries.rs
@@ -1,0 +1,401 @@
+//! Word boundaries inside a **single rotated text run**.
+//!
+//! A run drawn with a rotated text matrix advances along a rotated axis, but
+//! its span records the advance as `width` on the x-axis and the font size as
+//! `height` (ISO 32000-1:2008 §9.4.4 gives the displacement along the writing
+//! direction; the span flattens it). Word-gap detection then measures gaps on
+//! the wrong axis, so:
+//!
+//! * inter-word gaps inside one rotated run vanish and the words glue
+//!   (`large-scale two-omics integration` → `large-scaletwo-omicsintegration`);
+//! * consecutive rotated cells whose true advance separates them appear to
+//!   overlap, so no separator is emitted between them.
+//!
+//! The existing rotated-reading-order fixture draws one `Tm` + one `Tj` per
+//! word, so every rotated span holds exactly one word and never exercises
+//! either boundary. These fixtures put multiple words inside ONE rotated `Tm`,
+//! and place rotated cells at a true-axis pitch that the flattened geometry
+//! misreads.
+
+use pdf_oxide::document::PdfDocument;
+
+/// Portrait page, no `/Rotate`. One 90°-rotated run containing three
+/// space-separated words drawn as a single `Tj`, plus a second run at 270°.
+///
+/// Turned clockwise the page reads:
+///
+/// ```text
+/// large-scale two-omics integration      (90°  run at x=200)
+/// batch correction metrics               (270° run at x=400)
+/// ```
+fn multiword_rotated_runs_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    // 90°: advances along +y. One Tj, three words, real spaces.
+    content.extend_from_slice(b"0 1 -1 0 200 200 Tm (large-scale two-omics integration) Tj\n");
+    // 270°: advances along -y. One Tj, three words.
+    content.extend_from_slice(b"0 -1 1 0 400 600 Tm (batch correction metrics) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// The producer separates words with **TJ kerning offsets only** — no space
+/// glyph is ever drawn (ISO 32000-1:2008 §9.4.3: the number is expressed in
+/// thousandths of a unit of text space and is subtracted from the current
+/// coordinate). This is how the affected real-world documents draw rotated
+/// axis labels, and it is the case where a word boundary exists purely as a
+/// gap along the writing axis — invisible to a detector measuring on x.
+///
+/// Turned clockwise the page reads `large-scale two-omics integration`.
+fn tj_offset_separated_rotated_run_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    content.extend_from_slice(
+        b"0 1 -1 0 200 200 Tm [(large-scale)-333(two-omics)-333(integration)] TJ\n",
+    );
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A 3×3 grid of numeric cells, every cell drawn with a 90° text matrix, at a
+/// pitch along the true writing axis that is wider than a glyph advance — so a
+/// correct extractor separates every cell, while flattened geometry makes
+/// consecutive cells overlap on the x-axis and fuses them.
+///
+/// Turned clockwise:
+///
+/// ```text
+/// 0.11 0.12 0.13
+/// 0.21 0.22 0.23
+/// 0.31 0.32 0.33
+/// ```
+fn rotated_numeric_grid_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 9 Tf\n");
+    for (row, x) in [(1, 200), (2, 230), (3, 260)] {
+        for (col, y) in [(1, 300), (2, 360), (3, 420)] {
+            let cell = format!("0.{row}{col}");
+            content.extend_from_slice(format!("0 1 -1 0 {x} {y} Tm ({cell}) Tj\n").as_bytes());
+        }
+    }
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A rotated multi-line paragraph: three 90°-rotated lines, each a single `Tj`
+/// holding several words, stacked along the perpendicular axis.
+fn rotated_paragraph_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 10 Tf\n");
+    for (x, text) in [
+        (200, "the quick brown fox"),
+        (214, "jumps over the lazy"),
+        (228, "dog and keeps going"),
+    ] {
+        content.extend_from_slice(format!("0 1 -1 0 {x} 150 Tm ({text}) Tj\n").as_bytes());
+    }
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Upright body text plus a rotated table on the same page, with the upright
+/// content in the MAJORITY — so no page-level dominant-rotation vote fires and
+/// the rotated run must be handled on its own terms.
+fn upright_body_with_rotated_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"BT /F1 11 Tf\n");
+    for (i, line) in [
+        "The committee reviewed the annual report",
+        "and approved the budget for the coming",
+        "fiscal year without further amendment to",
+        "the schedule agreed in the prior session.",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let y = 700 - (i as i32) * 16;
+        content.extend_from_slice(format!("1 0 0 1 72 {y} Tm ({line}) Tj\n").as_bytes());
+    }
+    // Minority rotated run: a sideways table caption with several words.
+    content.extend_from_slice(b"0 1 -1 0 520 200 Tm (Engine oil capacity quarts) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Every word of a multi-word rotated run survives as its own token — no
+/// neighbouring pair is glued into one.
+#[test]
+fn multiword_rotated_run_keeps_word_boundaries() {
+    let doc = PdfDocument::from_bytes(multiword_rotated_runs_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in [
+        "large-scale",
+        "two-omics",
+        "integration",
+        "batch",
+        "correction",
+        "metrics",
+    ] {
+        assert!(words.iter().any(|w| w == expected), "word {expected:?} missing from {words:?}");
+    }
+    for glued in [
+        "large-scaletwo-omics",
+        "two-omicsintegration",
+        "large-scaletwo-omicsintegration",
+        "batchcorrection",
+        "correctionmetrics",
+    ] {
+        assert!(!words.iter().any(|w| w == glued), "words glued into {glued:?}: {words:?}");
+    }
+}
+
+/// The same run's words reach assembled text separated, and in forward order.
+#[test]
+fn multiword_rotated_run_reads_forward_in_text() {
+    let doc = PdfDocument::from_bytes(multiword_rotated_runs_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert!(
+        flat.contains("large-scale two-omics integration"),
+        "90° run not separated/forward in text: {flat:?}"
+    );
+    assert!(
+        flat.contains("batch correction metrics"),
+        "270° run not separated/forward in text: {flat:?}"
+    );
+}
+
+/// Words separated only by a TJ kerning offset inside a rotated run must still
+/// come apart — the gap is real, it just lies along the writing axis.
+#[test]
+fn tj_offset_word_gap_in_rotated_run_splits() {
+    let doc =
+        PdfDocument::from_bytes(tj_offset_separated_rotated_run_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in ["large-scale", "two-omics", "integration"] {
+        assert!(words.iter().any(|w| w == expected), "word {expected:?} missing from {words:?}");
+    }
+    assert!(
+        !words
+            .iter()
+            .any(|w| w.contains("large-scaletwo-omics") || w.contains("two-omicsintegration")),
+        "TJ-offset word gaps in a rotated run were not honoured: {words:?}"
+    );
+}
+
+/// Adjacent cells of a rotated grid never fuse into one token.
+#[test]
+fn rotated_grid_cells_do_not_fuse() {
+    let doc = PdfDocument::from_bytes(rotated_numeric_grid_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for row in 1..=3 {
+        for col in 1..=3 {
+            let cell = format!("0.{row}{col}");
+            assert!(words.iter().any(|w| w == &cell), "cell {cell:?} missing from {words:?}");
+        }
+    }
+    let longest = words.iter().map(|w| w.chars().count()).max().unwrap_or(0);
+    assert!(longest <= 4, "cells fused into a longer token (len {longest}): {words:?}");
+}
+
+/// Every cell of a rotated grid survives into assembled text — none is dropped
+/// by table-region removal that never re-emits it.
+#[test]
+fn rotated_grid_cells_survive_assembly() {
+    let doc = PdfDocument::from_bytes(rotated_numeric_grid_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    for row in 1..=3 {
+        for col in 1..=3 {
+            let cell = format!("0.{row}{col}");
+            assert!(text.contains(&cell), "cell {cell:?} dropped from assembled text: {text:?}");
+        }
+    }
+}
+
+/// A rotated paragraph keeps its words separated and its lines distinct.
+#[test]
+fn rotated_paragraph_keeps_words_and_lines() {
+    let doc = PdfDocument::from_bytes(rotated_paragraph_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in [
+        "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "keeps", "going",
+    ] {
+        assert!(words.iter().any(|w| w == expected), "word {expected:?} missing from {words:?}");
+    }
+    let text = doc.extract_text(0).expect("extract text");
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(flat.contains("the quick brown fox"), "rotated line 1 not contiguous: {flat:?}");
+}
+
+/// On a page whose MAJORITY is upright, a minority rotated run still gets its
+/// own word boundaries — and the upright body is untouched.
+#[test]
+fn minority_rotated_run_keeps_word_boundaries() {
+    let doc =
+        PdfDocument::from_bytes(upright_body_with_rotated_table_pdf()).expect("parse fixture");
+    let words: Vec<String> = doc
+        .extract_words(0)
+        .expect("extract words")
+        .into_iter()
+        .map(|w| w.text)
+        .collect();
+
+    for expected in ["Engine", "oil", "capacity", "quarts"] {
+        assert!(
+            words.iter().any(|w| w == expected),
+            "rotated word {expected:?} missing from {words:?}"
+        );
+    }
+    for glued in ["Engineoil", "oilcapacity", "capacityquarts"] {
+        assert!(
+            !words.iter().any(|w| w == glued),
+            "rotated words glued into {glued:?}: {words:?}"
+        );
+    }
+
+    // The upright majority must read normally and contiguously.
+    let text = doc.extract_text(0).expect("extract text");
+    let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        flat.contains("The committee reviewed the annual report"),
+        "upright body disturbed: {flat:?}"
+    );
+    assert!(
+        flat.contains("the schedule agreed in the prior session."),
+        "upright body disturbed: {flat:?}"
+    );
+}
+
+/// A rotated run's span geometry stays in the run's own frame: `width` is the
+/// advance along the writing axis and `height` the glyph height, whatever the
+/// rotation. This is the convention the reading-order and word passes read, so
+/// this test pins it rather than the page-space extent — reporting a page-space
+/// (tall, narrow) box for a vertical run is a separate change that has to move
+/// those consumers with it.
+#[test]
+fn rotated_run_span_extent_follows_the_writing_axis() {
+    let doc = PdfDocument::from_bytes(multiword_rotated_runs_pdf()).expect("parse fixture");
+    let spans = doc.extract_spans(0).expect("extract spans");
+
+    let rotated: Vec<_> = spans.iter().filter(|s| s.rotation_degrees != 0.0).collect();
+    assert!(!rotated.is_empty(), "fixture produced no rotated spans: {spans:?}");
+    for s in rotated {
+        assert!(
+            s.bbox.width > s.bbox.height,
+            "rotated span {:?} lost its along-axis advance: {}x{}",
+            s.text,
+            s.bbox.width,
+            s.bbox.height
+        );
+        // Each run holds three words, so the advance must exceed a single
+        // glyph height by a wide margin — a run whose width collapsed to the
+        // font size would mean the advance was measured on the wrong axis.
+        assert!(
+            s.bbox.width > s.bbox.height * 3.0,
+            "rotated span {:?} advance {} is too small for its text",
+            s.text,
+            s.bbox.width
+        );
+    }
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+/// A subscript inside a rotated run sits off the run's writing axis by the
+/// subscript drop, not by a line height. It must stay attached to the formula
+/// it belongs to: `N`, a smaller `2`, and `O` drawn as three runs of one
+/// rotated label are one chemical formula, not three fragments separated by
+/// unrelated page content.
+fn rotated_formula_with_subscript_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A 90-degree label "N2O" whose middle glyph is dropped below the baseline,
+    // the shape a rotated chart axis uses. Under a 90-degree matrix the drop is
+    // a displacement along -x, i.e. PERPENDICULAR to the +y writing axis — the
+    // exact quantity the continuation test measures.
+    //
+    // One BT/ET and one Tf size throughout, deliberately: `ET` flushes the run
+    // buffer and so does a Tf size change, either of which would leave the
+    // buffer empty at the next Tm and make the continuation test unreachable —
+    // the assertion below would then hold no matter what that test decided.
+    content.extend_from_slice(b"BT /F1 18 Tf\n");
+    content.extend_from_slice(b"0 1 -1 0 246 244 Tm (N) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 242 258 Tm (2) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 246 266 Tm (O) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A baseline drop inside a rotated run is a sub-glyph perpendicular offset, not
+/// a line break: the formula must not be split apart by the continuation test.
+#[test]
+fn rotated_subscript_formula_stays_contiguous() {
+    let doc = PdfDocument::from_bytes(rotated_formula_with_subscript_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    let flat: String = text.split_whitespace().collect::<Vec<_>>().join("");
+    assert!(flat.contains("N2O"), "rotated subscripted formula came apart: {text:?}");
+}

--- a/tests/test_rotated_span_page_space_bbox.rs
+++ b/tests/test_rotated_span_page_space_bbox.rs
@@ -1,0 +1,151 @@
+//! A rotated run must be able to report where the text sits on the page.
+//!
+//! A run drawn with `Tm [0 1 -1 0]` advances up the page, so its page-space box
+//! is tall and narrow. `bbox` carries the run's own extents instead — `width`
+//! is the advance along the writing axis whatever the rotation — so a
+//! vertically drawn run's `bbox` is wide and short.
+//!
+//! `bbox` keeps that meaning: it is the frame every existing consumer reads,
+//! and redefining it would move every word box on every rotated page. The
+//! page-space rectangle is exposed as a derived accessor instead.
+
+use pdf_oxide::document::PdfDocument;
+
+/// One 90°-rotated run of two words, drawn up the page from (200, 200).
+fn rotated_run_pdf() -> Vec<u8> {
+    let content = b"BT /F1 10 Tf 0 1 -1 0 200 200 Tm (Alpha Bravo) Tj ET".to_vec();
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+#[test]
+fn rotated_run_reports_a_page_space_box() {
+    let doc = PdfDocument::from_bytes(rotated_run_pdf()).expect("parse fixture");
+    let spans = doc.extract_spans(0).expect("extract spans");
+
+    let rotated: Vec<_> = spans.iter().filter(|s| s.rotation_degrees != 0.0).collect();
+    assert!(!rotated.is_empty(), "fixture produced no rotated spans");
+
+    for s in rotated {
+        let page = s.page_bbox();
+        assert!(
+            page.height > page.width,
+            "run drawn vertically reports a horizontal page box: {:?} is {}x{}",
+            s.text,
+            page.width,
+            page.height
+        );
+        // The run's own extents are unchanged — this is an added view, not a
+        // redefinition, so nothing reading `bbox` today moves.
+        assert!(
+            s.bbox.width > s.bbox.height,
+            "run's own extents changed: {:?} is {}x{}",
+            s.text,
+            s.bbox.width,
+            s.bbox.height
+        );
+        // Rotating a rectangle preserves its area, so the two views must agree
+        // on how much page the run covers.
+        let (a, b) = (page.width * page.height, s.bbox.width * s.bbox.height);
+        assert!(
+            (a - b).abs() <= 0.01 * b.max(1.0),
+            "page box area {a} does not match run extents area {b}"
+        );
+    }
+}
+
+/// The accessor is a no-op on upright text, which is what keeps every
+/// unrotated page byte-identical.
+#[test]
+fn upright_run_page_box_equals_its_bbox() {
+    let content = b"BT /F1 10 Tf 1 0 0 1 100 700 Tm (Alpha Bravo) Tj ET".to_vec();
+    let pdf = build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]");
+    let doc = PdfDocument::from_bytes(pdf).expect("parse fixture");
+    let spans = doc.extract_spans(0).expect("extract spans");
+    assert!(!spans.is_empty(), "fixture produced no spans");
+
+    for s in &spans {
+        assert_eq!(s.rotation_degrees, 0.0, "fixture span is not upright");
+        let page = s.page_bbox();
+        assert_eq!(
+            (page.x, page.y, page.width, page.height),
+            (s.bbox.x, s.bbox.y, s.bbox.width, s.bbox.height),
+            "page_bbox moved an upright run"
+        );
+    }
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+/// A subscript inside a rotated run sits off the run's writing axis by the
+/// subscript drop, not by a line height. It must stay attached to the formula
+/// it belongs to: `N`, a smaller `2`, and `O` drawn as three runs of one
+/// rotated label are one chemical formula, not three fragments separated by
+/// unrelated page content.
+fn rotated_formula_with_subscript_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A 90-degree label "N2O" whose middle glyph is dropped below the baseline,
+    // the shape a rotated chart axis uses. Under a 90-degree matrix the drop is
+    // a displacement along -x, i.e. PERPENDICULAR to the +y writing axis — the
+    // exact quantity the continuation test measures.
+    //
+    // One BT/ET and one Tf size throughout, deliberately: `ET` flushes the run
+    // buffer and so does a Tf size change, either of which would leave the
+    // buffer empty at the next Tm and make the continuation test unreachable —
+    // the assertion below would then hold no matter what that test decided.
+    content.extend_from_slice(b"BT /F1 18 Tf\n");
+    content.extend_from_slice(b"0 1 -1 0 246 244 Tm (N) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 242 258 Tm (2) Tj\n");
+    content.extend_from_slice(b"0 1 -1 0 246 266 Tm (O) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A baseline drop inside a rotated run is a sub-glyph perpendicular offset, not
+/// a line break: the formula must not be split apart by the continuation test.
+#[test]
+fn rotated_subscript_formula_stays_contiguous() {
+    let doc = PdfDocument::from_bytes(rotated_formula_with_subscript_pdf()).expect("parse fixture");
+    let text = doc.extract_text(0).expect("extract text");
+    let flat: String = text.split_whitespace().collect::<Vec<_>>().join("");
+    assert!(flat.contains("N2O"), "rotated subscripted formula came apart: {text:?}");
+}

--- a/tests/test_table_repeated_cell_text.rs
+++ b/tests/test_table_repeated_cell_text.rs
@@ -1,0 +1,307 @@
+//! Table extraction must not delete words the grid does not re-emit,
+//!
+//! Spans inside a detected table were dropped whenever their trimmed text
+//! appeared in a `HashSet` of every cell's text. A set records THAT a text is
+//! a cell, never HOW MANY cells hold it, so when more spans matched than the
+//! grid re-emits, the surplus was deleted outright.
+//!
+//! The corpus scan that found this reported losses only ever on repeated
+//! tokens — `")(" 28->7`, `"+1" 8->3` — which is the shape this pins.
+
+use std::collections::HashMap;
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::document::PdfDocument;
+
+fn token_counts(text: &str) -> HashMap<&str, usize> {
+    let mut counts = HashMap::new();
+    for t in text.split_whitespace() {
+        *counts.entry(t).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// A ruled table whose cells repeat a value, plus the same value again below
+/// the grid but still inside the table's outer frame — the case where more
+/// spans match a cell text than the grid can re-emit.
+fn repeated_value_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A closed 2x2 grid between y=600 and y=700: three horizontals, three
+    // verticals.
+    content.extend_from_slice(b"0.5 w\n");
+    for (x0, y0, x1, y1) in [
+        (100, 600, 100, 700),
+        (250, 600, 250, 700),
+        (400, 600, 400, 700),
+        (100, 700, 400, 700),
+        (100, 650, 400, 650),
+        (100, 600, 400, 600),
+    ] {
+        content.extend_from_slice(format!("{x0} {y0} m {x1} {y1} l S\n").as_bytes());
+    }
+    // One BT/ET block per run: consecutive Tj inside one block merge into a
+    // single span and the fixture stops resembling real pages.
+    for (x, y, text) in [
+        (110, 670, "0.00"),
+        (260, 670, "0.00"),
+        (110, 620, "0.00"),
+        (260, 620, "Total"),
+        // Straddles the y=650 rule. The spatial detector adopts it as its own
+        // cell, so this does not reproduce the bbox-containment deletion
+        // (the un-ruled-column fixture below does); it pins the
+        // repeated-value invariant on a grid the detector reshapes.
+        (110, 646, "0.00"),
+    ] {
+        content
+            .extend_from_slice(format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes());
+    }
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Turning table extraction on must never emit a token fewer times than
+/// leaving it off. Reflow is fine; deletion is not.
+#[test]
+fn table_extraction_does_not_delete_repeated_tokens() {
+    let doc = PdfDocument::from_bytes(repeated_value_table_pdf()).expect("parse fixture");
+    let on = ConversionOptions {
+        extract_tables: true,
+        ..Default::default()
+    };
+    let off = ConversionOptions {
+        extract_tables: false,
+        ..Default::default()
+    };
+
+    let with_tables = doc.extract_text_with_options(0, &on).expect("tables on");
+    let without = doc.extract_text_with_options(0, &off).expect("tables off");
+
+    // The fixture must actually reach the table path, or this pins nothing —
+    // three previous attempts at this test failed exactly there.
+    let tables = doc.extract_tables(0).unwrap_or_default();
+    assert!(
+        !tables.is_empty(),
+        "fixture produced no detected table; the comparison would be vacuous"
+    );
+    for t in &tables {
+        eprintln!("fixture table bbox={:?}", t.bbox);
+        for r in &t.rows {
+            for c in &r.cells {
+                eprintln!("  cell {:?} bbox={:?}", c.text, c.bbox);
+            }
+        }
+    }
+
+    let (a, b) = (token_counts(&with_tables), token_counts(&without));
+    for (token, n_off) in &b {
+        let n_on = a.get(token).copied().unwrap_or(0);
+        assert!(
+            n_on >= *n_off,
+            "token {token:?} appears {n_off} times with tables off but only {n_on} times with \
+             tables on\n  off: {without:?}\n  on:  {with_tables:?}"
+        );
+    }
+}
+
+/// A ruled table where one cell's text is assembled from two separate spans.
+/// The cell re-emits both words, so neither span may stay in the flow — the
+/// multiplicity budget must not resurrect fragments of merged cells (a
+/// fragment's text is not a cell text, so it has no budget entry).
+fn merged_cell_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // A closed 2x2 grid: three horizontals, three verticals.
+    content.extend_from_slice(b"0.5 w\n");
+    for (x0, y0, x1, y1) in [
+        (100, 600, 100, 700),
+        (250, 600, 250, 700),
+        (400, 600, 400, 700),
+        (100, 700, 400, 700),
+        (100, 650, 400, 650),
+        (100, 600, 400, 600),
+    ] {
+        content.extend_from_slice(format!("{x0} {y0} m {x1} {y1} l S\n").as_bytes());
+    }
+    // Top-left cell holds TWO spans; the other cells hold one each. One
+    // BT/ET block per run keeps the two fragments as separate spans — inside
+    // a single block they merge into one span equal to the cell text and the
+    // fragment case is never exercised.
+    for (x, y, text) in [
+        (110, 670, "Alpha"),
+        (160, 670, "Beta"),
+        (260, 670, "Gamma"),
+        (110, 620, "Delta"),
+        (260, 620, "Epsilon"),
+    ] {
+        content
+            .extend_from_slice(format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes());
+    }
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// Turning table extraction on must neither delete tokens nor emit them twice:
+/// a span whose content the table re-emits as part of a merged cell has to
+/// leave the flow even though its own text never appears as a cell text.
+#[test]
+fn table_extraction_does_not_duplicate_merged_cell_fragments() {
+    let doc = PdfDocument::from_bytes(merged_cell_table_pdf()).expect("parse fixture");
+    let on = ConversionOptions {
+        extract_tables: true,
+        ..Default::default()
+    };
+    let off = ConversionOptions {
+        extract_tables: false,
+        ..Default::default()
+    };
+
+    let with_tables = doc.extract_text_with_options(0, &on).expect("tables on");
+    let without = doc.extract_text_with_options(0, &off).expect("tables off");
+
+    let tables = doc.extract_tables(0).unwrap_or_default();
+    assert!(
+        !tables.is_empty(),
+        "fixture produced no detected table; the comparison would be vacuous"
+    );
+    // The comparison below only pins the fragment case if some cell actually
+    // merged two spans into one text.
+    assert!(
+        tables
+            .iter()
+            .flat_map(|t| t.rows.iter())
+            .flat_map(|r| r.cells.iter())
+            .any(|c| c.text.split_whitespace().count() >= 2),
+        "no cell merged multiple spans; the fragment case is not exercised"
+    );
+
+    let (a, b) = (token_counts(&with_tables), token_counts(&without));
+    for (token, n_off) in &b {
+        let n_on = a.get(token).copied().unwrap_or(0);
+        assert!(
+            n_on >= *n_off,
+            "token {token:?} appears {n_off} times with tables off but only {n_on} times with \
+             tables on\n  off: {without:?}\n  on:  {with_tables:?}"
+        );
+        assert!(
+            n_on <= *n_off,
+            "token {token:?} appears {n_on} times with tables on but only {n_off} times with \
+             tables off — a merged-cell fragment stayed in the flow\n  off: {without:?}\n  on:  \
+             {with_tables:?}"
+        );
+    }
+}
+
+/// A ruled table transcribed from the failing financial-page geometry: the
+/// header band is ruled across every column, but below it only the left
+/// columns have row-separator rules. The detector merges each right-hand
+/// column into ONE tall cell for the whole body. Such a cell's text does not
+/// include every value its bbox covers, so dropping spans on bbox containment
+/// alone deletes the column's figures while the cell re-emits none of them.
+fn unruled_value_column_table_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"0.5 w\n");
+    let lines: [(i32, i32, i32, i32); 8] = [
+        // Verticals, full height.
+        (100, 600, 100, 700),
+        (250, 600, 250, 700),
+        (400, 600, 400, 700),
+        (460, 600, 460, 700),
+        // Header band and outer frame span every column...
+        (100, 700, 460, 700),
+        (100, 675, 460, 675),
+        (100, 600, 460, 600),
+        // ...but the interior row rule stops at the value column.
+        (100, 640, 400, 640),
+    ];
+    for (x0, y0, x1, y1) in lines {
+        content.extend_from_slice(format!("{x0} {y0} m {x1} {y1} l S\n").as_bytes());
+    }
+    for (fs, x, y, text) in [
+        (10, 110, 682, "Item"),
+        (10, 260, 682, "Qty"),
+        (10, 410, 682, "Net"),
+        (10, 110, 655, "alpha"),
+        (10, 260, 655, "10"),
+        (10, 110, 615, "beta"),
+        (10, 260, 615, "20"),
+        // Small figure inside the tall un-ruled value cell.
+        (6, 410, 646, "-1,004"),
+    ] {
+        content.extend_from_slice(
+            format!("BT /F1 {fs} Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
+        );
+    }
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// A value covered only by a cell that does not carry its text must survive:
+/// that cell re-emits none of it, so dropping the span deletes real content.
+#[test]
+fn table_extraction_keeps_values_in_unruled_columns() {
+    let doc = PdfDocument::from_bytes(unruled_value_column_table_pdf()).expect("parse fixture");
+    let on = ConversionOptions {
+        extract_tables: true,
+        ..Default::default()
+    };
+    let off = ConversionOptions {
+        extract_tables: false,
+        ..Default::default()
+    };
+
+    let with_tables = doc.extract_text_with_options(0, &on).expect("tables on");
+    let without = doc.extract_text_with_options(0, &off).expect("tables off");
+
+    assert!(
+        !doc.extract_tables(0).unwrap_or_default().is_empty(),
+        "fixture produced no detected table; the comparison would be vacuous"
+    );
+
+    let (a, b) = (token_counts(&with_tables), token_counts(&without));
+    for (token, n_off) in &b {
+        let n_on = a.get(token).copied().unwrap_or(0);
+        assert!(
+            n_on >= *n_off,
+            "token {token:?} appears {n_off} times with tables off but only {n_on} times with \
+             tables on\n  off: {without:?}\n  on:  {with_tables:?}"
+        );
+    }
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    pdf.extend_from_slice(
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{off:010} 00000 n\r\n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}

--- a/tests/test_table_repeated_cell_text.rs
+++ b/tests/test_table_repeated_cell_text.rs
@@ -52,8 +52,9 @@ fn repeated_value_table_pdf() -> Vec<u8> {
         // repeated-value invariant on a grid the detector reshapes.
         (110, 646, "0.00"),
     ] {
-        content
-            .extend_from_slice(format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes());
+        content.extend_from_slice(
+            format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
+        );
     }
     build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
 }
@@ -131,8 +132,9 @@ fn merged_cell_table_pdf() -> Vec<u8> {
         (110, 620, "Delta"),
         (260, 620, "Epsilon"),
     ] {
-        content
-            .extend_from_slice(format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes());
+        content.extend_from_slice(
+            format!("BT /F1 10 Tf 1 0 0 1 {x} {y} Tm ({text}) Tj ET\n").as_bytes(),
+        );
     }
     build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
 }

--- a/tests/test_vertical_writing_mode_qa_probes.rs
+++ b/tests/test_vertical_writing_mode_qa_probes.rs
@@ -1501,3 +1501,35 @@ fn probe37_horizontal_extraction_bulk_within_bound() {
         elapsed.as_millis()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Probe 39 — a vertical (WMode 1) column positioned with a rotated per-glyph
+// Tm must stay one run.
+//
+// ISO 32000-1 §9.4.4 puts the glyph displacement along the text matrix's
+// (a, b) row only for WMode 0; for WMode 1 it runs along (c, d) — the branch
+// `GraphicsState::advance_text_matrix` already makes. Any same-line test that
+// assumes the WMode-0 axis therefore reads a vertical column's advance as a
+// perpendicular offset, refuses to continue the run, and emits one span per
+// glyph. Downstream cannot repair that: `rotation_compatible` in the span
+// merge refuses to re-join quadrant-vertical runs, so each glyph reaches the
+// output separated — spaces injected between CJK glyphs, i.e. wrong text.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn probe39_vertical_column_with_rotated_tm_stays_one_run() {
+    // Four CIDs (A..D) drawn as a 90° tategaki column, one Tm per glyph, `e`
+    // ascending — the coherent handedness for a negative vertical advance.
+    let content = b"BT /F1 12 Tf \
+0 1 -1 0 100 700 Tm <0001> Tj \
+0 1 -1 0 112 700 Tm <0002> Tj \
+0 1 -1 0 124 700 Tm <0003> Tj \
+0 1 -1 0 136 700 Tm <0004> Tj ET";
+    let pdf = build_pdf("Identity-V", content, 1000, (880, -1000), None, None);
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+
+    let text = doc.extract_text(0).expect("extract_text");
+    let flat: String = text.split_whitespace().collect::<Vec<_>>().join("");
+    assert!(flat.contains("ABCD"), "vertical column split glyph-by-glyph: {text:?}");
+    assert!(!text.contains("A B C D"), "spaces injected between vertical glyphs: {text:?}");
+}


### PR DESCRIPTION
## Linked issues

Closes #806, #981, #983, #984, #991.

Supersedes #982, #987, #988, #989, #992 — each was opened per-issue and carries that
issue's own reproducer and corpus gate. They are consolidated here because splitting them
left the crate internally inconsistent: `extract_text` would read a rotated page correctly
while `to_markdown`, `to_html` and `to_plain_text` read it wrongly.

## What this fixes

Every row is measured on the same 454,905-page corpus, per page rather than per document.

| issue | what a reader saw | after |
|---|---|---|
| **#806** | a run drawn sideways reported a wide, short box for text that is tall and narrow | `page_bbox()` returns the page-space rectangle; `bbox` keeps its meaning and **0 pages move** |
| **#983** | a landscape table came back as one line per cell — 458 words, 458 lines | **6,097** rotated-content pages regrouped; **392,109** upright pages byte-identical |
| **#984** | `extract_text` read a rotated page correctly and `to_markdown` did not | **1,620** rotated pages now read identically across text, markdown, HTML and plain text |
| **#991** | a glyph that failed to paint vanished silently while the cursor advanced | four rasterizer sites now report the drop; **0** upright pages change, rendering behaviour unchanged |
| **#981** | turning table extraction on deleted words the grid never re-emitted | losing pages **7,657 → 3,916** and lost token instances **78,019 → 17,995**; on every one of 454,930 pages the fix arm emits at least the characters the base arm does |
| — | `extract_text` returned different text for the same input, run to run | a font-size tie was a per-process coin flip: **6 of 12** runs disagreed, now **16 of 16** identical |
| — | a redacted PDF's bytes differed between runs | dictionary emission sorted; `ObjectSerializer` already did this, redaction was a second copy that missed it |
| — | table rule families ordered by hash iteration | ordered by geometry; latent, no corpus page reached it |
| — | `extract_chars` read a sideways chart axis flat while `extract_spans` read it rotated | both surfaces share one parser; 1,134 of 454,899 pages change, and agreement with PyMuPDF, pypdf and pdfminer improves in every rotation bucket |
| — | on pages over 256 KB, text relying on spacing, leading or colour set earlier on the page drifted, piled onto one line, or turned black | the fast-path parser now carries the full persistent graphics state into each text region |
| — | a Type0 font with a UTF-8 CMap extracted right and rendered garbage; a ligature rendered right but extracted lossy | one glyph decoder for both paths, carrying the union of the two feature sets |


## Problem

Text drawn under a rotated text matrix was assembled as if it ran left-to-right. Six
surfaces disagreed about the same page, and three unrelated defects surfaced while
measuring: glyphs dropped without a log line, output that was not reproducible between
runs of the same binary, and redacted PDFs that were not byte-reproducible.

```
before:  "the quick brown foxjumps over the lazydog and keeps going"
after:   "the quick brown fox" / "jumps over the lazy" / "dog and keeps going"
```

## Fixes

One commit each.

| # | commit | what it fixes |
|---|---|---|
| #982 | `fix(extract): sideways text joins consecutive lines together` | `Tm` run continuation judged along the run's own writing axis |
| #983 | `fix(extract): group a rotated line drawn as several runs into one line` | `extract_text_lines` returned one line per run — 458 words became 458 lines |
| #984 | `fix(convert): read a rotated page in the same frame on every text surface` | the rotated frame was applied in `extract_text` only |
| #806 | `feat(layout): expose where a rotated run sits on the page` | a sideways run's page-space rectangle, as a derived accessor |
| #991 | `fix(render): report glyphs that paint nothing` | four rasterizer sites swallowed a failed glyph while advancing the cursor |
| — | `fix(layout): break modal-statistic ties deterministically` | see below |
| — | `fix(redaction,compliance): emit hash-backed dictionaries in sorted order` | see below |
| — | `fix(tables): order rule families deterministically` | see below |
| — | `fix(content): reconstruct inherited graphics state in prescan text regions` | leading, spacing and fill colour were silently reset at synthesized region boundaries on pages over 256 KB; a follow-up hardens the colour replay — a stale name operand no longer fabricates a pattern (`/GS0 gs 0.5 scn`), and a colour with more components than the scanner can faithfully replay injects nothing rather than a truncated wrong value. Isolated against the corpus: 89 of 455,053 pages change, char-level colour only, every one in the over-256 KB prescan path, extracted text byte-identical everywhere |
| — | `fix(extract): parse chars and spans with the same parser` | `extract_chars` drove a second parser that rebuilt graphics state by a different route |
| — | `refactor(fonts): unify the duplicated glyph decoder` | see below |
| #981 | `fix(extract): stop table extraction deleting words the grid does not re-emit` | ownership of a span becomes a per-cell token budget instead of set membership and bbox containment |

### Why the reading frame is one change, not four

ISO 32000-1 §9.4.4 puts the glyph displacement along the text matrix's `(a, b)` row, so
under a ±90° matrix a run advances along `f` while successive **lines** separate along
`e` — the two axes are swapped. Every surface that assembled text made the same
assumption in a different place. Fixing one leaves the others wrong on the same document.

**Unrotated text cannot move.** For any `b = 0, a > 0` matrix the projection is termwise
the existing test: `along` **is** `e − e0`, `perp` **is** `f − f0`. Vertical writing
(WMode 1) is exempt — the displacement genuinely runs along `(c, d)` there.

### The determinism fixes

Found while measuring, not sought. `max_by_key` returns the **last** maximal element, and
over a `HashMap` that is the per-process-randomized iteration order:

- **`PageFontStats`** — two font-size buckets tying made `dominant_em` a coin flip.
  It feeds the multi-column gate that selects the reading-order branch, so the whole
  page's text reordered. Measured on `govdocs_046_046432.pdf` p3: the histogram is
  `8pt:32, 41pt:32`, an exact tie, and the page's extracted text alternated between two
  values across runs of the same binary — 6 of 12 runs each. With the tie-break, 16 of 16
  identical.
- **`redaction::serialize`** — `Object::Dictionary` is a `HashMap`, so a redacted PDF's
  bytes differed between runs. Unconditional, not tie-dependent.
  `writer::ObjectSerializer` already sorts its keys for this reason; this was a second
  copy that missed it.
- **PDF/X and font-embedding validators**, **table rule families** — same class.

Ties resolve to the smaller value and the lexicographically smaller name. For
`dominant_em` that is the conservative direction: it is meant to be the *body* em, and a
tighter cluster gap makes the multi-column gate stricter rather than looser.

## Testing

### Corpus

| property | value |
|---|---|
| documents | 14,911 |
| **pages compared** | **454,905** |
| sources | govdocs1 `.gov` crawl (60 slices), arXiv, PubMed Central OA, IRS forms, pdf.js corpus, PoC‖GTFO |
| named fixtures | vehicle owner's manual, 4 rotated arXiv papers, 2 vertical-Japanese novels, FAA Airplane Flying Handbook |
| machine | 32 vCPU, sharded 32 ways |

Compared **per page**: a single garbled page in a 200-page report barely moves a
whole-document score.

### Noise floor

The same binary swept twice over the whole corpus, before the determinism fixes:
**1 page** differed. That page is `govdocs_046_046432.pdf` p3 — the font-stats tie. Every
gate below is read against that floor, so a one-page difference is not evidence of
anything until it is reproduced.

> The corpus figures below were measured at `c5be50ff`. One later commit
> (`perf(extract): index rotated line offsets…`) is behaviour-preserving by
> construction but has not been re-swept yet, so these numbers describe the tree
> one commit back.

### Differential gate — every page, both arms

454,899 pages compared (8,832 excluded as empty in both arms). Signals compared per page:
extracted text, words+bboxes, spans+bboxes, lines, whitespace-free text, markdown, HTML,
table counts and `extract_chars`.

| bucket | pages | byte-identical | changed |
|---|---|---|---|
| **upright** | **392,109** | **392,109** | **0** |
| upright + rotated minority | 17,831 | 11,701 | 6,130 |
| rot90 | 34,355 | 30,241 | 4,114 |
| rot270 | 1,704 | 1,623 | 81 |
| skew | 42 | 31 | 11 |
| mixed | 25 | 15 | 10 |
| rot180 | 1 | 0 | 1 |

**Blockers: 0.** Not one upright page moves. Markdown and HTML are measured because table
detection consumes word geometry — a change confined to the assembler moves `text` alone,
one that perturbed geometry moves those too.

### Agreement with reference extractors

A token-multiset diff cannot distinguish "text got worse" from "text got reorganized", and
this change reorganizes rotated pages by design. Three independent extractors can. Both
arms scored on how closely they agree with each, 6,000 sampled pages.

| bucket | pages | reference | base | fix | |
|---|---|---|---|---|---|
| rot90 | 2,859 | PyMuPDF | 0.7920 | **0.7925** | improved |
| rot90 | 2,859 | pypdf | 0.7865 | **0.7871** | improved |
| rot90 | 2,859 | pdfminer.six | 0.7387 | **0.7392** | improved |
| upright | 2,869 | PyMuPDF | 0.9449 | 0.9449 | unchanged |
| upright | 2,869 | pypdf | 0.9244 | 0.9244 | unchanged |
| upright | 2,869 | pdfminer.six | 0.9389 | 0.9389 | unchanged |
| rot270 | 140 | all three | — | — | unchanged |
| upright + minority | 130 | all three | — | — | unchanged |

The fix moves toward all three references simultaneously on rotated pages and away from
none anywhere. The sample spans all rotated pages rather than only changed ones, so
unchanged pages dilute these means — the per-changed-page effect is larger.


### Unit tests

`cargo test` is green on the consolidated branch. Each fix carries its own tests, and the
tie-breaks are tested in pairs — one test pinning the tie resolution, one asserting a
unique winner is unaffected, because the failure mode of a tie-break is changing the
ordinary no-tie case.

### Harness trust

| check | result |
|---|---|
| null experiment (same binary twice) | 1 page — the flap, now fixed |
| determinism after the fix | 16/16 identical on the flapping page |
| arms differ | yes — a null result elsewhere is earned, not an artifact |
| shard completion | 32/32 reconciled against the corpus count |
| corpus manifest verified per machine | 14,911 files, sha256 |

### #981 — table extraction deleting words the grid does not re-emit

Three deletion mechanisms shared one root: ownership tests that overshoot. A cell-text
`HashSet` records *that* a text is a cell but never *how many* cells hold it, so repeated
values lost their surplus (`")(" 28→7`). Bbox containment is not ownership: a value column
without row rules becomes one tall empty-text cell whose box swallows every figure in the
column and re-emits none of them, and a rowspan-merged cell's box covers far more spans
than its text was built from. And with the containment and text-fallback paths keeping
separate accounts, one cell could be claimed twice — three identical labels dropped
against two rendering cells.

`render_text()` emits each cell's text exactly once, so ownership is now a per-cell token
budget drawn on by both paths. A covered span leaves the flow only by consuming its tokens
from a covering cell; a same-text span outside every cell claims a cell only while its
budget is whole; spans no cell can absorb stay in the flow — better to duplicate than to
silently drop. The drop set is a strict subset of the old one by construction.

| check | result |
|---|---|
| losing pages, table extraction on vs off | 7,657 → 3,916 of 454,905 |
| lost token instances | 78,019 → 17,995 |
| per-page character multisets, fix arm vs base arm, all 454,930 pages | fix ⊇ base everywhere; 27 pages differ only by hyphens consumed joining wrapped words |
| pages newly flagged by the token metric | 21, every one losing **zero** characters — kept spans shift token boundaries |
| reference agreement on a 1,500-page stride sample of the 7,329 changed pages | Jaccard 0.8425 → **0.8467**, recall 0.9160 → **0.9357** against PyMuPDF, pypdf and pdfminer |
| instrument determinism | two independently built binaries produced byte-identical loss reports across the corpus |

The regression test builds the failing geometry synthetically — header band ruled across
every column, row rules stopping short of the value column, a figure inside the resulting
tall empty cell — and fails on the old drop pass by deleting the figure. A second fixture
pins the opposite failure: an ownership rule that exempts unmatched spans resurrects
fragments of merged cells and duplicates them (the earlier counting attempt regressed 48
pages exactly that way; its per-page reference scores also fall, which is what killed it).

## Per-issue detail

Inlined from the superseded PRs.

### #983 — `extract_text_lines` bands words by y

A rotated run advances along y, so every word of one visual line lands in its own band. A
page of 458 words came back as 458 lines while `extract_text` read it correctly, so the
two surfaces disagreed about the same page.

### #984 — the frame was applied at one call site

| surface | before |
|---|---|
| `extract_text` | entered the rotated frame |
| `to_markdown`, `to_html`, `to_plain_text` | assembled in raw page space |
| `extract_text_filtered`, `..._in_rect` | assembled in raw page space |

Markdown and HTML byte-identity across all 392,109 upright pages is the signal that word
geometry did not move.

### #806 — why an accessor, not a redefinition

The run-local encoding is load-bearing: `document.rs:5452` and `page_order.rs:164` both
depend on the extents being run-local, and `TextSpan` is serialized to JS in `wasm.rs`, so
the field meaning is a public contract. Redefining `bbox` would move every word box on
every rotated page and change that contract in all bindings. `page_bbox()` is derived,
mirrors `Path::rendered_bbox()`, and returns `bbox` unchanged at rotation 0 — which is why
**0 pages move**.

### #991 — four sites that swallowed a glyph

| site | what was swallowed |
|---|---|
| `render_cid_direct` (`text_rasterizer.rs:1537`) | a `None` outline from ttf-parser paints nothing |
| encoding lookup → GID 0 (`:1488-1500`), `gid != 0 \|\| whitespace` gate (`:1533`) | an unmapped non-whitespace char never painted, not even `.notdef` |
| `decode_text_to_unicode` (`:653-668`) | chars resolving to U+FFFD leave the shaping input — no glyph, no advance, index skew |
| `render_unicode_text` total loss (`:1395-1401`) | reported at `debug` only |

Logging only; raster output is byte-identical. Drops are counted per text run, so a broken
font is named once rather than once per glyph, and one document's warning cannot suppress
the next document's.

## Consolidated from

Each of these was opened per-issue with its own reproducer and its own corpus gate. They
are closed in favour of this one because the reading-frame fixes are a single defect
across several surfaces: merging any subset leaves `extract_text` and the converters
disagreeing about the same page.

| PR | issue | what it carried | where it is now |
|---|---|---|---|
| #982 | #806 | `Tm` run continuation judged along the run's own writing axis | commit 1 |
| #987 | #983 | rotated line grouping — 458 words no longer become 458 lines | commit 2 |
| #988 | #984 | the rotated frame applied on every text surface | commit 3 |
| #989 | #806 | `page_bbox()` — where a sideways run sits on the page | commit 4 |
| #992 | #991 | four rasterizer sites that dropped glyphs silently | commit 5 |
| #990 | #981 | table extraction deleting words | closed — superseded by the per-cell budget commit here |

The three determinism commits (6–8) have no predecessor PR: they were found while
measuring this work, not filed beforehand.

<details>
<summary><b>Validation harness (click to expand)</b></summary>

**`rot_sweep.rs`**

```rust
//! Per-page extraction signatures for differential regression testing.
//!
//! Emits one TSV row per page so a single garbled page in a long document is
//! visible; whole-document scores hide exactly that. Each page carries a
//! rotation bucket so upright and rotated populations can be gated differently.
//!
//! ```text
//! rot_sweep <corpus_dir> [--text-out <dir>] [--shard <i>/<n>]
//! ```

use std::collections::hash_map::DefaultHasher;
use std::fmt;
use std::hash::{Hash, Hasher};
use std::path::{Path, PathBuf};

use pdf_oxide::converters::ConversionOptions;
use pdf_oxide::document::PdfDocument;
use pdf_oxide::layout::{TextChar, TextSpan, Word};

const HEADER: &str = "relpath\tpage\tbucket\tnchars\tchars_hash\trot_frac\ttext_hash\twords_hash\tspans_hash\tlines_hash\tnwords\tmaxword\tnlines\tnspans\tntables\twsfree_hash\tmd_hash\thtml_hash\tntable_tags";

/// Glyph-rotation classification of a page.
#[derive(Clone, Copy, PartialEq, Eq)]
enum Bucket {
    Empty,
    Upright,
    UprightMinorityRotated,
    Rot90,
    Rot180,
    Rot270,
    Mixed,
    Skew,
}

impl fmt::Display for Bucket {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
        f.write_str(match self {
            Self::Empty => "empty",
            Self::Upright => "upright",
            Self::UprightMinorityRotated => "upright_minority_rot",
            Self::Rot90 => "rot90",
            Self::Rot180 => "rot180",
            Self::Rot270 => "rot270",
            Self::Mixed => "mixed",
            Self::Skew => "skew",
        })
    }
}

/// Command-line inputs.
struct Args {
    corpus: PathBuf,
    text_out: Option<PathBuf>,
    shard_index: usize,
    shard_count: usize,
}

impl Args {
    fn parse() -> Self {
        let mut argv = std::env::args().skip(1);
        let corpus = argv
            .next()
            .map(PathBuf::from)
            .expect("usage: rot_sweep <corpus_dir> [--text-out <dir>] [--shard i/n]");
        let mut text_out = None;
        let mut shard = (0usize, 1usize);
        while let Some(flag) = argv.next() {
            match flag.as_str() {
                "--text-out" => text_out = argv.next().map(PathBuf::from),
                "--shard" => shard = parse_shard(&argv.next().unwrap_or_default()),
                _ => {},
            }
        }
        Self {
            corpus,
            text_out,
            shard_index: shard.0,
            shard_count: shard.1,
        }
    }

    /// Indices this shard owns, striped so every shard sees a similar file mix.
    fn owns(&self, index: usize) -> bool {
        index % self.shard_count == self.shard_index
    }
}

/// Parse an `i/n` shard selector, defaulting to the whole corpus.
fn parse_shard(spec: &str) -> (usize, usize) {
    let (index, count) = spec.split_once('/').unwrap_or(("0", "1"));
    let count = count.parse().unwrap_or(1).max(1);
    (index.parse().unwrap_or(0).min(count - 1), count)
}

/// Every PDF under `dir`, in a stable order so shards are reproducible.
fn collect_pdfs(dir: &Path, out: &mut Vec<PathBuf>) {
    let Ok(entries) = std::fs::read_dir(dir) else {
        return;
    };
    let mut paths: Vec<PathBuf> = entries.flatten().map(|entry| entry.path()).collect();
    paths.sort();
    for path in paths {
        if path.is_dir() {
            collect_pdfs(&path, out);
        } else if path.extension().and_then(|e| e.to_str()) == Some("pdf") {
            out.push(path);
        }
    }
}

fn hash_of(text: &str) -> u64 {
    let mut hasher = DefaultHasher::new();
    text.hash(&mut hasher);
    hasher.finish()
}

/// Quadrant a glyph rotation snaps to, or `None` for a free angle.
fn quadrant(degrees: f32) -> Option<u16> {
    if !degrees.is_finite() {
        return None;
    }
    let normalized = degrees.rem_euclid(360.0);
    [0u16, 90, 180, 270].into_iter().find(|&q| {
        let delta = (normalized - f32::from(q)).abs();
        delta < 0.5 || delta > 359.5
    })
}

/// Glyphs as the text assembler sees them.
///
/// Deliberately NOT `extract_chars`: on some pages that API returns a strict
/// subset of the glyphs `extract_spans` returns, and the rotated ones are
/// exactly what it omits. Bucketing from it labelled genuinely rotated pages
/// `upright` and held them to the byte-identity gate — measuring the wrong
/// population. Buckets must come from the glyphs the code under test consumes.
fn assembler_glyphs(spans: &[TextSpan]) -> Vec<TextChar> {
    spans.iter().flat_map(TextSpan::to_chars).collect()
}

/// Classify a page from its glyph rotations.
fn classify(chars: &[TextChar]) -> Bucket {
    if chars.is_empty() {
        return Bucket::Empty;
    }
    let mut quadrant_counts = [0usize; 4];
    let mut skewed = 0usize;
    for c in chars {
        match quadrant(c.rotation_degrees) {
            Some(0) => quadrant_counts[0] += 1,
            Some(90) => quadrant_counts[1] += 1,
            Some(180) => quadrant_counts[2] += 1,
            Some(270) => quadrant_counts[3] += 1,
            _ => skewed += 1,
        }
    }
    if skewed * 2 > chars.len() {
        return Bucket::Skew;
    }
    if quadrant_counts[1..].iter().sum::<usize>() + skewed == 0 {
        return Bucket::Upright;
    }
    let (index, &dominant) = quadrant_counts
        .iter()
        .enumerate()
        .max_by_key(|(_, &count)| count)
        .expect("quadrant_counts is non-empty");
    if dominant * 2 <= chars.len() {
        return Bucket::Mixed;
    }
    match index {
        0 => Bucket::UprightMinorityRotated,
        1 => Bucket::Rot90,
        2 => Bucket::Rot180,
        _ => Bucket::Rot270,
    }
}

/// Fraction of glyphs that are not upright.
fn rotated_fraction(chars: &[TextChar]) -> f64 {
    if chars.is_empty() {
        return 0.0;
    }
    let upright = chars
        .iter()
        .filter(|c| quadrant(c.rotation_degrees) == Some(0))
        .count();
    (chars.len() - upright) as f64 / chars.len() as f64
}

fn words_signature(words: &[Word]) -> String {
    let parts: Vec<String> = words
        .iter()
        .map(|w| {
            format!(
                "{}|{:.2},{:.2},{:.2},{:.2}",
                w.text, w.bbox.x, w.bbox.y, w.bbox.width, w.bbox.height
            )
        })
        .collect();
    parts.join("\u{1}")
}

fn chars_signature(chars: &[TextChar]) -> String {
    let parts: Vec<String> = chars
        .iter()
        .map(|c| {
            format!(
                "{}|{:.2},{:.2}|{:.1}",
                c.char, c.bbox.x, c.bbox.y, c.rotation_degrees
            )
        })
        .collect();
    parts.join("\u{1}")
}

fn spans_signature(spans: &[TextSpan]) -> String {
    let parts: Vec<String> = spans
        .iter()
        .map(|s| {
            format!(
                "{}|{:.2},{:.2},{:.2},{:.2}|{:.1}",
                s.text, s.bbox.x, s.bbox.y, s.bbox.width, s.bbox.height, s.rotation_degrees
            )
        })
        .collect();
    parts.join("\u{1}")
}

/// One page's measured signature.
struct PageRow {
    bucket: Bucket,
    chars: usize,
    chars_hash: u64,
    rotated_fraction: f64,
    text: u64,
    words: u64,
    spans: u64,
    lines: u64,
    whitespace_free: u64,
    markdown: u64,
    html: u64,
    word_count: usize,
    longest_word: usize,
    line_count: usize,
    span_count: usize,
    table_count: usize,
    table_tags: usize,
}

impl PageRow {
    /// Markdown and HTML are measured because table detection consumes word
    /// geometry: a change confined to the text assembler moves `text` alone,
    /// while one that perturbed geometry moves these too.
    fn measure(doc: &PdfDocument, page: usize, options: &ConversionOptions) -> Self {
        let text = doc.extract_text(page).unwrap_or_default();
        let words = doc.extract_words(page).unwrap_or_default();
        let spans = doc.extract_spans(page).unwrap_or_default();
        let glyphs = assembler_glyphs(&spans);
        let chars = doc.extract_chars(page).unwrap_or_default();
        let lines = doc.extract_text_lines(page).unwrap_or_default();
        let markdown = doc.to_markdown(page, options).unwrap_or_default();
        let html = doc.to_html(page, options).unwrap_or_default();

        let whitespace_free: String = text.chars().filter(|c| !c.is_whitespace()).collect();
        let line_texts: Vec<String> = lines.iter().map(|l| l.text.clone()).collect();

        Self {
            bucket: classify(&glyphs),
            chars: glyphs.len(),
            rotated_fraction: rotated_fraction(&glyphs),
            // `extract_chars` is a public API in its own right, so it is
            // hashed and gated even though it no longer decides the bucket.
            chars_hash: hash_of(&chars_signature(&chars)),
            text: hash_of(&text),
            words: hash_of(&words_signature(&words)),
            spans: hash_of(&spans_signature(&spans)),
            lines: hash_of(&line_texts.join("\u{1}")),
            whitespace_free: hash_of(&whitespace_free),
            markdown: hash_of(&markdown),
            html: hash_of(&html),
            word_count: words.len(),
            longest_word: words
                .iter()
                .map(|w| w.text.chars().count())
                .max()
                .unwrap_or(0),
            line_count: lines.len(),
            span_count: spans.len(),
            table_count: doc.extract_tables(page).map(|t| t.len()).unwrap_or(0),
            table_tags: html.matches("<table").count(),
        }
    }

    fn to_tsv(&self, relpath: &str, page: usize) -> String {
        format!(
            "{relpath}\t{page}\t{}\t{}\t{:016x}\t{:.4}\t{:016x}\t{:016x}\t{:016x}\t{:016x}\t{}\t{}\t{}\t{}\t{}\t{:016x}\t{:016x}\t{:016x}\t{}",
            self.bucket,
            self.chars,
            self.chars_hash,
            self.rotated_fraction,
            self.text,
            self.words,
            self.spans,
            self.lines,
            self.word_count,
            self.longest_word,
            self.line_count,
            self.span_count,
            self.table_count,
            self.whitespace_free,
            self.markdown,
            self.html,
            self.table_tags,
        )
    }
}

/// Write a page's assembled text so a changed page can be diffed verbatim.
fn dump_text(dir: &Path, relpath: &str, page: usize, doc: &PdfDocument) {
    let safe = relpath.replace(['/', '\\'], "_");
    let text = doc.extract_text(page).unwrap_or_default();
    let _ = std::fs::write(dir.join(format!("{safe}.{page}.txt")), text);
}

fn sweep_document(pdf: &Path, args: &Args, options: &ConversionOptions) {
    let relpath = pdf
        .strip_prefix(&args.corpus)
        .unwrap_or(pdf)
        .display()
        .to_string();
    let Ok(doc) = PdfDocument::open(pdf) else {
        println!("{relpath}\t-\tOPEN_ERR\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0");
        return;
    };
    let _ = doc.authenticate(b"");
    for page in 0..doc.page_count().unwrap_or(0) {
        println!(
            "{}",
            PageRow::measure(&doc, page, options).to_tsv(&relpath, page)
        );
        if let Some(dir) = &args.text_out {
            dump_text(dir, &relpath, page, &doc);
        }
    }
}

fn main() {
    let args = Args::parse();
    if let Some(dir) = &args.text_out {
        let _ = std::fs::create_dir_all(dir);
    }

    let mut pdfs = Vec::new();
    collect_pdfs(&args.corpus, &mut pdfs);
    let mine: Vec<&PathBuf> = pdfs
        .iter()
        .enumerate()
        .filter(|(index, _)| args.owns(*index))
        .map(|(_, path)| path)
        .collect();
    eprintln!(
        "corpus: {} pdfs, shard {}/{} -> {} pdfs",
        pdfs.len(),
        args.shard_index,
        args.shard_count,
        mine.len()
    );

    if args.shard_index == 0 {
        println!("{HEADER}");
    }
    let options = ConversionOptions {
        extract_tables: true,
        ..Default::default()
    };
    for (n, pdf) in mine.iter().enumerate() {
        if n % 100 == 0 {
            eprintln!("  shard {}: [{n}/{}]", args.shard_index, mine.len());
        }
        let path = (*pdf).clone();
        let swept = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
            sweep_document(&path, &args, &options);
        }));
        if swept.is_err() {
            let relpath = path
                .strip_prefix(&args.corpus)
                .unwrap_or(&path)
                .display()
                .to_string();
            println!("{relpath}\t-\tPANIC\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0");
        }
    }

    // Completion sentinel: the orchestrator reconciles these across shards, so a
    // shard that died mid-stripe cannot pass as a shorter corpus.
    eprintln!(
        "SHARD-DONE {} {} {}",
        args.shard_index,
        mine.len(),
        pdfs.len()
    );
}
```

**`sweep_diff.py`**

```python
#!/usr/bin/env python3
"""Differential audit of two rot_sweep runs.

Upright pages must be byte-identical between builds; rotated pages are allowed
to change and are reported with a content-conservation verdict instead.
"""

from __future__ import annotations

import argparse
import re
from collections import Counter
from dataclasses import dataclass, field
from pathlib import Path

try:
    from enum import StrEnum
except ImportError:  # Python < 3.11
    from enum import Enum

    class StrEnum(str, Enum):
        """Minimal StrEnum for interpreters that predate it."""

        __str__ = str.__str__

WORD_RE = re.compile(r"\S+")

#: Columns whose movement means a page's extraction changed.
SIGNAL_COLUMNS = (
    "chars_hash",
    "text_hash",
    "words_hash",
    "spans_hash",
    "lines_hash",
    "wsfree_hash",
    "md_hash",
    "html_hash",
    "nwords",
    "nlines",
    "nspans",
    "ntables",
    "maxword",
    "ntable_tags",
)


class Bucket(StrEnum):
    """Rotation classification emitted by rot_sweep."""

    EMPTY = "empty"
    UPRIGHT = "upright"
    UPRIGHT_MINORITY_ROTATED = "upright_minority_rot"
    ROT90 = "rot90"
    ROT180 = "rot180"
    ROT270 = "rot270"
    MIXED = "mixed"
    SKEW = "skew"
    OPEN_ERROR = "OPEN_ERR"


class Gate(StrEnum):
    """How a bucket's changes are judged."""

    BYTE_IDENTICAL = "byte-identical"
    REVIEW = "review"
    EXPECTED = "expected-change"


#: Buckets where any change fails the gate. The fix must not reach them.
GATE_BY_BUCKET = {
    Bucket.UPRIGHT: Gate.BYTE_IDENTICAL,
    # Skew means "most glyphs sit at a free angle", not "nothing on this page is
    # rotated". Such a page routinely carries genuine quarter-turn runs — a
    # vertical title beside curved display type — so a rotated-text change is
    # SUPPOSED to move it, and demanding byte-identity here fails a correct fix.
    #
    # Reviewed, not waived: on all ten pages this reclassified, word counts were
    # unchanged and no content was lost. Inspecting the two smallest showed the
    # base emitting one line per glyph for a vertical title ("P", "R", "I" at the
    # same x, stepping down in y) which the change correctly groups into one line.
    Bucket.SKEW: Gate.REVIEW,
    Bucket.EMPTY: Gate.BYTE_IDENTICAL,
    Bucket.OPEN_ERROR: Gate.BYTE_IDENTICAL,
    Bucket.UPRIGHT_MINORITY_ROTATED: Gate.REVIEW,
    Bucket.ROT90: Gate.EXPECTED,
    Bucket.ROT180: Gate.EXPECTED,
    Bucket.ROT270: Gate.EXPECTED,
    Bucket.MIXED: Gate.EXPECTED,
}


@dataclass(frozen=True)
class PageKey:
    """Identifies one page of one document."""

    relpath: str
    page: str


@dataclass(frozen=True)
class Change:
    """A page whose signature moved between arms."""

    key: PageKey
    bucket: Bucket
    columns: tuple[str, ...]
    base: dict[str, str]
    fix: dict[str, str]

    def summary(self) -> str:
        return (
            f"{self.key.relpath} p{self.key.page} [{self.bucket}] "
            f"changed: {','.join(self.columns)} | "
            f"words {self.base['nwords']}->{self.fix['nwords']} "
            f"lines {self.base['nlines']}->{self.fix['nlines']} "
            f"tables {self.base['ntables']}->{self.fix['ntables']}"
        )


def read_rows(path: Path) -> dict[PageKey, dict[str, str]]:
    """Load a rot_sweep TSV keyed by page."""
    rows: dict[PageKey, dict[str, str]] = {}
    with path.open() as handle:
        header = handle.readline().rstrip("\n").split("\t")
        for line in handle:
            fields = line.rstrip("\n").split("\t")
            if len(fields) != len(header):
                continue
            # zip(strict=) is 3.10+; the length check above already
            # guarantees the pairing, so plain zip is equivalent here.
            row = dict(zip(header, fields))
            rows[PageKey(row["relpath"], row["page"])] = row
    return rows


def changed_columns(base: dict[str, str], fix: dict[str, str]) -> tuple[str, ...]:
    """Signal columns that differ between the two arms."""
    return tuple(col for col in SIGNAL_COLUMNS if base.get(col) != fix.get(col))


#: Counters that must all be zero for a page to hold nothing worth gating.
EMPTINESS_COUNTERS = ("nchars", "nwords", "nspans", "nlines", "ntables")


def is_vacuous(row: dict[str, str]) -> bool:
    """Whether a page carries nothing any gated signal could observe."""
    return all(row.get(name, "0") == "0" for name in EMPTINESS_COUNTERS)


def bucket_of(row: dict[str, str]) -> Bucket:
    """Bucket for a row, tolerating an unrecognised value."""
    try:
        return Bucket(row["bucket"])
    except ValueError:
        return Bucket.OPEN_ERROR


@dataclass
class Verdict:
    """Outcome of comparing two arms."""

    blockers: list[Change]
    reviews: list[Change]
    expected: list[Change]
    identical: Counter[Bucket]
    seen: Counter[Bucket]
    vacuous: int
    missing_pages: int
    min_pages: int = 0
    require_change: bool = False
    content_losses: list[str] = field(default_factory=list)

    @property
    def compared(self) -> int:
        return sum(self.seen.values())

    @property
    def shortfalls(self) -> list[str]:
        """Reasons the comparison is too weak to conclude anything from."""
        reasons = []
        if self.missing_pages:
            reasons.append(f"{self.missing_pages} page(s) present in only one arm")
        if self.compared < self.min_pages:
            reasons.append(f"compared {self.compared} pages, below the required {self.min_pages}")
        if self.require_change and not self.expected and not self.reviews:
            reasons.append("the two arms produced identical output everywhere — "
                           "the fix arm is probably not the branch under test")
        if self.content_losses:
            reasons.append(f"{len(self.content_losses)} page(s) lost content")
        return reasons

    @property
    def passed(self) -> bool:
        return not self.blockers and not self.shortfalls


def compare(
    base: dict[PageKey, dict[str, str]],
    fix: dict[PageKey, dict[str, str]],
    min_pages: int = 0,
    require_change: bool = False,
) -> Verdict:
    """Compare two arms page by page and apply the per-bucket gate."""
    verdict = Verdict([], [], [], Counter(), Counter(), 0, 0, min_pages, require_change)
    verdict.missing_pages = len(set(base) ^ set(fix))

    for key in sorted(set(base) & set(fix), key=lambda k: (k.relpath, k.page)):
        base_row, fix_row = base[key], fix[key]
        bucket = bucket_of(base_row)
        verdict.seen[bucket] += 1

        # Only skip a page when every gated signal agrees it holds nothing.
        # Keying the skip on any single counter lets a page with real words,
        # spans and lines bypass the gate entirely.
        if is_vacuous(base_row) and is_vacuous(fix_row):
            verdict.vacuous += 1
            continue

        if bucket_of(fix_row) is not bucket:
            verdict.blockers.append(Change(key, bucket, ("bucket",), base_row, fix_row))
            continue

        columns = changed_columns(base_row, fix_row)
        if not columns:
            verdict.identical[bucket] += 1
            continue

        change = Change(key, bucket, columns, base_row, fix_row)
        # if/elif rather than match/case: the sweep pods run Python 3.8, and
        # gating had to be done on one special machine because of this. That
        # machine's watchdog terminated it mid-run and took every generated
        # report with it. The harness must run anywhere the corpus does.
        gate = GATE_BY_BUCKET.get(bucket, Gate.EXPECTED)
        if gate == Gate.BYTE_IDENTICAL:
            verdict.blockers.append(change)
        elif gate == Gate.REVIEW:
            verdict.reviews.append(change)
        else:
            verdict.expected.append(change)
    return verdict


def token_delta(base_text: Path, fix_text: Path) -> tuple[int, int, float]:
    """Tokens lost, gained, and the fix/base token ratio for one page."""
    base_words = Counter(WORD_RE.findall(base_text.read_text(errors="replace")))
    fix_words = Counter(WORD_RE.findall(fix_text.read_text(errors="replace")))
    lost = sum((base_words - fix_words).values())
    gained = sum((fix_words - base_words).values())
    total = sum(base_words.values())
    return lost, gained, (sum(fix_words.values()) / total if total else 1.0)


def is_fusion_artifact(token: str, fix_tokens: set[str]) -> bool:
    """Whether a token vanished because it was split into real words.

    A word-fusion fix removes strings that were never words — `RatioHa`,
    `MetabolismMediator`. Counting those as lost content measures the fix
    working. A token is an artifact when it decomposes into tokens the fix
    emits; anything else is genuine loss.
    """
    letters = re.sub(r"[^0-9A-Za-z]", "", token)
    if len(letters) < 2:
        return False
    for other in fix_tokens:
        piece = re.sub(r"[^0-9A-Za-z]", "", other)
        if len(piece) >= 2 and piece != letters and piece in letters:
            return True
    return False


def losses(changes: list[Change], base_dir: Path, fix_dir: Path) -> list[str]:
    """Changed pages that lost genuine content.

    Instance counts alone cannot distinguish three different things: removing a
    duplicate copy of text drawn twice, splitting a fused string into its words,
    and actually dropping content. Only the third is a defect.
    """
    dropped = []
    for change in changes:
        safe = change.key.relpath.replace("/", "_").replace("\\", "_")
        base_file = base_dir / f"{safe}.{change.key.page}.txt"
        fix_file = fix_dir / f"{safe}.{change.key.page}.txt"
        if not (base_file.exists() and fix_file.exists()):
            continue
        base_tokens = Counter(WORD_RE.findall(base_file.read_text(errors="replace")))
        fix_tokens = Counter(WORD_RE.findall(fix_file.read_text(errors="replace")))
        vanished = set(base_tokens) - set(fix_tokens)
        genuine = [t for t in vanished if not is_fusion_artifact(t, set(fix_tokens))]
        if genuine:
            sample = ", ".join(repr(t) for t in sorted(genuine)[:4])
            dropped.append(
                f"{change.key.relpath} p{change.key.page}: "
                f"{len(genuine)} token type(s) gone — {sample}"
            )
    return dropped


def content_report(changes: list[Change], base_dir: Path, fix_dir: Path) -> list[str]:
    """Per-page content conservation for changed pages."""
    lines = ["| page | tokens lost | tokens gained | content ratio |", "|---|---|---|---|"]
    for change in changes:
        safe = change.key.relpath.replace("/", "_").replace("\\", "_")
        base_file = base_dir / f"{safe}.{change.key.page}.txt"
        fix_file = fix_dir / f"{safe}.{change.key.page}.txt"
        if not (base_file.exists() and fix_file.exists()):
            continue
        lost, gained, ratio = token_delta(base_file, fix_file)
        lines.append(
            f"| {change.key.relpath} p{change.key.page} | {lost} | {gained} | {ratio:.4f} |"
        )
    return lines


def census_table(verdict: Verdict) -> list[str]:
    """Bucket census as a markdown table."""
    lines = ["| bucket | pages | byte-identical | changed |", "|---|---|---|---|"]
    for bucket in sorted(verdict.seen, key=str):
        seen = verdict.seen[bucket]
        identical = verdict.identical[bucket]
        lines.append(f"| {bucket} | {seen} | {identical} | {seen - identical} |")
    return lines


def render(verdict: Verdict, base_dir: Path | None, fix_dir: Path | None) -> str:
    """Full markdown report."""
    if verdict.passed:
        status = "GATE PASS"
    else:
        parts = [f"{len(verdict.blockers)} blocker(s)"] if verdict.blockers else []
        parts += verdict.shortfalls
        status = "GATE FAIL — " + "; ".join(parts)
    out = [f"# Differential sweep\n", f"**{status}**\n"]
    out.append(f"- pages compared: {verdict.compared}")
    out.append(f"- vacuous (empty in both arms, excluded): {verdict.vacuous}")
    out.append(f"- pages present in only one arm: {verdict.missing_pages}\n")
    out += ["## Bucket census\n", *census_table(verdict), ""]
    out.append(f"## Blockers ({len(verdict.blockers)})\n")
    out += [f"- {c.summary()}" for c in verdict.blockers[:100]] or ["_none_"]
    out.append(f"\n## Review — upright with rotated minority ({len(verdict.reviews)})\n")
    out += [f"- {c.summary()}" for c in verdict.reviews[:100]] or ["_none_"]
    out.append(f"\n## Expected change — rotated pages ({len(verdict.expected)})\n")
    out += [f"- {c.summary()}" for c in verdict.expected[:100]] or ["_none_"]
    if verdict.content_losses:
        out.append(f"\n## Content loss ({len(verdict.content_losses)})\n")
        out += [f"- {line}" for line in verdict.content_losses[:100]]
    if base_dir and fix_dir and verdict.expected:
        out += ["\n## Content conservation on changed pages\n"]
        out += content_report(verdict.expected[:100], base_dir, fix_dir)
    return "\n".join(out)


def main() -> int:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--base", required=True, type=Path)
    parser.add_argument("--fix", required=True, type=Path)
    parser.add_argument("--base-text", type=Path)
    parser.add_argument("--fix-text", type=Path)
    parser.add_argument("--report", type=Path)
    parser.add_argument("--min-pages", type=int, default=0)
    parser.add_argument("--require-change", action="store_true")
    args = parser.parse_args()

    verdict = compare(
        read_rows(args.base),
        read_rows(args.fix),
        min_pages=args.min_pages,
        require_change=args.require_change,
    )
    if args.base_text and args.fix_text:
        verdict.content_losses = losses(
            verdict.expected + verdict.reviews, args.base_text, args.fix_text
        )
    report = render(verdict, args.base_text, args.fix_text)
    print(report)
    if args.report:
        args.report.write_text(report)
    return 0 if verdict.passed else 1


if __name__ == "__main__":
    raise SystemExit(main())
```

**`oracle_compare.py`**

```python
#!/usr/bin/env python3
"""Score both pdf_oxide arms against reference extractors.

For every sampled page, the reference libraries the maintainer already compares
against produce a word multiset; each arm is scored on how closely it agrees.
The claim this supports is comparative, not absolute: on rotated pages the fix
arm must agree with the references at least as well as the base arm, and on
upright pages the two arms must score identically.

Arm text comes from the per-page dumps rot_sweep already wrote, so no pdf_oxide
extraction is repeated here.
"""

from __future__ import annotations

import argparse
import concurrent.futures
import os
import re
from collections import Counter
from dataclasses import dataclass, field
from pathlib import Path

try:
    from enum import StrEnum
except ImportError:  # Python < 3.11
    from enum import Enum

    class StrEnum(str, Enum):
        """Minimal StrEnum for interpreters that predate it."""

        __str__ = str.__str__
from statistics import mean

WORD_RE = re.compile(r"\S+")


class Oracle(StrEnum):
    """Reference extractor."""

    PYMUPDF = "pymupdf"
    PYPDF = "pypdf"
    PDFMINER = "pdfminer"


@dataclass(frozen=True)
class PageRef:
    """A page selected for comparison."""

    relpath: str
    page: int
    bucket: str

    def dump_name(self) -> str:
        safe = self.relpath.replace("/", "_").replace("\\", "_")
        return f"{safe}.{self.page}.txt"


@dataclass
class Scores:
    """Agreement scores for one arm against one oracle."""

    jaccard: list[float] = field(default_factory=list)
    recall: list[float] = field(default_factory=list)

    def add(self, arm_words: Counter[str], oracle_words: Counter[str]) -> None:
        """Record one page's agreement."""
        intersection = sum((arm_words & oracle_words).values())
        union = sum((arm_words | oracle_words).values())
        oracle_total = sum(oracle_words.values())
        self.jaccard.append(intersection / union if union else 1.0)
        self.recall.append(intersection / oracle_total if oracle_total else 1.0)

    def mean_jaccard(self) -> float:
        return mean(self.jaccard) if self.jaccard else 0.0

    def mean_recall(self) -> float:
        return mean(self.recall) if self.recall else 0.0


def words_of(text: str) -> Counter[str]:
    """Word multiset of a text block."""
    return Counter(WORD_RE.findall(text))


def _load_pymupdf():
    """PyMuPDF module under either of its import names."""
    try:
        import pymupdf
        return pymupdf
    except ImportError:
        import fitz
        return fitz


def extract_pymupdf(path: Path, page: int) -> str | None:
    """Reference text from PyMuPDF."""
    module = _load_pymupdf()
    try:
        with module.open(path) as doc:
            return doc[page].get_text()
    except Exception:  # noqa: BLE001 - a failed oracle page is skipped, not fatal
        return None


def extract_pypdf(path: Path, page: int) -> str | None:
    """Reference text from pypdf."""
    import pypdf

    try:
        return pypdf.PdfReader(str(path)).pages[page].extract_text()
    except Exception:  # noqa: BLE001
        return None


def extract_pdfminer(path: Path, page: int) -> str | None:
    """Reference text from pdfminer.six."""
    from pdfminer.high_level import extract_text

    try:
        return extract_text(str(path), page_numbers=[page])
    except Exception:  # noqa: BLE001
        return None


EXTRACTORS = {
    Oracle.PYMUPDF: extract_pymupdf,
    Oracle.PYPDF: extract_pypdf,
    Oracle.PDFMINER: extract_pdfminer,
}


def select_pages(
    sweep_tsv: Path, upright_sample: int, rotated_sample: int = 0
) -> list[PageRef]:
    """A stride sample of rotated and upright pages.

    Stride rather than head so the sample spans the whole corpus rather than
    whichever documents sort first.
    """
    rotated: list[PageRef] = []
    upright: list[PageRef] = []
    with sweep_tsv.open() as handle:
        header = handle.readline().rstrip("\n").split("\t")
        for line in handle:
            fields = line.rstrip("\n").split("\t")
            if len(fields) != len(header):
                continue
            row = dict(zip(header, fields))
            if row["page"] == "-" or row["nchars"] == "0":
                continue
            ref = PageRef(row["relpath"], int(row["page"]), row["bucket"])
            (rotated if ref.bucket.startswith("rot") else upright).append(ref)
    def sample(pages: list[PageRef], cap: int) -> list[PageRef]:
        if not cap or len(pages) <= cap:
            return pages
        stride = max(1, len(pages) // cap)
        return pages[::stride][:cap]

    return sample(rotated, rotated_sample) + sample(upright, upright_sample)


def read_arm_text(text_dir: Path, ref: PageRef) -> str | None:
    """Assembled text an arm produced for this page."""
    path = text_dir / ref.dump_name()
    return path.read_text(errors="replace") if path.is_file() else None


@dataclass
class BucketReport:
    """Per-bucket, per-oracle scores for both arms."""

    base: dict[Oracle, Scores] = field(default_factory=lambda: {o: Scores() for o in Oracle})
    fix: dict[Oracle, Scores] = field(default_factory=lambda: {o: Scores() for o in Oracle})
    pages: int = 0


def score_one(job: tuple[PageRef, Path, Path, Path]) -> tuple[str, list, bool] | None:
    """Agreement of both arms with each oracle for one page."""
    ref, corpus, base_text, fix_text = job
    base_raw = read_arm_text(base_text, ref)
    fix_raw = read_arm_text(fix_text, ref)
    pdf_path = corpus / ref.relpath
    if base_raw is None or fix_raw is None or not pdf_path.is_file():
        return None

    base_words, fix_words = words_of(base_raw), words_of(fix_raw)
    measurements = []
    for oracle, extract in EXTRACTORS.items():
        oracle_text = extract(pdf_path, ref.page)
        if oracle_text is None or not oracle_text.strip():
            continue
        measurements.append((oracle, base_words, fix_words, words_of(oracle_text)))
    return (ref.bucket, measurements, bool(measurements))


def score_pages(
    refs: list[PageRef],
    corpus: Path,
    base_text: Path,
    fix_text: Path,
    workers: int,
) -> dict[str, BucketReport]:
    """Score both arms against every oracle, one process per page batch."""
    reports: dict[str, BucketReport] = {}
    jobs = [(ref, corpus, base_text, fix_text) for ref in refs]
    with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as pool:
        for result in pool.map(score_one, jobs, chunksize=8):
            if result is None:
                continue
            bucket, measurements, counted = result
            report = reports.setdefault(bucket, BucketReport())
            for oracle, base_words, fix_words, oracle_words in measurements:
                report.base[oracle].add(base_words, oracle_words)
                report.fix[oracle].add(fix_words, oracle_words)
            if counted:
                report.pages += 1
    return reports


def render(reports: dict[str, BucketReport]) -> str:
    """Markdown comparison table."""
    lines = [
        "# pdf_oxide vs reference extractors\n",
        "Mean word-multiset agreement per page. `base` is upstream main, "
        "`fix` is the branch. Higher is closer to the reference.\n",
        "| bucket | pages | oracle | base Jaccard | fix Jaccard | base recall | fix recall | verdict |",
        "|---|---|---|---|---|---|---|---|",
    ]
    for bucket in sorted(reports):
        report = reports[bucket]
        for oracle in Oracle:
            base, fix = report.base[oracle], report.fix[oracle]
            if not base.jaccard:
                continue
            delta = fix.mean_jaccard() - base.mean_jaccard()
            verdict = "improved" if delta > 1e-6 else ("equal" if abs(delta) <= 1e-6 else "REGRESSED")
            lines.append(
                f"| {bucket} | {report.pages} | {oracle} | "
                f"{base.mean_jaccard():.4f} | {fix.mean_jaccard():.4f} | "
                f"{base.mean_recall():.4f} | {fix.mean_recall():.4f} | {verdict} |"
            )
    return "\n".join(lines)


def require_oracles() -> None:
    """Abort unless every reference extractor is importable."""
    missing = []
    for oracle, extract in EXTRACTORS.items():
        try:
            extract(Path("/nonexistent.pdf"), 0)
        except ImportError:
            missing.append(str(oracle))
    if missing:
        raise SystemExit(
            f"reference extractors unavailable: {', '.join(missing)}. "
            "A partial comparison would understate the evidence; install them and re-run."
        )


def main() -> int:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--corpus", required=True, type=Path)
    parser.add_argument("--sweep", required=True, type=Path, help="base arm rot_sweep TSV")
    parser.add_argument("--base-text", required=True, type=Path)
    parser.add_argument("--fix-text", required=True, type=Path)
    parser.add_argument("--upright-sample", type=int, default=2000)
    parser.add_argument("--rotated-sample", type=int, default=0,
                        help="cap rotated pages compared; 0 compares all")
    parser.add_argument("--workers", type=int, default=os.cpu_count() or 4)
    parser.add_argument("--report", type=Path)
    args = parser.parse_args()

    require_oracles()
    refs = select_pages(args.sweep, args.upright_sample, args.rotated_sample)
    print(
        f"comparing {len(refs)} pages against {len(EXTRACTORS)} reference "
        f"extractors on {args.workers} workers",
        flush=True,
    )
    reports = score_pages(refs, args.corpus, args.base_text, args.fix_text, args.workers)
    output = render(reports)
    print(output)
    if args.report:
        args.report.write_text(output)

    regressed = any(
        report.fix[oracle].mean_jaccard() < report.base[oracle].mean_jaccard() - 1e-6
        for report in reports.values()
        for oracle in Oracle
        if report.base[oracle].jaccard
    )
    return 1 if regressed else 0


if __name__ == "__main__":
    raise SystemExit(main())
```

**`fetch_corpus.py`**

```python
#!/usr/bin/env python3
"""Assemble the validation corpus.

Three populations, each present for a reason:

* ``govdocs1`` — crawled .gov documents: owner's and service manuals, landscape
  spec tables, scanned forms, engineering reports. This is the population that
  carries the rotated-table shape under test, at scale.
* ``curated`` — arXiv, PubMed Central OA, IRS forms, the pdf.js test corpus:
  the document types pdf_oxide is normally exercised on, so a regression outside
  the target population is visible.
* ``fixtures`` — the specific documents the rotated-text investigation cites,
  including the vehicle owner's manual whose capacities tables motivated it.
"""

from __future__ import annotations

import argparse
import concurrent.futures
import io
import urllib.request
import zipfile
from dataclasses import dataclass
from pathlib import Path

USER_AGENT = "pdf_oxide-rotated-text-validation"
GOVDOCS_URL = "https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/{slice:03d}.zip"

#: Documents the investigation cites by name.
FIXTURES: dict[str, str] = {
    "fixture_cv_manual.pdf": (
        "https://gist.githubusercontent.com/tobocop2/"
        "0d30905e2375e09b153ce50296316f91/raw/cv-manual.pdf"
    ),
    "fixture_arxiv_2510.24987.pdf": "https://arxiv.org/pdf/2510.24987",
    "fixture_arxiv_2510.25531.pdf": "https://arxiv.org/pdf/2510.25531",
    "fixture_arxiv_2510.26274.pdf": "https://arxiv.org/pdf/2510.26274",
    "fixture_arxiv_2510.21165.pdf": "https://arxiv.org/pdf/2510.21165",
    "fixture_tategaki_kokoro.pdf": "https://tatsu-zine.com/samples/aozora/kokoro.pdf",
    "fixture_tategaki_bocchan.pdf": "https://tatsu-zine.com/samples/aozora/bocchan.pdf",
    "fixture_faa_airplane_handbook.pdf": (
        "https://www.faa.gov/sites/faa.gov/files/regulations_policies/"
        "handbooks_manuals/aviation/airplane_handbook/00_afh_full.pdf"
    ),
}


@dataclass(frozen=True)
class Fetch:
    """One download and where it lands."""

    name: str
    url: str


def download(url: str, timeout: int = 600) -> bytes:
    """Fetch a URL's bytes."""
    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
    with urllib.request.urlopen(request, timeout=timeout) as response:
        return response.read()


def is_pdf(path: Path) -> bool:
    """Whether a file on disk is really a PDF."""
    if not path.is_file() or path.stat().st_size <= 1024:
        return False
    with path.open("rb") as handle:
        return handle.read(5).startswith(b"%PDF")


def fetch_file(job: Fetch, dest: Path) -> str:
    """Download one PDF, rejecting a non-PDF response.

    A 200 carrying an interstitial or error page would otherwise be cached under
    the fixture's name forever, and the fixture would silently never be tested.
    """
    target = dest / job.name
    if is_pdf(target):
        return f"cached  {job.name}"
    try:
        payload = download(job.url)
    except Exception as exc:  # noqa: BLE001 - reported, then asserted on by the caller
        return f"FAILED  {job.name}: {exc}"
    if not payload.startswith(b"%PDF"):
        target.unlink(missing_ok=True)
        return f"FAILED  {job.name}: response is not a PDF ({len(payload)} bytes)"
    target.write_bytes(payload)
    return f"ok      {job.name}"


def fetch_slice(index: int, dest: Path) -> str:
    """Extract every PDF from one govdocs1 archive."""
    marker = dest / f".govdocs_{index:03d}.done"
    if marker.is_file():
        return f"cached  govdocs slice {index:03d}"
    try:
        blob = download(GOVDOCS_URL.format(slice=index))
    except Exception as exc:  # noqa: BLE001 - a missing slice must not abort
        return f"FAILED  govdocs slice {index:03d}: {exc}"

    written = 0
    with zipfile.ZipFile(io.BytesIO(blob)) as archive:
        for member in archive.namelist():
            if not member.lower().endswith(".pdf"):
                continue
            payload = archive.read(member)
            if not payload.startswith(b"%PDF"):
                continue
            name = f"govdocs_{index:03d}_{Path(member).name}"
            (dest / name).write_bytes(payload)
            written += 1
    marker.touch()
    return f"ok      govdocs slice {index:03d}: {written} pdfs"


def run(dest: Path, slices: int, workers: int) -> list[str]:
    """Fetch every population into `dest`, returning each job's outcome."""
    dest.mkdir(parents=True, exist_ok=True)
    results: list[str] = []
    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
        futures = [pool.submit(fetch_file, Fetch(n, u), dest) for n, u in FIXTURES.items()]
        futures += [pool.submit(fetch_slice, i, dest) for i in range(slices)]
        for future in concurrent.futures.as_completed(futures):
            outcome = future.result()
            print(outcome, flush=True)
            results.append(outcome)
    return results


def verify(dest: Path, minimum: int) -> list[str]:
    """Reasons the corpus is unfit to run on."""
    problems = []
    missing = [name for name in FIXTURES if not is_pdf(dest / name)]
    if missing:
        problems.append(f"named fixtures missing or not PDFs: {', '.join(sorted(missing))}")
    count = len(list(dest.glob("*.pdf")))
    if count < minimum:
        problems.append(f"corpus has {count} pdfs, below the required {minimum}")
    return problems


def main() -> int:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--dest", required=True, type=Path)
    parser.add_argument("--slices", type=int, default=40)
    parser.add_argument("--workers", type=int, default=8)
    parser.add_argument("--min-pdfs", type=int, default=0)
    args = parser.parse_args()

    results = run(args.dest, args.slices, args.workers)
    failures = [line for line in results if line.startswith("FAILED")]
    problems = verify(args.dest, args.min_pdfs)

    print(f"total pdfs: {len(list(args.dest.glob('*.pdf')))}")
    if failures:
        print(f"download failures: {len(failures)}")
    for problem in problems:
        print(f"UNFIT: {problem}")
    # A partial corpus must stop the run: a gate that passes over a fraction of
    # the intended documents reads exactly like one that passed over all of them.
    return 1 if problems else 0


if __name__ == "__main__":
    raise SystemExit(main())
```


</details>

### The decoder unification

`decode_text_to_unicode` existed twice, an extraction copy and a rendering copy, and they drifted in both directions: UTF-8 codespace CMaps and the preserve-unmapped toggle lived only in extraction; ligature decomposition and dropped-glyph accounting only in rendering. So a Type0 font with a UTF-8 CMap extracted right and rendered garbage, while a ligature rendered right and extracted lossy. One decoder now lives in `fonts::unicode_decode` with the union of both feature sets; the two real policy differences are explicit flags. The 455k-page sweep is byte-identical before and after this commit, so it changes no extraction output. It is deliberately its own commit and can be split out if it reads as out of scope here.


