### PR TITLE
fix(redaction): wrap pruned body in q/Q before drawing overlays

### DIFF
--- a/src/redaction/engine.rs
+++ b/src/redaction/engine.rs
@@ -153,10 +153,22 @@ pub fn redact_content_stream(
         ));
     }
 
+    // Wrap the pruned body in its own outer q/Q. A content stream is under
+    // no obligation to leave the CTM at identity at end-of-stream (a
+    // trailing, unmatched `cm` — e.g. a Y-flip with no closing `Q` — is
+    // legal and common). Without this wrapper the overlay ops below, which
+    // draw in the region's absolute page-space coordinates, would inherit
+    // whatever CTM the pruned content left active and land in the wrong
+    // place. `q` at the very start of the stream saves the stream's
+    // original (identity) CTM; the matching `Q` restores it before any
+    // overlay is drawn, regardless of what the pruned operators did to the
+    // CTM in between. Same fix shape qpdf uses for the identical hazard.
     let mut body = Vec::with_capacity(content.len());
+    body.extend_from_slice(b"q\n");
     for op in &te.operators {
         serialize_operator(&mut body, op);
     }
+    body.extend_from_slice(b"Q\n");
 
     for region in &regions.regions {
         body.extend_from_slice(&region_overlay_ops(region, opts));
@@ -303,5 +315,29 @@ mod tests {
             &Stub,
         );
         let _ = redact_content_stream(b"", &regions, &RedactionOptions::default(), &Stub);
+    }
+
+    #[test]
+    fn pruned_body_wrapped_in_own_q_before_overlay() {
+        // A trailing, unmatched `cm` (e.g. a Y-flip a producer applies once
+        // and never restores — legal per ISO 32000-1: the CTM is not
+        // required to be identity at end-of-stream) must not leak into the
+        // overlay, which draws in the region's absolute page-space
+        // coordinates. The pruned body must be wrapped in its own `q`/`Q`
+        // so the overlay always starts from the stream's original CTM.
+        let doc = b"1 0 0 -1 0 792 cm\n";
+        let regions = one_region(90.0, 695.0, 160.0, 715.0);
+        let (out, _report) =
+            redact_content_stream(doc, &regions, &RedactionOptions::default(), &Stub).unwrap();
+
+        let s = String::from_utf8_lossy(&out);
+        assert!(s.starts_with("q\n"), "pruned body must open with q: {s}");
+        let wrapper_q_close = s.find("Q\n").expect("closing Q for the pruned-body wrapper");
+        let overlay_rg = s.find("rg\n").expect("overlay rg op");
+        assert!(
+            wrapper_q_close < overlay_rg,
+            "the wrapper Q must close (restoring the original CTM) before the \
+             overlay starts drawing: {s}"
+        );
     }
 }

--- a/src/redaction/engine.rs
+++ b/src/redaction/engine.rs
@@ -332,7 +332,9 @@ mod tests {
 
         let s = String::from_utf8_lossy(&out);
         assert!(s.starts_with("q\n"), "pruned body must open with q: {s}");
-        let wrapper_q_close = s.find("Q\n").expect("closing Q for the pruned-body wrapper");
+        let wrapper_q_close = s
+            .find("Q\n")
+            .expect("closing Q for the pruned-body wrapper");
         let overlay_rg = s.find("rg\n").expect("overlay rg op");
         assert!(
             wrapper_q_close < overlay_rg,


### PR DESCRIPTION
## Summary
`redact_content_stream` serialized the pruned text operators directly, then appended each region's opaque overlay right after — with no CTM reset in between. A content stream is under no obligation to leave the CTM at identity at end-of-stream (a Y-flip `cm` with no matching `Q` is legal and a common producer pattern); the overlay draws in the region's absolute page-space coordinates, so it inherited whatever CTM the pruned content left active and landed in the wrong place.

Wraps the pruned body in its own outer `q`/`Q`: the `q` at the very start of the stream saves the stream's original (identity) CTM, and the matching `Q` restores it before any overlay is drawn, regardless of what the pruned operators did to the CTM in between. Same fix shape qpdf uses for the identical hazard.

## Test plan
- [x] `pruned_body_wrapped_in_own_q_before_overlay` — content stream that is only a trailing unmatched Y-flip `cm` (isolates the positioning hazard from the unrelated question of whether CTM-aware text removal is itself correct); asserts the emitted stream opens with `q` and the wrapper's closing `Q` appears before the overlay's paint ops
- [x] `cargo test --release --lib` — 5789/5789 pass, 0 regressions (including all pre-existing redaction tests)

Closes #1015