### PR TITLE
fix(render): handle malformed geometry and make two read paths deterministic

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -6682,9 +6682,13 @@ impl<'doc> TextExtractor<'doc> {
 
                 if let Some(props_dict) = self.resolve_bdc_properties(&properties) {
                     if let Some(mcid_obj) = props_dict.get("MCID") {
-                        if let Some(mcid) = mcid_obj.as_integer() {
-                            own_mcid = Some(mcid as u32);
-                            self.current_mcid = Some(mcid as u32);
+                        // Same id-space contract as the structure-tree side:
+                        // wrapping would alias a malformed id onto a real MCID.
+                        if let Some(mcid) =
+                            mcid_obj.as_integer().and_then(crate::structure::checked_mcid)
+                        {
+                            own_mcid = Some(mcid);
+                            self.current_mcid = Some(mcid);
                             log::debug!("Entered marked content with MCID: {}", mcid);
                         }
                     }

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -6684,8 +6684,9 @@ impl<'doc> TextExtractor<'doc> {
                     if let Some(mcid_obj) = props_dict.get("MCID") {
                         // Same id-space contract as the structure-tree side:
                         // wrapping would alias a malformed id onto a real MCID.
-                        if let Some(mcid) =
-                            mcid_obj.as_integer().and_then(crate::structure::checked_mcid)
+                        if let Some(mcid) = mcid_obj
+                            .as_integer()
+                            .and_then(crate::structure::checked_mcid)
                         {
                             own_mcid = Some(mcid);
                             self.current_mcid = Some(mcid);

--- a/src/rendering/mesh_shading.rs
+++ b/src/rendering/mesh_shading.rs
@@ -962,7 +962,7 @@ fn eval_type3(
         return None;
     }
     let domain = dict.get("Domain").and_then(|o| o.as_array())?;
-    let (d0, d1) = (num(&domain[0]), num(domain.get(1)?));
+    let (d0, d1) = (num(domain.first()?), num(domain.get(1)?));
     let bounds: Vec<f32> = dict
         .get("Bounds")
         .and_then(|o| o.as_array())
@@ -1028,6 +1028,25 @@ fn eval_type0(func: &Object, dict: &HashMap<String, Object>, inputs: &[f32]) -> 
         return None;
     }
     if size.contains(&0) || domain.len() < m {
+        return None;
+    }
+    // `/Size` is document controlled. Bound the declared grid by what the
+    // sample stream can actually hold, so the flat-index and stride products
+    // below cannot wrap a bogus grid into a valid-looking sample offset.
+    let declared_bits = size
+        .iter()
+        .try_fold(1usize, |acc, &s| acc.checked_mul(s))
+        .and_then(|samples| samples.checked_mul(n))
+        .and_then(|values| values.checked_mul(bps as usize));
+    if declared_bits.is_none_or(|bits| bits > bytes.len() * 8) {
+        log::warn!(
+            "Skipping sampled function: /Size {:?} with {} outputs at {} bits declares \
+             more samples than the {}-byte sample stream holds",
+            size,
+            n,
+            bps,
+            bytes.len()
+        );
         return None;
     }
     let encode: Vec<f32> = dict

--- a/src/rendering/mesh_shading.rs
+++ b/src/rendering/mesh_shading.rs
@@ -1030,9 +1030,9 @@ fn eval_type0(func: &Object, dict: &HashMap<String, Object>, inputs: &[f32]) -> 
     if size.contains(&0) || domain.len() < m {
         return None;
     }
-    // `/Size` is document controlled. Bound the declared grid by what the
-    // sample stream can actually hold, so the flat-index and stride products
-    // below cannot wrap a bogus grid into a valid-looking sample offset.
+    // `/Size` is document controlled. Bounding the declared grid by what the
+    // sample stream holds keeps the stride and flat-index products below from
+    // wrapping a bogus grid into a valid-looking offset.
     let declared_bits = size
         .iter()
         .try_fold(1usize, |acc, &s| acc.checked_mul(s))

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -4173,23 +4173,34 @@ impl PageRenderer {
                                 let mh = mask_gray.height();
                                 let iw = rgba_image.width();
                                 let ih = rgba_image.height();
-                                for y in 0..ih {
-                                    for x in 0..iw {
-                                        let mx = (x * mw / iw).min(mw - 1);
-                                        let my = (y * mh / ih).min(mh - 1);
-                                        let mask_val = mask_gray.get_pixel(mx, my)[0];
-                                        let pixel = rgba_image.get_pixel_mut(x, y);
-                                        pixel[3] =
-                                            ((pixel[3] as u32 * mask_val as u32) / 255) as u8;
+                                if mw == 0 || mh == 0 {
+                                    // No mask sample to test: leave the base
+                                    // image fully opaque rather than guessing.
+                                    log::warn!(
+                                        "Ignoring image Mask: it is {mw}x{mh} and carries \
+                                         no sample to test"
+                                    );
+                                } else {
+                                    for y in 0..ih {
+                                        let my =
+                                            ((y as u64 * mh as u64 / ih as u64) as u32).min(mh - 1);
+                                        for x in 0..iw {
+                                            let mx = ((x as u64 * mw as u64 / iw as u64) as u32)
+                                                .min(mw - 1);
+                                            let mask_val = mask_gray.get_pixel(mx, my)[0];
+                                            let pixel = rgba_image.get_pixel_mut(x, y);
+                                            pixel[3] =
+                                                ((pixel[3] as u32 * mask_val as u32) / 255) as u8;
+                                        }
                                     }
+                                    log::debug!(
+                                        "Applied image Mask ({}x{}) to image ({}x{})",
+                                        mw,
+                                        mh,
+                                        iw,
+                                        ih
+                                    );
                                 }
-                                log::debug!(
-                                    "Applied image Mask ({}x{}) to image ({}x{})",
-                                    mw,
-                                    mh,
-                                    iw,
-                                    ih
-                                );
                             }
                         },
                         Err(_) => {
@@ -4201,16 +4212,19 @@ impl PageRenderer {
                                     .map(|o| matches!(o, Object::Boolean(true)))
                                     .unwrap_or(false);
                                 if is_image_mask {
+                                    // `as u32` would turn a negative /Width into a
+                                    // near-u32::MAX row stride that passes the
+                                    // check below; try_from rejects it instead.
                                     let mw = mask_dict
                                         .get("Width")
                                         .and_then(|o| o.as_integer())
-                                        .unwrap_or(0)
-                                        as u32;
+                                        .and_then(|v| u32::try_from(v).ok())
+                                        .unwrap_or(0);
                                     let mh = mask_dict
                                         .get("Height")
                                         .and_then(|o| o.as_integer())
-                                        .unwrap_or(0)
-                                        as u32;
+                                        .and_then(|v| u32::try_from(v).ok())
+                                        .unwrap_or(0);
                                     if mw > 0 && mh > 0 {
                                         if let Ok(raw_mask_data) =
                                             doc.decode_stream_with_encryption(&mask_stream, ref_obj)
@@ -4253,9 +4267,14 @@ impl PageRenderer {
                                             let ih = rgba_image.height();
                                             let row_bytes = (mw as usize + 7) / 8;
                                             for y in 0..ih {
+                                                let my = ((y as u64 * mh as u64 / ih as u64) as u32)
+                                                    .min(mh - 1)
+                                                    as usize;
                                                 for x in 0..iw {
-                                                    let mx = (x * mw / iw).min(mw - 1) as usize;
-                                                    let my = (y * mh / ih).min(mh - 1) as usize;
+                                                    let mx = ((x as u64 * mw as u64 / iw as u64)
+                                                        as u32)
+                                                        .min(mw - 1)
+                                                        as usize;
                                                     let byte_idx = my * row_bytes + mx / 8;
                                                     let bit_idx = 7 - (mx % 8);
                                                     // PDF spec 8.9.6.2: mask bit 1 = paint (opaque), 0 = don't paint (transparent)

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -7764,9 +7764,12 @@ impl PageRenderer {
             if let Some(ap_obj) = annot.raw_dict.as_ref().and_then(|d| d.get("AP")) {
                 let ap_stream_obj = doc.resolve_object(ap_obj)?;
 
-                // Normal appearance (N)
+                // ISO 32000-1 §12.5.5: /N is the normal appearance. /D and /R
+                // are the down and rollover appearances, shown only while the
+                // pointer presses or hovers the annotation, so an /AP without
+                // /N has no appearance to draw in a static render.
                 if let Object::Dictionary(ap_dict) = ap_stream_obj {
-                    if let Some(n_entry) = ap_dict.get("N").or_else(|| ap_dict.values().next()) {
+                    if let Some(n_entry) = ap_dict.get("N") {
                         let n_stream_obj = doc.resolve_object(n_entry)?;
                         if let Object::Stream { ref dict, .. } = n_stream_obj {
                             let ap_data = if let Some(r) = n_entry.as_reference() {

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -4212,9 +4212,9 @@ impl PageRenderer {
                                     .map(|o| matches!(o, Object::Boolean(true)))
                                     .unwrap_or(false);
                                 if is_image_mask {
-                                    // `as u32` would turn a negative /Width into a
-                                    // near-u32::MAX row stride that passes the
-                                    // check below; try_from rejects it instead.
+                                    // `as u32` turns a negative /Width into a
+                                    // near-u32::MAX stride that passes the
+                                    // check below.
                                     let mw = mask_dict
                                         .get("Width")
                                         .and_then(|o| o.as_integer())
@@ -4553,7 +4553,10 @@ impl PageRenderer {
         name.eq_ignore_ascii_case("CCITTFaxDecode") || name.eq_ignore_ascii_case("CCF")
     }
 
-    fn image_mask_layout(
+    /// `(width, height, row_bytes, packed_len, rgba_len)` for a 1-bpc stencil,
+    /// rejecting geometry that does not fit or that no stream could back —
+    /// before anything is allocated from it.
+    pub(crate) fn image_mask_layout(
         dict: &HashMap<String, Object>,
     ) -> Result<(u32, u32, usize, usize, usize)> {
         let dimension = |key: &str| -> Result<u32> {
@@ -7764,10 +7767,9 @@ impl PageRenderer {
             if let Some(ap_obj) = annot.raw_dict.as_ref().and_then(|d| d.get("AP")) {
                 let ap_stream_obj = doc.resolve_object(ap_obj)?;
 
-                // ISO 32000-1 §12.5.5: /N is the normal appearance. /D and /R
-                // are the down and rollover appearances, shown only while the
-                // pointer presses or hovers the annotation, so an /AP without
-                // /N has no appearance to draw in a static render.
+                // ISO 32000-1 §12.5.5: /N is the normal appearance; /D and /R
+                // show only under pointer press or hover, so an /AP without /N
+                // draws nothing in a static render.
                 if let Object::Dictionary(ap_dict) = ap_stream_obj {
                     if let Some(n_entry) = ap_dict.get("N") {
                         let n_stream_obj = doc.resolve_object(n_entry)?;

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -3057,8 +3057,16 @@ fn paint_image_mask_to_plates(
         Object::Stream { dict, .. } => dict,
         _ => return Ok(()),
     };
-    let w = dict.get("Width").and_then(|o| o.as_integer()).unwrap_or(0) as usize;
-    let h = dict.get("Height").and_then(|o| o.as_integer()).unwrap_or(0) as usize;
+    let raw_w = dict.get("Width").and_then(|o| o.as_integer()).unwrap_or(0);
+    let raw_h = dict.get("Height").and_then(|o| o.as_integer()).unwrap_or(0);
+    let dims = usize::try_from(raw_w).ok().zip(usize::try_from(raw_h).ok());
+    let Some((w, h)) = dims.filter(|(w, h)| w.checked_mul(*h).is_some()) else {
+        log::warn!(
+            "Skipping image mask '{name}': /Width {raw_w} /Height {raw_h} is not a \
+             representable pixel count"
+        );
+        return Ok(());
+    };
     let pixel_count = w * h;
     if pixel_count == 0 {
         return Ok(());

--- a/src/rendering/separation_renderer.rs
+++ b/src/rendering/separation_renderer.rs
@@ -3057,20 +3057,15 @@ fn paint_image_mask_to_plates(
         Object::Stream { dict, .. } => dict,
         _ => return Ok(()),
     };
-    let raw_w = dict.get("Width").and_then(|o| o.as_integer()).unwrap_or(0);
-    let raw_h = dict.get("Height").and_then(|o| o.as_integer()).unwrap_or(0);
-    let dims = usize::try_from(raw_w).ok().zip(usize::try_from(raw_h).ok());
-    let Some((w, h)) = dims.filter(|(w, h)| w.checked_mul(*h).is_some()) else {
-        log::warn!(
-            "Skipping image mask '{name}': /Width {raw_w} /Height {raw_h} is not a \
-             representable pixel count"
-        );
+    // Same geometry contract as the stencil path in `page_renderer`, which
+    // already rejects non-positive and unbacked dimensions before allocating.
+    let layout = crate::rendering::page_renderer::PageRenderer::image_mask_layout(dict);
+    let Ok((w32, h32, _row_bytes, packed_len, _rgba_len)) = layout else {
+        log::warn!("Skipping image mask '{name}': {}", layout.unwrap_err());
         return Ok(());
     };
+    let (w, h) = (w32 as usize, h32 as usize);
     let pixel_count = w * h;
-    if pixel_count == 0 {
-        return Ok(());
-    }
     let bpc = dict
         .get("BitsPerComponent")
         .and_then(|o| o.as_integer())
@@ -3088,10 +3083,18 @@ fn paint_image_mask_to_plates(
     } else {
         xobject.decode_stream_data()?
     };
-    let mut stencil = expand_1bpc_to_8bpc(&packed, w as u32, h as u32);
-    if stencil.len() < pixel_count {
+    // Checked before expanding, because `expand_1bpc_to_8bpc` zero-pads and
+    // would size the buffer from the declaration: `/Width 2147483648 /Height
+    // 2147483648` is representable and asks for 2^62 bytes.
+    if packed.len() < packed_len {
+        log::warn!(
+            "Skipping image mask '{name}': {w}x{h} needs {packed_len} bytes, the stream \
+             carries {}",
+            packed.len()
+        );
         return Ok(());
     }
+    let mut stencil = expand_1bpc_to_8bpc(&packed, w32, h32);
 
     // §8.9.6.2: decoded sample value 0 marks the pixel with the current
     // colour; value 1 leaves it transparent. /Decode defaults to [0 1] —

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -49,6 +49,7 @@ pub mod types;
 
 pub use article_threads::{parse_article_threads, ArticleThread, Bead};
 pub use converter::StructureConverter;
+pub(crate) use parser::checked_mcid;
 pub use parser::{parse_structure_tree, parse_structure_tree_with_budget};
 pub use spatial_table_detector::{
     detect_tables_from_spans, DetectedTable, SpatialTableDetector, TableDetectionConfig,

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -779,11 +779,11 @@ fn parse_marked_content_ref(
 ///
 /// Wrapping collides a malformed id with a real one: `2^32 + 5` becomes MCID 5
 /// and duplicates that entry in the page's reading order.
-fn checked_mcid(raw: i64) -> Option<u32> {
+pub(crate) fn checked_mcid(raw: i64) -> Option<u32> {
     match u32::try_from(raw) {
         Ok(mcid) => Some(mcid),
         Err(_) => {
-            log::warn!("Structure tree: marked-content id {raw} is out of range, skipping");
+            log::warn!("Marked-content id {raw} is out of range, skipping");
             None
         },
     }

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -533,12 +533,14 @@ fn parse_k_children(
             // Single MCID — bare integer child references the page's
             // own content stream (ISO 32000-1:2008 §14.7.5.4.2 "MCR"
             // form is reserved for cross-stream refs).
-            let page = parent.page.unwrap_or(0);
-            parent.add_child(StructChild::MarkedContentRef {
-                mcid: *mcid as u32,
-                page,
-                scope: crate::structure::McidScope::Page(page),
-            });
+            if let Some(mcid) = checked_mcid(*mcid) {
+                let page = parent.page.unwrap_or(0);
+                parent.add_child(StructChild::MarkedContentRef {
+                    mcid,
+                    page,
+                    scope: crate::structure::McidScope::Page(page),
+                });
+            }
         },
 
         Object::Array(arr) => {
@@ -568,12 +570,14 @@ fn parse_k_children(
                 match &child_obj {
                     Object::Integer(mcid) => {
                         // Bare integer MCID — page's own content stream.
-                        let page = parent.page.unwrap_or(0);
-                        parent.add_child(StructChild::MarkedContentRef {
-                            mcid: *mcid as u32,
-                            page,
-                            scope: crate::structure::McidScope::Page(page),
-                        });
+                        if let Some(mcid) = checked_mcid(*mcid) {
+                            let page = parent.page.unwrap_or(0);
+                            parent.add_child(StructChild::MarkedContentRef {
+                                mcid,
+                                page,
+                                scope: crate::structure::McidScope::Page(page),
+                            });
+                        }
                     },
 
                     Object::Dictionary(_) => {
@@ -746,6 +750,9 @@ fn parse_marked_content_ref(
         Some(mcid) => mcid,
         None => return Ok(None), // Missing /MCID, skip gracefully
     };
+    let Some(mcid) = checked_mcid(mcid) else {
+        return Ok(None);
+    };
 
     // Get /Pg (page reference) and resolve to page number.
     let page = dict
@@ -765,11 +772,23 @@ fn parse_marked_content_ref(
     // namespace.
     let scope = resolve_mcr_scope(document, dict, page);
 
-    Ok(Some(StructChild::MarkedContentRef {
-        mcid: mcid as u32,
-        page,
-        scope,
-    }))
+    Ok(Some(StructChild::MarkedContentRef { mcid, page, scope }))
+}
+
+/// Narrow a `/K` or `/MCID` integer to the `u32` marked-content id space,
+/// rejecting anything that does not fit.
+///
+/// Wrapping instead would make a malformed id collide with a real one: an id
+/// of `2^32 + 5` becomes MCID 5 and duplicates that entry in the page's
+/// reading order. An out-of-range id is dropped rather than guessed at.
+fn checked_mcid(raw: i64) -> Option<u32> {
+    match u32::try_from(raw) {
+        Ok(mcid) => Some(mcid),
+        Err(_) => {
+            log::warn!("Structure tree: marked-content id {raw} is out of range, skipping");
+            None
+        },
+    }
 }
 
 /// Determine the `McidScope` for a marked-content reference dict.

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -775,12 +775,10 @@ fn parse_marked_content_ref(
     Ok(Some(StructChild::MarkedContentRef { mcid, page, scope }))
 }
 
-/// Narrow a `/K` or `/MCID` integer to the `u32` marked-content id space,
-/// rejecting anything that does not fit.
+/// Narrow a `/K` or `/MCID` integer to the `u32` marked-content id space.
 ///
-/// Wrapping instead would make a malformed id collide with a real one: an id
-/// of `2^32 + 5` becomes MCID 5 and duplicates that entry in the page's
-/// reading order. An out-of-range id is dropped rather than guessed at.
+/// Wrapping collides a malformed id with a real one: `2^32 + 5` becomes MCID 5
+/// and duplicates that entry in the page's reading order.
 fn checked_mcid(raw: i64) -> Option<u32> {
     match u32::try_from(raw) {
         Ok(mcid) => Some(mcid),

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -542,6 +542,13 @@ fn recover_from_objstms<R: Read + Seek>(
         let Ok(contained) = crate::objstm::parse_object_stream(&container) else {
             continue;
         };
+        // Ordered by object number: the `get_or_insert` calls below keep the
+        // FIRST candidate they meet, and `parse_object_stream` returns a
+        // `HashMap`, whose iteration order Rust randomizes per instance. Without
+        // this, a damaged file carrying two page trees recovers a different one
+        // between reconstructions of the same bytes.
+        let mut contained: Vec<(u32, Object)> = contained.into_iter().collect();
+        contained.sort_by_key(|(num, _)| *num);
         for (num, obj) in contained {
             match obj
                 .as_dict()

--- a/src/xref_reconstruction.rs
+++ b/src/xref_reconstruction.rs
@@ -542,11 +542,9 @@ fn recover_from_objstms<R: Read + Seek>(
         let Ok(contained) = crate::objstm::parse_object_stream(&container) else {
             continue;
         };
-        // Ordered by object number: the `get_or_insert` calls below keep the
-        // FIRST candidate they meet, and `parse_object_stream` returns a
-        // `HashMap`, whose iteration order Rust randomizes per instance. Without
-        // this, a damaged file carrying two page trees recovers a different one
-        // between reconstructions of the same bytes.
+        // `get_or_insert` below keeps the first candidate it meets, and
+        // `parse_object_stream` returns a `HashMap` whose iteration order Rust
+        // randomizes per instance — so the walk has to be ordered.
         let mut contained: Vec<(u32, Object)> = contained.into_iter().collect();
         contained.sort_by_key(|(num, _)| *num);
         for (num, obj) in contained {

--- a/tests/malformed_render_input.rs
+++ b/tests/malformed_render_input.rs
@@ -1,0 +1,176 @@
+//! Renderer robustness against malformed, document-controlled geometry.
+//!
+//! Every construct here is legal PDF syntax carrying out-of-range values.
+//! The renderer must skip the construct and return a `Result` — never panic,
+//! and never fabricate a plausible-but-wrong result.
+
+#![cfg(feature = "rendering")]
+
+use pdf_oxide::document::PdfDocument;
+use pdf_oxide::rendering::{render_page, render_separations, RenderOptions};
+
+/// Assemble a PDF with a correct xref from raw object bodies.
+/// `objects[i]` is the body of object i+1 (no "N 0 obj"/"endobj" wrapper).
+fn build_pdf(objects: &[Vec<u8>]) -> Vec<u8> {
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"%PDF-1.4\n");
+    let mut offsets = Vec::new();
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(out.len());
+        out.extend_from_slice(format!("{} 0 obj\n", i + 1).as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref_pos = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
+    out.extend_from_slice(b"0000000000 65535 f \n");
+    for off in &offsets {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            objects.len() + 1,
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+fn obj(s: &str) -> Vec<u8> {
+    s.as_bytes().to_vec()
+}
+
+fn stream_obj(dict: &str, data: &[u8]) -> Vec<u8> {
+    let mut v = format!("<< {} /Length {} >>\nstream\n", dict, data.len()).into_bytes();
+    v.extend_from_slice(data);
+    v.extend_from_slice(b"\nendstream");
+    v
+}
+
+/// A Type 1 shading whose `/Function` is a Type 3 stitching function with an
+/// empty `/Domain`. The stitching function has no sub-domain to select from,
+/// so it contributes no colour; the page must still render.
+#[test]
+fn stitching_function_with_empty_domain_renders() {
+    let objects = vec![
+        obj("<< /Type /Catalog /Pages 2 0 R >>"),
+        obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 40 40] /Contents 4 0 R \
+             /Resources << /Shading << /Sh0 5 0 R >> >> >>"),
+        stream_obj("", b"q /Sh0 sh Q"),
+        obj("<< /ShadingType 1 /ColorSpace /DeviceRGB /Domain [0 1 0 1] /Function 6 0 R >>"),
+        obj("<< /FunctionType 3 /Domain [] /Functions [7 0 R] /Bounds [] /Encode [0 1] >>"),
+        obj("<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0] /C1 [1 1 1] >>"),
+    ];
+    let doc = PdfDocument::from_bytes(build_pdf(&objects)).expect("synthetic PDF parses");
+
+    let img = render_page(&doc, 0, &RenderOptions::default())
+        .expect("page with an empty-domain stitching function renders");
+    assert!(!img.data.is_empty(), "renderer produced an empty buffer");
+}
+
+/// A Type 0 sampled function declaring a `/Size` grid far larger than its
+/// sample stream. The declared grid overflows the flat-index arithmetic, so
+/// the function must be rejected rather than indexed with a wrapped offset.
+#[test]
+fn sampled_function_size_larger_than_stream_renders() {
+    let samples = vec![0u8; 64];
+    let objects = vec![
+        obj("<< /Type /Catalog /Pages 2 0 R >>"),
+        obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 40 40] /Contents 4 0 R \
+             /Resources << /Shading << /Sh0 5 0 R >> >> >>"),
+        stream_obj("", b"q /Sh0 sh Q"),
+        obj("<< /ShadingType 1 /ColorSpace /DeviceRGB /Domain [0 1 0 1] /Function 6 0 R >>"),
+        // Two input dimensions with ~2^32 samples each: the stride reaches 2^64.
+        stream_obj(
+            "/FunctionType 0 /Domain [0 1 0 1] /Range [0 1 0 1 0 1] \
+             /Size [4294967296 4294967296] /BitsPerSample 8",
+            &samples,
+        ),
+    ];
+    let doc = PdfDocument::from_bytes(build_pdf(&objects)).expect("synthetic PDF parses");
+
+    let img = render_page(&doc, 0, &RenderOptions::default())
+        .expect("page with an oversized sampled function renders");
+    assert!(!img.data.is_empty(), "renderer produced an empty buffer");
+}
+
+fn separation_imagemask_pdf(w: &str, h: &str) -> Vec<u8> {
+    let stencil: Vec<u8> = vec![0x00; 8];
+    let objects = vec![
+        obj("<< /Type /Catalog /Pages 2 0 R >>"),
+        obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R \
+             /Resources << /XObject << /Im1 5 0 R >> /ColorSpace << /CS1 6 0 R >> >> >>"),
+        stream_obj("", b"q\n/CS1 cs\n1 scn\n50 0 0 50 25 25 cm\n/Im1 Do\nQ\n"),
+        stream_obj(
+            &format!(
+                "/Type /XObject /Subtype /Image /Width {w} /Height {h} \
+                 /ImageMask true /BitsPerComponent 1"
+            ),
+            &stencil,
+        ),
+        obj("[/Separation /Pantone-185 /DeviceCMYK 7 0 R]"),
+        obj("<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0 0] /C1 [0 0.85 0.45 0] >>"),
+    ];
+    build_pdf(&objects)
+}
+
+/// A separation `/ImageMask` with negative dimensions. Only the sign differs
+/// from the control below, so a clean render proves the dimensions are
+/// rejected rather than reinterpreted as a near-`usize::MAX` pixel count.
+#[test]
+fn separation_image_mask_negative_dimensions_render() {
+    let control = PdfDocument::from_bytes(separation_imagemask_pdf("8", "8")).expect("parse");
+    let control_plates =
+        render_separations(&control, 0, 72).expect("8x8 control image mask renders");
+    assert!(
+        !control_plates.is_empty(),
+        "control produced no separation plates, so the image-mask path is not reached"
+    );
+
+    let doc = PdfDocument::from_bytes(separation_imagemask_pdf("-1", "-1")).expect("parse");
+    let plates =
+        render_separations(&doc, 0, 72).expect("page with a negative-dimension image mask renders");
+    assert_eq!(
+        plates.len(),
+        control_plates.len(),
+        "skipping the malformed mask must not drop the separation plates"
+    );
+}
+
+fn masked_image_pdf(mask_dict: &str, mask_data: &[u8]) -> Vec<u8> {
+    let objects = vec![
+        obj("<< /Type /Catalog /Pages 2 0 R >>"),
+        obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        obj("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 50 50] /Contents 4 0 R \
+             /Resources << /XObject << /Im0 5 0 R >> >> >>"),
+        stream_obj("", b"q 20 0 0 20 10 10 cm /Im0 Do Q"),
+        stream_obj(
+            "/Type /XObject /Subtype /Image /Width 2 /Height 2 \
+             /ColorSpace /DeviceGray /BitsPerComponent 8 /Mask 6 0 R",
+            &[0x10u8, 0x20, 0x30, 0x40],
+        ),
+        stream_obj(mask_dict, mask_data),
+    ];
+    build_pdf(&objects)
+}
+
+/// An image whose `/Mask` sub-image is zero pixels wide. There is no mask
+/// sample to read, so the mask is skipped and the base image still paints.
+#[test]
+fn zero_width_mask_sub_image_renders() {
+    let pdf = masked_image_pdf(
+        "/Type /XObject /Subtype /Image /Width 0 /Height 1 \
+         /ColorSpace /DeviceGray /BitsPerComponent 8",
+        &[],
+    );
+    let doc = PdfDocument::from_bytes(pdf).expect("synthetic PDF parses");
+
+    let img = render_page(&doc, 0, &RenderOptions::default())
+        .expect("page with a zero-width mask renders");
+    assert!(!img.data.is_empty(), "renderer produced an empty buffer");
+}

--- a/tests/malformed_render_input.rs
+++ b/tests/malformed_render_input.rs
@@ -174,3 +174,83 @@ fn zero_width_mask_sub_image_renders() {
         .expect("page with a zero-width mask renders");
     assert!(!img.data.is_empty(), "renderer produced an empty buffer");
 }
+
+/// Build a page carrying one `/AP` dictionary with the given entries, or no
+/// annotation at all when `ap_entries` is `None`.
+fn annotation_ap_pdf(ap_entries: Option<&str>) -> Vec<u8> {
+    let red =
+        stream_obj("/Type /XObject /Subtype /Form /BBox [0 0 30 30]", b"1 0 0 rg 0 0 30 30 re f");
+    let green =
+        stream_obj("/Type /XObject /Subtype /Form /BBox [0 0 30 30]", b"0 1 0 rg 0 0 30 30 re f");
+    let annots = match ap_entries {
+        Some(_) => "/Annots [5 0 R]",
+        None => "",
+    };
+    let annot = match ap_entries {
+        Some(ap) => {
+            format!("<< /Type /Annot /Subtype /Square /Rect [10 10 40 40] /F 4 /AP << {ap} >> >>")
+        },
+        None => "<< /Type /Annot /Subtype /Square /Rect [10 10 40 40] /F 4 >>".to_string(),
+    };
+    let objects = vec![
+        obj("<< /Type /Catalog /Pages 2 0 R >>"),
+        obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+        obj(&format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 50 50] /Contents 4 0 R {annots} >>"
+        )),
+        stream_obj("", b""),
+        obj(&annot),
+        red,
+        green,
+    ];
+    build_pdf(&objects)
+}
+
+/// Render the same bytes `n` times, reparsing each time, and return the set of
+/// distinct pixel buffers.
+fn distinct_renders(pdf: &[u8], n: usize) -> std::collections::HashSet<Vec<u8>> {
+    let mut distinct = std::collections::HashSet::new();
+    for _ in 0..n {
+        let doc = PdfDocument::from_bytes(pdf.to_vec()).expect("synthetic PDF parses");
+        let img = render_page(&doc, 0, &RenderOptions::default()).expect("page renders");
+        distinct.insert(img.data);
+    }
+    distinct
+}
+
+/// ISO 32000-1 §12.5.5: `/N` is the normal appearance. An `/AP` carrying only
+/// `/D` and `/R` has no normal appearance, so nothing is drawn — picking an
+/// arbitrary sibling stream made identical bytes render differently per run.
+#[test]
+fn annotation_appearance_without_normal_entry_draws_nothing() {
+    let blank = distinct_renders(&annotation_ap_pdf(None), 1)
+        .into_iter()
+        .next()
+        .expect("baseline render");
+
+    let renders = distinct_renders(&annotation_ap_pdf(Some("/D 6 0 R /R 7 0 R")), 64);
+    assert_eq!(renders.len(), 1, "identical bytes produced {} distinct renders", renders.len());
+    assert_eq!(
+        renders.into_iter().next().expect("one render"),
+        blank,
+        "an /AP without /N must draw no appearance"
+    );
+}
+
+/// Control: the same annotation WITH `/N` draws that stream, deterministically.
+/// Without this the test above would also pass if annotations stopped rendering.
+#[test]
+fn annotation_appearance_with_normal_entry_is_deterministic() {
+    let blank = distinct_renders(&annotation_ap_pdf(None), 1)
+        .into_iter()
+        .next()
+        .expect("baseline render");
+
+    let renders = distinct_renders(&annotation_ap_pdf(Some("/N 6 0 R /R 7 0 R")), 64);
+    assert_eq!(renders.len(), 1, "identical bytes produced {} distinct renders", renders.len());
+    assert_ne!(
+        renders.into_iter().next().expect("one render"),
+        blank,
+        "the /N appearance stream must actually be drawn"
+    );
+}

--- a/tests/malformed_render_input.rs
+++ b/tests/malformed_render_input.rs
@@ -142,6 +142,27 @@ fn separation_image_mask_negative_dimensions_render() {
     );
 }
 
+/// A separation `/ImageMask` whose declared geometry is positive, in range and
+/// overflows nothing — and which no stream of any size could back. Rejecting
+/// only unrepresentable dimensions still let this one through to an allocation
+/// sized from the declaration: 2^31 x 2^31 is 2^62 bytes.
+#[test]
+fn separation_image_mask_larger_than_its_stream_renders() {
+    let control = PdfDocument::from_bytes(separation_imagemask_pdf("8", "8")).expect("parse");
+    let control_plates =
+        render_separations(&control, 0, 72).expect("8x8 control image mask renders");
+
+    let doc = PdfDocument::from_bytes(separation_imagemask_pdf("2147483648", "2147483648"))
+        .expect("parse");
+    let plates = render_separations(&doc, 0, 72)
+        .expect("page with an image mask larger than its stream renders");
+    assert_eq!(
+        plates.len(),
+        control_plates.len(),
+        "skipping the unbacked mask must not drop the separation plates"
+    );
+}
+
 fn masked_image_pdf(mask_dict: &str, mask_data: &[u8]) -> Vec<u8> {
     let objects = vec![
         obj("<< /Type /Catalog /Pages 2 0 R >>"),

--- a/tests/malformed_render_input.rs
+++ b/tests/malformed_render_input.rs
@@ -99,7 +99,10 @@ fn sampled_function_size_larger_than_stream_renders() {
 }
 
 fn separation_imagemask_pdf(w: &str, h: &str) -> Vec<u8> {
-    let stencil: Vec<u8> = vec![0x00; 8];
+    separation_imagemask_pdf_with(w, h, "", &[0x00; 8])
+}
+
+fn separation_imagemask_pdf_with(w: &str, h: &str, extra_dict: &str, stencil: &[u8]) -> Vec<u8> {
     let objects = vec![
         obj("<< /Type /Catalog /Pages 2 0 R >>"),
         obj("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
@@ -109,14 +112,23 @@ fn separation_imagemask_pdf(w: &str, h: &str) -> Vec<u8> {
         stream_obj(
             &format!(
                 "/Type /XObject /Subtype /Image /Width {w} /Height {h} \
-                 /ImageMask true /BitsPerComponent 1"
+                 /ImageMask true /BitsPerComponent 1{extra_dict}"
             ),
-            &stencil,
+            stencil,
         ),
         obj("[/Separation /Pantone-185 /DeviceCMYK 7 0 R]"),
         obj("<< /FunctionType 2 /Domain [0 1] /N 1 /C0 [0 0 0 0] /C1 [0 0.85 0.45 0] >>"),
     ];
     build_pdf(&objects)
+}
+
+fn pantone_plate(pdf: Vec<u8>) -> pdf_oxide::rendering::SeparationPlate {
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    render_separations(&doc, 0, 72)
+        .expect("separations render")
+        .into_iter()
+        .find(|p| p.ink_name == "Pantone-185")
+        .expect("Pantone-185 plate emitted")
 }
 
 /// A separation `/ImageMask` with negative dimensions. Only the sign differs
@@ -160,6 +172,37 @@ fn separation_image_mask_larger_than_its_stream_renders() {
         plates.len(),
         control_plates.len(),
         "skipping the unbacked mask must not drop the separation plates"
+    );
+}
+
+/// A CCITT-compressed separation stencil. The decode chain passes
+/// `/CCITTFaxDecode` through raw, so the mask path receives the compressed
+/// bytes — fewer than the 8 the 8x8 geometry needs. The mask must be skipped,
+/// not expanded from zero-padded compressed bytes (padded 0-bits mean "paint",
+/// so padding fabricates ink the file never specified). Skipping loses the
+/// mask's real ink until this path grows a CCITT decode like the page
+/// renderer's stencil path has; this test pins the skip-not-fabricate half.
+#[test]
+fn ccitt_separation_image_mask_is_skipped_not_fabricated() {
+    // Control: an uncompressed all-paint stencil must put ink on the plate,
+    // proving the assertion below is reached through a painting mask path.
+    let control = pantone_plate(separation_imagemask_pdf("8", "8"));
+    assert!(
+        control.data.iter().any(|&v| v > 0),
+        "control stencil painted no ink, so the mask path is not reached"
+    );
+
+    // Payload bytes are never decoded (pass-through); only their length —
+    // shorter than the 8-byte 8x8 geometry, as compressed data is — matters.
+    let plate = pantone_plate(separation_imagemask_pdf_with(
+        "8",
+        "8",
+        " /Filter /CCITTFaxDecode /DecodeParms << /K -1 /Columns 8 /Rows 8 >>",
+        &[0x25, 0x88, 0x40, 0x80],
+    ));
+    assert!(
+        plate.data.iter().all(|&v| v == 0),
+        "a stencil the decoded stream cannot back must be skipped, not painted from padding"
     );
 }
 

--- a/tests/objstm_recovery_determinism.rs
+++ b/tests/objstm_recovery_determinism.rs
@@ -1,0 +1,71 @@
+//! Recovering a damaged file must pick the same page tree every time.
+//!
+//! `recover_from_objstms` keeps the first `/Type /Pages` it meets while walking
+//! what an object stream yields. That walk has to be ordered by object number:
+//! `parse_object_stream` returns a `HashMap`, and Rust seeds each map instance
+//! separately, so an unordered walk lets the same bytes recover a different
+//! page tree between reconstructions inside one process.
+
+use pdf_oxide::object::Object;
+use pdf_oxide::xref_reconstruction::reconstruct_xref;
+use std::io::Cursor;
+
+/// The object number the recovered Catalog points its `/Pages` at.
+fn synthesized_pages_target(synthetic: &[(pdf_oxide::object::ObjectRef, Object)]) -> Option<u32> {
+    synthetic.iter().find_map(|(_, obj)| {
+        let dict = obj.as_dict()?;
+        if dict.get("Type").and_then(|t| t.as_name()) != Some("Catalog") {
+            return None;
+        }
+        match dict.get("Pages")? {
+            Object::Reference(r) => Some(r.id),
+            _ => None,
+        }
+    })
+}
+
+/// One object stream holding two `/Type /Pages` objects, numbered 3 and 4, in a
+/// file with no usable xref so reconstruction has to run.
+fn pdf_with_two_page_trees_in_an_objstm() -> Vec<u8> {
+    let page_tree = b"<</Type/Pages/Kids[]/Count 0>>";
+    let mut objects = Vec::new();
+    objects.extend_from_slice(page_tree);
+    objects.push(b' ');
+    objects.extend_from_slice(page_tree);
+
+    let pairs = format!("3 0 4 {} ", page_tree.len() + 1);
+    let first = pairs.len();
+    let mut data = pairs.into_bytes();
+    data.extend_from_slice(&objects);
+
+    let dict = format!("<< /Type /ObjStm /N 2 /First {} /Length {} >>", first, data.len());
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n1 0 obj\n");
+    pdf.extend_from_slice(dict.as_bytes());
+    pdf.extend_from_slice(b"\nstream\n");
+    pdf.extend_from_slice(&data);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n%%EOF\n");
+    pdf
+}
+
+#[test]
+fn recovery_picks_the_same_page_tree_every_run() {
+    let pdf = pdf_with_two_page_trees_in_an_objstm();
+
+    // Repeated in ONE process: each `HashMap` instance is seeded separately, so
+    // this alternates without needing separate runs.
+    let mut seen = Vec::new();
+    for _ in 0..64 {
+        let mut cursor = Cursor::new(pdf.clone());
+        let (_xref, _trailer, synthetic) =
+            reconstruct_xref(&mut cursor).expect("recovery finds the packed page trees");
+        seen.push(synthesized_pages_target(&synthetic));
+    }
+
+    let first = seen[0];
+    assert!(
+        seen.iter().all(|&r| r == first),
+        "recovered page tree varies between reconstructions: {seen:?}"
+    );
+    assert_eq!(first, Some(3), "recovery must anchor on the lowest-numbered page tree");
+}

--- a/tests/structure_mcid_range.rs
+++ b/tests/structure_mcid_range.rs
@@ -1,0 +1,119 @@
+//! `/K` marked-content ids that do not fit a `u32` must be rejected, not wrapped.
+//!
+//! A structure element's `/K` may carry integer children (bare MCIDs) and
+//! marked-content reference dictionaries carrying `/MCID`. Both are `u32` in
+//! the reading-order model. Truncating a wider or negative integer into that
+//! `u32` makes a malformed id alias a real one, which silently corrupts the
+//! page's reading order rather than dropping the bad entry.
+
+use pdf_oxide::PdfDocument;
+
+fn obj(buf: &mut Vec<u8>, off: &mut [usize], id: usize, body: &str) {
+    off[id] = buf.len();
+    buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+}
+
+fn stream(buf: &mut Vec<u8>, off: &mut [usize], id: usize, data: &[u8]) {
+    off[id] = buf.len();
+    buf.extend_from_slice(format!("{id} 0 obj\n<< /Length {} >>\nstream\n", data.len()).as_bytes());
+    buf.extend_from_slice(data);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+}
+
+fn finish(buf: &mut Vec<u8>, off: &[usize], max_id: usize) {
+    let xref = buf.len();
+    buf.extend_from_slice(format!("xref\n0 {}\n0000000000 65535 f \n", max_id + 1).as_bytes());
+    for id in 1..=max_id {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n", max_id + 1).as_bytes(),
+    );
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+}
+
+/// A one-page tagged PDF whose single paragraph carries the given `/K` body.
+/// The page's content stream declares one real marked-content id, MCID 5.
+fn tagged_pdf_with_k(k_body: &str) -> Vec<u8> {
+    let content = b"BT /F1 12 Tf\n\
+        /P <</MCID 5>> BDC 1 0 0 1 60 700 Tm (Real content with MCID five) Tj EMC\n\
+        ET\n";
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 9];
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(
+        &mut buf,
+        &mut off,
+        1,
+        "<< /Type /Catalog /Pages 2 0 R /MarkInfo << /Marked true >> /StructTreeRoot 7 0 R >>",
+    );
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 6 0 R >> >> /Contents 4 0 R /StructParents 0 >>",
+    );
+    stream(&mut buf, &mut off, 4, content);
+    obj(&mut buf, &mut off, 5, "<< >>");
+    obj(&mut buf, &mut off, 6, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    obj(&mut buf, &mut off, 7, "<< /Type /StructTreeRoot /K [8 0 R] >>");
+    obj(
+        &mut buf,
+        &mut off,
+        8,
+        &format!("<< /Type /StructElem /S /P /P 7 0 R /Pg 3 0 R /K {k_body} >>"),
+    );
+    finish(&mut buf, &off, 8);
+    buf
+}
+
+fn reading_order(k_body: &str) -> Vec<u32> {
+    let doc = PdfDocument::from_bytes(tagged_pdf_with_k(k_body)).expect("fixture parses");
+    let tree = doc
+        .structure_tree()
+        .expect("structure tree read")
+        .expect("structure tree present");
+    pdf_oxide::structure::extract_reading_order(&tree, 0).expect("reading order")
+}
+
+#[test]
+fn k_mcid_above_u32_max_is_skipped_not_wrapped() {
+    // 4294967301 is 2^32 + 5. Truncated to u32 it becomes 5 and aliases the
+    // page's real MCID 5, so the page reports MCID 5 twice.
+    let order = reading_order("[4294967301 5]");
+    assert_eq!(order, vec![5], "out-of-range /K child aliased onto the real MCID 5");
+}
+
+#[test]
+fn negative_k_mcid_is_skipped_not_wrapped() {
+    let order = reading_order("-1");
+    assert!(
+        order.is_empty(),
+        "negative /K child was kept as {order:?} instead of being skipped"
+    );
+}
+
+#[test]
+fn negative_k_mcid_in_an_array_is_skipped_not_wrapped() {
+    let order = reading_order("[-1 5]");
+    assert_eq!(order, vec![5], "negative /K child was not skipped: {order:?}");
+}
+
+#[test]
+fn out_of_range_mcr_mcid_is_skipped_not_wrapped() {
+    // The marked-content reference dictionary form of the same defect.
+    let order = reading_order("[<< /Type /MCR /Pg 3 0 R /MCID 4294967301 >> 5]");
+    assert_eq!(
+        order,
+        vec![5],
+        "out-of-range /MCID in an /MCR dict aliased onto the real MCID 5"
+    );
+}
+
+#[test]
+fn in_range_k_mcids_are_unaffected() {
+    let order = reading_order("[5]");
+    assert_eq!(order, vec![5]);
+}

--- a/tests/structure_mcid_range.rs
+++ b/tests/structure_mcid_range.rs
@@ -1,10 +1,11 @@
-//! `/K` marked-content ids that do not fit a `u32` must be rejected, not wrapped.
+//! Marked-content ids that do not fit a `u32` must be rejected, not wrapped.
 //!
-//! A structure element's `/K` may carry integer children (bare MCIDs) and
-//! marked-content reference dictionaries carrying `/MCID`. Both are `u32` in
-//! the reading-order model. Truncating a wider or negative integer into that
-//! `u32` makes a malformed id alias a real one, which silently corrupts the
-//! page's reading order rather than dropping the bad entry.
+//! The id space is written from two sides: a structure element's `/K` (bare
+//! integer MCIDs and `/MCR` dictionaries carrying `/MCID`) and the content
+//! stream's BDC property dictionaries. All are `u32` in the reading-order
+//! model. Truncating a wider or negative integer into that `u32` makes a
+//! malformed id alias a real one, which silently corrupts the page's reading
+//! order rather than dropping the bad entry.
 
 use pdf_oxide::PdfDocument;
 
@@ -116,4 +117,62 @@ fn out_of_range_mcr_mcid_is_skipped_not_wrapped() {
 fn in_range_k_mcids_are_unaffected() {
     let order = reading_order("[5]");
     assert_eq!(order, vec![5]);
+}
+
+/// A one-page untagged PDF whose content stream carries the given BDC bodies.
+/// Same id-space contract as the `/K` fixtures above, exercised from the
+/// content-stream (BDC `/MCID`) side.
+fn pdf_with_content(content: &str) -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 6];
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    stream(&mut buf, &mut off, 4, content.as_bytes());
+    obj(&mut buf, &mut off, 5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    finish(&mut buf, &off, 5);
+    buf
+}
+
+fn span_mcids(bad_mcid: &str) -> Vec<(String, Option<u32>)> {
+    let content = format!(
+        "BT /F1 12 Tf\n\
+         /P <</MCID {bad_mcid}>> BDC 1 0 0 1 60 700 Tm (Aliased) Tj EMC\n\
+         /P <</MCID 5>> BDC 1 0 0 1 60 650 Tm (Real) Tj EMC\n\
+         ET\n"
+    );
+    let doc = PdfDocument::from_bytes(pdf_with_content(&content)).expect("fixture parses");
+    let spans = doc.extract_spans(0).expect("spans extract");
+    spans.into_iter().map(|s| (s.text, s.mcid)).collect()
+}
+
+fn mcid_of(spans: &[(String, Option<u32>)], needle: &str) -> Option<u32> {
+    spans
+        .iter()
+        .find(|(text, _)| text.contains(needle))
+        .unwrap_or_else(|| panic!("no span containing {needle:?} in {spans:?}"))
+        .1
+}
+
+#[test]
+fn bdc_mcid_above_u32_max_is_dropped_not_wrapped() {
+    // 4294967301 is 2^32 + 5. Truncated to u32 it becomes 5 and aliases the
+    // real MCID 5 region in the same content stream.
+    let spans = span_mcids("4294967301");
+    assert_eq!(mcid_of(&spans, "Aliased"), None, "out-of-range BDC /MCID aliased a real id");
+    assert_eq!(mcid_of(&spans, "Real"), Some(5));
+}
+
+#[test]
+fn negative_bdc_mcid_is_dropped_not_wrapped() {
+    let spans = span_mcids("-1");
+    assert_eq!(mcid_of(&spans, "Aliased"), None, "negative BDC /MCID was kept");
+    assert_eq!(mcid_of(&spans, "Real"), Some(5));
 }


### PR DESCRIPTION
## Linked issue

Closes #997.

## What and why

Seven defects on the read path. Five crash on a file that opened cleanly. Two return a different answer on every run. Each defect starts from legal PDF syntax carrying an out-of-range value. The file parses, and it only fails once something reads the geometry.

| construct | on `main` | after |
|---|---|---|
| FunctionType 3 (stitching) function with empty `/Domain`, under a ShadingType 1 | panics | function rejected, shading skipped, page renders |
| Type 0 `/Size` bigger than its sample stream | panics | function rejected, page renders |
| `/Mask` sub-image 0 px wide or tall | panics | mask ignored, base image still paints |
| Separation `/ImageMask`, negative or unbacked size | aborts, asks for a 2^62-byte buffer | mask skipped, other plates intact |
| Annotation `/AP` with no `/N` | paints whichever sibling the `HashMap` yields first | draws nothing (§12.5.5) |
| `/K` marked-content id above `u32` | wraps, aliasing a real id | entry skipped |
| Damaged file, several page trees | recovers a different one per run | the same one, every run (ascending container order, `/Parent`-less root preferred) |

The seven fall into three shapes. Each defect class gets one commit, and the rationale sits in the commit bodies.

**Shape 1: malformed geometry panics the renderer.** `fix(render): reject out-of-range shading and image-mask geometry` bounds the declared grid against the sample stream. It does this once, up front. The stride and flat-index products then cannot overflow.

`fix(render): reject a separation image mask its stream cannot back` reuses `PageRenderer::image_mask_layout`. That helper already implements and tests this contract.

**Shape 2: marked-content ids wrapped instead of being rejected.** `fix(structure): reject out-of-range marked-content ids instead of wrapping` puts `u32::try_from` at all three cast sites, and the guard covers the other entry point too.

The content-stream `BDC /MCID` reader carried the identical `as u32` wrap. So `2^32 + 5` in a content stream aliased a real MCID 5. Both sides now route through the same `checked_mcid` guard. An out-of-range id behaves as a BDC with no `/MCID`.

**Shape 3: two read paths returned a different answer per run.** `fix(render): draw only the normal appearance stream of an annotation` removes the `/N`-less fallback. It does not merely order it. Painting `/D` on a static page is wrong in every iteration order.

`fix(recovery): pick the same page tree every time a damaged file is rebuilt` orders the recovery walk by object number. The nondeterminism sits *within* one process, because Rust seeds each `HashMap` instance separately. It therefore reproduces without separate runs.

**One deliberate behaviour change.** An `/AP` with `/D` or `/R` but no `/N` now renders blank instead of a press or hover state. With more than one entry it was previously a coin flip. This replaces randomness, not a settled result.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after** (revert-checked against v0.3.77). Every reproducer is a minimal synthetic PDF built in code.
- [x] Test named by defect **class**, not an issue/PR number; no contributor or company names in code or fixtures.
- [ ] `cargo test` passes, **and** the affected feature tiers: `rendering`. Left unticked: the Rust test jobs (`Test (…)`, `Rendering Tests`, `Feature Tests`) are still queued on the current head commit. There is nothing to attest to yet.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean. I verified `cargo fmt --check` on this head commit. `clippy -D warnings` was green on CI for the preceding commit, and the only change since is rustfmt line breaks.

These tests ship with the fixes: the seven reproducers below, and the marked-content overflow and negative cases with an in-range control. `ccitt_separation_image_mask_is_skipped_not_fabricated` covers the separation-stencil behaviour described under regression.

<details>
<summary><b>Verification</b>: red on v0.3.77, green after</summary>

On v0.3.77 the suite does not finish. The separation mask aborts the binary.

```text
running 7 tests
test zero_width_mask_sub_image_renders ... FAILED
test stitching_function_with_empty_domain_renders ... FAILED
test sampled_function_size_larger_than_stream_renders ... FAILED
memory allocation of 4611686018427387904 bytes failed
  process didn't exit successfully: (signal: 6, SIGABRT)
```

4611686018427387904 = 2^62 = `/Width 2147483648` x `/Height 2147483648`.

I re-ran the cases individually, so the cut-short ones still report:

```text
separation_image_mask_negative_dimensions_render      FAILED  panicked at separation_renderer.rs:3062
annotation_appearance_without_normal_entry_draws_nothing  FAILED  2 distinct renders, left: 2 right: 1
separation_image_mask_larger_than_its_stream_renders  SIGABRT
annotation_appearance_with_normal_entry_is_deterministic  ok      <- control, passes before too
```

After: `7 passed; 0 failed`.

Recovery, 64 reconstructions in one process:

```text
recovered page tree varies: [Some(3), Some(4), Some(3), Some(3), Some(4), ...]
```

Marked-content ids:

```text
k_mcid_above_u32_max_is_skipped_not_wrapped   left: [5, 5]           right: [5]
negative_k_mcid_is_skipped_not_wrapped        left: [4294967295, 5]  right: [5]
```

</details>

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 9,749 PDFs from my own collection. They are govdocs1 crawled .gov (manuals, spec tables, scanned forms, engineering reports), arXiv, PubMed Central OA, IRS forms, and pdf.js fixtures.

`corpus_sig` is not enough here. It hashes `extract_text`/`extract_words` and never renders. That makes it blind to `mesh_shading.rs`, `separation_renderer.rs` and both `page_renderer.rs` edits. This sweep renders instead.

- [x] Diffed against **`main`**. Every page of every document, **9,748 of 9,749 docs, 288,899 pages**. Per page: raster hash. Per document: text, table count, image geometry, and two in-process reconstructions.
- [ ] Diffed against the **latest release** (`v0.3.77`): same sweep; `main` is v0.3.77.
- [x] Judged with a structural metric: byte-identity of the rendered raster, not char-Levenshtein.

**Diff summary vs `main`:** one page changed, and it is the change this PR intends.

That page is `govdocs_033_033815.pdf` page 2. It carries a `/Widget` whose `/AP` holds only `/D`:

```text
page index 0  annots: 0
page index 1  annots: 1          <- the differing page
   [0] Subtype=/Widget  AP=['/D']  has_N=False
```

Nothing else moved. No text, table, image or reconstruction column changed, on any document. Page 0 alone was identical across all 9,749, so this only appears when every page is compared.

`govdocs_020_020747.pdf` is not covered: it aborts on `main` too (#1001), so neither arm can render it.

**Diff summary vs latest release:** not run separately. The sweep ran against `main`, which is at the v0.3.77 release commit.

**Scope caveat.** This render sweep never calls `render_separations`, and `paint_image_mask_to_plates` is reachable only through it. The byte-identity result therefore says nothing about `separation_renderer.rs`. That file's coverage is the synthetic cases plus the test added above.

The mask skip has one consequence on real files. CCITTFaxDecode is pass-through in the decode chain. CCITT-compressed separation stencils therefore always arrive shorter than their geometry needs. They are now skipped, where base painted zero-padded garbage.

The separation stencil path has no CCITT decode, though the page renderer's stencil path does. Until the separation path grows one, such stencils drop their ink instead of painting garbage. That is a follow-up candidate. So is consolidating the three independent Type 0 sampled-function evaluators, which now each carry their own bounds check.

<details>
<summary><b>Malformed-input coverage</b></summary>

Five of these constructs cannot occur in a well-formed file. A corpus sweep alone therefore cannot tell "the fix works" from "the fix is unreachable". Hence two arms.

**Arm A, regression.** Per document, both arms: raster hash per page, `extract_text`, `extract_tables`, `extract_images`, two reconstructions in one process. Byte-identity is the bar.

**Arm B, reach.** 56 generated documents: 29 malformed, 27 controls, over four entry points (28 `render_page`, 13 `extract_reading_order`, 8 `reconstruct_xref`, 7 `render_separations`).

Each case runs in a child process, with a deadline, 64 times. How the 29 malformed rows fail on `main`:

| how `main` fails | release | dev |
|---|---|---|
| panics | 8 | 9 |
| returns a different result than the fix | 11 | 11 |
| varies between identical runs | 8 | 8 |
| aborts (SIGABRT; `catch_unwind` cannot see it) | 1 | 1 |
| hangs (34 GB buffer from a truncated `/Width`) | 1 | 0 |

The release and dev columns differ because several defects are integer overflows. They abort a debug build. In a release build they silently compute a wrong index.

The gate exits non-zero on any of three conditions. A malformed case survives on both arms. A control's digest moves. The fix arm panics, aborts, hangs or varies.

```text
case                             main/release   main/dev
annotation_ap_d_and_r            varies:2       varies:2
annotation_ap_d_only             differs        differs
annotation_ap_r_only             differs        differs
mask_gray_both_zero              panic          panic
mask_gray_zero_height            panic          panic
mask_gray_zero_width             panic          panic
mcid_array_aliases_five          differs        differs
mcid_array_i64_max               differs        differs
mcid_array_negative_one          differs        differs
mcid_array_u32_max_plus_one      differs        differs
mcid_bare_aliases_five           differs        differs
mcid_bare_negative_one           differs        differs
mcid_mcr_aliases_five            differs        differs
mcid_mcr_negative_one            differs        differs
recovery_2_page_trees            varies:2       varies:2
recovery_3_page_trees            varies:3       varies:3
recovery_4_page_trees            varies:4       varies:4
recovery_5_page_trees            varies:5       varies:5
recovery_6_page_trees            varies:6       varies:6
recovery_7_page_trees            varies:7       varies:7
recovery_8_page_trees            varies:8       varies:8
separation_mask_i64_max          panic          panic
separation_mask_neg_one          panic          panic
separation_mask_neg_width_only   abort:sig6     panic
separation_mask_two_pow_31       abort:sig6     abort:sig6
shading_type0_size_over          differs        differs
shading_type0_size_overflow      panic          panic
shading_type0_size_u32max        panic          panic
shading_type3_domain_empty       panic          panic

27 controls: identical on both profiles.
56 case(s) x 2 profile(s), 0 blocker(s)      <- the branch as it ships
```

**Sabotage run.** I also checked the gate against a run that is supposed to fail. That run is this branch with `src/structure/parser.rs` restored to its `main` state, nothing else changed. 8 blockers is the pass condition there: exactly the eight cases that fix is responsible for. The other 48 stay green.

```text
mcid_array_aliases_five        survived   survived   <-- BLOCKER
mcid_array_i64_max             survived   survived   <-- BLOCKER
mcid_array_negative_one        survived   survived   <-- BLOCKER
mcid_array_u32_max_plus_one    survived   survived   <-- BLOCKER
mcid_bare_aliases_five         survived   survived   <-- BLOCKER
mcid_bare_negative_one         survived   survived   <-- BLOCKER
mcid_mcr_aliases_five          survived   survived   <-- BLOCKER
mcid_mcr_negative_one          survived   survived   <-- BLOCKER

56 case(s) x 2 profile(s), 8 blocker(s)      <- with parser.rs deleted
```

**What it cannot see.** Not your corpus. The generated documents prove these shapes, not every malformed file. Nothing here touches the writer, editor, signing or compliance paths.

</details>

<details>
<summary><b>Wider corpus inventory</b>: 19,151 documents, ~470,000 pages, run twice with matching results</summary>

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

| Verification surface | Scale | Result |
|---|---|---|
| synthesized malformed suite | 22 crash families | 44 baseline crashes drop to 6 |
| clean-corpus null | 470k pages | one page differs on revert; no clean-page regressions observed |

On the synthesized malformed corpus the baseline is 44 crashing families. This branch reduces them to 6, fixing 19 of the 22 families it targets.

**Observability caveat.** Reverting this fix changes only one page of 470k on the clean corpus. Its regression evidence therefore rests on the synthetic suite and unit tests rather than the sweep.

</details>

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: used throughout for investigation, the fixes, the test and sweep harnesses, and drafting this description.
- [x] I understand and can explain every line; the description and my review replies are written by me, not generated. This PR is not fully or predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off**.
- [ ] Docs/`CHANGELOG.md` updated if user-facing. Not done. `CHANGELOG.md` is written per release under a version heading and has no `[Unreleased]` section, so this looks like yours to write at release time.
- [x] Public-API changes considered for semver: none; `image_mask_layout` moved from private to `pub(crate)`.



