### PR TITLE
fix(text): Tw must not apply to a multi-byte CID 32

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -8408,11 +8408,13 @@ impl<'doc> TextExtractor<'doc> {
                 // 2-byte codes per ToUnicode codespace.
                 buffer.append(text)?;
                 let mut w_sum = 0.0f32;
-                for (char_code, _) in TextCharIter::new(text, Some(font)) {
+                for (char_code, nbytes) in TextCharIter::new(text, Some(font)) {
                     let mut w = font.get_glyph_width(char_code) * fs_factor * hs_factor;
                     w += cs_hs;
-                    // Standard PDF space character (code 32) triggers word spacing
-                    if char_code == 32 {
+                    // Per ISO 32000-1:2008 §9.3.3: Tw applies only to the
+                    // single-byte character code 32 — a 2-byte CID 32 inside
+                    // an Identity-H/CJK font must not take Tw.
+                    if nbytes == 1 && char_code == 32 {
                         w += ws_hs;
                     }
                     w_sum += w;
@@ -8428,11 +8430,13 @@ impl<'doc> TextExtractor<'doc> {
                 // axis per §9.3.4).
                 buffer.append(text)?;
                 let mut w_sum = 0.0f32;
-                for (char_code, _) in TextCharIter::new(text, Some(font)) {
+                for (char_code, nbytes) in TextCharIter::new(text, Some(font)) {
                     let w1y = font.get_vertical_metrics(char_code).w1y;
                     let mut w = w1y * fs_factor;
                     w += char_space;
-                    if char_code == 32 {
+                    // Per ISO 32000-1:2008 §9.3.3: Tw applies only to the
+                    // single-byte character code 32.
+                    if nbytes == 1 && char_code == 32 {
                         w += word_space;
                     }
                     w_sum += w;

--- a/src/rendering/text_rasterizer.rs
+++ b/src/rendering/text_rasterizer.rs
@@ -1141,6 +1141,11 @@ impl TextRasterizer {
         let mut y_cursor: f32 = 0.0;
         let mut last_fallback_cluster: Option<usize> = None;
         let wmode = gs.text_wmode;
+        // Per ISO 32000-1:2008 §9.3.3, Tw applies only to the single-byte
+        // character code 32 — never to the byte value 32 inside a
+        // multi-byte code (e.g. CID 32 under Identity-H/V, always 2 bytes).
+        // `font_info` is constant for the whole call, so resolve this once.
+        let word_space_eligible = get_byte_mode(font_info) != ByteMode::TwoByte;
 
         // Pre-resolve CIDs for Type0 fonts using our iterator
         let cids: Vec<u16> = if let Some(info) = font_info {
@@ -1321,12 +1326,12 @@ impl TextRasterizer {
                 if char_at_pos.is_whitespace() {
                     if wmode == 0 {
                         x_cursor += x_advance + gs.char_space;
-                        if char_at_pos == ' ' {
+                        if char_at_pos == ' ' && word_space_eligible {
                             x_cursor += gs.word_space;
                         }
                     } else {
                         y_cursor += y_step + gs.char_space;
-                        if char_at_pos == ' ' {
+                        if char_at_pos == ' ' && word_space_eligible {
                             y_cursor += gs.word_space;
                         }
                     }
@@ -1409,13 +1414,13 @@ impl TextRasterizer {
             if wmode == 0 {
                 x_cursor += x_advance_override.unwrap_or(x_advance);
                 x_cursor += gs.char_space;
-                if char_at_pos == ' ' {
+                if char_at_pos == ' ' && word_space_eligible {
                     x_cursor += gs.word_space;
                 }
             } else {
                 y_cursor += y_step;
                 y_cursor += gs.char_space;
-                if char_at_pos == ' ' {
+                if char_at_pos == ' ' && word_space_eligible {
                     y_cursor += gs.word_space;
                 }
             }
@@ -1466,7 +1471,7 @@ impl TextRasterizer {
         let wmode = gs.text_wmode;
 
         // Iterate over character codes from the raw bytes
-        for (char_code, _bytes_consumed) in TextCharIter::new(bytes, Some(font_info)) {
+        for (char_code, bytes_consumed) in TextCharIter::new(bytes, Some(font_info)) {
             // Map character code to GID based on font type:
             // - Type0 (CID-keyed) without CIDToGIDMap → CID is GID
             //   (Identity-H/Identity-V emission, the case our writer
@@ -1560,14 +1565,19 @@ impl TextRasterizer {
                 }
             }
 
+            // Per ISO 32000-1:2008 §9.3.3, Tw applies only to the
+            // single-byte character code 32 — a 2-byte CID 32 (0x0020)
+            // under Identity-H/V or another multi-byte CMap must not
+            // take Tw.
+            let word_space_eligible = bytes_consumed == 1 && char_code == 32;
             if wmode == 0 {
                 x_cursor += x_advance + gs.char_space;
-                if char_at_pos == ' ' {
+                if word_space_eligible {
                     x_cursor += gs.word_space;
                 }
             } else {
                 y_cursor += y_step + gs.char_space;
-                if char_at_pos == ' ' {
+                if word_space_eligible {
                     y_cursor += gs.word_space;
                 }
             }
@@ -1648,7 +1658,7 @@ impl TextRasterizer {
         let mut glyphs_painted: usize = 0;
         let mut glyphs_missing: usize = 0;
 
-        for (char_code, _) in TextCharIter::new(bytes, Some(font_info)) {
+        for (char_code, bytes_consumed) in TextCharIter::new(bytes, Some(font_info)) {
             // code == CID holds by construction: the load-time gate in
             // `FontInfo::from_dict` only sets `cjk_substitution` when the
             // /Encoding resolved to `Encoding::Identity` (Identity-H/V or an
@@ -1739,14 +1749,22 @@ impl TextRasterizer {
                 glyphs_missing += 1;
             }
 
+            // Per ISO 32000-1:2008 §9.3.3, Tw applies only to the
+            // single-byte character code 32. This substitution path is
+            // only reached for Identity-encoded CIDFonts (see the
+            // `code == CID` comment above), which are always 2-byte, so
+            // `bytes_consumed == 1` never holds today — kept explicit
+            // (rather than dropping Tw unconditionally) so this stays
+            // correct if this path is ever reached for a 1-byte codespace.
+            let word_space_eligible = bytes_consumed == 1 && ch == ' ';
             if wmode == 0 {
                 x_cursor += x_advance + gs.char_space;
-                if ch == ' ' {
+                if word_space_eligible {
                     x_cursor += gs.word_space;
                 }
             } else {
                 y_cursor += y_step + gs.char_space;
-                if ch == ' ' {
+                if word_space_eligible {
                     y_cursor += gs.word_space;
                 }
             }
@@ -2013,7 +2031,7 @@ fn measure_text_bytes(
     let mut advance: f32 = 0.0;
 
     if let Some(font) = font_info {
-        for (char_code, _) in TextCharIter::new(bytes, Some(font)) {
+        for (char_code, nbytes) in TextCharIter::new(bytes, Some(font)) {
             // Per ISO 32000-1 §9.4.4 the advance formula differs by writing
             // mode:
             //   horizontal: tx = ((w0 * Tfs) + Tc + Tw) * Th
@@ -2021,17 +2039,21 @@ fn measure_text_bytes(
             // Tz is defined as glyph stretching along the *horizontal*
             // direction only (§9.3.4); it does not scale vertical w1y or
             // vertical Tc / Tw.
+            // Per §9.3.3, Tw applies only to the single-byte code 32 — a
+            // 2-byte CID 0x0020 under Identity-H/V or another multi-byte
+            // CMap must not take Tw.
+            let word_space_eligible = nbytes == 1 && char_code == 0x20;
             if wmode == 0 {
                 let glyph_adv = font.get_glyph_width(char_code) * font_size / 1000.0;
                 advance += (glyph_adv + gs.char_space) * h_scale;
-                if char_code == 0x20 {
+                if word_space_eligible {
                     advance += gs.word_space * h_scale;
                 }
             } else {
                 let w1y = font.get_vertical_metrics(char_code).w1y;
                 let glyph_adv = w1y * font_size / 1000.0;
                 advance += glyph_adv + gs.char_space;
-                if char_code == 0x20 {
+                if word_space_eligible {
                     advance += gs.word_space;
                 }
             }
@@ -2255,6 +2277,63 @@ mod tests {
         assert!(
             ((-advance) - 9.0).abs() < 0.01,
             "vertical Tc must NOT pick up Tz: expected -9, got {}",
+            advance
+        );
+    }
+
+    /// Minimal simple (non-Type0) FontInfo for word-spacing tests — every
+    /// content byte is inherently single-byte, so `get_byte_mode` always
+    /// resolves to `ByteMode::OneByte` for it.
+    fn make_simple_test_font() -> FontInfo {
+        let mut font = make_vertical_test_font();
+        font.subtype = "Type1".to_string();
+        font.encoding = Encoding::Standard("WinAnsiEncoding".to_string());
+        font.cid_to_gid_map = None;
+        font.cid_font_type = None;
+        font.wmode = 0;
+        font
+    }
+
+    /// Per ISO 32000-1:2008 §9.3.3, Tw applies only to the single-byte
+    /// character code 32 — never to the byte value 32 inside a multi-byte
+    /// code. A 2-byte Identity CID `<0020>` (code 32, but a 2-byte code)
+    /// must NOT receive word spacing, even though the raw code equals 32.
+    #[test]
+    fn measure_text_bytes_skips_tw_for_multibyte_cid_32() {
+        let font = make_vertical_test_font(); // Type0, Identity (2-byte codes)
+        let mut gs = GraphicsState::new();
+        gs.font_size = 12.0;
+        gs.text_wmode = 0;
+        gs.word_space = 100.0;
+
+        let bytes: &[u8] = &[0x00, 0x20]; // 2-byte CID 32
+        let advance = measure_text_bytes(bytes, &gs, Some(&font));
+
+        // Glyph width only (1000/1000 * 12 = 12); Tw must be excluded.
+        assert!(
+            (advance - 12.0).abs() < 0.01,
+            "Tw must not apply to a 2-byte CID 32, expected 12.0, got {}",
+            advance
+        );
+    }
+
+    /// Control for the test above: a *simple* font's single-byte code 32
+    /// is exactly the case §9.3.3 targets, so Tw must still apply there.
+    #[test]
+    fn measure_text_bytes_applies_tw_for_single_byte_code_32() {
+        let font = make_simple_test_font();
+        let mut gs = GraphicsState::new();
+        gs.font_size = 12.0;
+        gs.text_wmode = 0;
+        gs.word_space = 100.0;
+
+        let bytes: &[u8] = &[0x20]; // single-byte code 32
+        let advance = measure_text_bytes(bytes, &gs, Some(&font));
+
+        // Glyph width (12.0) + Tw (100.0) = 112.0.
+        assert!(
+            (advance - 112.0).abs() < 0.01,
+            "Tw must apply to a single-byte code 32, expected 112.0, got {}",
             advance
         );
     }

--- a/tests/word_spacing_multibyte_cid.rs
+++ b/tests/word_spacing_multibyte_cid.rs
@@ -22,9 +22,8 @@ fn build_identity_h_pdf(word_space: f32) -> Vec<u8> {
     let size = 24.0f32;
     let w_units = 500u32;
 
-    let content = format!(
-        "{word_space} Tw\nBT\n/F1 {size} Tf\n1 0 0 1 40 720 Tm\n<004100200042> Tj\nET\n"
-    );
+    let content =
+        format!("{word_space} Tw\nBT\n/F1 {size} Tf\n1 0 0 1 40 720 Tm\n<004100200042> Tj\nET\n");
     let content_b = content.into_bytes();
 
     // /ToUnicode: CID 0x0041 -> 'A', CID 0x0020 -> U+0020 (space), CID 0x0042 -> 'B'.
@@ -118,8 +117,7 @@ fn word_spacing_does_not_shift_glyph_after_multibyte_cid_32() {
 #[test]
 fn word_spacing_shifts_glyph_after_single_byte_space() {
     fn build_simple_pdf(word_space: f32) -> Vec<u8> {
-        let content =
-            format!("{word_space} Tw\nBT\n/F1 24 Tf\n1 0 0 1 40 720 Tm\n(A B) Tj\nET\n");
+        let content = format!("{word_space} Tw\nBT\n/F1 24 Tf\n1 0 0 1 40 720 Tm\n(A B) Tj\nET\n");
         let content_b = content.into_bytes();
         let objs: Vec<String> = vec![
             "<< /Type /Catalog /Pages 2 0 R >>".to_string(),

--- a/tests/word_spacing_multibyte_cid.rs
+++ b/tests/word_spacing_multibyte_cid.rs
@@ -1,0 +1,171 @@
+//! Word spacing (`Tw`) must apply only to the single-byte character code 32
+//! (ISO 32000-1:2008 §9.3.3): "Word spacing shall be applied to every
+//! occurrence of the single-byte character code 32 in a string... Word
+//! spacing shall not apply to occurrences of the byte value 32 in
+//! multiple-byte codes." A Type0/Identity-H font's codes are always 2 bytes,
+//! so CID 32 (content-stream bytes `<0020>`) must never receive `Tw`, even
+//! though its Unicode mapping (or raw numeric value) happens to be 32 — a
+//! real embedded glyph at that code point must not be over-advanced as if
+//! it were a word gap.
+//!
+//! The fixture is 100% synthetic: a 3-glyph Identity-H run (`A`, CID 32
+//! mapped to U+0020 via `/ToUnicode`, `B`) with an explicit uniform `/W`
+//! width, compared under `Tw = 0` and `Tw = 50` — the span's total advance
+//! width must be identical in both, proving the multi-byte CID 32 did not
+//! absorb the word-spacing addend.
+
+use pdf_oxide::PdfDocument;
+
+/// Build a single-page PDF drawing 3 Identity-H CIDs (`0041`, `0020`, `0042`)
+/// each with declared width 500/1000 em, with the given `Tw` value active.
+fn build_identity_h_pdf(word_space: f32) -> Vec<u8> {
+    let size = 24.0f32;
+    let w_units = 500u32;
+
+    let content = format!(
+        "{word_space} Tw\nBT\n/F1 {size} Tf\n1 0 0 1 40 720 Tm\n<004100200042> Tj\nET\n"
+    );
+    let content_b = content.into_bytes();
+
+    // /ToUnicode: CID 0x0041 -> 'A', CID 0x0020 -> U+0020 (space), CID 0x0042 -> 'B'.
+    let cmap = "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n\
+         /CIDSystemInfo <</Registry (Adobe) /Ordering (UCS) /Supplement 0>> def\n\
+         /CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n\
+         1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n\
+         3 beginbfchar\n<0041> <0041>\n<0020> <0020>\n<0042> <0042>\nendbfchar\nendcmap\nend\nend";
+    let cmap_b = cmap.as_bytes();
+
+    let basefont = "AAAAAA+Sub";
+    let objs: Vec<String> = vec![
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .to_string(),
+        format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            content_b.len(),
+            String::from_utf8_lossy(&content_b)
+        ),
+        format!(
+            "<< /Type /Font /Subtype /Type0 /BaseFont /{basefont} /Encoding /Identity-H \
+             /DescendantFonts [6 0 R] /ToUnicode 8 0 R >>"
+        ),
+        format!(
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /{basefont} \
+             /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> \
+             /FontDescriptor 7 0 R /DW {w_units} \
+             /W [65 [{w_units}] 32 [{w_units}] 66 [{w_units}]] /CIDToGIDMap /Identity >>"
+        ),
+        format!(
+            "<< /Type /FontDescriptor /FontName /{basefont} /Flags 4 \
+             /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 800 /Descent -200 \
+             /CapHeight 700 /StemV 80 /MissingWidth {w_units} >>"
+        ),
+        format!(
+            "<< /Length {} >>\nstream\n{}\nendstream",
+            cmap_b.len(),
+            String::from_utf8_lossy(cmap_b)
+        ),
+    ];
+
+    let mut out: Vec<u8> = b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n".to_vec();
+    let mut offsets = Vec::with_capacity(objs.len());
+    for (i, body) in objs.iter().enumerate() {
+        offsets.push(out.len());
+        out.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", i + 1).as_bytes());
+    }
+    let xref_pos = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n0000000000 65535 f \n", objs.len() + 1).as_bytes());
+    for off in &offsets {
+        out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF",
+            objs.len() + 1
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+/// Total advance width of the single Tj span on page 0 — directly reflects
+/// whatever the extractor accumulated across all 3 CIDs, including any
+/// (incorrectly) applied Tw.
+fn span_width(pdf: &[u8]) -> f32 {
+    let doc = PdfDocument::from_bytes(pdf.to_vec()).expect("parse pdf");
+    let spans = doc.extract_spans(0).expect("extract_spans");
+    assert_eq!(spans.len(), 1, "expected exactly 1 span, got {:?}", spans);
+    spans[0].bbox.width
+}
+
+#[test]
+fn word_spacing_does_not_shift_glyph_after_multibyte_cid_32() {
+    let w_no_tw = span_width(&build_identity_h_pdf(0.0));
+    let w_with_tw = span_width(&build_identity_h_pdf(50.0));
+
+    assert!(
+        (w_no_tw - w_with_tw).abs() < 0.01,
+        "Tw must not apply to the 2-byte CID 32 glyph: no-Tw width={}, Tw=50 width={}",
+        w_no_tw,
+        w_with_tw
+    );
+}
+
+/// Control: the same word-spacing value DOES shift a simple (single-byte)
+/// font's real space character, proving the fix does not disable Tw wholesale.
+#[test]
+fn word_spacing_shifts_glyph_after_single_byte_space() {
+    fn build_simple_pdf(word_space: f32) -> Vec<u8> {
+        let content =
+            format!("{word_space} Tw\nBT\n/F1 24 Tf\n1 0 0 1 40 720 Tm\n(A B) Tj\nET\n");
+        let content_b = content.into_bytes();
+        let objs: Vec<String> = vec![
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+             /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+                .to_string(),
+            format!(
+                "<< /Length {} >>\nstream\n{}\nendstream",
+                content_b.len(),
+                String::from_utf8_lossy(&content_b)
+            ),
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
+                .to_string(),
+        ];
+        let mut out: Vec<u8> = b"%PDF-1.4\n".to_vec();
+        let mut offsets = Vec::with_capacity(objs.len());
+        for (i, body) in objs.iter().enumerate() {
+            offsets.push(out.len());
+            out.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", i + 1).as_bytes());
+        }
+        let xref_pos = out.len();
+        out.extend_from_slice(
+            format!("xref\n0 {}\n0000000000 65535 f \n", objs.len() + 1).as_bytes(),
+        );
+        for off in &offsets {
+            out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+        }
+        out.extend_from_slice(
+            format!(
+                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF",
+                objs.len() + 1
+            )
+            .as_bytes(),
+        );
+        out
+    }
+
+    let w_no_tw = span_width(&build_simple_pdf(0.0));
+    let w_with_tw = span_width(&build_simple_pdf(50.0));
+
+    assert!(
+        w_with_tw - w_no_tw > 40.0,
+        "Tw=50 must widen the span containing a single-byte space by ~50pt: \
+         no-Tw width={}, Tw=50 width={}",
+        w_no_tw,
+        w_with_tw
+    );
+}


### PR DESCRIPTION
## Summary
ISO 32000-1:2008 §9.3.3: word spacing applies only to the single-byte character code 32 — never to the byte value 32 inside a multi-byte code (e.g. a 2-byte Identity-H CID). This gate was correctly present at 2 call sites in this codebase but missing at 6 others, all of which discarded the byte-width `TextCharIter` already reports and gated on the character code alone:

- `extractors/text.rs::append_and_advance` (Type0 horizontal + vertical arms)
- `rendering/text_rasterizer.rs::measure_text_bytes`, `render_cid_direct`, `render_substituted_cjk`, and `render_unicode_text` (2 locations)

`render_unicode_text` shapes already-decoded text through harfbuzz, so it has no per-glyph byte-width signal of its own; gated on `get_byte_mode(font_info) != ByteMode::TwoByte` instead, computed once per call — the same per-font byte-mode classifier `TextCharIter` itself is built on.

`render_text_fallback` (no font info at all) was checked and left unchanged — its unconditional space check matches this codebase's existing "no font info implies single-byte" convention used identically elsewhere (`measure_text_bytes`'s and `advance_position_for_string`'s own no-font arms).

## Test plan
- [x] `measure_text_bytes_skips_tw_for_multibyte_cid_32` + single-byte control, inline unit tests in `text_rasterizer.rs`
- [x] `word_spacing_does_not_shift_glyph_after_multibyte_cid_32` + single-byte-font control — Identity-H 3-glyph run, `Tw=0` vs `Tw=50` span-width comparison
- [x] `cargo test --release --test word_spacing_multibyte_cid` — 2/2 pass
- [x] `cargo test --release --lib` — 5789/5789 pass, 0 regressions

Closes #1016