### PR TITLE
fix(render): skip zero-dimension image blits instead of panicking

### DIFF
--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -4378,8 +4378,8 @@ impl PageRenderer {
             (src_w, src_h, rgba_image.into_raw(), image_transform)
         };
 
-        if let Some(img_pixmap) =
-            Pixmap::from_vec(blit_data, tiny_skia::IntSize::from_wh(blit_w, blit_h).unwrap())
+        if let Some(img_pixmap) = tiny_skia::IntSize::from_wh(blit_w, blit_h)
+            .and_then(|size| Pixmap::from_vec(blit_data, size))
         {
             pixmap.draw_pixmap(0, 0, img_pixmap.as_ref(), &paint, blit_transform, clip_mask);
         }
@@ -10994,5 +10994,79 @@ mod tests {
             img.width,
             img.height
         );
+    }
+
+    /// Build a minimal single-page PDF whose only content is a `Do` of an
+    /// image XObject declaring `/Height 0`. The image decodes to an empty
+    /// buffer, so the blit dimensions computed by `render_image` are
+    /// degenerate.
+    fn build_zero_height_image_pdf() -> Vec<u8> {
+        let mut pdf = Vec::new();
+        let mut offsets: Vec<usize> = Vec::new();
+        pdf.extend_from_slice(b"%PDF-1.4\n");
+
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\n");
+
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\n");
+
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(
+            b"3 0 obj\n\
+              << /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100]\n\
+                 /Contents 4 0 R\n\
+                 /Resources << /XObject << /Im0 5 0 R >> >>\n\
+              >>\nendobj\n\n",
+        );
+
+        let content = b"q 100 0 0 100 0 0 cm /Im0 Do Q";
+        offsets.push(pdf.len());
+        let hdr = format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len());
+        pdf.extend_from_slice(hdr.as_bytes());
+        pdf.extend_from_slice(content);
+        pdf.extend_from_slice(b"\nendstream\nendobj\n\n");
+
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(
+            b"5 0 obj\n\
+              << /Type /XObject /Subtype /Image /Width 4 /Height 0\n\
+                 /ColorSpace /DeviceGray /BitsPerComponent 8 /Length 0 >>\n\
+              stream\n\nendstream\nendobj\n\n",
+        );
+
+        let xref_offset = pdf.len();
+        let n_obj = offsets.len() + 1;
+        let mut xref = format!("xref\n0 {}\n", n_obj);
+        xref.push_str("0000000000 65535 f \n");
+        for off in &offsets {
+            xref.push_str(&format!("{:010} 00000 n \n", off));
+        }
+        pdf.extend_from_slice(xref.as_bytes());
+        let trailer = format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            n_obj, xref_offset
+        );
+        pdf.extend_from_slice(trailer.as_bytes());
+        pdf
+    }
+
+    /// `IntSize::from_wh` rejects a zero dimension, so a degenerate image must
+    /// take the same quiet-skip path as any other pixmap that cannot be built.
+    #[test]
+    fn zero_dimension_image_blit_is_skipped() {
+        use crate::document::PdfDocument;
+
+        let pdf = build_zero_height_image_pdf();
+        let doc = PdfDocument::from_bytes(pdf).expect("parse degenerate-image PDF");
+
+        let opts = RenderOptions {
+            format: ImageFormat::RawRgba8,
+            ..RenderOptions::with_dpi(72)
+        };
+        let mut renderer = PageRenderer::new(opts);
+        let img = renderer.render_page(&doc, 0).expect("render page");
+
+        assert_eq!(img.data.len(), (img.width * img.height * 4) as usize);
     }
 }


### PR DESCRIPTION
## Linked issue

Closes #1019.

## What and why

**The panic.** Rendering a page that carries a zero-dimension image panics. The blit path calls `IntSize::from_wh(blit_w, blit_h).unwrap()`. `from_wh` returns `None` when a dimension is zero. So an image declaring `/Height 0` kills the render of a page that extracts fine.

**The fix.** The fix chains the size through `and_then`. A degenerate blit then takes the existing skip path of the surrounding `if let`. That is two lines.

**The alternative I dropped.** I considered rejecting the malformed image earlier, in decoding. That would fail the whole page to guard one empty draw. The code can simply skip that draw instead.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after** (revert-checked). The reproducer is `build_zero_height_image_pdf()`, a minimal synthetic PDF built in code. On unmodified `main` it panics with the identical backtrace to the corpus page.
- [x] Test named by defect **class** (`zero_dimension_image_blit_is_skipped`). No contributor or company names appear in code or fixtures.
- [x] `cargo test` passes (5,964 lib tests). The affected feature tier `rendering` passes too.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 PDFs / ~470,000 pages. The kinds are crawled US government documents (govdocs1), academic papers, technical manuals, and Japanese vertical-writing texts. It also covers the veraPDF, pdf.js, and pdfium test corpora.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv, manuals, Japanese vertical texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Diffed my branch against **`main`** with a per-page structural signature sweep. The sweep covers 49 columns per page: text, words, spans, lines, tables, images, links, render hash. No unintended regressions.
- [x] Diffed against the **latest release** (`v0.3.77`): same result. `main` is currently the v0.3.77 release commit.
- [x] Judged structurally (per-column signatures, not char distance).

**Diff summary vs `main`:** a targeted 580-page check changed exactly 1 page, the fixed one. The full-corpus sweep is running. Its verdict lands here before this leaves draft, and I expect the same single page.

**Diff summary vs latest release:** identical to the `main` diff (same commit).

**Documents specifically examined:**

| Document | Pages | Demonstrates |
|---|---|---|
| [046760.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/046.zip) (046.zip) | 38 | the fixed page: rendered content instead of a panic (144 chars extracted either way) |
| [020747.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/020.zip) (020.zip) | 3, 6, 8 | unchanged by this PR: those panic on huge coordinates inside the rasterizer, fixed by #1002 |
| synthetic zero-height-image fixture | 0 | the in-code reproducer for the regression test |

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: implementation, test authoring, and corpus verification tooling, under my direction and review
- [x] I understand and can explain every line. This PR is not fully or predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the CHANGELOG (not in code). No entry here. `CHANGELOG.md` is written per release, under a version heading, with a consolidated contributors block, so it reads as the maintainer's to write at release time.
- [x] Public-API changes: none.


