### PR TITLE
fix(convert): strip_running_headers_footers must match whole lines

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -20180,7 +20180,11 @@ impl PdfDocument {
                     .get_page_media_box(page_index)
                     .map(|m| m.3)
                     .unwrap_or(792.0);
-                base_spans.retain(|s| !Self::is_running_head_foot(s, media_h, &repeated));
+                let head_foot_lines =
+                    self.running_head_foot_line_bboxes(page_index, media_h, &repeated);
+                if !head_foot_lines.is_empty() {
+                    base_spans.retain(|s| !head_foot_lines.iter().any(|lb| lb.intersects(&s.bbox)));
+                }
             }
         }
 
@@ -21638,6 +21642,16 @@ impl PdfDocument {
     /// of pages — running headers/footers. Page-number digits are stripped so
     /// "Page 3"/"Page 4" collapse to one signature. Empty for documents under
     /// 3 pages (repetition can't be judged) or when nothing repeats.
+    /// Collects repetition signatures from whole assembled **lines**, not
+    /// individual spans (#1022). A genuine running header/footer is the
+    /// same complete line of text on every page it appears on; a SPAN is
+    /// often just a fragment of a line (font/color-run boundaries split one
+    /// visual line into several spans), and matching at fragment
+    /// granularity lets a phrase that coincidentally recurs across
+    /// unrelated body paragraphs — e.g. the first line of a column, which
+    /// also falls inside the geometric head/foot band in a dense
+    /// multi-column layout — masquerade as page furniture and get deleted
+    /// everywhere it occurs, including mid-sentence.
     pub(crate) fn repeated_running_head_foot(
         &self,
         threshold: f32,
@@ -21654,15 +21668,15 @@ impl PdfDocument {
         let mut occ: HashMap<String, usize> = HashMap::new();
         for p in 0..page_count {
             let media_h = self.get_page_media_box(p).map(|m| m.3).unwrap_or(792.0);
-            let Ok(spans) = self.extract_spans(p) else {
+            let Ok(lines) = self.extract_text_lines(p) else {
                 continue;
             };
             let mut seen: HashSet<String> = HashSet::new();
-            for s in &spans {
-                if !Self::in_head_foot_band(s, media_h) {
+            for line in &lines {
+                if !Self::in_head_foot_band(line.bbox.y, line.bbox.height, media_h) {
                     continue;
                 }
-                let norm = Self::normalize_band_line(&s.text);
+                let norm = Self::normalize_band_line(&line.text);
                 // Count each distinct line once per page.
                 if norm.len() > 3 && seen.insert(norm.clone()) {
                     *occ.entry(norm).or_default() += 1;
@@ -21677,9 +21691,11 @@ impl PdfDocument {
         out
     }
 
-    /// True when a span sits in the top or bottom 15% band of the page.
-    fn in_head_foot_band(s: &crate::layout::TextSpan, media_h: f32) -> bool {
-        s.bbox.y > media_h * 0.85 || (s.bbox.y + s.bbox.height) < media_h * 0.15
+    /// True when a region sits in the top or bottom 15% band of the page.
+    /// `y`/`height` are a bbox's own fields (shared by `TextSpan` and
+    /// `TextLine`, which don't share a common bbox-accessor trait).
+    fn in_head_foot_band(y: f32, height: f32, media_h: f32) -> bool {
+        y > media_h * 0.85 || (y + height) < media_h * 0.15
     }
 
     /// Normalize a band line for repetition matching: drop ASCII digits (page
@@ -21693,15 +21709,30 @@ impl PdfDocument {
             .to_lowercase()
     }
 
-    /// True when `span` is a running header/footer to strip: in the top/bottom
-    /// band and its normalized text is one of the `repeated` signatures.
-    fn is_running_head_foot(
-        span: &crate::layout::TextSpan,
+    /// Bounding boxes (on this page) of assembled lines whose normalized
+    /// text matches a `repeated_running_head_foot` signature. The
+    /// signature set is collected at whole-line granularity (see above),
+    /// but the actual stripping in `to_markdown_inner` still operates on
+    /// individual spans; this bridges the two by giving the caller the
+    /// matched lines' geometry so it can strip every span that belongs to
+    /// one, rather than re-matching (fragile) text at the span level.
+    fn running_head_foot_line_bboxes(
+        &self,
+        page_index: usize,
         media_h: f32,
         repeated: &std::collections::HashSet<String>,
-    ) -> bool {
-        Self::in_head_foot_band(span, media_h)
-            && repeated.contains(&Self::normalize_band_line(&span.text))
+    ) -> Vec<crate::geometry::Rect> {
+        let Ok(lines) = self.extract_text_lines(page_index) else {
+            return Vec::new();
+        };
+        lines
+            .into_iter()
+            .filter(|line| {
+                Self::in_head_foot_band(line.bbox.y, line.bbox.height, media_h)
+                    && repeated.contains(&Self::normalize_band_line(&line.text))
+            })
+            .map(|line| line.bbox)
+            .collect()
     }
 
     /// Extract embedded files / attachments (WS1.8a, ISO 32000-1 §7.11.4).

--- a/tests/strip_running_head_foot_multicolumn.rs
+++ b/tests/strip_running_head_foot_multicolumn.rs
@@ -1,0 +1,149 @@
+//! `ConversionOptions::strip_running_headers_footers` must strip only
+//! whole, verbatim-repeated running header/footer **lines**, never a
+//! fragment that merely recurs across pages while its surrounding line
+//! differs (#1022).
+//!
+//! `repeated_running_head_foot` previously collected repetition
+//! signatures from individual **spans**, not assembled lines. A span is
+//! often just a fragment of a visual line (a font/emphasis-run boundary
+//! splits one line into several spans — common in academic-paper body
+//! text with italicized terms). If that fragment happens to recur
+//! verbatim across enough pages — while the rest of the line it's part of
+//! differs every time, because it's ordinary body text, not page furniture
+//! — the old code treated the fragment itself as a running-header/footer
+//! signature and deleted it everywhere it occurred, including mid-sentence
+//! in unrelated paragraphs.
+//!
+//! The fixture is a synthetic 3-page PDF (no third-party files): every
+//! page has a genuine, identical, whole-line footer ("CONFIDENTIAL DRAFT")
+//! that must still be stripped, and a body paragraph whose first line
+//! starts with an italic-font fragment ("individual genes") — landing it
+//! in its own span — followed by page-specific continuation text in the
+//! regular font, so the *complete* first line differs on every page even
+//! though the leading fragment repeats.
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::PdfDocument;
+
+const FOOTER: &str = "CONFIDENTIAL DRAFT";
+const FRAGMENT: &str = "individual genes";
+
+/// Page-specific continuation text following the recurring `FRAGMENT`, so
+/// the complete first line is unique per page.
+const SUFFIXES: [&str; 3] = [
+    " contribute to observed traits.",
+    " affect disease onset here.",
+    " shape the outcome always.",
+];
+
+fn build_pdf() -> Vec<u8> {
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets: Vec<usize> = vec![0];
+
+    let mut obj = |pdf: &mut Vec<u8>, id: usize, head: String, stream: Option<&[u8]>| {
+        while offsets.len() <= id {
+            offsets.push(0);
+        }
+        offsets[id] = pdf.len();
+        pdf.extend_from_slice(format!("{id} 0 obj\n{head}").as_bytes());
+        if let Some(s) = stream {
+            pdf.extend_from_slice(b"\nstream\n");
+            pdf.extend_from_slice(s);
+            pdf.extend_from_slice(b"\nendstream");
+        }
+        pdf.extend_from_slice(b"\nendobj\n");
+    };
+
+    // 1: Catalog, 2: Pages
+    obj(&mut pdf, 1, "<< /Type /Catalog /Pages 2 0 R >>".to_string(), None);
+    obj(
+        &mut pdf,
+        2,
+        "<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 >>".to_string(),
+        None,
+    );
+
+    // MediaBox height 600: top-15% band is y > 510, bottom-15% band is y < 90.
+    // 3 Page objects: 3, 4, 5. Content streams: 6, 7, 8. Fonts: 9 (regular), 10 (italic).
+    for i in 0..3usize {
+        obj(
+            &mut pdf,
+            3 + i,
+            format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 600] \
+                 /Resources << /Font << /F1 9 0 R /F2 10 0 R >> >> /Contents {} 0 R >>",
+                6 + i
+            ),
+            None,
+        );
+    }
+    for i in 0..3usize {
+        let content = format!(
+            "BT\n/F2 12 Tf\n1 0 0 1 40 560 Tm\n({FRAGMENT}) Tj\n\
+             /F1 12 Tf\n({}) Tj\nET\n\
+             BT\n/F1 10 Tf\n1 0 0 1 40 30 Tm\n({FOOTER}) Tj\nET\n",
+            SUFFIXES[i]
+        );
+        let content = content.into_bytes();
+        obj(&mut pdf, 6 + i, format!("<< /Length {} >>", content.len()), Some(&content));
+    }
+
+    obj(
+        &mut pdf,
+        9,
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
+            .to_string(),
+        None,
+    );
+    obj(
+        &mut pdf,
+        10,
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding >>"
+            .to_string(),
+        None,
+    );
+
+    let xref_pos = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", offsets.len()).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for &off in &offsets[1..] {
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", off).as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            offsets.len(),
+            xref_pos
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+#[test]
+fn coincidentally_repeating_fragment_survives_while_footer_is_stripped() {
+    let doc = PdfDocument::from_bytes(build_pdf()).expect("fixture parses");
+    let opts = ConversionOptions {
+        strip_running_headers_footers: true,
+        ..Default::default()
+    };
+
+    for page in 0..3usize {
+        let md = doc.to_markdown(page, &opts).expect("to_markdown");
+        assert!(
+            !md.contains(FOOTER),
+            "page {page}: the genuine repeated footer must be stripped, got: {md:?}"
+        );
+        assert!(
+            md.contains(FRAGMENT),
+            "page {page}: the coincidentally-repeating fragment must survive — \
+             its complete line differs per page, so it is not real page furniture, \
+             got: {md:?}"
+        );
+        assert!(
+            md.contains(SUFFIXES[page].trim()),
+            "page {page}: the page-specific continuation must survive alongside \
+             the fragment, got: {md:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
`repeated_running_head_foot` collected repetition signatures from individual spans, not assembled lines. A span is often just a fragment of a visual line (font/emphasis-run boundaries split one line into several spans, common in academic-paper body text with italicized terms). A fragment that coincidentally recurs across pages while the rest of its line differs every time — e.g. the first line of a column, which also falls inside the geometric head/foot band in a dense multi-column layout — got treated as a running header/footer signature and deleted everywhere it occurred, including mid-sentence in unrelated paragraphs.

`repeated_running_head_foot` now collects signatures from whole assembled lines (`extract_text_lines`) instead of raw spans. The actual per-span stripping in `to_markdown_inner` still operates on spans (that's the granularity its content pipeline works in), so a new `running_head_foot_line_bboxes` helper bridges the two: a span is stripped when its bbox intersects a matched line's bbox, not by re-matching text at span granularity.

## Test plan
- [x] `strip_running_head_foot_multicolumn.rs` — synthetic 3-page PDF: a genuine identical-every-page footer (must still be stripped) and a body paragraph whose first line starts with a recurring italic-font fragment followed by page-specific continuation text (the fragment must survive, since its complete line differs per page)
- [x] `cargo test --release --test strip_running_head_foot_multicolumn` — 1/1 pass

Closes #1022