### PR TITLE
fix(content): recover a top-level cm with no enclosing q in >256KB prescan

### DIFF
--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -1114,6 +1114,14 @@ fn find_region_start(data: &[u8], pos: usize) -> (usize, bool) {
     // Find the last unmatched q by tracking Q/q balance backwards
     let mut q_depth: i32 = 0;
     let mut best_q_pos = pos; // Default: start from text position itself
+                              // A `cm` operator encountered while `q_depth == 0` sits outside any
+                              // enclosing `q`/`Q` bracket this scan can see — a common CAD-exporter
+                              // pattern is a single top-level `cm` right at the start of the stream
+                              // (no `q` at all) establishing a scale/offset for everything after it.
+                              // This function only tracks `q`/`Q`, so on its own it would report
+                              // `best_q_pos == pos` (nothing found) and, if the scan also reached
+                              // byte 0, `hit_limit == false` — silently discarding that transform.
+    let mut saw_top_level_cm = false;
     let mut i = region.len();
 
     while i > 0 {
@@ -1151,14 +1159,33 @@ fn find_region_start(data: &[u8], pos: usize) -> (usize, bool) {
                     }
                 }
             }
+        } else if b == b'm' && i > 0 && region[i - 1] == b'c' && q_depth == 0 {
+            // Look for a standalone 'cm' operator (2-byte token) at
+            // q_depth == 0 — i.e. not nested inside an already-matched
+            // (skipped-over) q/Q pair.
+            let tok_start = i - 1;
+            let before_ok = tok_start == 0 || {
+                let prev = region[tok_start - 1];
+                prev.is_ascii_whitespace() || matches!(prev, b')' | b'>' | b']')
+            };
+            let after_ok = i + 1 >= region.len() || {
+                let next = region[i + 1];
+                next.is_ascii_whitespace() || next == b'%'
+            };
+            if before_ok && after_ok {
+                saw_top_level_cm = true;
+            }
         }
     }
 
     // We can only guarantee complete CTM context if we scanned all the way
     // to the beginning of the data. Even if we found an unmatched 'q' within
     // 4KB, there may be additional enclosing q/cm operators before the scan
-    // window that establish scaling transforms we're missing.
-    let hit_limit = scan_start > 0;
+    // window that establish scaling transforms we're missing. A top-level
+    // `cm` visible in the scanned window but outside any `q`/`Q` this
+    // function tracks needs the same fallback, even when the scan reached
+    // byte 0 of the stream.
+    let hit_limit = scan_start > 0 || saw_top_level_cm;
     (best_q_pos, hit_limit)
 }
 
@@ -5141,6 +5168,72 @@ mod tests {
         assert!(
             has_scaled_cm,
             "injected Cm should include outer 0.1x scaling, got: {:?}",
+            cm_ops
+        );
+    }
+
+    #[test]
+    fn test_prescan_captures_top_level_cm_with_no_enclosing_q() {
+        // Regression test for issue #974: a common CAD-exporter pattern
+        // issues a single top-level `cm` (no enclosing q/Q at all) right at
+        // the start of the stream, with text shortly after — within the
+        // same <4KB window `find_region_start` scans backward from BT.
+        // That scan only tracks q/Q; when it found no unmatched q and
+        // reached all the way back to byte 0, it reported "nothing
+        // missing" (hit_limit == false), silently discarding the leading
+        // cm. The resulting text region started exactly at BT — excluding
+        // the cm's bytes entirely — and no forward-scan fallback ever ran
+        // to recover it, so the text was parsed under an identity CTM
+        // instead of the real ~16.67x scale (matching the reported
+        // extract_spans-vs-extract_chars position mismatch).
+        let mut cs = Vec::new();
+
+        // Top-level scaling cm — NO enclosing q, unlike the other prescan
+        // tests in this module.
+        cs.extend_from_slice(b"16.6666667 0 0 16.6666667 0 0 cm\n");
+
+        cs.extend_from_slice(b"BT\n");
+        cs.extend_from_slice(b"/F1 80 Tf\n");
+        cs.extend_from_slice(b"(G0.2) Tj\n");
+        cs.extend_from_slice(b"ET\n");
+
+        // >256KB of filler AFTER the text, so the overall stream crosses
+        // the prescan fast-path threshold while the BT position itself
+        // stays well within the first 4KB find_region_start scans.
+        for i in 0..13000u32 {
+            let line = format!(
+                "{}.0 {}.0 m {}.0 {}.0 l n\n",
+                i % 500,
+                (i * 7) % 500,
+                (i * 3) % 500,
+                (i * 11) % 500
+            );
+            cs.extend_from_slice(line.as_bytes());
+        }
+        assert!(cs.len() > 256 * 1024, "stream must exceed 256KB prescan threshold");
+
+        let mut ops = Vec::new();
+        parse_and_execute_text_only(&cs, |op| {
+            ops.push(op);
+            Ok(())
+        })
+        .unwrap();
+
+        let cm_ops: Vec<_> = ops
+            .iter()
+            .filter(|op| matches!(op, Operator::Cm { .. }))
+            .collect();
+        let has_scaled_cm = cm_ops.iter().any(|op| {
+            matches!(
+                op,
+                Operator::Cm { a, d, .. }
+                    if (*a - 16.666_666).abs() < 0.01 && (*d - 16.666_666).abs() < 0.01
+            )
+        });
+        assert!(
+            has_scaled_cm,
+            "the top-level 16.6667x cm (no enclosing q) must not be silently \
+             dropped, got: {:?}",
             cm_ops
         );
     }


### PR DESCRIPTION
## Summary
`extract_spans`'s >256KB fast-path prescan finds each `BT`/`Do` region's starting graphics-state context by scanning backward for the nearest unmatched `q`, within a 4KB window. When it found no unmatched `q` and the scan reached all the way back to byte 0, it reported "nothing missing" — but that scan only ever tracked `q`/`Q` tokens, never `cm`. A common CAD-exporter pattern issues a single top-level `cm` (no enclosing `q` at all) right at the start of the stream; that `cm`'s bytes sit before the carved-out region's start (which defaults to the `BT`/`Do` position itself when no `q` is found), so they were silently excluded from the region entirely and no forward-CTM-scan fallback ever ran to recover the missing transform. Text was then parsed under an identity CTM instead of the real scale, producing spans positioned in raw pre-CTM text space while `extract_chars` (which doesn't use this fast path) reported the same glyphs correctly.

`find_region_start` now also tracks whether it saw a `cm` operator at `q_depth == 0` (i.e. not nested inside an already-matched `q`/`Q` pair) and forces the existing `forward_scan_ctm()` fallback when it did, even when the backward scan reached byte 0.

## Test plan
- [x] `test_prescan_captures_top_level_cm_with_no_enclosing_q` — >256KB synthetic stream with a top-level 16.6667x `cm` and no enclosing `q`, text shortly after; asserts the `cm` survives (as itself or via an injected `Cm`) rather than being silently dropped
- [x] `cargo test --release --lib` — 5786/5786 pass, plus isolated confirmation of the new test specifically (1/1 pass)

Closes #974