### PR TITLE
fix(editor): decode Info dictionary text strings correctly

### DIFF
--- a/src/editor/document_editor.rs
+++ b/src/editor/document_editor.rs
@@ -117,33 +117,39 @@ impl DocumentInfo {
     }
 
     /// Parse from a PDF Info dictionary object.
+    ///
+    /// PDF text strings are UTF-16BE-with-BOM or PDFDocEncoding, never raw
+    /// UTF-8 (ISO 32000-1:2008 §7.9.2.2) — decoded via
+    /// [`crate::optional_content::decode_pdf_text_string`], which every
+    /// other text-string call site in this codebase already uses.
     pub fn from_object(obj: &Object) -> Self {
+        use crate::optional_content::decode_pdf_text_string;
         let mut info = Self::default();
 
         if let Some(dict) = obj.as_dict() {
             if let Some(Object::String(s)) = dict.get("Title") {
-                info.title = String::from_utf8_lossy(s).to_string().into();
+                info.title = decode_pdf_text_string(s).into();
             }
             if let Some(Object::String(s)) = dict.get("Author") {
-                info.author = String::from_utf8_lossy(s).to_string().into();
+                info.author = decode_pdf_text_string(s).into();
             }
             if let Some(Object::String(s)) = dict.get("Subject") {
-                info.subject = String::from_utf8_lossy(s).to_string().into();
+                info.subject = decode_pdf_text_string(s).into();
             }
             if let Some(Object::String(s)) = dict.get("Keywords") {
-                info.keywords = String::from_utf8_lossy(s).to_string().into();
+                info.keywords = decode_pdf_text_string(s).into();
             }
             if let Some(Object::String(s)) = dict.get("Creator") {
-                info.creator = String::from_utf8_lossy(s).to_string().into();
+                info.creator = decode_pdf_text_string(s).into();
             }
             if let Some(Object::String(s)) = dict.get("Producer") {
-                info.producer = String::from_utf8_lossy(s).to_string().into();
+                info.producer = decode_pdf_text_string(s).into();
             }
             if let Some(Object::String(s)) = dict.get("CreationDate") {
-                info.creation_date = String::from_utf8_lossy(s).to_string().into();
+                info.creation_date = decode_pdf_text_string(s).into();
             }
             if let Some(Object::String(s)) = dict.get("ModDate") {
-                info.mod_date = String::from_utf8_lossy(s).to_string().into();
+                info.mod_date = decode_pdf_text_string(s).into();
             }
         }
 

--- a/tests/document_info_utf16_encoding.rs
+++ b/tests/document_info_utf16_encoding.rs
@@ -1,0 +1,103 @@
+//! `/Info` dictionary text strings (`/Title`, `/Author`, ...) are PDF text
+//! strings per ISO 32000-1:2008 §7.9.2.2 — UTF-16BE with a `FE FF` byte-order
+//! mark, or PDFDocEncoding when unprefixed. They are never raw UTF-8.
+//! `DocumentInfo::from_object` used `String::from_utf8_lossy` directly on
+//! the string bytes, which mangles every non-ASCII UTF-16BE-encoded value
+//! into replacement characters (each source character is 2 bytes, almost
+//! none of which form valid UTF-8 sequences).
+//!
+//! The fixture is a synthetic PDF whose `/Info /Title` is the Cyrillic word
+//! "Привет" (Russian for "hello"), UTF-16BE-encoded with a BOM — a value
+//! that has no valid interpretation as UTF-8 at all, so any UTF-8-based
+//! decode reliably corrupts it.
+
+use pdf_oxide::editor::{DocumentEditor, EditableDocument};
+
+const TITLE: &str = "Привет";
+
+fn utf16be_bom(s: &str) -> Vec<u8> {
+    let mut bytes = vec![0xFE, 0xFF];
+    for unit in s.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_be_bytes());
+    }
+    bytes
+}
+
+/// Escape raw bytes into a PDF string literal `(...)` body — only `(`, `)`,
+/// and `\` need a backslash per ISO 32000-1:2008 §7.3.4.2.
+fn escape_pdf_string_literal(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len() + 2);
+    out.push(b'(');
+    for &b in bytes {
+        if b == b'(' || b == b')' || b == b'\\' {
+            out.push(b'\\');
+        }
+        out.push(b);
+    }
+    out.push(b')');
+    out
+}
+
+fn build_pdf_with_utf16_title() -> Vec<u8> {
+    let title_literal = escape_pdf_string_literal(&utf16be_bom(TITLE));
+
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets = vec![0usize];
+
+    let off1 = pdf.len();
+    offsets.push(off1);
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    offsets.push(off2);
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    offsets.push(off3);
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << >> >>\nendobj\n",
+    );
+
+    let off4 = pdf.len();
+    offsets.push(off4);
+    let content = b"";
+    pdf.extend_from_slice(format!("4 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    offsets.push(off5);
+    pdf.extend_from_slice(b"5 0 obj\n<< /Title ");
+    pdf.extend_from_slice(&title_literal);
+    pdf.extend_from_slice(b" >>\nendobj\n");
+
+    let xref_offset = pdf.len();
+    let count = offsets.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", count).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \r\n");
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n \r\n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R /Info 5 0 R >>\nstartxref\n{}\n%%EOF\n",
+            count, xref_offset
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn info_title_decodes_utf16be_bom_correctly() {
+    let mut editor =
+        DocumentEditor::open_from_bytes(build_pdf_with_utf16_title()).expect("open pdf");
+    let info = editor.get_info().expect("get_info");
+
+    assert_eq!(
+        info.title.as_deref(),
+        Some(TITLE),
+        "UTF-16BE /Title with BOM must decode to the original Unicode string, got {:?}",
+        info.title
+    );
+}

--- a/tests/document_info_utf16_encoding.rs
+++ b/tests/document_info_utf16_encoding.rs
@@ -90,8 +90,7 @@ fn build_pdf_with_utf16_title() -> Vec<u8> {
 
 #[test]
 fn info_title_decodes_utf16be_bom_correctly() {
-    let mut editor =
-        DocumentEditor::open_from_bytes(build_pdf_with_utf16_title()).expect("open pdf");
+    let mut editor = DocumentEditor::from_bytes(build_pdf_with_utf16_title()).expect("open pdf");
     let info = editor.get_info().expect("get_info");
 
     assert_eq!(


### PR DESCRIPTION
## Summary
`DocumentInfo::from_object` called `String::from_utf8_lossy` directly on every `/Info` field's raw bytes. PDF text strings are UTF-16BE with a `FE FF` BOM, or PDFDocEncoding when unprefixed (ISO 32000-1:2008 §7.9.2.2) — never raw UTF-8. A UTF-16BE-encoded `/Title`, `/Author`, etc. decoded this way is mangled into replacement characters, since each source character is 2 bytes and almost none of those byte pairs form valid UTF-8.

Routes all 8 fields through the already-correct `optional_content::decode_pdf_text_string`, which every other text-string call site in this codebase already uses (handles the BOM cases, lenient UTF-8, and PDFDocEncoding fallback).

## Test plan
- [x] `info_title_decodes_utf16be_bom_correctly` — synthetic PDF with `/Info /Title` set to the Cyrillic word "Привет" UTF-16BE-encoded with a BOM (no valid interpretation as UTF-8 at all, so any UTF-8-based decode reliably corrupts it)
- [x] `cargo test --release --test document_info_utf16_encoding` — 1/1 pass

Closes #978