### PR TITLE
fix(content): balance marked-content scope per prescan region

### DIFF
--- a/src/content/parser.rs
+++ b/src/content/parser.rs
@@ -1449,6 +1449,20 @@ where
 
 /// Parse a sub-region of a content stream for text operators.
 /// Used by the pre-scan path to parse only identified text-bearing regions.
+///
+/// Each region is bracketed in `SaveState`/`RestoreState` by the caller, and
+/// CTM/font state is injected fresh per region — but the marked-content
+/// stack gets no such treatment, and a scope this region *opens* (BDC/BMC)
+/// without also *closing* (EMC) before the region ends would otherwise leak
+/// into every subsequent region indefinitely (#1033). This is fatal when
+/// the tag is `/PlacedPDF`: `is_content_suppressed` stays true forever,
+/// discarding all remaining text on the page. Tracks this region's own
+/// BDC/BMC vs EMC balance and emits synthetic `EndMarkedContent` operators
+/// for anything still open when the region ends — closing only what THIS
+/// region itself opened, never touching scopes open when it started (the
+/// safer half of a full cross-region marked-content-state carry, which
+/// isn't needed for the reported failure mode: it can only ever end scopes
+/// this region opened, never fabricate a scope's original tag/properties).
 fn parse_region_text_only<F>(data: &[u8], handler: &mut F) -> Result<()>
 where
     F: FnMut(Operator) -> Result<()>,
@@ -1457,6 +1471,19 @@ where
     let mut consecutive_errors: usize = 0;
     let mut inside_text = false;
     let mut op_count: usize = 0;
+    let mut mc_depth: u32 = 0;
+    let mut call = |op: Operator, handler: &mut F| -> Result<()> {
+        match &op {
+            Operator::BeginMarkedContent { .. } | Operator::BeginMarkedContentDict { .. } => {
+                mc_depth += 1;
+            },
+            Operator::EndMarkedContent => {
+                mc_depth = mc_depth.saturating_sub(1);
+            },
+            _ => {},
+        }
+        handler(op)
+    };
 
     while !input.is_empty() {
         while !input.is_empty() && input[0].is_ascii_whitespace() {
@@ -1475,7 +1502,7 @@ where
                 if matches!(op, Operator::EndText) {
                     inside_text = false;
                 }
-                handler(op)?;
+                call(op, handler)?;
                 op_count += 1;
                 input = rest;
                 consecutive_errors = 0;
@@ -1485,7 +1512,7 @@ where
                         if matches!(op, Operator::EndText) {
                             inside_text = false;
                         }
-                        handler(op)?;
+                        call(op, handler)?;
                         op_count += 1;
                         input = rest;
                         consecutive_errors = 0;
@@ -1507,7 +1534,7 @@ where
             match scan_graphics_region(input, &mut consecutive_errors) {
                 ScanResult::EndOfData => break,
                 ScanResult::FoundBT { rest } => {
-                    handler(Operator::BeginText)?;
+                    call(Operator::BeginText, handler)?;
                     op_count += 1;
                     input = rest;
                     inside_text = true;
@@ -1521,7 +1548,7 @@ where
                     after_op,
                 } => match parse_operator_with_operands(operand_start) {
                     Ok((rest2, op)) => {
-                        handler(op)?;
+                        call(op, handler)?;
                         op_count += 1;
                         input = rest2;
                     },
@@ -1535,7 +1562,7 @@ where
                     while remaining.len() > trigger_start.len() {
                         match parse_operator_with_operands(remaining) {
                             Ok((rest2, op)) => {
-                                handler(op)?;
+                                call(op, handler)?;
                                 op_count += 1;
                                 remaining = rest2;
                             },
@@ -1552,13 +1579,22 @@ where
                     consecutive_errors = 0;
                 },
                 ScanResult::SimpleOp { op, rest } => {
-                    handler(op)?;
+                    call(op, handler)?;
                     op_count += 1;
                     input = rest;
                 },
                 ScanResult::TooManyErrors { .. } => break,
             }
         }
+    }
+
+    // Balance any marked-content scope this region opened but did not
+    // close (BDC/BMC with no matching EMC before the region ended) — see
+    // the function doc comment. Closing only what this region itself
+    // opened is always safe: it never affects a scope that was already
+    // open when the region started.
+    for _ in 0..mc_depth {
+        handler(Operator::EndMarkedContent)?;
     }
 
     Ok(())

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -9774,6 +9774,59 @@ mod tests {
         );
     }
 
+    /// Regression test for issue #1033: a `/PlacedPDF` marked-content scope
+    /// whose `BDC` lands inside the first prescanned (>256KB fast-path)
+    /// text region but whose matching `EMC` falls outside it — past tens
+    /// of thousands of bytes of artwork the prescan never turns into a
+    /// text region — must not suppress text in every subsequent region.
+    /// Before the fix, `inside_placed_pdf` stayed `true` forever once the
+    /// scope's `EMC` fell outside a prescanned region's byte range, since
+    /// the marked-content stack (unlike CTM/font) got no
+    /// per-region balancing.
+    #[test]
+    fn test_prescan_marked_content_scope_does_not_leak_across_regions() {
+        let mut cs = Vec::new();
+        cs.extend_from_slice(b"/PlacedPDF /MC0 BDC\n");
+        cs.extend_from_slice(b"BT /F1 12 Tf 100 700 Td (Figure Label) Tj ET\n");
+        // >256KB of filler path data (the artwork) with no BT/Do at all,
+        // so the prescan never turns it into its own text region — the
+        // EMC below lands in the gap between the two BT regions.
+        for i in 0..13000u32 {
+            let line = format!(
+                "{}.0 {}.0 m {}.0 {}.0 l n\n",
+                i % 500,
+                (i * 7) % 500,
+                (i * 3) % 500,
+                (i * 11) % 500
+            );
+            cs.extend_from_slice(line.as_bytes());
+        }
+        cs.extend_from_slice(b"EMC\n");
+        cs.extend_from_slice(b"BT /F1 12 Tf 100 600 Td (Body Text After Figure) Tj ET\n");
+        assert!(cs.len() > 256 * 1024, "stream must exceed 256KB prescan threshold");
+
+        let font = create_test_font();
+        let mut extractor = TextExtractor::new();
+        extractor.add_font("F1".to_string(), font);
+
+        let spans = extractor.extract_text_spans(&cs).unwrap();
+        let all_text: String = spans
+            .iter()
+            .map(|s| s.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(
+            !all_text.contains("Figure Label"),
+            "text inside the /PlacedPDF scope must still be suppressed, got: {all_text:?}"
+        );
+        assert!(
+            all_text.contains("Body Text After Figure"),
+            "text after the /PlacedPDF scope closes (EMC) must not be suppressed \
+             just because the EMC fell outside the prescanned region, got: {all_text:?}"
+        );
+    }
+
     #[test]
     fn test_extract_save_restore() {
         let mut extractor = TextExtractor::new();


### PR DESCRIPTION
## Summary
The >256KB prescan fast path wraps each text region in `SaveState`/`RestoreState` with CTM/font state injected fresh per region, but the marked-content stack gets no such treatment. A `/PlacedPDF` scope whose `BDC` lands inside the first prescanned region but whose matching `EMC` falls outside it — e.g. Adobe InDesign wrapping a placed figure's label and artwork in one scope, where the artwork is tens of thousands of path operators the prescan never turns into its own text region — leaves `inside_placed_pdf` stuck `true` forever, since the region ends at `ET` and the `EMC` is never parsed. Every subsequent region's text is then silently discarded.

Suppressing text *inside* the placed figure is correct behavior; the defect is the suppression outliving the scope. `parse_region_text_only` now tracks its own BDC/BMC-vs-EMC balance while parsing a region and emits synthetic `EndMarkedContent` operators for anything still open when the region ends — closing only what that region itself opened, never touching a scope that was already open when it started (the safer half of a full cross-region marked-content-state carry, which isn't needed for this failure mode).

## Test plan
- [x] `test_prescan_marked_content_scope_does_not_leak_across_regions` — >256KB stream with a `/PlacedPDF` BDC+label+huge filler+EMC+body text; asserts the label stays suppressed (scope working correctly) and the body text survives (scope closes correctly, doesn't leak)
- [x] `cargo test --release --lib` — 5787/5787 pass, 0 regressions

Closes #1033