### PR TITLE
fix(editor): decrypt stream data before re-serializing an encrypted source

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1361,6 +1361,55 @@ impl PdfDocument {
         }
     }
 
+    /// Decrypt a stream object's raw bytes for re-serialization elsewhere,
+    /// **without** decompressing it — unlike [`Self::decode_stream_with_encryption`],
+    /// which both decrypts and applies `/Filter` (needed by extraction, which
+    /// wants the final bytes). A writer that re-emits the object verbatim
+    /// (same `/Filter`, e.g. FlateDecode) wants the opposite: decrypt only,
+    /// leave the filter's compressed bytes alone, so the `/Filter` entry it
+    /// copies stays valid.
+    ///
+    /// A no-op when the document isn't encrypted or the object isn't a
+    /// stream, so callers can apply it unconditionally to every object they
+    /// copy out of `self` — e.g. every write path that copies objects from
+    /// an already-open, possibly-encrypted source document into a new
+    /// output file with no `/Encrypt` dictionary of its own (issue #1032:
+    /// those paths were re-serializing the source's raw ciphertext
+    /// verbatim, producing a structurally valid but unreadable PDF with no
+    /// error or warning).
+    pub(crate) fn decrypt_stream_for_copy(
+        &self,
+        obj: Object,
+        obj_ref: ObjectRef,
+    ) -> Result<Object> {
+        let Object::Stream { mut dict, data } = obj else {
+            return Ok(obj);
+        };
+        // Per ISO 32000-2:2020 §7.6.3, object streams and cross-reference
+        // streams are never encrypted — same exclusion as
+        // `decode_stream_with_encryption` above.
+        let is_unencrypted_stream_type = dict
+            .get("Type")
+            .and_then(|t| t.as_name())
+            .map(|name| name == "ObjStm" || name == "XRef")
+            .unwrap_or(false);
+        if is_unencrypted_stream_type {
+            return Ok(Object::Stream { dict, data });
+        }
+        let handler_ref = self.encryption_handler.lock_or_recover();
+        let Some(handler) = handler_ref.as_ref() else {
+            drop(handler_ref);
+            return Ok(Object::Stream { dict, data });
+        };
+        let decrypted = handler.decrypt_stream(&data, obj_ref.id, obj_ref.gen as u32)?;
+        drop(handler_ref);
+        dict.insert("Length".to_string(), Object::Integer(decrypted.len() as i64));
+        Ok(Object::Stream {
+            dict,
+            data: decrypted.into(),
+        })
+    }
+
     /// Open with custom extraction profile.
     ///
     /// Currently, the profile is not used at the document level but is reserved

--- a/src/editor/document_editor.rs
+++ b/src/editor/document_editor.rs
@@ -1550,6 +1550,27 @@ impl DocumentEditor {
     /// Write an incremental update to the PDF.
     #[cfg(not(target_arch = "wasm32"))]
     fn write_incremental(&mut self, path: impl AsRef<Path>) -> Result<()> {
+        // Refuse rather than silently corrupt (#1032): an incremental
+        // update appends new/modified objects as plain, unencrypted bytes
+        // after the untouched original file (which keeps its own streams
+        // correctly encrypted and readable under the original password),
+        // but the trailer's /Prev chain still points back to the source's
+        // /Encrypt dictionary — a conforming reader would try to decrypt
+        // the newly-appended plaintext objects with the document's
+        // original key and corrupt them. Properly supporting this would
+        // mean re-encrypting the appended objects under the source's own
+        // key (EncryptionHandler already exposes what that needs), which
+        // is a real but separate feature; for now, direct callers to the
+        // full-rewrite path instead, which already decrypts-then-emits
+        // every copied stream plaintext.
+        if self.source.is_encrypted() {
+            return Err(Error::InvalidPdf(
+                "incremental save is not supported for encrypted documents; \
+                 use save_to_bytes()/save_with_options(SaveOptions::full_rewrite()) instead"
+                    .to_string(),
+            ));
+        }
+
         // Read original file
         let original_bytes = self.read_source_bytes()?;
         let original_len = original_bytes.len();
@@ -1834,6 +1855,19 @@ impl DocumentEditor {
         reachable
     }
 
+    /// Load an object from `self.source` for copying into the output file,
+    /// decrypting its stream data (if any) so it survives into an output
+    /// with no `/Encrypt` dictionary of its own (#1032). A no-op beyond the
+    /// plain load when the source isn't encrypted. Every `self.source.load_object`
+    /// call in `write_full_to_writer` whose result can reach the output
+    /// writer goes through this instead of the raw accessor — the one
+    /// exception is `collect_reachable_ids`'s graph walk just above, which
+    /// only inspects references and never emits bytes.
+    fn load_source_object(&self, r: ObjectRef) -> Result<Object> {
+        let obj = self.source.load_object(r)?;
+        self.source.decrypt_stream_for_copy(obj, r)
+    }
+
     /// Write a full rewrite of the PDF to a generic writer.
     fn write_full_to_writer(
         &mut self,
@@ -1844,6 +1878,17 @@ impl DocumentEditor {
             generate_file_id, Algorithm, EncryptDictBuilder, EncryptionWriteHandler,
         };
         use flate2::{write::ZlibEncoder, Compression};
+
+        // Fail closed rather than silently copying unreadable ciphertext
+        // (#1032): every stream object read from `self.source` below goes
+        // through `load_source_object` to decrypt it, but that requires an
+        // authenticated encryption handler. An encrypted-but-unauthenticated
+        // source has no key to decrypt with at all — refuse rather than
+        // write out raw source ciphertext with no /Encrypt dict, which
+        // silently produces a structurally valid but unreadable PDF.
+        if self.source.is_encrypted() && !self.source.is_authenticated() {
+            return Err(Error::EncryptedPdf);
+        }
 
         /// Compress a stream object with FlateDecode if it has no filter yet.
         fn compress_stream_if_raw(obj: Object) -> Object {
@@ -2121,7 +2166,7 @@ impl DocumentEditor {
                         .and_then(|d| d.get("AcroForm"))
                         .and_then(|o| o.as_reference())
                     {
-                        if let Ok(af) = self.source.load_object(af_ref) {
+                        if let Ok(af) = self.load_source_object(af_ref) {
                             if let Some(orig_fields) = af
                                 .as_dict()
                                 .and_then(|d| d.get("Fields"))
@@ -2245,7 +2290,7 @@ impl DocumentEditor {
         // Get and write pages tree
         if let Some(catalog_dict) = catalog_obj.as_dict() {
             if let Some(pages_ref) = catalog_dict.get("Pages").and_then(|p| p.as_reference()) {
-                let pages_obj = self.source.load_object(pages_ref)?;
+                let pages_obj = self.load_source_object(pages_ref)?;
 
                 // Rebuild Pages tree: filter by page_order, reorder, append merged pages
                 let final_pages_obj = if let Some(pages_dict) = pages_obj.as_dict() {
@@ -2311,7 +2356,7 @@ impl DocumentEditor {
                         let mut page_index = 0;
                         for kid in kids {
                             if let Some(page_ref) = kid.as_reference() {
-                                let page_obj = self.source.load_object(page_ref)?;
+                                let page_obj = self.load_source_object(page_ref)?;
 
                                 // Resolve the original source page index for all HashMap lookups.
                                 // Merged pages (appended after source pages) use the loop counter.
@@ -2621,7 +2666,7 @@ impl DocumentEditor {
                                                         .get("Parent")
                                                         .and_then(|p| p.as_reference())
                                                         .and_then(|r| {
-                                                            self.source.load_object(r).ok()
+                                                            self.load_source_object(r).ok()
                                                         });
                                                     let mut inherited_font: Option<Object> = None;
                                                     let mut guard = 0;
@@ -2646,7 +2691,7 @@ impl DocumentEditor {
                                                             .get("Parent")
                                                             .and_then(|p| p.as_reference())
                                                             .and_then(|r| {
-                                                                self.source.load_object(r).ok()
+                                                                self.load_source_object(r).ok()
                                                             });
                                                     }
                                                     let mut seeded: HashMap<String, Object> =
@@ -2712,7 +2757,7 @@ impl DocumentEditor {
                                     let mut resources_dict = match resources {
                                         Some(Object::Dictionary(d)) => d,
                                         Some(Object::Reference(res_ref)) => {
-                                            match self.source.load_object(res_ref) {
+                                            match self.load_source_object(res_ref) {
                                                 Ok(Object::Dictionary(d)) => d,
                                                 _ => HashMap::new(),
                                             }
@@ -2724,7 +2769,7 @@ impl DocumentEditor {
                                     let mut xobject_dict = match resources_dict.get("XObject") {
                                         Some(Object::Dictionary(d)) => d.clone(),
                                         Some(Object::Reference(xobj_ref)) => {
-                                            match self.source.load_object(*xobj_ref) {
+                                            match self.load_source_object(*xobj_ref) {
                                                 Ok(Object::Dictionary(d)) => d,
                                                 _ => HashMap::new(),
                                             }
@@ -2865,7 +2910,7 @@ impl DocumentEditor {
                                     let mut resources_dict = match resources {
                                         Some(Object::Dictionary(d)) => d,
                                         Some(Object::Reference(res_ref)) => {
-                                            match self.source.load_object(res_ref) {
+                                            match self.load_source_object(res_ref) {
                                                 Ok(Object::Dictionary(d)) => d,
                                                 _ => HashMap::new(),
                                             }
@@ -2877,7 +2922,7 @@ impl DocumentEditor {
                                     let mut xobject_dict = match resources_dict.get("XObject") {
                                         Some(Object::Dictionary(d)) => d.clone(),
                                         Some(Object::Reference(xobj_ref)) => {
-                                            match self.source.load_object(*xobj_ref) {
+                                            match self.load_source_object(*xobj_ref) {
                                                 Ok(Object::Dictionary(d)) => d,
                                                 _ => HashMap::new(),
                                             }
@@ -2907,7 +2952,7 @@ impl DocumentEditor {
                                         let annots_array = match annots {
                                             Object::Array(arr) => arr,
                                             Object::Reference(annots_ref) => {
-                                                match self.source.load_object(annots_ref) {
+                                                match self.load_source_object(annots_ref) {
                                                     Ok(Object::Array(arr)) => arr,
                                                     _ => vec![],
                                                 }
@@ -2920,7 +2965,7 @@ impl DocumentEditor {
                                         for annot_ref in annots_array {
                                             if let Some(ref_obj) = annot_ref.as_reference() {
                                                 if let Ok(annot_obj) =
-                                                    self.source.load_object(ref_obj)
+                                                    self.load_source_object(ref_obj)
                                                 {
                                                     if let Some(annot_dict) = annot_obj.as_dict() {
                                                         let subtype = annot_dict
@@ -2961,7 +3006,7 @@ impl DocumentEditor {
                                         {
                                             Some(Object::Array(arr)) => arr,
                                             Some(Object::Reference(annots_ref)) => {
-                                                match self.source.load_object(annots_ref) {
+                                                match self.load_source_object(annots_ref) {
                                                     Ok(Object::Array(arr)) => arr,
                                                     _ => vec![],
                                                 }
@@ -3226,7 +3271,7 @@ impl DocumentEditor {
                                                 .and_then(|c| c.as_reference())
                                             {
                                                 let contents_obj =
-                                                    self.source.load_object(contents_ref)?;
+                                                    self.load_source_object(contents_ref)?;
                                                 let offset = writer.stream_position()?;
                                                 let bytes = serialize_obj(
                                                     &serializer,
@@ -3251,7 +3296,7 @@ impl DocumentEditor {
                                         page_dict.get("Resources").and_then(|r| r.as_reference())
                                     {
                                         let mut resources_obj =
-                                            self.source.load_object(resources_ref)?;
+                                            self.load_source_object(resources_ref)?;
 
                                         // Inject new XObject refs into Resources dict
                                         if !new_xobject_refs.is_empty() {
@@ -3379,7 +3424,7 @@ impl DocumentEditor {
                                                     Object::Dictionary(d) => Some(d.clone()),
                                                     Object::Reference(r) => {
                                                         let loaded =
-                                                            self.source.load_object(*r).map_err(|e| {
+                                                            self.load_source_object(*r).map_err(|e| {
                                                                 log::warn!("Failed to load resource object {} during save: {}", r.id, e);
                                                                 e
                                                             }).ok();
@@ -3411,7 +3456,7 @@ impl DocumentEditor {
                                                         {
                                                             if !written_ids.contains(&ref_obj.id) {
                                                                 if let Ok(xobj_obj) =
-                                                                    self.source.load_object(ref_obj)
+                                                                    self.load_source_object(ref_obj)
                                                                 {
                                                                     let offset =
                                                                         writer.stream_position()?;
@@ -3440,7 +3485,7 @@ impl DocumentEditor {
                                                     Object::Dictionary(d) => Some(d.clone()),
                                                     Object::Reference(r) => {
                                                         let loaded =
-                                                            self.source.load_object(*r).map_err(|e| {
+                                                            self.load_source_object(*r).map_err(|e| {
                                                                 log::warn!("Failed to load resource object {} during save: {}", r.id, e);
                                                                 e
                                                             }).ok();
@@ -3471,7 +3516,7 @@ impl DocumentEditor {
                                                         {
                                                             if !written_ids.contains(&ref_obj.id) {
                                                                 if let Ok(obj) =
-                                                                    self.source.load_object(ref_obj)
+                                                                    self.load_source_object(ref_obj)
                                                                 {
                                                                     let offset =
                                                                         writer.stream_position()?;
@@ -4079,7 +4124,7 @@ impl DocumentEditor {
             let loaded = if let Some(m) = self.modified_objects.get(&obj_id) {
                 Ok(m.clone())
             } else {
-                self.source.load_object(ObjectRef { id: obj_id, gen: 0 })
+                self.load_source_object(ObjectRef { id: obj_id, gen: 0 })
             };
             match loaded {
                 Ok(obj) => {

--- a/tests/encrypted_source_write_paths.rs
+++ b/tests/encrypted_source_write_paths.rs
@@ -1,0 +1,148 @@
+//! Every write path that copies objects out of an already-open, encrypted
+//! source document — `save()`/`save_to_bytes()`, `extract_pages()`,
+//! `remove_page()` + save — must decrypt stream data before re-emitting it
+//! into an output with no `/Encrypt` dictionary of its own. Before this
+//! fix, they re-serialized the source's raw ciphertext verbatim: the
+//! output was a structurally valid PDF that opened without a password, but
+//! every copied content stream was still AES ciphertext behind
+//! `/Filter /FlateDecode`, so a conforming reader failed to inflate it and
+//! rendered a blank page — silently, with no error or warning (#1032).
+//!
+//! The fixture is built entirely in-code (no third-party PDF): a plain
+//! single-page PDF with known text, encrypted AES-128 via this crate's own
+//! authoring path (`DocumentEditor::save_with_options` +
+//! `SaveOptions::with_encryption`), matching the exact shape of the
+//! original report (a small AES-128 `/V 4 /R 4` document).
+//!
+//! `/V 4 /R 4` derives its key via MD5, which the FIPS `CryptoProvider`
+//! refuses to build regardless of the stream cipher being AES (FIPS 140-3
+//! forbids MD5 outright) — this whole file is gated to non-FIPS builds,
+//! matching the same fixture-shape constraint already applied to
+//! `permissions_some_on_encrypted_pdf` in
+//! `tests/extraction_api_regression.rs`.
+#![cfg(not(feature = "fips"))]
+
+use pdf_oxide::editor::{
+    DocumentEditor, EditableDocument, EncryptionAlgorithm, EncryptionConfig, SaveOptions,
+};
+use pdf_oxide::writer::{DocumentBuilder, DocumentMetadata, PageSize};
+use pdf_oxide::PdfDocument;
+
+const SECRET_TEXT: &str = "HELLO-FROM-PAGE-ONE";
+const USER_PASSWORD: &str = "test-password";
+
+/// A plain, single-page PDF containing `SECRET_TEXT`, then encrypted
+/// AES-128 with `USER_PASSWORD`, matching the original report's fixture
+/// shape (`/V 4 /R 4 /CFM /AESV2`).
+fn build_encrypted_source() -> Vec<u8> {
+    let mut builder = DocumentBuilder::new();
+    builder = builder.metadata(DocumentMetadata::new().title("Encrypted Source"));
+    {
+        let page = builder.page(PageSize::Letter);
+        page.at(72.0, 720.0).text(SECRET_TEXT).done();
+    }
+    let plain_pdf = builder.build().expect("build plain pdf");
+
+    let mut editor = DocumentEditor::from_bytes(plain_pdf).expect("open plain pdf");
+    let config = EncryptionConfig::new(USER_PASSWORD, "owner-password")
+        .with_algorithm(EncryptionAlgorithm::Aes128);
+    editor
+        .save_to_bytes_with_options(SaveOptions::with_encryption(config))
+        .expect("save encrypted pdf")
+}
+
+/// Open the encrypted fixture and authenticate, returning a `DocumentEditor`
+/// ready to exercise a write path.
+fn open_authenticated_editor() -> DocumentEditor {
+    let doc = PdfDocument::from_bytes(build_encrypted_source()).expect("parse encrypted pdf");
+    assert!(doc.is_encrypted(), "fixture must actually be encrypted");
+    let authed = doc
+        .authenticate(USER_PASSWORD.as_bytes())
+        .expect("authenticate");
+    assert!(authed, "authentication with the correct password must succeed");
+    assert!(doc.is_authenticated(), "document must report authenticated");
+    DocumentEditor::from_document(doc).expect("wrap authenticated document")
+}
+
+/// The output of a write path must contain the original plaintext (not
+/// ciphertext/garbage), and — since we never asked for output encryption —
+/// must carry no `/Encrypt` dictionary.
+fn assert_output_is_readable_plaintext(output_bytes: &[u8]) {
+    let out_doc = PdfDocument::from_bytes(output_bytes.to_vec()).expect("parse output pdf");
+    assert!(
+        !out_doc.is_encrypted(),
+        "output must not carry an /Encrypt dictionary when none was requested"
+    );
+    let text = out_doc.extract_text(0).expect("extract_text on output");
+    assert!(
+        text.contains(SECRET_TEXT),
+        "output must contain the original plaintext, got: {text:?}"
+    );
+}
+
+#[test]
+fn save_to_bytes_decrypts_encrypted_source() {
+    let mut editor = open_authenticated_editor();
+    let output = editor
+        .save_to_bytes()
+        .expect("save_to_bytes on authenticated source");
+    assert_output_is_readable_plaintext(&output);
+}
+
+#[test]
+fn extract_pages_decrypts_encrypted_source() {
+    let mut editor = open_authenticated_editor();
+    let output = editor
+        .extract_pages_to_bytes(&[0])
+        .expect("extract_pages_to_bytes on authenticated source");
+    assert_output_is_readable_plaintext(&output);
+}
+
+#[test]
+fn remove_page_then_save_decrypts_remaining_pages() {
+    // Build a 2-page encrypted source so there's a page left after removal.
+    let mut builder = DocumentBuilder::new();
+    builder = builder.metadata(DocumentMetadata::new().title("Encrypted Source 2 pages"));
+    {
+        let page = builder.page(PageSize::Letter);
+        page.at(72.0, 720.0).text("REMOVE ME").done();
+    }
+    {
+        let page = builder.page(PageSize::Letter);
+        page.at(72.0, 720.0).text(SECRET_TEXT).done();
+    }
+    let plain_pdf = builder.build().expect("build plain pdf");
+    let mut plain_editor = DocumentEditor::from_bytes(plain_pdf).expect("open plain pdf");
+    let config = EncryptionConfig::new(USER_PASSWORD, "owner-password")
+        .with_algorithm(EncryptionAlgorithm::Aes128);
+    let encrypted = plain_editor
+        .save_to_bytes_with_options(SaveOptions::with_encryption(config))
+        .expect("save encrypted 2-page pdf");
+
+    let doc = PdfDocument::from_bytes(encrypted).expect("parse encrypted pdf");
+    doc.authenticate(USER_PASSWORD.as_bytes())
+        .expect("authenticate");
+    let mut editor = DocumentEditor::from_document(doc).expect("wrap authenticated document");
+
+    EditableDocument::remove_page(&mut editor, 0).expect("remove first page");
+    let output = editor.save_to_bytes().expect("save after remove_page");
+    assert_output_is_readable_plaintext(&output);
+}
+
+#[test]
+fn write_incremental_refuses_encrypted_source() {
+    let mut editor = open_authenticated_editor();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("incremental.pdf");
+    let result = editor.save_with_options(
+        &path,
+        SaveOptions {
+            incremental: true,
+            ..SaveOptions::full_rewrite()
+        },
+    );
+    assert!(
+        result.is_err(),
+        "incremental save on an encrypted source must fail closed, not silently corrupt"
+    );
+}


### PR DESCRIPTION
## Summary
After a successful `authenticate()`, every write path that copies objects from an encrypted source document (`save()`/`save_to_bytes()`, `extract_pages()`, `remove_page()` + save) emitted the source's raw ciphertext into an output carrying no `/Encrypt` dictionary. The result was structurally valid and opened without a password, but every copied content stream was still AES ciphertext behind `/Filter /FlateDecode`, so a conforming reader failed to inflate it and rendered a blank page — silently, with no error or warning.

String literals inside dictionaries are already auto-decrypted at object-load time (`decrypt_strings_in_object`, gated on `handler.is_authenticated()`) — only `Object::Stream.data` bytes remain ciphertext through `load_object()`. Added `PdfDocument::decrypt_stream_for_copy`, a decrypt-only counterpart to the read path's `decode_stream_with_encryption`: the write path needs to keep `/Filter` valid (re-emit the same compressed bytes, just decrypted), not decompress. A no-op for non-stream objects and for unencrypted documents, so it's safe to apply unconditionally to every object a write path copies.

`write_full_to_writer` now routes every `self.source.load_object()` call whose result can reach the output writer (19 call sites) through a new `load_source_object` wrapper that applies the decrypt step, and fails closed (`Error::EncryptedPdf`) up front when the source is encrypted but never successfully authenticated.

`write_incremental` has a different, related bug: it appends new/modified objects as plain bytes after the untouched original file, but the trailer's `/Prev` chain still points at the source's `/Encrypt` dict, so a reader would try to decrypt the newly-appended plaintext objects with the original key and corrupt them. Properly supporting this means re-encrypting appended objects under the source's own key (real but separable future work); for now it refuses outright for an encrypted source and directs callers to the full-rewrite path.

## Test plan
- [x] `encrypted_source_write_paths.rs` — builds a plain PDF in-code, encrypts it AES-128 via this crate's own authoring path (`DocumentEditor::save_with_options` + `SaveOptions::with_encryption`, matching the `/V 4 /R 4` shape of the original report — no third-party PDF), authenticates, and exercises `save_to_bytes`, `extract_pages_to_bytes`, `remove_page` + `save_to_bytes`, plus the incremental-refusal case — 4/4 pass
- [x] `cargo test --release --lib` — 5785/5785 pass
- [x] `cargo test --release --test test_editor_coverage --test test_encryption_write --test test_document_builder_encryption` — 15/15 + 127/127 + 19/19 pass, 0 regressions across the full editor/encryption test surface despite the 19-call-site change

Closes #1032