### PR TITLE
fix(image): resolve indirect /Width and /Height references

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -22446,14 +22446,20 @@ impl PdfDocument {
                 // Pre-decompression filtering using dictionary metadata.
                 // These checks use Width/Height/ColorSpace from the XObject dictionary
                 // which are available WITHOUT decompressing the image stream data.
-                let w = xobject_dict
-                    .get("Width")
-                    .and_then(|o| o.as_integer())
-                    .unwrap_or(0);
-                let h = xobject_dict
-                    .get("Height")
-                    .and_then(|o| o.as_integer())
-                    .unwrap_or(0);
+                // /Width and /Height may themselves be indirect references
+                // (ISO 32000-1 §7.3.10); resolve them the same way
+                // `extract_image_from_xobject` does, so an indirect width
+                // doesn't fall through to the `unwrap_or(0)` default and get
+                // silently filtered out by the `min_width`/`min_height` gate
+                // below.
+                let resolve_int = |o: &Object| -> Option<i64> {
+                    match o.as_reference() {
+                        Some(r) => self.load_object(r).ok().and_then(|v| v.as_integer()),
+                        None => o.as_integer(),
+                    }
+                };
+                let w = xobject_dict.get("Width").and_then(resolve_int).unwrap_or(0);
+                let h = xobject_dict.get("Height").and_then(resolve_int).unwrap_or(0);
                 if w < filter.min_width || h < filter.min_height {
                     return Ok(images);
                 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -22459,7 +22459,10 @@ impl PdfDocument {
                     }
                 };
                 let w = xobject_dict.get("Width").and_then(resolve_int).unwrap_or(0);
-                let h = xobject_dict.get("Height").and_then(resolve_int).unwrap_or(0);
+                let h = xobject_dict
+                    .get("Height")
+                    .and_then(resolve_int)
+                    .unwrap_or(0);
                 if w < filter.min_width || h < filter.min_height {
                     return Ok(images);
                 }

--- a/src/extractors/images.rs
+++ b/src/extractors/images.rs
@@ -743,14 +743,25 @@ pub fn extract_image_from_xobject(
         return Err(Error::Image(format!("XObject subtype is not Image: {}", subtype)));
     }
 
+    // /Width and /Height may be indirect references (ISO 32000-1 §7.3.10
+    // permits any object entry to be an indirect reference); resolve them
+    // the same way the /ColorSpace resolution just below does.
+    let resolve_int = |obj: &Object| -> Option<i64> {
+        if let (Some(d), Some(r)) = (doc, obj.as_reference()) {
+            d.load_object(r).ok().and_then(|o| o.as_integer())
+        } else {
+            obj.as_integer()
+        }
+    };
+
     let width = dict
         .get("Width")
-        .and_then(|obj| obj.as_integer())
+        .and_then(resolve_int)
         .ok_or_else(|| Error::Image("Image missing /Width".to_string()))? as u32;
 
     let height = dict
         .get("Height")
-        .and_then(|obj| obj.as_integer())
+        .and_then(resolve_int)
         .ok_or_else(|| Error::Image("Image missing /Height".to_string()))? as u32;
 
     let bits_per_component = dict
@@ -3043,14 +3054,22 @@ pub(crate) fn image_handle_from_xobject<'doc>(
     paint_order: usize,
     color_space_resources: &std::collections::HashMap<String, crate::object::Object>,
 ) -> Option<PdfImageHandle<'doc>> {
+    // /Width and /Height may be indirect references (ISO 32000-1 §7.3.10);
+    // resolve them the same way `extract_image_from_xobject` does.
+    let resolve_int = |o: &crate::object::Object| -> Option<i64> {
+        match o.as_reference() {
+            Some(r) => doc.load_object(r).ok().and_then(|v| v.as_integer()),
+            None => o.as_integer(),
+        }
+    };
     let w = xobject_dict
         .get("Width")
-        .and_then(|o| o.as_integer())
+        .and_then(resolve_int)
         .filter(|&n| n > 0)
         .map(|n| n as u32)?;
     let h = xobject_dict
         .get("Height")
-        .and_then(|o| o.as_integer())
+        .and_then(resolve_int)
         .filter(|&n| n > 0)
         .map(|n| n as u32)?;
     let bpc = xobject_dict

--- a/tests/indirect_image_dimensions.rs
+++ b/tests/indirect_image_dimensions.rs
@@ -1,0 +1,87 @@
+//! An image XObject's `/Width` and `/Height` entries may be indirect
+//! references — ISO 32000-1:2008 §7.3.10 permits any dictionary/stream
+//! entry to be an indirect reference unless the spec explicitly forbids it
+//! for that key, and neither `/Width` nor `/Height` is on that exclusion
+//! list. `extract_image_from_xobject` read both via a raw `.as_integer()`
+//! call with no reference resolution, so an indirect `/Width` (a pattern
+//! some PDF producers use, e.g. to share a single "standard photo width"
+//! object across many images) made extraction fail with "Image missing
+//! /Width" even though the value was present, just one hop away.
+//!
+//! The fixture is a hand-built minimal PDF (no third-party files): a single
+//! 10×8 8-bit DeviceGray image whose `/Width` is `6 0 R`, an indirect
+//! reference to a bare integer object, while `/Height` stays inline. (10x8,
+//! not smaller, to clear `extract_images`'s unrelated default 8x8
+//! decorative-artifact size filter.)
+
+use pdf_oxide::PdfDocument;
+
+fn pdf_with_indirect_width_image() -> Vec<u8> {
+    // `extract_images`'s default `ImageExtractFilter` skips anything under
+    // 8x8 (decorative-artifact heuristic, unrelated to this fix) — stay at
+    // or above that floor so the fixture isn't filtered out for a reason
+    // that has nothing to do with indirect /Width resolution.
+    let width = 10u32;
+    let height = 8u32;
+    let img: Vec<u8> = (0..width * height).map(|i| (i * 3) as u8).collect();
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = [0usize; 7];
+    buf.extend_from_slice(b"%PDF-1.7\n");
+    let mut obj = |buf: &mut Vec<u8>, id: usize, head: String, stream: Option<&[u8]>| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{head}").as_bytes());
+        if let Some(s) = stream {
+            buf.extend_from_slice(b"\nstream\n");
+            buf.extend_from_slice(s);
+            buf.extend_from_slice(b"\nendstream");
+        }
+        buf.extend_from_slice(b"\nendobj\n");
+    };
+    obj(&mut buf, 1, "<< /Type /Catalog /Pages 2 0 R >>".into(), None);
+    obj(&mut buf, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(), None);
+    obj(
+        &mut buf,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] \
+         /Resources << /XObject << /Im0 4 0 R >> >> /Contents 5 0 R >>"
+            .into(),
+        None,
+    );
+    obj(
+        &mut buf,
+        4,
+        format!(
+            "<< /Type /XObject /Subtype /Image /Width 6 0 R /Height {height} \
+             /ColorSpace /DeviceGray /BitsPerComponent 8 /Length {} >>",
+            img.len()
+        ),
+        Some(&img),
+    );
+    let content = format!("q {width} 0 0 {height} 10 10 cm /Im0 Do Q");
+    obj(
+        &mut buf,
+        5,
+        format!("<< /Length {} >>", content.len()),
+        Some(content.as_bytes()),
+    );
+    // The indirect /Width value: a bare integer object.
+    obj(&mut buf, 6, format!("{width}"), None);
+
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 7\n0000000000 65535 f \n");
+    for id in 1..=6 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+#[test]
+fn indirect_width_reference_resolves_to_correct_dimensions() {
+    let doc = PdfDocument::from_bytes(pdf_with_indirect_width_image()).expect("fixture parses");
+    let images = doc.extract_images(0).expect("extract_images");
+    assert_eq!(images.len(), 1, "the image must be found despite indirect /Width");
+    assert_eq!((images[0].width(), images[0].height()), (10, 8));
+}


### PR DESCRIPTION
## Summary
ISO 32000-1:2008 §7.3.10 permits any dictionary entry to be an indirect reference unless the spec explicitly excludes it, and neither `/Width` nor `/Height` is excluded. Three call sites read them via a raw `.as_integer()` with no reference resolution, so an indirect `/Width`/`/Height` (e.g. a shared "standard photo width" object referenced from many images) silently dropped the image:

- `extractors/images.rs::extract_image_from_xobject`
- `document.rs::extract_images_from_xobject_do`'s pre-decompression size filter — this one gates *first*: an indirect `/Width` silently defaulted to 0 here and got rejected by the `min_width`/`min_height` gate before ever reaching the function above
- `extractors/images.rs::image_handle_from_xobject` — a separate lazy `PdfImageHandle` extraction path with the identical bug

All three now resolve `Object::Reference` the same way `/ColorSpace` is already resolved in `extract_image_from_xobject`.

## Test plan
- [x] `indirect_width_reference_resolves_to_correct_dimensions` — synthetic PDF with `/Width 6 0 R` (indirect) + inline `/Height`
- [x] `cargo test --release --test indirect_image_dimensions` — 1/1 pass

Closes #1031