### PR TITLE
chore(dependencies): migrate to xberg-ttf-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2062,7 +2062,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3174,7 +3174,6 @@ dependencies = [
  "tiny-skia",
  "tokenizers",
  "tract-onnx",
- "ttf-parser",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-normalization",
@@ -3186,6 +3185,7 @@ dependencies = [
  "weezl 0.2.1",
  "x509-parser",
  "x509-tsp",
+ "xberg-ttf-parser",
 ]
 
 [[package]]
@@ -4174,7 +4174,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4732,7 +4732,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5446,7 +5446,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5685,6 +5685,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xberg-ttf-parser"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0187fcfcd202849428d311f214bdd0429e7afe3ca199df207f30397b1d3b1994"
 
 [[package]]
 name = "y4m"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5688,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "xberg-ttf-parser"
-version = "1.0.14"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0187fcfcd202849428d311f214bdd0429e7afe3ca199df207f30397b1d3b1994"
+checksum = "92b07d4e7aae5dd7a6c145dfbce4f5dbec692b5e1bb56149841401c4f197956b"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,8 +150,9 @@ weezl = "0.2"                                                                  #
 brotli = "8"                                                                   # Brotli compression (PDF 2.0, ISO 32000-2:2020)
 
 # Font parsing
-ttf-parser = "0.25" # TrueType/OpenType parsing: embedded-font cmap, glyph outlines, metrics, name records.
-# Unmaintained (RUSTSEC-2026-0192); fontations (skrifa) migration is upstream-gated — rationale in osv-scanner.toml.
+xberg-ttf-parser = "1.0" # TrueType/OpenType parsing: embedded-font cmap, glyph outlines, metrics, name records.
+# Maintained fork of harfbuzz/ttf-parser 0.25.1 (unmaintained upstream, RUSTSEC-2026-0192). Upstream ttf-parser
+# still reaches the tree transitively via fontdb and ab_glyph — see osv-scanner.toml.
 subsetter = "0.2" # Binary TrueType/OpenType subsetting (Typst's; MIT/Apache). Used by writer-side
 # EmbeddedFont to shrink embedded fonts to only the glyphs actually used.
 taffy = { version = "0.12", default-features = false, features = [

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -58,8 +58,10 @@ id = "RUSTSEC-2026-0192"
 # transitively two ways, neither of which we control:
 #   1. fontdb (system-fonts) -> ttf-parser — latest fontdb 0.23.0 still depends
 #      on it and ships no skrifa/fontations release;
-#   2. imageproc (ml) -> ab_glyph -> owned_ttf_parser -> ttf-parser — likewise
-#      no fontations-based release exists.
+#   2. imageproc (ocr) -> ab_glyph -> owned_ttf_parser -> ttf-parser — likewise
+#      no fontations-based release exists. Note this is the `ocr` feature, not
+#      `ml`: `ml` = ocr-tract + linfa + tokenizers and pulls no ttf-parser at
+#      all, so an `ml`-only build is already clear of the advisory.
 # Both are informational-only exposure: no CVE, no memory-safety or RCE
 # implication. Fully clearing the advisory now requires only that fontdb and
 # ab_glyph move off ttf-parser (or that we replace them) — the direct-usage

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -47,23 +47,23 @@ id = "RUSTSEC-2026-0192"
 # receive no further fixes; its repo has since moved under the harfbuzz org).
 # There is no patched version.
 #
-# Decision: keep waiting. Removing ttf-parser is NOT achievable by a version
-# bump — it reaches the tree three independent ways:
-#   1. directly — we parse embedded-font cmap tables, glyph outlines, metrics
-#      and name records through it (core font parsing + the render outline
-#      path), ~29 call sites;
-#   2. fontdb (system-fonts) -> ttf-parser — latest fontdb 0.23.0 still depends
+# Our *direct* usage no longer hits the unmaintained crate: the core font
+# parsing and render outline paths (~28 call sites across src/fonts/ and
+# src/rendering/text_rasterizer.rs) now use `xberg-ttf-parser`, a maintained
+# fork of harfbuzz/ttf-parser 0.25.1 that carries additional correctness fixes
+# (loca tables at the 65535-glyph limit, bounded composite-glyph and COLRv1
+# graph traversal, avar overflow, CFF dotsection).
+#
+# The advisory still fires because upstream ttf-parser reaches the tree
+# transitively two ways, neither of which we control:
+#   1. fontdb (system-fonts) -> ttf-parser — latest fontdb 0.23.0 still depends
 #      on it and ships no skrifa/fontations release;
-#   3. imageproc (ml) -> ab_glyph -> owned_ttf_parser -> ttf-parser — likewise
+#   2. imageproc (ml) -> ab_glyph -> owned_ttf_parser -> ttf-parser — likewise
 #      no fontations-based release exists.
-# The actively-maintained successor is `skrifa`/`read-fonts` (fontations),
-# already in our tree via subsetter (and via harfrust once the shaping
-# migration off rustybuzz lands). Fully clearing this advisory requires porting
-# our direct usage to skrifa AND replacing both fontdb and ab_glyph with
-# fontations-based equivalents — a large, multi-crate migration touching the
-# core font-parsing and render paths, with real regression risk that is
-# disproportionate while the advisory remains informational-only.
-# Re-evaluate when fontdb or ab_glyph ship a fontations backend, or when the
-# standalone font-stack migration is scheduled.
+# Both are informational-only exposure: no CVE, no memory-safety or RCE
+# implication. Fully clearing the advisory now requires only that fontdb and
+# ab_glyph move off ttf-parser (or that we replace them) — the direct-usage
+# half of the migration is done.
+# Re-evaluate when fontdb or ab_glyph ship a fontations backend.
 ignoreUntil = 2026-12-31
 

--- a/src/fonts/font_dict.rs
+++ b/src/fonts/font_dict.rs
@@ -481,7 +481,7 @@ impl FontInfo {
                 if font_data.is_empty() {
                     return None;
                 }
-                let face = match ttf_parser::Face::parse(font_data, 0) {
+                let face = match xberg_ttf_parser::Face::parse(font_data, 0) {
                     Ok(f) => f,
                     Err(e) => {
                         log::debug!(
@@ -498,7 +498,7 @@ impl FontInfo {
                 let mut found_any = false;
                 for g in 0..n {
                     let name = face
-                        .glyph_name(ttf_parser::GlyphId(g))
+                        .glyph_name(xberg_ttf_parser::GlyphId(g))
                         .filter(|s| !s.is_empty() && *s != ".notdef")
                         .map(|s| s.to_string());
                     if name.is_some() {
@@ -10503,7 +10503,7 @@ mod tests {
 
         // ttf-parser should be able to parse the header (head + hhea + maxp)
         // without panicking, even if CFF data is minimal
-        let result = ttf_parser::Face::parse(&otf, 0);
+        let result = xberg_ttf_parser::Face::parse(&otf, 0);
         // May fail on CFF content but should not panic on table parsing
         // The fact that it doesn't panic is the test
         let _ = result;

--- a/src/fonts/truetype_cmap.rs
+++ b/src/fonts/truetype_cmap.rs
@@ -144,9 +144,9 @@ impl TrueTypeCMap {
     /// time. Reuses `ttf-parser` (already a dependency). Empty when the font has
     /// no such subtable or fails to parse — decode then treats the byte as a GID.
     fn build_symbol_code_to_gid(data: &[u8]) -> HashMap<u32, u16> {
-        use ttf_parser::PlatformId;
+        use xberg_ttf_parser::PlatformId;
         let mut map = HashMap::new();
-        let Ok(face) = ttf_parser::Face::parse(data, 0) else {
+        let Ok(face) = xberg_ttf_parser::Face::parse(data, 0) else {
             return map;
         };
         let Some(cmap) = face.tables().cmap else {

--- a/src/fonts/truetype_parser.rs
+++ b/src/fonts/truetype_parser.rs
@@ -14,7 +14,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::io::{self, Write};
 
-use ttf_parser::{Face, GlyphId};
+use xberg_ttf_parser::{Face, GlyphId};
 
 /// Error types for TrueType font parsing.
 #[derive(Debug, thiserror::Error)]
@@ -119,7 +119,7 @@ impl<'a> TrueTypeFont<'a> {
         self.face
             .names()
             .into_iter()
-            .find(|name| name.name_id == ttf_parser::name_id::POST_SCRIPT_NAME)
+            .find(|name| name.name_id == xberg_ttf_parser::name_id::POST_SCRIPT_NAME)
             .and_then(|name| name.to_string())
     }
 
@@ -128,7 +128,7 @@ impl<'a> TrueTypeFont<'a> {
         self.face
             .names()
             .into_iter()
-            .find(|name| name.name_id == ttf_parser::name_id::FAMILY)
+            .find(|name| name.name_id == xberg_ttf_parser::name_id::FAMILY)
             .and_then(|name| name.to_string())
     }
 

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use tiny_skia::{Paint, PathBuilder, Pixmap, Transform};
-use ttf_parser::OutlineBuilder;
+use xberg_ttf_parser::OutlineBuilder;
 
 /// Outline builder that converts ttf-parser paths to tiny-skia paths.
 struct SkiaOutlineBuilder<'a>(&'a mut PathBuilder);
@@ -51,7 +51,7 @@ impl<'a> OutlineBuilder for SkiaOutlineBuilder<'a> {
 /// - `has_unicode_cmap`: a Unicode/Windows cmap is present → Unicode shaping
 ///   is likely to produce non-.notdef glyphs; use `render_unicode_text`.
 ///
-/// This is a zero-copy `ttf_parser` table probe (no glyph parsing, no
+/// This is a zero-copy `xberg_ttf_parser` table probe (no glyph parsing, no
 /// shaping), cheap enough to run per call. It was previously memoised in a
 /// process-wide `HashMap` keyed on `Arc::as_ptr(data)`, but that key is
 /// unsound under concurrency: when an `Arc<Vec<u8>>` font buffer is dropped
@@ -62,12 +62,12 @@ impl<'a> OutlineBuilder for SkiaOutlineBuilder<'a> {
 /// Computing it locally removes the shared mutable state entirely.
 fn classify_embedded_font(data: &Arc<Vec<u8>>) -> (bool, bool) {
     (|| {
-        let face = ttf_parser::Face::parse(data, 0).ok()?;
+        let face = xberg_ttf_parser::Face::parse(data, 0).ok()?;
         let cmap = face.tables().cmap?;
         let mut saw_byte_indexed = false;
         let mut saw_unicode = false;
         for sub in cmap.subtables {
-            use ttf_parser::PlatformId;
+            use xberg_ttf_parser::PlatformId;
             match sub.platform_id {
                 PlatformId::Unicode => saw_unicode = true,
                 PlatformId::Windows if sub.encoding_id == 1 || sub.encoding_id == 10 => {
@@ -86,10 +86,10 @@ fn classify_embedded_font(data: &Arc<Vec<u8>>) -> (bool, bool) {
 /// own cmap subtables. Prefers a byte-indexed (Macintosh Roman) subtable
 /// when present; falls back to ttf-parser's default Unicode resolution
 /// for ASCII-range bytes if no byte-indexed subtable exists.
-fn cmap_byte_to_gid(face: &ttf_parser::Face, byte: u8) -> Option<u16> {
+fn cmap_byte_to_gid(face: &xberg_ttf_parser::Face, byte: u8) -> Option<u16> {
     if let Some(cmap) = face.tables().cmap {
         for sub in cmap.subtables {
-            use ttf_parser::PlatformId;
+            use xberg_ttf_parser::PlatformId;
             if matches!(sub.platform_id, PlatformId::Macintosh) && sub.encoding_id == 0 {
                 if let Some(gid) = sub.glyph_index(byte as u32) {
                     return Some(gid.0);
@@ -180,7 +180,7 @@ fn cached_font_bytes(id: fontdb::ID, db: &fontdb::Database) -> Option<(Arc<Vec<u
 
 /// Parsed font faces cached by fontdb ID.
 ///
-/// harfrust's `FontRef` and `ttf_parser::Face` both borrow the backing bytes.
+/// harfrust's `FontRef` and `xberg_ttf_parser::Face` both borrow the backing bytes.
 /// We use a self-referential pattern (backed Arc keeps bytes alive) with
 /// unsafe 'static transmute so we can store them in a process-wide cache
 /// and reuse them across hundreds of render_text calls for the same font.
@@ -197,11 +197,11 @@ struct CachedFace {
     _data: Arc<Vec<u8>>,
     font: harfrust::FontRef<'static>,
     shaper_data: harfrust::ShaperData,
-    ttf_face: ttf_parser::Face<'static>,
+    ttf_face: xberg_ttf_parser::Face<'static>,
     pub units_per_em: f32,
 }
 
-// SAFETY: harfrust::FontRef and ttf_parser::Face only borrow immutable bytes;
+// SAFETY: harfrust::FontRef and xberg_ttf_parser::Face only borrow immutable bytes;
 // harfrust::ShaperData owns the cached tables it derives from the font.
 unsafe impl Send for CachedFace {}
 unsafe impl Sync for CachedFace {}
@@ -209,13 +209,14 @@ unsafe impl Sync for CachedFace {}
 impl CachedFace {
     fn new(data: Arc<Vec<u8>>, index: u32) -> Option<Self> {
         let font: harfrust::FontRef<'_> = harfrust::FontRef::from_index(&data, index).ok()?;
-        let ttf_face: ttf_parser::Face<'_> = ttf_parser::Face::parse(&data, index).ok()?;
+        let ttf_face: xberg_ttf_parser::Face<'_> =
+            xberg_ttf_parser::Face::parse(&data, index).ok()?;
         let units_per_em = ttf_face.units_per_em() as f32;
         // SAFETY: both the font and ttf_face borrow the data slice. We store an
         // Arc to that data in `_data`, ensuring the bytes stay alive for this
         // struct's lifetime.
         let font: harfrust::FontRef<'static> = unsafe { std::mem::transmute(font) };
-        let ttf_face: ttf_parser::Face<'static> = unsafe { std::mem::transmute(ttf_face) };
+        let ttf_face: xberg_ttf_parser::Face<'static> = unsafe { std::mem::transmute(ttf_face) };
         // ShaperData owns its derived tables (no borrow of `font`), so it is
         // safe to build from the now-'static font and store it alongside.
         let shaper_data = harfrust::ShaperData::new(&font);
@@ -466,7 +467,7 @@ impl TextRasterizer {
                     // `Tj` / `TJ` call, not just the ones whose decoded Unicode
                     // happens to miss the cmap.
                     // Classify the embedded font's cmap tables. Computed
-                    // locally on every call — a cheap zero-copy `ttf_parser`
+                    // locally on every call — a cheap zero-copy `xberg_ttf_parser`
                     // probe; the process-wide memoisation was removed as
                     // unsound under concurrency (issue #505).
                     let (is_byte_indexed, has_unicode_cmap) = classify_embedded_font(embedded);
@@ -1022,12 +1023,12 @@ impl TextRasterizer {
         // Storage for locally-created faces when there is no cache entry
         // (embedded fonts, first-ever render of a system font).
         let _local_font: Option<harfrust::FontRef<'_>>;
-        let _local_ttf: Option<ttf_parser::Face<'_>>;
+        let _local_ttf: Option<xberg_ttf_parser::Face<'_>>;
         let _local_shaper_data: Option<harfrust::ShaperData>;
 
         let font_ref: &harfrust::FontRef<'_>;
         let shaper_data_ref: &harfrust::ShaperData;
-        let ttf_face_ref: &ttf_parser::Face<'_>;
+        let ttf_face_ref: &xberg_ttf_parser::Face<'_>;
         let units_per_em: f32;
 
         if let Some(ref c) = cached_arc {
@@ -1073,7 +1074,7 @@ impl TextRasterizer {
                 );
             }
             _local_font = font_opt;
-            _local_ttf = ttf_parser::Face::parse(&font_data, index).ok();
+            _local_ttf = xberg_ttf_parser::Face::parse(&font_data, index).ok();
             if _local_ttf.is_none() {
                 return Err(Error::InvalidPdf(format!("Failed to parse font: {}", pdf_font_name)));
             }
@@ -1284,7 +1285,7 @@ impl TextRasterizer {
             let mut pb = PathBuilder::new();
             let mut builder = SkiaOutlineBuilder(&mut pb);
             let mut has_outline = ttf_face_ref
-                .outline_glyph(ttf_parser::GlyphId(glyph_id as u16), &mut builder)
+                .outline_glyph(xberg_ttf_parser::GlyphId(glyph_id as u16), &mut builder)
                 .is_some();
 
             if has_outline && glyph_id != 0 {
@@ -1446,7 +1447,7 @@ impl TextRasterizer {
         let font_size = gs.font_size;
         let h_scale = gs.horizontal_scaling / 100.0;
 
-        let ttf_face = ttf_parser::Face::parse(font_data, index)
+        let ttf_face = xberg_ttf_parser::Face::parse(font_data, index)
             .map_err(|e| Error::InvalidPdf(format!("Failed to parse embedded font: {}", e)))?;
         let units_per_em = ttf_face.units_per_em() as f32;
         let scale = font_size / units_per_em;
@@ -1535,7 +1536,7 @@ impl TextRasterizer {
                     let mut pb = PathBuilder::new();
                     let mut builder = SkiaOutlineBuilder(&mut pb);
                     if ttf_face
-                        .outline_glyph(ttf_parser::GlyphId(gid), &mut builder)
+                        .outline_glyph(xberg_ttf_parser::GlyphId(gid), &mut builder)
                         .is_some()
                     {
                         if let Some(path) = pb.finish() {
@@ -1712,7 +1713,7 @@ impl TextRasterizer {
                 let mut pb = PathBuilder::new();
                 let mut builder = SkiaOutlineBuilder(&mut pb);
                 if ttf_face
-                    .outline_glyph(ttf_parser::GlyphId(gid), &mut builder)
+                    .outline_glyph(xberg_ttf_parser::GlyphId(gid), &mut builder)
                     .is_some()
                 {
                     if let Some(path) = pb.finish() {
@@ -2097,7 +2098,7 @@ mod tests {
         // the Adobe-Japan1 / Adobe-GB1 / Adobe-Korea1 collections.
         let covered = db
             .with_face_data(id, |data, index| {
-                let face = ttf_parser::Face::parse(data, index).expect("parse bundled face");
+                let face = xberg_ttf_parser::Face::parse(data, index).expect("parse bundled face");
                 ['東', '中', '가']
                     .iter()
                     .all(|&c| face.glyph_index(c).is_some())

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -2343,4 +2343,225 @@ mod tests {
             "Th=50% must halve the returned advance (§9.4.4 tx·Th): got {half}, full was {full}"
         );
     }
+
+    /// Encodes a CFF INDEX (CFF1 spec §5) over `items`.
+    ///
+    /// Uses a 1-byte offset size, which is valid only while the concatenated
+    /// payload stays under 255 bytes — true for the synthetic fonts here and
+    /// asserted so a future edit can't silently produce a corrupt INDEX.
+    fn cff_index(items: &[&[u8]]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(items.len() as u16).to_be_bytes());
+        if items.is_empty() {
+            return out;
+        }
+        let total: usize = items.iter().map(|i| i.len()).sum();
+        assert!(total < 255, "1-byte INDEX offsets cannot address {total} bytes");
+        out.push(1);
+        let mut off: u8 = 1;
+        out.push(off);
+        for item in items {
+            off += item.len() as u8;
+            out.push(off);
+        }
+        for item in items {
+            out.extend_from_slice(item);
+        }
+        out
+    }
+
+    /// A CFF DICT integer in the fixed-width 5-byte form (b0 = 29 + i32).
+    ///
+    /// The shorter encodings are size-dependent on the value, which would make
+    /// the Top DICT's length vary with the very offsets computed from it. The
+    /// wide form keeps the Top DICT a constant 17 bytes so the layout below can
+    /// be computed in a single pass.
+    fn cff_dict_int(value: i32) -> [u8; 5] {
+        let b = value.to_be_bytes();
+        [29, b[0], b[1], b[2], b[3]]
+    }
+
+    /// Builds a minimal OpenType/CFF face whose one drawable glyph (GID 1)
+    /// brackets its outline with the deprecated Type 2 `dotsection` operator.
+    ///
+    /// `dotsection` (`12 0`) is a Type 1 hinting operator that marks the dot
+    /// subpath of glyphs like `i`, `j`, `!` and `.`. Adobe's Type 1 → Type 2
+    /// conversion preserves it, so fonts in the wild still carry it. It takes
+    /// no operands and contributes no geometry.
+    ///
+    /// The glyph draws a 200×200 square starting at (100, 100), with the
+    /// `dotsection` placed *before* the drawing operators — so an interpreter
+    /// that rejects the operator aborts the whole charstring and emits no
+    /// outline at all, rather than merely skipping a hint.
+    fn cff_face_with_dotsection_glyph() -> Vec<u8> {
+        // Type 2 charstring. Operand encoding (CFF2 spec §4): a value in
+        // -107..=107 is the single byte v + 139; 108..=1131 is
+        // [247..=250, b1]; -1131..=-108 is [251..=254, b1].
+        #[rustfmt::skip]
+        let dotsection_glyph: Vec<u8> = vec![
+            239, 239, 21,      // 100 100 rmoveto
+            12, 0,             // dotsection  <- rejected by an unpatched parser
+            247, 92, 139, 5,   // 200 0 rlineto
+            139, 247, 92, 5,   // 0 200 rlineto
+            251, 92, 139, 5,   // -200 0 rlineto
+            14,                // endchar (closes the contour implicitly)
+        ];
+        let notdef_glyph: Vec<u8> = vec![14];
+
+        let name_index = cff_index(&[b"T"]);
+        let charstrings_index = cff_index(&[&notdef_glyph, &dotsection_glyph]);
+        // defaultWidthX = 0 (op 20), nominalWidthX = 0 (op 21); 139 encodes 0.
+        let private_dict: Vec<u8> = vec![139, 20, 139, 21];
+
+        // The Top DICT INDEX is a constant 22 bytes: 2 (count) + 1 (offSize)
+        // + 2 (offsets) + 17 (payload, see cff_dict_int).
+        const TOP_DICT_INDEX_LEN: usize = 22;
+        let charstrings_off =
+            4 + name_index.len() + TOP_DICT_INDEX_LEN + 2 /* String */ + 2 /* GSubr */;
+        let private_off = charstrings_off + charstrings_index.len();
+
+        let mut top_dict = Vec::new();
+        top_dict.extend_from_slice(&cff_dict_int(private_dict.len() as i32));
+        top_dict.extend_from_slice(&cff_dict_int(private_off as i32));
+        top_dict.push(18); // Private
+        top_dict.extend_from_slice(&cff_dict_int(charstrings_off as i32));
+        top_dict.push(17); // CharStrings
+        let top_dict_index = cff_index(&[&top_dict]);
+        assert_eq!(
+            top_dict_index.len(),
+            TOP_DICT_INDEX_LEN,
+            "Top DICT INDEX size drifted; the offsets above are computed from it"
+        );
+
+        let mut cff = vec![1, 0, 4, 1]; // major, minor, hdrSize, offSize
+        cff.extend_from_slice(&name_index);
+        cff.extend_from_slice(&top_dict_index);
+        cff.extend_from_slice(&[0, 0]); // String INDEX (empty)
+        cff.extend_from_slice(&[0, 0]); // Global Subr INDEX (empty)
+        assert_eq!(cff.len(), charstrings_off, "CharStrings offset mismatch");
+        cff.extend_from_slice(&charstrings_index);
+        assert_eq!(cff.len(), private_off, "Private DICT offset mismatch");
+        cff.extend_from_slice(&private_dict);
+
+        // `head`, `hhea` and `maxp` are the three tables Face::parse requires.
+        let mut head = Vec::new();
+        head.extend_from_slice(&0x0001_0000u32.to_be_bytes()); // version
+        head.extend_from_slice(&0x0001_0000u32.to_be_bytes()); // fontRevision
+        head.extend_from_slice(&0u32.to_be_bytes()); // checkSumAdjustment
+        head.extend_from_slice(&0x5F0F_3CF5u32.to_be_bytes()); // magicNumber
+        head.extend_from_slice(&0u16.to_be_bytes()); // flags
+        head.extend_from_slice(&1000u16.to_be_bytes()); // unitsPerEm
+        head.extend_from_slice(&0i64.to_be_bytes()); // created
+        head.extend_from_slice(&0i64.to_be_bytes()); // modified
+        head.extend_from_slice(&0i16.to_be_bytes()); // xMin
+        head.extend_from_slice(&0i16.to_be_bytes()); // yMin
+        head.extend_from_slice(&1000i16.to_be_bytes()); // xMax
+        head.extend_from_slice(&1000i16.to_be_bytes()); // yMax
+        head.extend_from_slice(&0u16.to_be_bytes()); // macStyle
+        head.extend_from_slice(&8u16.to_be_bytes()); // lowestRecPPEM
+        head.extend_from_slice(&0i16.to_be_bytes()); // fontDirectionHint
+        head.extend_from_slice(&0i16.to_be_bytes()); // indexToLocFormat
+        head.extend_from_slice(&0i16.to_be_bytes()); // glyphDataFormat
+
+        let mut hhea = Vec::new();
+        hhea.extend_from_slice(&0x0001_0000u32.to_be_bytes()); // version
+        hhea.extend_from_slice(&800i16.to_be_bytes()); // ascender
+        hhea.extend_from_slice(&(-200i16).to_be_bytes()); // descender
+        hhea.extend_from_slice(&0i16.to_be_bytes()); // lineGap
+        hhea.extend_from_slice(&1000u16.to_be_bytes()); // advanceWidthMax
+        hhea.extend_from_slice(&0i16.to_be_bytes()); // minLeftSideBearing
+        hhea.extend_from_slice(&0i16.to_be_bytes()); // minRightSideBearing
+        hhea.extend_from_slice(&1000i16.to_be_bytes()); // xMaxExtent
+        hhea.extend_from_slice(&1i16.to_be_bytes()); // caretSlopeRise
+        hhea.extend_from_slice(&0i16.to_be_bytes()); // caretSlopeRun
+        hhea.extend_from_slice(&0i16.to_be_bytes()); // caretOffset
+        hhea.extend_from_slice(&[0u8; 8]); // 4 reserved i16
+        hhea.extend_from_slice(&0i16.to_be_bytes()); // metricDataFormat
+        hhea.extend_from_slice(&2u16.to_be_bytes()); // numberOfHMetrics
+
+        let mut maxp = Vec::new();
+        maxp.extend_from_slice(&0x0000_5000u32.to_be_bytes()); // version 0.5 (CFF)
+        maxp.extend_from_slice(&2u16.to_be_bytes()); // numGlyphs
+
+        // sfnt wrapper. Tables must be listed in ascending tag order.
+        let tables: [(&[u8; 4], &[u8]); 4] = [
+            (b"CFF ", &cff),
+            (b"head", &head),
+            (b"hhea", &hhea),
+            (b"maxp", &maxp),
+        ];
+        let mut font = Vec::new();
+        font.extend_from_slice(b"OTTO");
+        font.extend_from_slice(&(tables.len() as u16).to_be_bytes());
+        font.extend_from_slice(&0u16.to_be_bytes()); // searchRange
+        font.extend_from_slice(&0u16.to_be_bytes()); // entrySelector
+        font.extend_from_slice(&0u16.to_be_bytes()); // rangeShift
+
+        let mut offset = 12 + tables.len() * 16;
+        let mut records = Vec::new();
+        for (tag, data) in &tables {
+            records.extend_from_slice(*tag);
+            records.extend_from_slice(&0u32.to_be_bytes()); // checksum (unverified)
+            records.extend_from_slice(&(offset as u32).to_be_bytes());
+            records.extend_from_slice(&(data.len() as u32).to_be_bytes());
+            offset += data.len().next_multiple_of(4);
+        }
+        font.extend_from_slice(&records);
+        for (_, data) in &tables {
+            font.extend_from_slice(data);
+            font.resize(font.len().next_multiple_of(4), 0);
+        }
+        font
+    }
+
+    /// A CFF glyph that brackets its outline with `dotsection` must still
+    /// produce geometry.
+    ///
+    /// The operator is a no-op for outlining, but an interpreter that treats it
+    /// as unsupported fails the entire charstring — so the glyph silently
+    /// renders blank. In a real font converted from Type 1 that removes the
+    /// dotted glyphs (`i`, `j`, `!`, `.`) from the page, which is a text-loss
+    /// bug rather than a hinting artifact.
+    ///
+    /// Drives the same `SkiaOutlineBuilder` the glyph-painting paths use, so a
+    /// regression shows up here exactly as it would on a rendered page.
+    #[test]
+    fn cff_dotsection_glyph_produces_outline() {
+        let font = cff_face_with_dotsection_glyph();
+        let face = xberg_ttf_parser::Face::parse(&font, 0)
+            .expect("synthetic OpenType/CFF face must parse");
+
+        let mut path_builder = PathBuilder::new();
+        let outlined = {
+            let mut builder = SkiaOutlineBuilder(&mut path_builder);
+            face.outline_glyph(xberg_ttf_parser::GlyphId(1), &mut builder)
+        };
+
+        assert!(
+            outlined.is_some(),
+            "charstring using `dotsection` must outline; rejecting the operator \
+             aborts the whole charstring and the glyph renders blank"
+        );
+
+        let path = path_builder
+            .finish()
+            .expect("outlining must emit a path, not an empty builder");
+        let bounds = path.bounds();
+
+        // Proves the operators *after* the dotsection ran: the full 200×200
+        // square at (100, 100), not just the opening move_to.
+        assert!(
+            (bounds.left() - 100.0).abs() < 0.01 && (bounds.top() - 100.0).abs() < 0.01,
+            "outline should start at (100, 100), got ({}, {})",
+            bounds.left(),
+            bounds.top()
+        );
+        assert!(
+            (bounds.width() - 200.0).abs() < 0.01 && (bounds.height() - 200.0).abs() < 0.01,
+            "outline should span 200×200, got {}×{} — the drawing operators \
+             following `dotsection` were not executed",
+            bounds.width(),
+            bounds.height()
+        );
+    }
 }


### PR DESCRIPTION
### Linked issue

Relates to #852 and #980 — see my comment on #852. Not `Closes`: upstream `ttf-parser` remains in the tree transitively, so #852 stays open.

### What and why

`ttf-parser` is unmaintained with no patched version (RUSTSEC-2026-0192). As of today upstream has confirmed it: harfbuzz/ttf-parser#230 — @behdad asked for a PR declaring the crate deprecated and pointing at fontations, which is now open as harfbuzz/ttf-parser#231.

That leaves two options, not one. Migrating to `skrifa` is the right long-term direction and I'm not arguing against it. But it is a rewrite of the font layer, not a swap — and it does not clear the advisory on its own, because `fontdb` also pulls `ttf-parser`. This PR takes the cheap half now: repoint our ~28 direct call sites at `xberg-ttf-parser`, a maintained fork of v0.25.1 with the same API and feature flags. The diff is import paths; no logic changes.

**On the fixes — most of them are not ours.** The fork is v0.25.1 plus nine pull requests from upstream, cherry-picked as-is, each recorded in its README with the upstream PR and cherry-pick commit:

| Upstream PR | Author | Fix |
| --- | --- | --- |
| #203 | @dereified | `Face::style()` rustdoc |
| #207 | @asibahi | `set_variation` returns `None` for an undefined axis |
| #216 | @SamusAranX | `fvar` `HIDDEN_AXIS` read from bit 0, not reserved bit 3 |
| #222 | @scadastrangelove | Guard CFF2 `blend` against an empty argument stack |
| #223 | @scadastrangelove | Promote `avar` mapping to `i32` so it cannot wrap |
| #224 | @scadastrangelove | Cap component visits in `glyf`/`gvar` composite outlining |
| #225 | @scadastrangelove | Cap paint-graph node visits in COLRv1 |
| #226 | @asibahi | Parse `loca` for a face carrying the maximum 65535 glyphs |
| #228 | @tobocop2 | Ignore the deprecated `dotsection` operator |

All nine are still open upstream with no maintainer response. Only #228 is ours; it is why we forked.

**Considered and rejected:**
- **`skrifa` now** — the direction in #852. Deferred, not rejected: it's a font-layer rewrite with real regression risk on a heuristic path, and it leaves `fontdb` pulling `ttf-parser` regardless, so the advisory stays either way. I'd rather do it deliberately than bundled into a dependency swap.
- **Status quo** — rejected because two of the carried fixes are user-visible correctness bugs, not cleanups. See Type of change.

**This does not clear RUSTSEC-2026-0192.** Upstream `ttf-parser` still reaches the tree via `fontdb` (`system-fonts`) and via `imageproc → ab_glyph → owned_ttf_parser` (`ocr`). The suppression in `osv-scanner.toml` stays; this PR updates its rationale to describe only the transitive half. What changes is that no *direct* usage remains.

**Unrelated finding, flagged not fixed:** `imageproc` is declared under the `ocr` feature but referenced zero times in the codebase — `cargo check --features ocr` passes with it removed. Dropping it would delete the entire `ab_glyph → owned_ttf_parser → ttf-parser` path. That's a separate logical change so it isn't in this PR; happy to open one if you want it.

**MSRV:** unchanged at 1.88. `xberg-ttf-parser` 1.1.0 declares `rust-version = "1.88"`, matching this project's floor exactly. Verified with `cargo +1.88 build --lib` — the same command the MSRV CI job runs.

**Licensing:** MIT OR Apache-2.0, identical to upstream `ttf-parser` and to this project. The fork ships under MIT retaining the upstream copyright notice. No new obligations.

### Type of change

- [x] Docs / CI / chore
- [x] Bug fix — carries fixes for CFF `dotsection` glyphs (`i`, `j`, `!`, `.` produced no outline at all) and `loca` parsing at 65535 glyphs (dropped every TrueType outline in the face)
- [ ] New feature / Performance / Refactor / Breaking change

### Tests

- [x] **Regression test that fails before / passes after** — revert-checked.
      `cff_dotsection_glyph_produces_outline` in `src/rendering/text_rasterizer.rs`
      builds a minimal synthetic OpenType/CFF face in code — no third-party PDF or
      font binary — whose glyph brackets a 200×200 square with the deprecated Type 2
      `dotsection` operator (`12 0`), and drives the same `OutlineBuilder` the
      glyph-painting paths use. It asserts the path *bounds*, so it proves the
      drawing operators following the `dotsection` actually executed rather than
      merely that parsing returned something.

      A/B on identical font bytes:

      | | upstream ttf-parser 0.25.1 | xberg-ttf-parser 1.1.0 |
      | --- | --- | --- |
      | control glyph, no `dotsection` | `Some(5)` | `Some(5)` |
      | same glyph with `dotsection` | **`None`** | `Some(5)` |

      The control row rules out a malformed synthetic font: the `None` is the
      operator rejection, which fails the whole charstring. In a real Type 1–converted
      font that silently removes `i`, `j`, `!` and `.` from the page.

- [x] Test named by defect class, no issue/PR numbers, no contributor or company
      names in code or fixtures. (`xberg-ttf-parser` appears in `Cargo.toml` as a
      dependency name, not a fixture or test name, so it is outside the
      fixture-naming rule.)
- [x] `cargo test` passes, and the affected tiers: **`rendering,system-fonts`** →
      5964 passed, 0 failed, 2 ignored. Default tier: 533 font tests pass.
- [x] `cargo fmt --check` and `cargo clippy --features rendering,system-fonts
      --all-targets -- -D warnings` both clean.

Not run: `fips,icc`. The `ml` tier has two pre-existing failures in
`layout::clustering` that reproduce identically on unmodified `main` (`10b87f15`)
and are unrelated to this change.

### Regression on real PDFs

<!-- TODO — NOT YET DONE. Must be filled before marking ready for review.
     Run the corpus_sig sweep per CONTRIBUTING.md and record real numbers here.
     Include CJK (the loca fix) and Type 1-converted fonts (the dotsection fix):
     those are where a deliberate diff is expected and should be explained. -->

**Corpus I tested** (count + kinds + source): _pending_

- [ ] Ran `corpus_sig` and diffed against **`main`** — no unintended regressions.
- [ ] Diffed against the **latest release** (`v0.3.77`) — same.
- [ ] Judged with a structural metric (word-Jaccard + spacing outliers), not char-Levenshtein.

**Diff summary vs `main`:** _pending_

**Diff summary vs latest release:** _pending_

### AI assistance disclosure

- [x] AI assistance: **assisted** — tool: Claude Code (Opus). Extent: performed the
      mechanical migration (28 import-path rewrites across 4 files, the `Cargo.toml`
      and `osv-scanner.toml` edits), authored the synthetic-font regression test and
      its A/B revert-check, and ran the build/test/clippy/MSRV gates. The fork, its
      contents, the provenance table above and the decision to propose this are mine.
- [ ] I understand and can explain every line; the description and my review replies
      are written by me, not generated. This PR is not fully or predominantly
      AI-generated.
      <!-- TODO — do not tick until you have reviewed and rewritten the above in
           your own words. CONTRIBUTING.md:225 is explicit about this. -->

### Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are DCO signed-off.
- [ ] Docs/`CHANGELOG.md` updated if user-facing. <!-- no [Unreleased] section exists; tell me where you want this and I'll add it -->
- [x] Public-API changes considered for semver — none; internal dependency swap only.
