### PR TITLE
fix(content): restore text state in the prescan for streams over 256 KB

### DIFF
--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -5623,16 +5623,16 @@ mod tests {
 
         let injected = last_region_injected(&ops);
         assert!(
-            injected
-                .iter()
-                .any(|op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.5).abs() < 1e-6)),
+            injected.iter().any(
+                |op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.5).abs() < 1e-6)
+            ),
             "inherited Tc not injected: {:?}",
             injected
         );
         assert!(
-            injected
-                .iter()
-                .any(|op| matches!(op, Operator::Tw { word_space } if (*word_space - 0.25).abs() < 1e-6)),
+            injected.iter().any(
+                |op| matches!(op, Operator::Tw { word_space } if (*word_space - 0.25).abs() < 1e-6)
+            ),
             "inherited Tw not injected: {:?}",
             injected
         );
@@ -5715,9 +5715,7 @@ mod tests {
 
         let injected = last_region_injected(&ops);
         assert!(
-            !injected
-                .iter()
-                .any(|op| matches!(op, Operator::Tc { .. })),
+            !injected.iter().any(|op| matches!(op, Operator::Tc { .. })),
             "Tc from a closed q/Q scope must not leak into a later region: {:?}",
             injected
         );

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -687,7 +687,6 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
     // in ctm_stack to avoid String cloning on every q/Q.
     let mut font_table: Vec<(String, f32)> = Vec::new();
     let mut current_font_idx: Option<usize> = None;
-    #[allow(clippy::type_complexity)]
     let mut ctm_stack: Vec<(
         Matrix,
         Option<usize>,

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -5597,6 +5597,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_prescan_merged_region_injects_earliest_state() {
+        // Two BT blocks close enough that marked-content extension merges them
+        // into one region. The merge keeps one state for the whole span, and it
+        // must be the state at the EARLIEST text position — the state in effect
+        // where parsing actually starts. Keeping a later block's state would
+        // apply char spacing the first block never had.
+        //
+        // This holds because region starts are monotonic in BT position
+        // (nearest-preceding BDC is monotonic, and the pos-256 clamp only
+        // tightens as pos grows), so sorting by start never reorders. The test
+        // pins that invariant rather than leaving it to inspection.
+        let mut cs = Vec::new();
+        for i in 0..14000u32 {
+            let line = format!(
+                "{}.0 {}.0 m {}.0 {}.0 l n\n",
+                i % 500,
+                (i * 7) % 500,
+                (i * 3) % 500,
+                (i * 11) % 500
+            );
+            cs.extend_from_slice(line.as_bytes());
+        }
+        assert!(cs.len() > 256 * 1024);
+
+        cs.extend_from_slice(b"3 Tc\n");
+        cs.extend_from_slice(b"/Span <</MCID 0>> BDC\n");
+        cs.extend_from_slice(b"BT (First) Tj ET\n");
+        cs.extend_from_slice(b"7 Tc\n");
+        cs.extend_from_slice(b"BT (Second) Tj ET\n");
+        cs.extend_from_slice(b"EMC\n");
+
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let first_tc = ops.iter().find_map(|op| match op {
+            Operator::Tc { char_space } => Some(*char_space),
+            _ => None,
+        });
+        assert_eq!(
+            first_tc,
+            Some(3.0),
+            "merged region must inject the earliest block's char spacing, got {first_tc:?}"
+        );
+    }
+
     /// Build a stream with two BT regions separated by >256KB of path filler,
     /// forcing the prescan's forward-scan path. `first_region` is the body of
     /// the first BT block (state setters + show ops).

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -869,7 +869,6 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                         }
                     }
                     num_count = 0;
-                    last_name = None;
                 },
                 b"Tc" => {
                     if num_count >= 1 {

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -600,12 +600,12 @@ pub fn parse_content_stream_text_only(data: &[u8]) -> Result<Vec<Operator>> {
 
 /// Text-state parameters tracked by [`forward_scan_ctm`].
 ///
-/// These persist across `BT`/`ET` (ISO 32000-1 §9.3.1 — only `Tm` resets at
-/// `BT`) and are saved/restored by `q`/`Q`, so a BT block may rely on a value
-/// set by an earlier block or between blocks. The prescan path parses each
-/// region in isolation inside a synthesized SaveState/RestoreState wrap, which
-/// would silently reset them; the scan tracks them so the region wrapper can
-/// re-inject the inherited values.
+/// These persist across `BT`/`ET` (ISO 32000-1 §9.3 — `BT` resets only the
+/// text and line matrices, §9.4.1) and are saved/restored by `q`/`Q`, so a
+/// BT block may rely on a value set by an earlier block or between blocks.
+/// The prescan path parses each region in isolation inside a synthesized
+/// SaveState/RestoreState wrap, which would silently reset them; the scan
+/// tracks them so the region wrapper can re-inject the inherited values.
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct PrescanTextState {
     /// Character spacing (`Tc`).
@@ -655,9 +655,11 @@ struct PrescanState {
 
 /// Lightweight forward scan that tracks graphics state across the full content stream.
 ///
-/// Scans the stream recognizing only `q`, `Q`, `cm`, `Tf`, and the persistent
+/// Scans the stream recognizing only `q`, `Q`, `cm`, `Tf`, the persistent
 /// text-state operators (`Tc`, `Tw`, `Tz`, `TL`, `Ts`, `Tr`, plus `TD`'s
-/// implicit leading), skipping all path, color, and text-showing operators.
+/// implicit leading and `"`'s implicit `Tw`/`Tc`), and the fill-color
+/// operators (`rg`, `g`, `k`, `cs`, `sc`, `scn`), skipping all path and
+/// text-showing operators.
 /// Records the accumulated CTM, font, and text state at each position in
 /// `text_positions`.
 ///
@@ -956,10 +958,11 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                 },
                 b"sc" => {
                     // Operands are the TAIL of the rolling buffer, like every
-                    // other arm. More than 4 means a color space this replay
-                    // cannot represent (and the rotated buffer has lost the
-                    // leading operands) — inject nothing rather than a
-                    // truncated, plausible-looking wrong color.
+                    // other arm. The buffer holds 6, so at 7+ operands the
+                    // leading ones have rotated away and a full count no
+                    // longer proves a complete window; replay only the 1-4
+                    // component device-sized spaces rather than a truncated,
+                    // plausible-looking wrong color.
                     if (1..=4).contains(&num_count) {
                         fill_op = Some(Operator::SetFillColor {
                             components: num_buf[..num_count].to_vec(),
@@ -987,7 +990,24 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
             continue;
         }
 
-        // Skip string literals to avoid false matches
+        // `'` and `"` are the only operators that don't start with an
+        // alphabetic byte. `aw ac string "` also persistently sets the word
+        // and character spacing, like `Tw`/`Tc` (§9.4.3); the operands
+        // survive the string skip because strings don't reset the buffer.
+        if b == b'"' || b == b'\'' {
+            if b == b'"' && num_count >= 2 {
+                text_state.word_spacing = num_buf[num_count - 2];
+                text_state.char_spacing = num_buf[num_count - 1];
+            }
+            num_count = 0;
+            last_name = None;
+            i += 1;
+            continue;
+        }
+
+        // Skip string literals to avoid false matches. Numeric operands are
+        // kept: they may belong to a following `"`, and any other operator
+        // resets the buffer itself.
         if b == b'(' {
             i += 1;
             let mut depth = 1u32;
@@ -1000,7 +1020,6 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                 }
                 i += 1;
             }
-            num_count = 0;
             continue;
         }
         if b == b'<' {
@@ -1019,8 +1038,9 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                         i += 1;
                     }
                 }
+                num_count = 0;
             } else {
-                // Hex string <...>
+                // Hex string <...> — operands kept, like literal strings.
                 i += 1;
                 while i < len && data[i] != b'>' {
                     i += 1;
@@ -1029,7 +1049,6 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     i += 1;
                 }
             }
-            num_count = 0;
             continue;
         }
 
@@ -5617,10 +5636,11 @@ mod tests {
 
     #[test]
     fn test_prescan_injects_inherited_text_state() {
-        // Tc, Tw, and the leading persist across BT/ET (ISO 32000-1 §9.3.1;
-        // only Tm resets at BT), so the second region legitimately runs with
-        // the first region's values. The prescan path parses each region in
-        // an isolated SaveState/RestoreState wrap; without reconstruction the
+        // Tc, Tw, and the leading persist across BT/ET (ISO 32000-1 §9.3;
+        // BT resets only the text and line matrices, §9.4.1), so the second
+        // region legitimately runs with the first region's values. The
+        // prescan path parses each region in an isolated
+        // SaveState/RestoreState wrap; without reconstruction the
         // second region's T* would step by zero leading and every advance
         // would lose Tc — glyphs land on the wrong line, slightly compressed
         // (govdocs_040_040921.pdf p22, govdocs_055_055555.pdf p23).
@@ -5652,6 +5672,65 @@ mod tests {
                 .iter()
                 .any(|op| matches!(op, Operator::TL { leading } if (*leading - 12.0).abs() < 1e-6)),
             "leading set via TD not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_injects_double_quote_spacing() {
+        // `aw ac string "` persistently sets the word and character spacing
+        // (ISO 32000-1 §9.4.3), exactly like `Tw`/`Tc` — a later region
+        // relies on the persisted values the same way.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf 12 TL 1.5 0.3 (A) \"");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            injected.iter().any(
+                |op| matches!(op, Operator::Tw { word_space } if (*word_space - 1.5).abs() < 1e-6)
+            ),
+            "Tw persisted by \" not injected: {:?}",
+            injected
+        );
+        assert!(
+            injected.iter().any(
+                |op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.3).abs() < 1e-6)
+            ),
+            "Tc persisted by \" not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_double_quote_hex_string_operand() {
+        // The string operand of `"` may be a hex string; the numeric
+        // operands must survive the <...> skip too.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf 12 TL 2.0 0.5 <41> \"");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            injected.iter().any(
+                |op| matches!(op, Operator::Tw { word_space } if (*word_space - 2.0).abs() < 1e-6)
+            ),
+            "Tw persisted by \" with hex string not injected: {:?}",
+            injected
+        );
+        assert!(
+            injected.iter().any(
+                |op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.5).abs() < 1e-6)
+            ),
+            "Tc persisted by \" with hex string not injected: {:?}",
             injected
         );
     }

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -922,6 +922,7 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                             b: num_buf[num_count - 1],
                         });
                     }
+                    fill_space = None;
                     num_count = 0;
                 },
                 b"g" => {
@@ -930,6 +931,7 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                             gray: num_buf[num_count - 1],
                         });
                     }
+                    fill_space = None;
                     num_count = 0;
                 },
                 b"k" => {
@@ -941,6 +943,7 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                             k: num_buf[num_count - 1],
                         });
                     }
+                    fill_space = None;
                     num_count = 0;
                 },
                 b"cs" => {
@@ -953,17 +956,22 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     num_count = 0;
                 },
                 b"sc" => {
-                    if num_count >= 1 {
+                    // Operands are the TAIL of the rolling buffer, like every
+                    // other arm. More than 4 means a color space this replay
+                    // cannot represent (and the rotated buffer has lost the
+                    // leading operands) — inject nothing rather than a
+                    // truncated, plausible-looking wrong color.
+                    if (1..=4).contains(&num_count) {
                         fill_op = Some(Operator::SetFillColor {
-                            components: num_buf[..num_count.min(4)].to_vec(),
+                            components: num_buf[..num_count].to_vec(),
                         });
                     }
                     num_count = 0;
                 },
                 b"scn" => {
-                    if num_count >= 1 || last_name.is_some() {
+                    if (1..=4).contains(&num_count) || (num_count == 0 && last_name.is_some()) {
                         fill_op = Some(Operator::SetFillColorN {
-                            components: num_buf[..num_count.min(4)].to_vec(),
+                            components: num_buf[..num_count].to_vec(),
                             name: last_name.take().map(Box::new),
                         });
                     }
@@ -973,6 +981,10 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     num_count = 0;
                 },
             }
+            // A name operand belongs to the operator that follows it; once any
+            // operator has executed, a surviving `last_name` is stale. Without
+            // this, `/GS0 gs 0.5 scn` fabricated a pattern named GS0.
+            last_name = None;
             continue;
         }
 
@@ -5697,6 +5709,50 @@ mod tests {
                     if (*r - 0.2).abs() < 1e-6 && (*g - 0.4).abs() < 1e-6 && (*b - 0.6).abs() < 1e-6
             )),
             "inherited fill color not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_scn_does_not_inherit_stale_name() {
+        // `/GS0 gs 0.5 scn`: the name operand belongs to `gs`; the scanner
+        // must not hand it to `scn` as a pattern name.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET /GS0 gs 0.5 scn BT (X) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected
+                .iter()
+                .any(|op| matches!(op, Operator::SetFillColorN { name: Some(_), .. })),
+            "stale name fabricated a pattern: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_scn_with_too_many_operands_injects_nothing() {
+        // A 6-component scn (DeviceN) exceeds what the rolling buffer can
+        // faithfully replay; a truncated color would be plausible and wrong.
+        let cs =
+            two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET 0.1 0.2 0.3 0.4 0.5 0.6 scn BT (X) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected.iter().any(|op| matches!(
+                op,
+                Operator::SetFillColor { .. } | Operator::SetFillColorN { .. }
+            )),
+            "truncated color injected: {:?}",
             injected
         );
     }

--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -598,6 +598,43 @@ pub fn parse_content_stream_text_only(data: &[u8]) -> Result<Vec<Operator>> {
     Ok(operators)
 }
 
+/// Text-state parameters tracked by [`forward_scan_ctm`].
+///
+/// These persist across `BT`/`ET` (ISO 32000-1 §9.3.1 — only `Tm` resets at
+/// `BT`) and are saved/restored by `q`/`Q`, so a BT block may rely on a value
+/// set by an earlier block or between blocks. The prescan path parses each
+/// region in isolation inside a synthesized SaveState/RestoreState wrap, which
+/// would silently reset them; the scan tracks them so the region wrapper can
+/// re-inject the inherited values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct PrescanTextState {
+    /// Character spacing (`Tc`).
+    char_spacing: f32,
+    /// Word spacing (`Tw`).
+    word_spacing: f32,
+    /// Horizontal scaling percentage (`Tz`).
+    horiz_scaling: f32,
+    /// Text leading (`TL`, and `TD`'s implicit `TL = -ty`).
+    leading: f32,
+    /// Text rise (`Ts`).
+    rise: f32,
+    /// Text rendering mode (`Tr`).
+    render_mode: u8,
+}
+
+impl Default for PrescanTextState {
+    fn default() -> Self {
+        PrescanTextState {
+            char_spacing: 0.0,
+            word_spacing: 0.0,
+            horiz_scaling: 100.0,
+            leading: 0.0,
+            rise: 0.0,
+            render_mode: 0,
+        }
+    }
+}
+
 /// Graphics state snapshot captured at a text position by [`forward_scan_ctm`].
 #[derive(Debug)]
 struct PrescanState {
@@ -605,13 +642,24 @@ struct PrescanState {
     ctm: (f32, f32, f32, f32, f32, f32),
     /// Current font name and size from the most recent `Tf` operator, if any.
     font: Option<(String, f32)>,
+    /// Persistent text-state parameters at this position.
+    text: PrescanTextState,
+    /// Fill color space set by `cs`, if any. Replayed before `fill_op` so the
+    /// components are interpreted in the right space.
+    fill_space: Option<String>,
+    /// Most recent fill-color operator (`rg`/`g`/`k`/`sc`/`scn`), if any.
+    /// Glyph color comes from the fill state, so losing this across region
+    /// boundaries turns colored text black (`chars_hash`-only sweep diffs).
+    fill_op: Option<Operator>,
 }
 
 /// Lightweight forward scan that tracks graphics state across the full content stream.
 ///
-/// Scans the stream recognizing only `q`, `Q`, `cm`, and `Tf` operators, skipping
-/// all path, color, and text operators. Records the accumulated CTM and font state
-/// at each position in `text_positions`.
+/// Scans the stream recognizing only `q`, `Q`, `cm`, `Tf`, and the persistent
+/// text-state operators (`Tc`, `Tw`, `Tz`, `TL`, `Ts`, `Tr`, plus `TD`'s
+/// implicit leading), skipping all path, color, and text-showing operators.
+/// Records the accumulated CTM, font, and text state at each position in
+/// `text_positions`.
 ///
 /// This is much cheaper than full parsing. Numeric operands are tracked in a
 /// rolling buffer so `cm` operands are always available when the operator is
@@ -637,8 +685,18 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
     // in ctm_stack to avoid String cloning on every q/Q.
     let mut font_table: Vec<(String, f32)> = Vec::new();
     let mut current_font_idx: Option<usize> = None;
-    let mut ctm_stack: Vec<(Matrix, Option<usize>)> = Vec::with_capacity(32);
+    #[allow(clippy::type_complexity)]
+    let mut ctm_stack: Vec<(
+        Matrix,
+        Option<usize>,
+        PrescanTextState,
+        Option<String>,
+        Option<Operator>,
+    )> = Vec::with_capacity(32);
     let mut ctm = Matrix::identity();
+    let mut text_state = PrescanTextState::default();
+    let mut fill_space: Option<String> = None;
+    let mut fill_op: Option<Operator> = None;
 
     // Rolling buffer of recent numeric operands (for cm's 6 floats)
     let mut num_buf: [f32; 6] = [0.0; 6];
@@ -658,6 +716,9 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
         .map(|_| PrescanState {
             ctm: (0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
             font: None,
+            text: PrescanTextState::default(),
+            fill_space: None,
+            fill_op: None,
         })
         .collect();
 
@@ -671,6 +732,9 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
             results[orig_idx] = PrescanState {
                 ctm: (ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f),
                 font: current_font_idx.map(|idx| font_table[idx].clone()),
+                text: text_state,
+                fill_space: fill_space.clone(),
+                fill_op: fill_op.clone(),
             };
             next_tp_idx += 1;
         }
@@ -758,13 +822,24 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     continue;
                 },
                 b"q" => {
-                    ctm_stack.push((ctm, current_font_idx));
+                    ctm_stack.push((
+                        ctm,
+                        current_font_idx,
+                        text_state,
+                        fill_space.clone(),
+                        fill_op.clone(),
+                    ));
                     num_count = 0;
                 },
                 b"Q" => {
-                    if let Some((saved_ctm, saved_font_idx)) = ctm_stack.pop() {
+                    if let Some((saved_ctm, saved_font_idx, saved_text, saved_space, saved_fill)) =
+                        ctm_stack.pop()
+                    {
                         ctm = saved_ctm;
                         current_font_idx = saved_font_idx;
+                        text_state = saved_text;
+                        fill_space = saved_space;
+                        fill_op = saved_fill;
                     }
                     num_count = 0;
                 },
@@ -795,6 +870,104 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
                     }
                     num_count = 0;
                     last_name = None;
+                },
+                b"Tc" => {
+                    if num_count >= 1 {
+                        text_state.char_spacing = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Tw" => {
+                    if num_count >= 1 {
+                        text_state.word_spacing = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Tz" => {
+                    if num_count >= 1 {
+                        text_state.horiz_scaling = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"TL" => {
+                    if num_count >= 1 {
+                        text_state.leading = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Ts" => {
+                    if num_count >= 1 {
+                        text_state.rise = num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"Tr" => {
+                    if num_count >= 1 {
+                        text_state.render_mode = num_buf[num_count - 1] as u8;
+                    }
+                    num_count = 0;
+                },
+                b"TD" => {
+                    // `tx ty TD` also sets the leading to -ty (§9.4.2).
+                    if num_count >= 2 {
+                        text_state.leading = -num_buf[num_count - 1];
+                    }
+                    num_count = 0;
+                },
+                b"rg" => {
+                    if num_count >= 3 {
+                        fill_op = Some(Operator::SetFillRgb {
+                            r: num_buf[num_count - 3],
+                            g: num_buf[num_count - 2],
+                            b: num_buf[num_count - 1],
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"g" => {
+                    if num_count >= 1 {
+                        fill_op = Some(Operator::SetFillGray {
+                            gray: num_buf[num_count - 1],
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"k" => {
+                    if num_count >= 4 {
+                        fill_op = Some(Operator::SetFillCmyk {
+                            c: num_buf[num_count - 4],
+                            m: num_buf[num_count - 3],
+                            y: num_buf[num_count - 2],
+                            k: num_buf[num_count - 1],
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"cs" => {
+                    // `cs` resets the fill color to the space's initial value,
+                    // so any earlier color operator no longer applies.
+                    if let Some(name) = last_name.take() {
+                        fill_space = Some(name);
+                        fill_op = None;
+                    }
+                    num_count = 0;
+                },
+                b"sc" => {
+                    if num_count >= 1 {
+                        fill_op = Some(Operator::SetFillColor {
+                            components: num_buf[..num_count.min(4)].to_vec(),
+                        });
+                    }
+                    num_count = 0;
+                },
+                b"scn" => {
+                    if num_count >= 1 || last_name.is_some() {
+                        fill_op = Some(Operator::SetFillColorN {
+                            components: num_buf[..num_count.min(4)].to_vec(),
+                            name: last_name.take().map(Box::new),
+                        });
+                    }
+                    num_count = 0;
                 },
                 _ => {
                     num_count = 0;
@@ -885,6 +1058,9 @@ fn forward_scan_ctm(data: &[u8], text_positions: &[usize]) -> Option<Vec<Prescan
         results[orig_idx] = PrescanState {
             ctm: (ctm.a, ctm.b, ctm.c, ctm.d, ctm.e, ctm.f),
             font: current_font_idx.map(|idx| font_table[idx].clone()),
+            text: text_state,
+            fill_space: fill_space.clone(),
+            fill_op: fill_op.clone(),
         };
         next_tp_idx += 1;
     }
@@ -1313,6 +1489,16 @@ where
                         let (a, b, c, d, e, f) = state.ctm;
                         handler(Operator::SaveState)?;
                         handler(Operator::Cm { a, b, c, d, e, f })?;
+                        // Re-inject inherited fill color: glyph color reads the
+                        // fill state, which the region wrap would otherwise
+                        // reset to black. Space first so components are
+                        // interpreted in the right color space.
+                        if let Some(ref name) = state.fill_space {
+                            handler(Operator::SetFillColorSpace { name: name.clone() })?;
+                        }
+                        if let Some(ref op) = state.fill_op {
+                            handler(op.clone())?;
+                        }
                         // Inject font state if the forward scan tracked one.
                         // This handles BT blocks that inherit Tf from a prior
                         // scope instead of setting their own.
@@ -1320,6 +1506,41 @@ where
                             handler(Operator::Tf {
                                 font: font_name.clone(),
                                 size: font_size,
+                            })?;
+                        }
+                        // Re-inject inherited text state the same way. These
+                        // parameters persist across BT/ET, so a region may rely
+                        // on a value set by an earlier region — which the
+                        // SaveState/RestoreState wrap would otherwise reset.
+                        // Only non-default values are injected, keeping the
+                        // operator stream unchanged for the common case.
+                        let ts = &state.text;
+                        if ts.char_spacing != 0.0 {
+                            handler(Operator::Tc {
+                                char_space: ts.char_spacing,
+                            })?;
+                        }
+                        if ts.word_spacing != 0.0 {
+                            handler(Operator::Tw {
+                                word_space: ts.word_spacing,
+                            })?;
+                        }
+                        if ts.horiz_scaling != 100.0 {
+                            handler(Operator::Tz {
+                                scale: ts.horiz_scaling,
+                            })?;
+                        }
+                        if ts.leading != 0.0 {
+                            handler(Operator::TL {
+                                leading: ts.leading,
+                            })?;
+                        }
+                        if ts.rise != 0.0 {
+                            handler(Operator::Ts { rise: ts.rise })?;
+                        }
+                        if ts.render_mode != 0 {
+                            handler(Operator::Tr {
+                                render: ts.render_mode,
                             })?;
                         }
                         parse_region_text_only(&data[*start..*end], &mut handler)?;
@@ -5343,6 +5564,162 @@ mod tests {
             tf_ops.len() >= 2,
             "expected Tf for both BT blocks (explicit + inherited), got {}",
             tf_ops.len()
+        );
+    }
+
+    /// Build a stream with two BT regions separated by >256KB of path filler,
+    /// forcing the prescan's forward-scan path. `first_region` is the body of
+    /// the first BT block (state setters + show ops).
+    fn two_region_prescan_stream(first_region: &[u8]) -> Vec<u8> {
+        let mut cs = Vec::new();
+        cs.extend_from_slice(b"BT ");
+        cs.extend_from_slice(first_region);
+        cs.extend_from_slice(b" ET\n");
+        for i in 0..14000u32 {
+            let line = format!(
+                "{}.0 {}.0 m {}.0 {}.0 l n\n",
+                i % 500,
+                (i * 7) % 500,
+                (i * 3) % 500,
+                (i * 11) % 500
+            );
+            cs.extend_from_slice(line.as_bytes());
+        }
+        assert!(cs.len() > 256 * 1024, "stream must exceed 256KB prescan threshold");
+        cs.extend_from_slice(b"BT (B) Tj T* (C) Tj ET\n");
+        cs
+    }
+
+    /// The operators injected for the LAST region: everything between the
+    /// final SaveState and the final BeginText.
+    fn last_region_injected(ops: &[Operator]) -> &[Operator] {
+        let last_bt = ops
+            .iter()
+            .rposition(|op| matches!(op, Operator::BeginText))
+            .expect("no BeginText");
+        let save = ops[..last_bt]
+            .iter()
+            .rposition(|op| matches!(op, Operator::SaveState))
+            .expect("no SaveState before last BeginText");
+        &ops[save..last_bt]
+    }
+
+    #[test]
+    fn test_prescan_injects_inherited_text_state() {
+        // Tc, Tw, and the leading persist across BT/ET (ISO 32000-1 §9.3.1;
+        // only Tm resets at BT), so the second region legitimately runs with
+        // the first region's values. The prescan path parses each region in
+        // an isolated SaveState/RestoreState wrap; without reconstruction the
+        // second region's T* would step by zero leading and every advance
+        // would lose Tc — glyphs land on the wrong line, slightly compressed
+        // (govdocs_040_040921.pdf p22, govdocs_055_055555.pdf p23).
+        let cs = two_region_prescan_stream(b"/F1 10 Tf 0.5 Tc 0.25 Tw 0 -12 TD (A) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            injected
+                .iter()
+                .any(|op| matches!(op, Operator::Tc { char_space } if (*char_space - 0.5).abs() < 1e-6)),
+            "inherited Tc not injected: {:?}",
+            injected
+        );
+        assert!(
+            injected
+                .iter()
+                .any(|op| matches!(op, Operator::Tw { word_space } if (*word_space - 0.25).abs() < 1e-6)),
+            "inherited Tw not injected: {:?}",
+            injected
+        );
+        assert!(
+            injected
+                .iter()
+                .any(|op| matches!(op, Operator::TL { leading } if (*leading - 12.0).abs() < 1e-6)),
+            "leading set via TD not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_does_not_inject_default_text_state() {
+        // A first region that never touches text state must not cause any
+        // text-state operator to be synthesized for the second region.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected.iter().any(|op| matches!(
+                op,
+                Operator::Tc { .. }
+                    | Operator::Tw { .. }
+                    | Operator::Tz { .. }
+                    | Operator::TL { .. }
+                    | Operator::Ts { .. }
+                    | Operator::Tr { .. }
+            )),
+            "default text state must not be injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_injects_inherited_fill_color() {
+        // Glyph color reads the fill state, which persists across BT/ET like
+        // the rest of the graphics state. A region relying on a color set
+        // before or in an earlier region must get it re-injected, or colored
+        // text silently turns black on the prescan path (the old vec parser
+        // preserved color operators, so this shows up as chars_hash-only
+        // sweep diffs).
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET 0.2 0.4 0.6 rg BT (X) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            injected.iter().any(|op| matches!(
+                op,
+                Operator::SetFillRgb { r, g, b }
+                    if (*r - 0.2).abs() < 1e-6 && (*g - 0.4).abs() < 1e-6 && (*b - 0.6).abs() < 1e-6
+            )),
+            "inherited fill color not injected: {:?}",
+            injected
+        );
+    }
+
+    #[test]
+    fn test_prescan_text_state_respects_q_restore() {
+        // Text state set inside a q/Q scope is restored at Q, so it must not
+        // be injected into a region that begins after the Q.
+        let cs = two_region_prescan_stream(b"/F1 10 Tf (A) Tj ET q 3 Tc BT (X) Tj ET Q BT (Y) Tj");
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let injected = last_region_injected(&ops);
+        assert!(
+            !injected
+                .iter()
+                .any(|op| matches!(op, Operator::Tc { .. })),
+            "Tc from a closed q/Q scope must not leak into a later region: {:?}",
+            injected
         );
     }
 

--- a/tests/prescan_state_over_256kb.rs
+++ b/tests/prescan_state_over_256kb.rs
@@ -1,0 +1,135 @@
+//! Text state must survive the >256 KB prescan boundary.
+//!
+//! Streams past 256 KB route through the SIMD prescan, which parses each
+//! text region in isolation. State set before a region — the font, its
+//! size, the fill colour, a `"` operator's spacing operands — belongs to
+//! the region all the same. The fixture sets state early, crosses the
+//! boundary with ~280 KB of path filler, and draws text that never restates
+//! it; the extracted spans must carry the state from before the boundary.
+//!
+//! No crawled corpus document exercises this boundary, so the fixture is
+//! built in code and asserts its own reachability: the content stream must
+//! actually exceed 256 * 1024 bytes or the test proves nothing.
+
+use pdf_oxide::PdfDocument;
+
+/// One-page PDF whose content stream crosses the prescan threshold.
+/// Layout: red 24 pt text state + one marker line, ~280 KB of path filler,
+/// then two text blocks that rely on earlier state:
+/// - "After the big stream" with no `Tf` after the boundary;
+/// - a `"` (quote) operator with word spacing 40 set by its own operand.
+fn big_stream_pdf() -> Vec<u8> {
+    big_stream_pdf_with_quote_spacing("40")
+}
+
+/// The same page with the `"` operator's word-spacing operand substituted:
+/// the differential pair for the injection test below.
+fn big_stream_pdf_with_quote_spacing(aw: &str) -> Vec<u8> {
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(
+        b"BT /F1 24 Tf 1 0 0 rg 1 0 0 1 100 700 Tm (Before the big stream) Tj ET\n",
+    );
+    for _ in 0..20000 {
+        content.extend_from_slice(b"0 0 m 1 1 l S\n");
+    }
+    content.extend_from_slice(b"BT 1 0 0 1 100 600 Tm (After the big stream) Tj ET\n");
+    content.extend_from_slice(
+        format!(
+            "BT /F1 12 Tf 1 0 0 1 100 500 Tm (first line) Tj 0 -20 TD {aw} 2 (quote line) \" ET\n"
+        )
+        .as_bytes(),
+    );
+    // Path filler between text blocks, so the trailing block sits in its own
+    // prescan region and can only see the quote's Tw through state injection.
+    for _ in 0..500 {
+        content.extend_from_slice(b"0 0 m 1 1 l S\n");
+    }
+    content.extend_from_slice(b"BT /F1 12 Tf 1 0 0 1 100 400 Tm (space separated words) Tj ET\n");
+    assert!(content.len() > 256 * 1024, "fixture must cross the prescan threshold");
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = [0usize; 6];
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    {
+        let mut obj = |buf: &mut Vec<u8>, off: &mut [usize; 6], id: usize, body: &str| {
+            off[id] = buf.len();
+            buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+        };
+        obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+        obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        obj(
+            &mut buf,
+            &mut off,
+            3,
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        );
+        off[4] = buf.len();
+        buf.extend_from_slice(
+            format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes(),
+        );
+        buf.extend_from_slice(&content);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+        obj(&mut buf, &mut off, 5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    }
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for id in 1..=5 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+#[test]
+fn text_state_survives_the_prescan_boundary() {
+    let doc = PdfDocument::from_bytes(big_stream_pdf()).expect("fixture parses");
+    let text = doc.extract_text(0).expect("extract_text");
+    assert!(
+        text.contains("After the big stream"),
+        "text after the boundary must extract: {text:?}"
+    );
+
+    let spans = doc.extract_spans(0).expect("extract_spans");
+    let after = spans
+        .iter()
+        .find(|s| s.text.contains("After the big stream"))
+        .expect("span after the boundary");
+    assert!(
+        (after.font_size - 24.0).abs() < 0.01,
+        "the 24 pt Tf from before the boundary must reach the span, got {}",
+        after.font_size
+    );
+    assert!(
+        after.color.r > 0.9 && after.color.g < 0.1,
+        "the red fill from before the boundary must reach the span, got {:?}",
+        after.color
+    );
+}
+
+/// The `"` operator's Tw operand is persistent state: text drawn in a later
+/// prescan region must still be spaced by it. The pair differs only in the
+/// operand (0 vs 40), so the trailing span — two word gaps — must widen by
+/// exactly 80 pt; without operand tracking through the prescan the two
+/// fixtures render identically.
+#[test]
+fn quote_operator_spacing_survives_the_prescan_boundary() {
+    let width_of_trailing = |aw: &str| -> f32 {
+        let doc =
+            PdfDocument::from_bytes(big_stream_pdf_with_quote_spacing(aw)).expect("fixture parses");
+        let spans = doc.extract_spans(0).expect("extract_spans");
+        spans
+            .iter()
+            .filter(|s| s.text.contains("space separated words"))
+            .map(|s| s.bbox.width)
+            .fold(0.0, f32::max)
+    };
+    let narrow = width_of_trailing("0");
+    let wide = width_of_trailing("40");
+    assert!(
+        (wide - narrow - 80.0).abs() < 1.0,
+        "40 pt of word spacing across two spaces must widen the trailing span by 80 pt: \
+         aw=0 width {narrow}, aw=40 width {wide}"
+    );
+}

--- a/tests/prescan_state_over_256kb.rs
+++ b/tests/prescan_state_over_256kb.rs
@@ -51,7 +51,7 @@ fn big_stream_pdf_with_quote_spacing(aw: &str) -> Vec<u8> {
     let mut off = [0usize; 6];
     buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
     {
-        let mut obj = |buf: &mut Vec<u8>, off: &mut [usize; 6], id: usize, body: &str| {
+        let obj = |buf: &mut Vec<u8>, off: &mut [usize; 6], id: usize, body: &str| {
             off[id] = buf.len();
             buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
         };


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #1081 and #1083.** Those two remove the remaining sources of nondeterminism in `main`; ~~#1008~~ is merged (landed as 690711ed). Until they land, a corpus comparison against `main` can flag pages that move on their own, so before/after evidence on this PR carries that caveat.

## Linked issue

Closes #1005.

## What and why

Pages over 256 KB take a prescan fast path. That path parses each text region inside a synthesized SaveState/RestoreState wrap. Some text state persists across BT/ET (ISO 32000-1 §9.3): Tc, Tw, leading, and fill colour. The synthesized boundaries reset it, so glyphs landed on the wrong line slightly compressed, and coloured text came out black.

**State reconstruction.** The forward scan tracks the persistent text and fill state. It re-injects that state into each region's wrap. Defaults are not injected, and q/Q scoping is respected. Streams that never set text state produce the same operators as before.

**Colour replay.** A name operand now dies at its operator boundary. `/GS0 gs 0.5 scn` no longer fabricates a pattern named GS0. `sc` and `scn` read the tail of the rolling operand buffer, like every other arm. A colour with more components than the buffer can hold now injects nothing, instead of a truncated, plausible-looking one.

**Quote operators.** `aw ac (text) "` sets Tw and Tc persistently. The scan dispatched only on alphabetic first bytes. The string and hex-string skips also cleared the operands before the scan could read them. Both are fixed, and string skips no longer reset the buffer.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after** (revert-checked). It runs on minimal streams built in code past the 256 KB threshold. No third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no contributor/company names in code or fixtures.
- [ ] `cargo test` passes, **and** the affected feature tiers: none. this is core content parsing. `cargo test --release` was green locally (358 suites). CI results are still outstanding. The previous CI batch was cancelled by runner-queue starvation, so CI has not yet compiled or tested the `src/content/parser.rs` change. This box stays unticked until the current run reports.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

| check | result |
|---|---|
| colour replay isolated against the corpus | extracted text byte-identical on all 455,053 pages; 89 pages change char-level colour only, every one in the >256 KB prescan path |
| state reconstruction | inherited Tc/Tw/leading/fill colour injected; defaults not injected; q/Q scoping respected |

## Regression on real PDFs

**Corpus I tested:** 19,151 documents, ~470,000 pages. Every changed page corpus-wide carries the big-stream class the fix targets. The corpus isolation covers the colour-replay change. The tests above cover state reconstruction and the quote-operator fix.

**The boundary itself is now proven end to end.** No corpus document crosses the 256 KB threshold, so `tests/prescan_state_over_256kb.rs` builds a ~280 KB stream in code and asserts its own size. State set before the boundary — a 24 pt `Tf`, a red fill, a `"` operator's word-spacing operand — must reach the spans extracted after it. Both tests fail on `main` and pass here.

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended regressions (no new word-fusions, over-splits, dropped spans, reversed scripts, or crashes).
- [ ] Diffed my branch against the **latest release** (`v0.3.77`): same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not char-Levenshtein.

**Diff summary vs `main`:** text byte-identical on all 455,053 pages. 89 pages change char-level colour only. All of them are in the >256 KB prescan path.

**Diff summary vs latest release:** not run separately. The sweep was against `main`, whose merge base is the v0.3.77 release commit.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

| Document | Pages | Demonstrates |
|---|---|---|
| [056715.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/056.zip) (056.zip) | 0 | base double-emits the title text; fixed output emits once |
| [027408.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/027.zip) (027.zip) | 9 | flagged "loss" is exactly base's duplicate emission removed |
| [003484.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/003.zip) (003.zip) | 104 | base produced whole-paragraph mega-tokens; word count goes from 104 to 272 with the spacing state restored |

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: extensive
- [x] I understand and can explain every line; the description and my review replies are written by me, not generated. This PR is not fully or predominantly AI-generated.

## Checklist

- [x] One logical change: the >256 KB prescan's state replay.
- [x] Commits follow Conventional Commits and are **DCO signed-off**.
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the CHANGELOG (not in code). No entry here. `CHANGELOG.md` is written per release, under a version heading, with a consolidated contributors block, so it reads as the maintainer's to write at release time.
- [x] Public-API changes considered for semver: there are none.








