### PR TITLE
fix(tables): reuse the merger's word boundaries when building cell text

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -16767,7 +16767,9 @@ impl PdfDocument {
         // Default: include /Artifact-tagged spans (matches pre-0.3.42
         // behavior). The spec-correct (§14.8.2.2.1) variant lives in
         // [`Self::extract_words_with_thresholds_no_artifacts`].
-        self.extract_words_inner(page_index, word_gap_threshold, profile, true)
+        Ok(self
+            .extract_words_inner(page_index, word_gap_threshold, profile, true)?
+            .0)
     }
 
     /// Same as [`Self::extract_words_with_thresholds`] but drops spans tagged
@@ -16779,7 +16781,9 @@ impl PdfDocument {
         word_gap_threshold: Option<f32>,
         profile: Option<crate::config::ExtractionProfile>,
     ) -> Result<Vec<crate::layout::Word>> {
-        self.extract_words_inner(page_index, word_gap_threshold, profile, false)
+        Ok(self
+            .extract_words_inner(page_index, word_gap_threshold, profile, false)?
+            .0)
     }
 
     fn extract_words_inner(
@@ -16788,7 +16792,7 @@ impl PdfDocument {
         word_gap_threshold: Option<f32>,
         profile: Option<crate::config::ExtractionProfile>,
         include_artifacts: bool,
-    ) -> Result<Vec<crate::layout::Word>> {
+    ) -> Result<(Vec<crate::layout::Word>, Vec<bool>)> {
         use crate::layout::{clustering, AdaptiveLayoutParams, DocumentProperties, Word};
 
         // Span source. The default (no profile) flows through the canonical
@@ -16832,7 +16836,7 @@ impl PdfDocument {
             },
         };
         if spans.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         }
 
         // Compute adaptive parameters from all characters for consistent thresholds.
@@ -16853,7 +16857,7 @@ impl PdfDocument {
             span_char_ranges.push(start..all_chars.len());
         }
         if all_chars.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         }
         let props =
             DocumentProperties::analyze(&all_chars, page_bbox).map_err(Error::LayoutAnalysis)?;
@@ -16884,6 +16888,14 @@ impl PdfDocument {
         let mut rotated_word_indices: std::collections::HashSet<usize> =
             std::collections::HashSet::new();
         let mut words = Vec::new();
+        // continues_prev[i]: the span-level merger joined word i to word i-1
+        // with no word boundary — their glyphs are consecutive in one span
+        // with not even a whitespace char between them, and only the
+        // geometric clustering below re-split them. Kept parallel to
+        // `words` through the merge loop; consumed by the table path, which
+        // must not re-decide a join the merger already made from per-glyph
+        // advance evidence.
+        let mut continues_prev: Vec<bool> = Vec::new();
         for (span_idx, span) in spans.iter().enumerate() {
             let span_chars = &all_chars[span_char_ranges[span_idx].clone()];
             if span_chars.is_empty() {
@@ -16901,29 +16913,61 @@ impl PdfDocument {
             let is_split_boundary = span.split_boundary_before;
             let is_rotated_run = span.rotation_degrees != 0.0;
 
+            // Source-index interval of each word emitted for this span,
+            // aligned to `words[first_word_idx..]`. Two words continue each
+            // other exactly when the second's lowest source index directly
+            // follows the first's highest — a dropped whitespace char (or a
+            // glyph of another word) in between would occupy that index.
+            let mut word_src_ranges: Vec<(usize, usize)> = Vec::new();
             for cluster_indices in clusters {
-                let cluster_chars: Vec<_> = cluster_indices
-                    .iter()
-                    .map(|&i| span_chars[i].clone())
-                    .collect();
-
                 let mut current_word_chars = Vec::new();
-                for c in cluster_chars {
+                let mut src_lo = usize::MAX;
+                let mut src_hi = 0usize;
+                for &ci in &cluster_indices {
+                    let c = span_chars[ci].clone();
                     if c.char.is_whitespace() || c.char == '\n' || c.char == '\r' {
                         if !current_word_chars.is_empty() {
-                            let mut word = Word::from_chars(current_word_chars);
+                            let mut word =
+                                Word::from_chars(std::mem::take(&mut current_word_chars));
                             word.sequence = span.sequence;
                             words.push(word);
-                            current_word_chars = Vec::new();
+                            continues_prev.push(false);
+                            word_src_ranges.push((src_lo, src_hi));
+                            src_lo = usize::MAX;
+                            src_hi = 0;
                         }
                     } else {
                         current_word_chars.push(c);
+                        src_lo = src_lo.min(ci);
+                        src_hi = src_hi.max(ci);
                     }
                 }
                 if !current_word_chars.is_empty() {
                     let mut word = Word::from_chars(current_word_chars);
                     word.sequence = span.sequence;
                     words.push(word);
+                    continues_prev.push(false);
+                    word_src_ranges.push((src_lo, src_hi));
+                }
+            }
+            // Rotated and vertical runs advance perpendicular to the line
+            // axis the clustering assumes, so every glyph lands in its own
+            // cluster and index adjacency would mark a whole column as one
+            // continued word. Leave those unmarked; the rotated case is also
+            // what the merge loop below skips.
+            //
+            // The mark is a source-order statement only. It deliberately
+            // carries no geometric test: `to_chars` stamps the span's single
+            // `bbox.y` onto every glyph it emits, so all words from one span
+            // share a y and no same-line test can discriminate here. Geometry
+            // is the consumer's job, where the real coordinates are in hand.
+            if !is_rotated_run && span.wmode == 0 {
+                for k in 1..word_src_ranges.len() {
+                    let (_, prev_hi) = word_src_ranges[k - 1];
+                    let (cur_lo, _) = word_src_ranges[k];
+                    if cur_lo == prev_hi + 1 {
+                        continues_prev[first_word_idx + k] = true;
+                    }
                 }
             }
 
@@ -16973,8 +17017,9 @@ impl PdfDocument {
         // `looks_rtl(a + b) == looks_rtl(a) || looks_rtl(b)`: maintain it
         // incrementally instead.
         let mut merged_rtl: Vec<bool> = Vec::with_capacity(words.len());
+        let mut merged_continues: Vec<bool> = Vec::with_capacity(words.len());
         let mut prev_rotated = false;
-        for (idx, word) in words.into_iter().enumerate() {
+        for (idx, (word, word_continues)) in words.into_iter().zip(continues_prev).enumerate() {
             let cur_rotated = rotated_word_indices.contains(&idx);
             let word_rtl = crate::text::bidi::looks_rtl(&word.text);
             if !cur_rotated && !prev_rotated && !split_boundary_word_indices.contains(&idx) {
@@ -17008,22 +17053,7 @@ impl PdfDocument {
                         // Incremental merge — O(k) per merge, O(total_chars) overall.
                         // Avoids the O(n²) clone+from_chars pattern that caused
                         // catastrophic slowdown on TOC dot-leader pages.
-                        let prev_n = prev.chars.len() as f32;
-                        let word_n = word.chars.len() as f32;
-                        prev.bbox = prev.bbox.union(&word.bbox);
-                        prev.avg_font_size = (prev.avg_font_size * prev_n
-                            + word.avg_font_size * word_n)
-                            / (prev_n + word_n);
-                        if word_n > prev_n {
-                            prev.dominant_font = word.dominant_font;
-                        }
-                        prev.is_bold |= word.is_bold;
-                        prev.is_italic |= word.is_italic;
-                        if prev.mcid != word.mcid {
-                            prev.mcid = None;
-                        }
-                        prev.text.push_str(&word.text);
-                        prev.chars.extend(word.chars);
+                        prev.absorb(word);
                         if let Some(flag) = merged_rtl.last_mut() {
                             *flag |= word_rtl;
                         }
@@ -17033,10 +17063,11 @@ impl PdfDocument {
             }
             merged.push(word);
             merged_rtl.push(word_rtl);
+            merged_continues.push(word_continues);
             prev_rotated = cur_rotated;
         }
 
-        Ok(merged)
+        Ok((merged, merged_continues))
     }
 
     /// Extract text lines from a page.
@@ -17959,27 +17990,45 @@ impl PdfDocument {
         )
     }
 
-    /// Extract tables from a page using a custom configuration (v0.3.14).
-    pub fn extract_tables_with_config(
-        &self,
-        page_index: usize,
-        config: crate::structure::spatial_table_detector::TableDetectionConfig,
-    ) -> Result<Vec<crate::structure::table_extractor::Table>> {
-        use crate::structure::spatial_table_detector::detect_tables_with_lines;
-
-        // Use words instead of spans for better granularity.
-        // This ensures that strings with spaces are split into separate columns
-        // for the spatial detector.
-        let words = self.extract_words(page_index)?;
-        // Use all table primitives (lines, rectangles, borders) not just straight lines
-        let lines: Vec<_> = self
-            .extract_paths(page_index)?
-            .into_iter()
-            .filter(|p| p.is_table_primitive())
-            .collect();
-
-        // Convert Words to TextSpans for the spatial detector
-        let spans: Vec<_> = words
+    /// Word-level span source for the spatial table detector.
+    ///
+    /// Words give the detector cell granularity (a spaced string splits into
+    /// separate columns), but the geometric word clustering re-decides every
+    /// join from raw bbox gaps — and a sub-em kerned split defeats any gap
+    /// threshold, so a word the span-level merger had correctly assembled
+    /// from per-glyph advance evidence can come back in fragments and
+    /// surface as spaces inside a table cell. Re-glue the fragments the
+    /// merger marked as boundary-free before handing spans to the detector.
+    fn extract_table_word_spans(&self, page_index: usize) -> Result<Vec<crate::layout::TextSpan>> {
+        let (words, continues_prev) = self.extract_words_inner(page_index, None, None, true)?;
+        let mut fused: Vec<crate::layout::Word> = Vec::with_capacity(words.len());
+        for (word, continues) in words.into_iter().zip(continues_prev) {
+            // Half-em BAND, tested on the absolute gap. Source adjacency says
+            // the producer drew these glyphs consecutively; it does not say
+            // they are typographically adjacent, so geometry still has a veto,
+            // and it needs both bounds:
+            //   above  — the merger also concatenates runs across a column
+            //            jump when neither side carries a space glyph, and
+            //            honouring that here would dissolve the grid;
+            //   below  — a large NEGATIVE gap is the signature of a backtrack
+            //            (displayed-math denominators) or a line-wrap reset,
+            //            the two cases the word merge loop guards with
+            //            `gap < -font_size` and `delta_x < -5 * font_size`.
+            //            A one-sided upper bound admits every one of them.
+            // A sub-em kerned seam — the case this whole path exists for — is
+            // ~0.2 em, comfortably inside the band from either side.
+            match fused.last_mut() {
+                Some(prev)
+                    if continues
+                        && (word.bbox.x - (prev.bbox.x + prev.bbox.width)).abs()
+                            < prev.avg_font_size.max(word.avg_font_size).max(1.0) * 0.5 =>
+                {
+                    prev.absorb(word)
+                },
+                _ => fused.push(word),
+            }
+        }
+        Ok(fused
             .into_iter()
             .map(|w| crate::layout::TextSpan {
                 provenance: None,
@@ -18013,6 +18062,26 @@ impl PdfDocument {
                 text_rise: 0.0,
                 rtl_draw_logical: false,
             })
+            .collect())
+    }
+
+    /// Extract tables from a page using a custom configuration (v0.3.14).
+    pub fn extract_tables_with_config(
+        &self,
+        page_index: usize,
+        config: crate::structure::spatial_table_detector::TableDetectionConfig,
+    ) -> Result<Vec<crate::structure::table_extractor::Table>> {
+        use crate::structure::spatial_table_detector::detect_tables_with_lines;
+
+        // Use words instead of spans for better granularity.
+        // This ensures that strings with spaces are split into separate columns
+        // for the spatial detector.
+        let spans = self.extract_table_word_spans(page_index)?;
+        // Use all table primitives (lines, rectangles, borders) not just straight lines
+        let lines: Vec<_> = self
+            .extract_paths(page_index)?
+            .into_iter()
+            .filter(|p| p.is_table_primitive())
             .collect();
 
         // Same prose-rejection filter `extract_page_tables` applies to the
@@ -19778,42 +19847,9 @@ impl PdfDocument {
         }
         let paths = table_paths;
 
-        let words = self.extract_words(page_index).unwrap_or_default();
-        let word_spans: Vec<crate::layout::TextSpan> = words
-            .into_iter()
-            .map(|w| crate::layout::TextSpan {
-                provenance: None,
-                artifact_type: None,
-                text: w.text,
-                bbox: w.bbox,
-                font_name: w.dominant_font,
-                font_size: w.avg_font_size,
-                font_weight: if w.is_bold {
-                    crate::layout::FontWeight::Bold
-                } else {
-                    crate::layout::FontWeight::Normal
-                },
-                is_italic: w.is_italic,
-                is_monospace: false,
-                color: crate::layout::Color::black(),
-                mcid: w.mcid,
-                mcid_scope: None,
-                sequence: 0,
-                split_boundary_before: false,
-                offset_semantic: false,
-                char_spacing: 0.0,
-                word_spacing: 0.0,
-                horizontal_scaling: 1.0,
-                primary_detected: false,
-                char_widths: vec![],
-                char_x_offsets: Vec::new(),
-                heading_level: None,
-                rotation_degrees: 0.0,
-                wmode: 0,
-                text_rise: 0.0,
-                rtl_draw_logical: false,
-            })
-            .collect();
+        let word_spans = self
+            .extract_table_word_spans(page_index)
+            .unwrap_or_default();
 
         // Fall back to raw spans if word extraction failed
         let input_spans = if !word_spans.is_empty() {

--- a/src/layout/text_block.rs
+++ b/src/layout/text_block.rs
@@ -777,6 +777,44 @@ impl TextBlock {
         }
     }
 
+    /// Append `other`'s glyphs to this block, growing the bbox to their union
+    /// and re-deriving the aggregate attributes.
+    ///
+    /// Incremental by design: O(len(other)) per call, so folding a run of `k`
+    /// blocks costs O(total_chars) instead of the O(n²) of rebuilding through
+    /// [`Self::from_chars`] at every step.
+    ///
+    /// Attribute rules, which are NOT the same as rebuilding from the
+    /// concatenated chars: `avg_font_size` becomes the glyph-count-weighted
+    /// mean, `dominant_font` follows the larger side, the style flags OR
+    /// together, and a differing `mcid` collapses to `None` (the union no
+    /// longer belongs to one marked-content sequence). `sequence` and
+    /// `rotation_degrees` are left as this block's — callers fold blocks from
+    /// a single run, where both already agree.
+    pub(crate) fn absorb(&mut self, other: TextBlock) {
+        let self_n = self.chars.len() as f32;
+        let other_n = other.chars.len() as f32;
+        self.bbox = self.bbox.union(&other.bbox);
+        // Both sides can be chars-empty (several call sites build blocks with
+        // no chars); a plain weighted mean would divide 0.0 by 0.0 and poison
+        // the font size with NaN, which then propagates into every downstream
+        // gap threshold.
+        if self_n + other_n > 0.0 {
+            self.avg_font_size =
+                (self.avg_font_size * self_n + other.avg_font_size * other_n) / (self_n + other_n);
+        }
+        if other_n > self_n {
+            self.dominant_font = other.dominant_font;
+        }
+        self.is_bold |= other.is_bold;
+        self.is_italic |= other.is_italic;
+        if self.mcid != other.mcid {
+            self.mcid = None;
+        }
+        self.text.push_str(&other.text);
+        self.chars.extend(other.chars);
+    }
+
     /// Get the center point of the text block.
     pub fn center(&self) -> Point {
         self.bbox.center()

--- a/tests/table_cell_word_seam.rs
+++ b/tests/table_cell_word_seam.rs
@@ -1,0 +1,255 @@
+//! A table cell must not re-decide word joins the span-level merger already
+//! made from per-glyph advance evidence.
+//!
+//! A producer that draws one word as several show operations, repositioning
+//! between them with sub-em gaps (declared glyph widths understating the true
+//! pen steps), puts the cell text builder in a position no gap threshold can
+//! win from. The fixture below reproduces that inversion exactly:
+//!
+//!   intra-word seam, must NOT become a space :  1.75 pt
+//!   real word space, must     become a space :  1.53 pt
+//!
+//! The seam is WIDER than the legitimate space, so no constant separates
+//! them: a threshold high enough to keep "Credit" whole (>= 1.75) also
+//! swallows the space before "<", and one low enough to keep that space
+//! (< 1.53) also splits "Credit". Only the source-order evidence tells them
+//! apart — the space is a space GLYPH occupying its own character position,
+//! while the seam is pure repositioning between consecutive glyphs. The
+//! span-level merger reads that evidence and joins correctly, so table
+//! extraction must consume its verdict rather than re-derive the join from
+//! raw bbox gaps.
+
+use pdf_oxide::document::PdfDocument;
+
+/// A fully ruled 3-row, 2-column grid whose middle value cell draws
+/// "Credit < 21 500 euros" as four show ops: `(Cre) (d) (it)` with 1.75 pt
+/// seam gaps, then `( < 21 500 euros)` continuing at the exact pen position.
+///
+/// Glyph widths are 453/1000 em (4.077 pt at 9 pt) except the space, which is
+/// declared 170/1000 em — a 1.53 pt advance, NARROWER than the 1.75 pt seams
+/// yet still above the cell builder's own `font_size * 0.15` (1.35 pt) floor,
+/// so a correct implementation keeps it. That inversion is the whole point of
+/// the fixture: a threshold high enough to keep "Credit" whole also swallows
+/// the space before "<", and one low enough to keep that space also splits
+/// "Credit".
+fn fragmented_cell_pdf() -> Vec<u8> {
+    let mut content = Vec::new();
+    // Grid rules: 3 rows x 2 cols, fully stroked.
+    for y in [710.0f32, 690.0, 670.0, 650.0] {
+        content.extend_from_slice(format!("0.7 w 95 {y} m 420 {y} l S\n").as_bytes());
+    }
+    for x in [95.0f32, 300.0, 420.0] {
+        content.extend_from_slice(format!("0.7 w {x} 650 m {x} 710 l S\n").as_bytes());
+    }
+    content.extend_from_slice(b"BT /F1 9 Tf\n");
+    // Header row + a plain last row so the detector sees a real grid.
+    content.extend_from_slice(b"1 0 0 1 100 695 Tm (Garanties) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 305 695 Tm (Montant) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 100 655 Tm (Duree) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 305 655 Tm (25 ans) Tj\n");
+    // Value cell drawn as fragments. Glyph advance = 0.453 * 9 = 4.077 pt.
+    // (Cre) spans 100 .. 112.231; each following fragment starts 1.75 pt
+    // past the declared end of the previous one.
+    content.extend_from_slice(b"1 0 0 1 100 675 Tm (Cre) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 113.981 675 Tm (d) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 119.808 675 Tm (it) Tj\n");
+    // Continuation at the exact pen position: 119.808 + 2 * 4.077 = 127.962.
+    content.extend_from_slice(b"1 0 0 1 127.962 675 Tm ( < 21 500 euros) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 305 675 Tm (Oui) Tj\n");
+    content.extend_from_slice(b"ET");
+    build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]")
+}
+
+/// The fixture is only meaningful while no constant can separate an
+/// intra-word seam from a legitimate word space. Measure both from the
+/// extracted geometry and assert the inversion, so that a future change to
+/// the fixture (or to how widths become advances) cannot quietly turn these
+/// tests into something a threshold tweak would satisfy.
+#[test]
+fn seam_is_wider_than_the_word_space_it_must_be_told_apart_from() {
+    let doc = PdfDocument::from_bytes(fragmented_cell_pdf()).expect("open");
+    let words = doc.extract_words(0).expect("words");
+    let gap_after = |text: &str| -> f32 {
+        let i = words
+            .iter()
+            .position(|w| w.text == text)
+            .unwrap_or_else(|| {
+                panic!(
+                    "no word {text:?} in {:?}",
+                    words.iter().map(|w| &w.text).collect::<Vec<_>>()
+                )
+            });
+        words[i + 1].bbox.x - (words[i].bbox.x + words[i].bbox.width)
+    };
+
+    // "Cre" -> "d": pure repositioning between consecutive glyphs.
+    let seam = gap_after("Cre");
+    // "it" -> "<": a real space glyph sits between them in the source.
+    let space = gap_after("it");
+
+    assert!(
+        (seam - 1.75).abs() < 0.05,
+        "fixture drift: intra-word seam is {seam:.3} pt, expected 1.75"
+    );
+    assert!(
+        (space - 1.53).abs() < 0.05,
+        "fixture drift: word space is {space:.3} pt, expected 1.53"
+    );
+    assert!(
+        seam > space,
+        "fixture no longer pins the defect: the intra-word seam ({seam:.3} pt) must be \
+         WIDER than the legitimate word space ({space:.3} pt), or a gap threshold could \
+         separate them and the fix under test would be unnecessary"
+    );
+    // The space must also stay above the cell builder's own floor, or the
+    // second test would be demanding a space this change does not restore
+    // (it re-glues split words; it does not re-split fused ones).
+    assert!(
+        space > 9.0 * 0.15,
+        "fixture drift: word space {space:.3} pt fell below the cell builder's \
+         font_size * 0.15 floor, so it is dropped for reasons this change does not address"
+    );
+}
+
+#[test]
+fn sub_em_fragment_seams_do_not_split_cell_words() {
+    let doc = PdfDocument::from_bytes(fragmented_cell_pdf()).expect("open");
+
+    // The span-level merger must see the fragments as one unspaced word —
+    // this pins the fixture's geometry; if it drifts (a seam wide enough
+    // that the merger itself inserts a space), fail here, loudly.
+    let spans = doc.extract_spans(0).expect("spans");
+    let flow = spans
+        .iter()
+        .find(|s| s.text.contains("euros"))
+        .expect("flow span with the fragmented line");
+    assert!(
+        flow.text.contains("Credit < 21 500 euros"),
+        "fixture drift: span-level merger no longer joins the seams: {:?}",
+        flow.text
+    );
+
+    let tables = doc.extract_tables(0).expect("tables");
+    let cell = tables
+        .iter()
+        .flat_map(|t| &t.rows)
+        .flat_map(|r| &r.cells)
+        .find(|c| c.text.contains("euros"))
+        .expect("cell with the fragmented line");
+    assert_eq!(
+        cell.text, "Credit < 21 500 euros",
+        "cell builder re-split a word the span-level merger had joined"
+    );
+}
+
+/// Same fixture through the text-assembly table path (`extract_text`), which
+/// feeds the detector from its own word-derived spans.
+#[test]
+fn sub_em_fragment_seams_do_not_split_words_in_extracted_text() {
+    let doc = PdfDocument::from_bytes(fragmented_cell_pdf()).expect("open");
+    // Pin that this page really does exercise the table path: without a
+    // detected table the assertions below are satisfied by ordinary flow
+    // text and would pass with the fix reverted.
+    assert!(
+        !doc.extract_tables(0).expect("tables").is_empty(),
+        "fixture no longer detects a table, so this test would not cover the table path"
+    );
+    let text = doc.extract_text(0).expect("text");
+    assert!(text.contains("Credit"), "extracted text lost the fragmented word: {text:?}");
+    assert!(!text.contains("Cre d it"), "extracted text shows the re-split word: {text:?}");
+}
+
+/// A word the merger drew consecutively but which then jumps BACKWARD is a
+/// displayed-math denominator or a wrapped line, not a kerned seam. Source
+/// adjacency alone would fuse it; the gap band's lower bound is what refuses
+/// it. Without that bound the cell reads `= dt` fused as one token.
+#[test]
+fn backward_jump_within_a_run_is_not_fused_into_the_previous_word() {
+    let mut content = Vec::new();
+    for y in [710.0f32, 690.0, 670.0, 650.0] {
+        content.extend_from_slice(format!("0.7 w 95 {y} m 420 {y} l S\n").as_bytes());
+    }
+    for x in [95.0f32, 300.0, 420.0] {
+        content.extend_from_slice(format!("0.7 w {x} 650 m {x} 710 l S\n").as_bytes());
+    }
+    content.extend_from_slice(b"BT /F1 9 Tf\n");
+    content.extend_from_slice(b"1 0 0 1 100 695 Tm (Garanties) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 305 695 Tm (Montant) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 100 655 Tm (Duree) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 305 655 Tm (25 ans) Tj\n");
+    // `=` drawn at the fraction's mid-height, then the denominator `dt`
+    // repositioned ~3 em back to the left — consecutive in the source, far
+    // apart on the page.
+    content.extend_from_slice(b"1 0 0 1 140 675 Tm (=) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 113 675 Tm (dt) Tj\n");
+    content.extend_from_slice(b"1 0 0 1 305 675 Tm (Oui) Tj\n");
+    content.extend_from_slice(b"ET");
+    let pdf = build_minimal_pdf_raw(&content, b"/Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]");
+
+    let doc = PdfDocument::from_bytes(pdf).expect("open");
+    for table in doc.extract_tables(0).expect("tables") {
+        for row in &table.rows {
+            for cell in &row.cells {
+                assert!(
+                    !cell.text.contains("=dt") && !cell.text.contains("dt="),
+                    "a backward jump was fused into one token: {:?}",
+                    cell.text
+                );
+            }
+        }
+    }
+}
+
+fn build_minimal_pdf_raw(content: &[u8], page_extra: &[u8]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+
+    let off1 = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    pdf.extend_from_slice(b"3 0 obj\n<< ");
+    pdf.extend_from_slice(page_extra);
+    pdf.extend_from_slice(b" /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n");
+
+    let off4 = pdf.len();
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    // 453/1000 em for every WinAnsi code except the space (code 32, the first
+    // entry), which is 170/1000. At 9 pt that is a 1.53 pt word space — see
+    // the module docs: NARROWER than the 1.75 pt intra-word seams so no
+    // constant separates the two, yet still above the cell builder's
+    // font_size * 0.15 floor so a correct implementation keeps it.
+    let off5 = pdf.len();
+    let mut widths_v = vec!["453"; 95];
+    widths_v[0] = "170";
+    let widths = widths_v.join(" ");
+    pdf.extend_from_slice(
+        format!(
+            "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+             /Encoding /WinAnsiEncoding /FirstChar 32 /LastChar 126 /Widths [{widths}] >>\nendobj\n"
+        )
+        .as_bytes(),
+    );
+
+    let xref_pos = pdf.len();
+    let offsets = [0usize, off1, off2, off3, off4, off5];
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(format!("{:010} 65535 f\r\n", 0).as_bytes());
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n\r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}


### PR DESCRIPTION
## Linked issue

Closes #1018

## What and why

Two code paths decide where words break. They use different evidence. They disagree.

- `cell_span_separator` adds a space when the gap between two spans is more than `font_size * 0.15`.
- The span merger decides from per-glyph advance evidence.

Some producers draw a single word as several show operations. The two paths then give different results:

| Surface | Result |
|---|---|
| `extract_spans` | `Crédit < 21 500 euros` (correct) |
| `extract_tables` | `Cré d it < 21 500 euros` (wrong) |

**No constant fixes this.** On the reported page, at 9 pt type:

| Gap | Measured | Correct action |
|---|---|---|
| Inside the word `Crédit` | 2.04 pt | Do not add a space |
| Before the `<` | 1.92 pt | Add a space |

The gap inside the word is **wider** than the real space. Raise the threshold and the word survives, but the space disappears. Lower it and the space survives, but the word splits.

`cell_span_separator` also carries one earlier retune for this same class of report. That is the second reason not to reach for a third constant.

**The fix.** The table path now consumes the merger's verdict. It does not derive the verdict again.

1. Word extraction records one fact per word: did the merger join this word to the word before it with no boundary at all?
2. That fact is source-index adjacency inside a single span. No gap threshold can recover it.
3. The table path re-glues those fragments before the detector sees them.

`extract_words` output is unchanged. Only the detector's input moves.

**Geometry keeps a veto** over the re-glue. The band is two-sided and half an em wide.

- The upper bound stops a column jump from fusing two cells into one.
- The lower bound excludes backtracks and line-wrap resets. The word merge loop already guards those with `gap < -font_size` and `delta_x < -5 * font_size`. A one-sided bound would admit every one of them.

Considered and rejected:

| Alternative | Why rejected |
|---|---|
| Retune `cell_span_separator` | Measured impossible, above. It would also be the third patch to that constant. |
| De-fuse at the word layer instead | #831 narrowed away from exactly this. Changing `extract_words` geometry, which `extract_page_tables` consumes, fabricated tables on prose pages. This change leaves `extract_words` byte-identical and moves only the table path's private input. |
| Teach the cell/flow matcher to consume concatenations | It creates a new deletion path and reintroduces order-dependent behaviour. The spacing is the defect; the matcher is not. |

## Type of change

- [x] Bug fix

## Tests

- [x] I added a test that **fails before this change and passes after** (revert-checked). For bug fixes the reproducer is a **minimal synthetic PDF built in code**. No third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no contributor/company names in code or fixtures.
- [x] `cargo test` passes, **and** the affected feature tiers: `rendering` / `fips,icc` / `ml` / binding (list which): **`python` (the `make check` tier), `ml`, `rendering`**. `ml` matters here because `cluster_chars_into_words` has two implementations gated on it, and this change sits directly on its output.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

`tests/table_cell_word_seam.rs` builds a ruled grid. Its value cell is drawn as four show operations.

The fixture is calibrated so that **no constant can pass it**:

| Gap | Value | Correct action |
|---|---|---|
| Intra-word seam | 1.75 pt | Do not add a space |
| Real word space | 1.53 pt | Add a space |

One test asserts that inversion directly. The reproducer therefore cannot drift into something a threshold tweak would satisfy. A fourth test pins the band's lower bound: it draws a backward jump and asserts the fragments are not fused.

**One caveat, reported rather than hidden.** The `ml` tier has two failing lib tests:

| Test | Result | Expected |
|---|---|---|
| `layout::clustering::tests::test_pdx2_clustering_scales_on_large_input` | 2475 clusters | 2500 |
| `layout::clustering::tests::test_column_gap_threshold_is_font_relative_not_flat` | 1 cell | 3 |

**Both fail identically on unmodified `10b87f15`.** I ran them against a pristine checkout of the base commit to be sure. They exercise the `ml`-gated clustering functions directly, but they encode the *non-*`ml` implementation's grouping behaviour. This change touches neither `clustering.rs` nor those functions. Filed separately as #1026.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents / 470,208 pages, diffed against `main`. The breakdown by source is in the sweep section below.

- [x] Ran a per-page differential against **`main`**. No unintended regressions (no new word-fusions, over-splits, dropped spans, reversed scripts, or crashes).
- [x] Diffed against the **latest release (`v0.3.77`)**. `10b87f15` is simultaneously the tip of `main` and the `v0.3.77` tag. This is the same measurement, not a second one.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not char-Levenshtein.

I built both sides from the same toolchain and feature set. An earlier run used a pre-built reference binary and showed a 100 % `render_hash` delta. That was a feature-set mismatch in the reference, not a code difference.

**Targeted prose check.** Within the corpus I also swept 8 documents where `main` detects **zero** tables, plus 4 arXiv math papers, 8,668 pages. I chose them to probe the failure mode #831 was narrowed for: a change to detector input that fabricates tables on prose. Result: **zero pages changed, in any column.** Table count moved on no page in either direction.

**Pages that do change.** Four, all on the table path. On every page in the corpus, including those four, `spans_hash`, `words_hash` and `chars_sig` are byte-identical. The span and word layers do not move.

Word-Jaccard on the four is 0.90–0.99. Every token that disappears is a fragment whose whole form was already present:

- `Cré` + `d` + `it` → `Crédit`
- `Am` + `ericaB…` → one token
- `Anne’` + `s` + `m` + `e` + `lon` → `Anne’s melon`

Non-whitespace character conservation is exact on two of the four pages. The other two lose precisely one copy of a duplicated segment. On those pages a split cell token could not pair with its merged flow span, so both surfaces emitted the line.

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: extensive
- [ ] ~~written by me, not generated~~. See disclosure

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the CHANGELOG (not in code). No CHANGELOG entry. That matches recent feature PRs, which leave it to the release commit.
- [x] Public-API changes considered for semver (`semver-checks` will run). None: the one new method is `pub(crate)`, and the two public `extract_words` signatures are unchanged.

## Full-corpus regression sweep

Complete: 470,208 pages over 19,151 documents diffed against `main`, with a measured per-page noise floor.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv, manuals, Japanese vertical texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

**Documents specifically examined:**

| Document | Page | Demonstrates |
|---|---|---|
| [issue7454.pdf](https://raw.githubusercontent.com/mozilla/pdf.js/master/test/pdfs/issue7454.pdf) (pdf.js corpus) | 0 | the reproducer: cell text now matches the flow text; the duplicate emission disappears |
| [002397.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/002.zip) (002.zip) | 32 | spacing corrected with zero character delta |
| [019233.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/019.zip) (019.zip) | 153 | duplicated segment collapses; lost characters are exactly one copy of the duplicate |
| [023521.pdf](https://digitalcorpora.s3.amazonaws.com/corpora/files/govdocs1/zipfiles/023.zip) (023.zip) | 123 | same duplicate-collapse shape on an unrelated document |

**Unintended movement: none.** Two groups of pages were flagged, and neither is attributable to this change:

- Seven blocker pages are a base-side render-panic artifact. They panic under rendering on unmodified `main` and extract normally with rendering off. Tracked upstream separately.
- Two hand-read pages reproduce their differences on unmodified `main`. They are known nondeterministic pages.

**The corpus is quiet on this fix by expectation, not by omission.** Documents that carry sub-em-split cell text are rare. Engagement is therefore demonstrated two other ways:

1. The regression test fails first and passes after.
2. The four affected pages above were read directly, and each was checked for character-multiset conservation.

The sweep's role is to establish the absence of collateral change everywhere else.

## CI note

On the [first run](https://github.com/yfedoseev/pdf_oxide/actions/runs/31197068822/job/93023993082), `Docker smoke (alpine-3)` failed on a network flake, not on this change. The runner could not reach Docker Hub:

```
docker: Error response from daemon: Get "https://registry-1.docker.io/v2/":
net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

The job stopped at exit code 125, before any project code ran. Every other check passed: 198 pass, 1 fail, 36 skipped.

I re-pushed the commit to re-trigger CI. The tree is unchanged. `912a6e87` and `03372a80` have the identical tree `b76f712c`.

