### PR TITLE
fix(image): CCITT /K absent must default to Group 3, not Group 4

### DIFF
--- a/src/decoders/predictor.rs
+++ b/src/decoders/predictor.rs
@@ -98,7 +98,7 @@ pub struct CcittParams {
 impl Default for CcittParams {
     fn default() -> Self {
         Self {
-            k: -1, // Group 4
+            k: 0, // ISO 32000-1 Table 11: default is Group 3, pure 1-D
             columns: 1,
             rows: None,
             black_is_1: false, // PDF default: white=0, black=1

--- a/src/object.rs
+++ b/src/object.rs
@@ -423,8 +423,10 @@ pub fn extract_ccitt_params_with_width(
         _ => return None,
     };
 
-    // Extract CCITT parameters with PDF defaults
-    let k = dict.get("K").and_then(|obj| obj.as_integer()).unwrap_or(-1); // Default: Group 4
+    // Extract CCITT parameters with PDF defaults.
+    // ISO 32000-1:2008 Table 11: /K absent defaults to 0 (pure 1-D Group 3),
+    // not Group 4 (-2) or mixed Group 3/4 (K > 0).
+    let k = dict.get("K").and_then(|obj| obj.as_integer()).unwrap_or(0); // Default: Group 3, 1-D
 
     let columns = dict
         .get("Columns")
@@ -945,7 +947,7 @@ mod tests {
     fn test_extract_ccitt_params_defaults() {
         let dict = Object::Dictionary(HashMap::new());
         let result = extract_ccitt_params(Some(&dict)).unwrap();
-        assert_eq!(result.k, -1); // Default: Group 4
+        assert_eq!(result.k, 0); // ISO 32000-1 Table 11 default: Group 3, 1-D
         assert_eq!(result.columns, 1);
         assert!(result.rows.is_none());
         assert!(!result.black_is_1);


### PR DESCRIPTION
## Summary
ISO 32000-1:2008 Table 11 specifies `/K` absent defaults to `0` (pure 1-D Group 3 encoding). `extract_ccitt_params_with_width` and `CcittParams::default()` both defaulted to `-1` (Group 4), decoding CCITT-encoded images with no explicit `/K` using the wrong algorithm and rendering them blank.

The Group 3 decoder already existed and is correct — this is a one-value correction to the default.

## Test plan
- [x] `object::tests::test_extract_ccitt_params_defaults` — updated to assert the new default
- [x] `absent_k_uses_pdf_group3_one_dimensional_default` (pre-existing, `tests/test_ccitt_image_mask_rendering.rs`) — now passes; this test already existed and directly covered this exact scenario, suggesting the bug was previously known but the default-value fix itself was never applied
- [x] `cargo test --release --lib` — 5789/5789 pass, 0 regressions
- [x] `cargo test --release --features rendering --test test_ccitt_image_mask_rendering` — 8/8 pass

Closes #1030