### PR TITLE
fix(extract): sparse two-column pages follow stream order, not row-major

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -30220,6 +30220,167 @@ mod tests {
         );
     }
 
+    /// Regression test for issue #979: a page with only 2 spans per column
+    /// (4 spans total) is below `min_spans_for_split` (5), so it never
+    /// reaches the geometric column-split logic the 6-span test above
+    /// exercises — every statistical prose/table classifier
+    /// (`classify_region_kind`, `detect_two_column_prose`,
+    /// `detect_narrow_gutter_prose`) also has its own internal minimum-span
+    /// floor (6/8/24) far above 4, so none of them can classify this page
+    /// either. Before the fix, the base case fell back to a flat
+    /// Y-then-X sort, interleaving the two columns (L1, R1, L2, R2)
+    /// instead of reading each column through.
+    ///
+    /// A pure geometric gutter check can't distinguish this from a 2x2
+    /// table at this scale (see `test_column_aware_sparse_2x2_table_stays_row_major`
+    /// below), so the fix defers to content-stream emission order when a
+    /// clean gutter exists — PDFium parity per the issue's own cross-tool
+    /// probe. This fixture's `sequence` mirrors the exact reporter's
+    /// repro (`reportlab` draws the whole left column, then the whole
+    /// right column): L1, L2, R1, R2.
+    #[test]
+    fn test_column_aware_sparse_two_column_follows_stream_order() {
+        use crate::geometry::Rect;
+        use crate::layout::{Color, FontWeight, TextSpan};
+        use crate::pipeline::reading_order::{
+            ReadingOrderContext as ROContext, ReadingOrderStrategy, XYCutStrategy,
+        };
+
+        fn make_span(label: &str, x: f32, y: f32, sequence: usize) -> TextSpan {
+            TextSpan {
+                provenance: None,
+                text_rise: 0.0,
+                artifact_type: None,
+                text: label.to_string(),
+                bbox: Rect::new(x, y, 80.0, 12.0),
+                font_size: 12.0,
+                font_name: "Test".to_string(),
+                font_weight: FontWeight::Normal,
+                is_italic: false,
+                is_monospace: false,
+                color: Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                },
+                mcid: None,
+                mcid_scope: None,
+                sequence,
+                split_boundary_before: false,
+                offset_semantic: false,
+                char_spacing: 0.0,
+                word_spacing: 0.0,
+                horizontal_scaling: 100.0,
+                primary_detected: false,
+                char_widths: vec![],
+                char_x_offsets: Vec::new(),
+                heading_level: None,
+                rotation_degrees: 0.0,
+                wmode: 0,
+                rtl_draw_logical: false,
+            }
+        }
+
+        // Column-major stream order, matching a two-column-prose generator
+        // that fills the left text box then the right one — exactly the
+        // reporter's `reportlab` repro.
+        let spans = vec![
+            make_span("L1", 10.0, 700.0, 0),
+            make_span("L2", 10.0, 680.0, 1),
+            make_span("R1", 200.0, 700.0, 2),
+            make_span("R2", 200.0, 680.0, 3),
+        ];
+
+        let strategy = XYCutStrategy::new();
+        let context = ROContext::new();
+        let ordered = strategy
+            .apply(spans, &context)
+            .expect("XYCut should not fail");
+        let labels: Vec<&str> = ordered.iter().map(|o| o.span.text.as_str()).collect();
+
+        assert_eq!(
+            labels,
+            vec!["L1", "L2", "R1", "R2"],
+            "a sparse 2-column page below min_spans_for_split must follow \
+             content-stream order (column-major here), not interleave the \
+             columns via a flat Y-then-X sort"
+        );
+    }
+
+    /// Companion to the test above: a genuine 2x2 table emitted **row-major**
+    /// in-stream (the common table-generator pattern — draw row 1's cells
+    /// left-to-right, then row 2's) must stay row-major. The same clean
+    /// gutter exists between the two columns as in the prose case above —
+    /// nothing in this codebase can geometrically tell the two apart at
+    /// 4-span scale — so the fix's content-stream-order fallback is
+    /// correct for *both* shapes precisely because it never has to decide
+    /// between them: it just preserves however the source authored it.
+    #[test]
+    fn test_column_aware_sparse_2x2_table_stays_row_major() {
+        use crate::geometry::Rect;
+        use crate::layout::{Color, FontWeight, TextSpan};
+        use crate::pipeline::reading_order::{
+            ReadingOrderContext as ROContext, ReadingOrderStrategy, XYCutStrategy,
+        };
+
+        fn make_cell(label: &str, x: f32, y: f32, sequence: usize) -> TextSpan {
+            TextSpan {
+                provenance: None,
+                text_rise: 0.0,
+                artifact_type: None,
+                text: label.to_string(),
+                bbox: Rect::new(x, y, 80.0, 12.0),
+                font_size: 12.0,
+                font_name: "Test".to_string(),
+                font_weight: FontWeight::Normal,
+                is_italic: false,
+                is_monospace: false,
+                color: Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                },
+                mcid: None,
+                mcid_scope: None,
+                sequence,
+                split_boundary_before: false,
+                offset_semantic: false,
+                char_spacing: 0.0,
+                word_spacing: 0.0,
+                horizontal_scaling: 100.0,
+                primary_detected: false,
+                char_widths: vec![],
+                char_x_offsets: Vec::new(),
+                heading_level: None,
+                rotation_degrees: 0.0,
+                wmode: 0,
+                rtl_draw_logical: false,
+            }
+        }
+
+        // Row-major stream order: row 1's two cells, then row 2's two cells.
+        let spans = vec![
+            make_cell("R1C1", 10.0, 700.0, 0),
+            make_cell("R1C2", 200.0, 700.0, 1),
+            make_cell("R2C1", 10.0, 680.0, 2),
+            make_cell("R2C2", 200.0, 680.0, 3),
+        ];
+
+        let strategy = XYCutStrategy::new();
+        let context = ROContext::new();
+        let ordered = strategy
+            .apply(spans, &context)
+            .expect("XYCut should not fail");
+        let labels: Vec<&str> = ordered.iter().map(|o| o.span.text.as_str()).collect();
+
+        assert_eq!(
+            labels,
+            vec!["R1C1", "R1C2", "R2C1", "R2C2"],
+            "a row-major-emitted 2x2 table must stay row-major, not be \
+             reshuffled into a column-major read order"
+        );
+    }
+
     // ========================================================================
     // COLUMN-ORDER: persistent-gutter-corridor accept path (#607)
     // ========================================================================

--- a/src/pipeline/reading_order/xycut.rs
+++ b/src/pipeline/reading_order/xycut.rs
@@ -512,8 +512,41 @@ impl XYCutStrategy {
             return Vec::new();
         }
 
-        // Base case: small region, don't split further
+        // Base case: small region, don't split further via the recursive
+        // partitioner. Below `min_spans_for_split`, the statistical
+        // prose/table classifiers (`classify_region_kind`,
+        // `detect_two_column_prose`, `detect_narrow_gutter_prose`) all have
+        // their own internal minimum-span floors (6/8/24) far above this
+        // one and unconditionally decline to classify — so a flat
+        // "impose Y-then-X row-major order" was applied even to a genuine
+        // sparse 2-column page (#979: a 2-column, 2-row prose page —
+        // 4 spans — read back row-major/interleaved instead of
+        // column-major).
+        //
+        // A geometric gutter check alone can't distinguish "sparse 2-column
+        // prose" from "a 2x2 row-major table" at this scale either — both
+        // produce an identical clean-gutter signature, and the table-row
+        // guard inside `find_horizontal_split_indexed` needs >=3 rows to
+        // reach confidence, so it's a no-op at 2 rows. Rather than commit
+        // to a (left, right) column grouping we can't justify being
+        // correct, fall back to the page's own content-stream emission
+        // order when a clean gutter exists at all (PDFium parity, per the
+        // reporter's own cross-tool probe: PDFium performs no prose/table
+        // decision here either, it just follows stream order). This
+        // relies on the empirical tendency of table generators to emit
+        // cells row-major and column-generators to emit column-major, in
+        // the absence of any other geometric signal being decidable at
+        // this scale. Falls back to the flat Y-then-X sort when no clean
+        // gutter is found at all (ordinary short single-column snippets).
         if indices.len() < self.min_spans_for_split {
+            if self
+                .find_horizontal_split_indexed(all_spans, indices)
+                .is_some()
+            {
+                let mut stream_order: Vec<usize> = indices.to_vec();
+                stream_order.sort_by_key(|&i| all_spans[i].sequence);
+                return vec![stream_order];
+            }
             return vec![self.sort_indices(all_spans, indices)];
         }
 


### PR DESCRIPTION
## Summary
`ReadingOrder::ColumnAware` interleaved a page with only 2 spans per column (4 spans total): below `min_spans_for_split` (5), the recursive partitioner's base case fell back to a flat Y-then-X sort before ever reaching the geometric column-split logic. Lowering the floor alone isn't safe: every statistical prose/table classifier in this module (`classify_region_kind`, `detect_two_column_prose`, `detect_narrow_gutter_prose`) has its own internal minimum-span floor (6/8/24) independently far above 4, and none of them can classify a region this small either way.

No signal in this codebase can geometrically distinguish sparse 2-column prose from a 2x2 row-major table at 4-span scale — both produce an identical clean-gutter signature in `find_horizontal_split_indexed`, and its existing table-row guard needs ≥3 rows to reach confidence (a no-op at 2 rows). Rather than commit to a `(left, right)` grouping that can't be trusted to mean column-major vs. table-row-shredding at this scale, the base case now uses `find_horizontal_split_indexed` purely as a yes/no "is there a clean gutter" check: when one exists, sort by the page's own content-stream emission order (`TextSpan::sequence`) instead of imposing Y-then-X — PDFium parity, per the reporter's own cross-tool probe showing PDFium performs no prose/table decision here either. Falls back to the existing flat sort when no clean gutter exists at all (ordinary short single-column snippets).

**Caveat, carried forward openly**: correctness rests on the empirical tendency of table generators to emit cells row-major and column-generators to emit column-major in the content stream — not a proven invariant, but the same assumption the reporter's own cross-tool probe validated. Worth spot-checking against a real-document corpus sweep before merging.

## Test plan
- [x] `test_column_aware_sparse_two_column_follows_stream_order` — the reporter's exact repro shape (2 spans/column, column-major stream emission matching their `reportlab` code) — output stays column-major, not interleaved
- [x] `test_column_aware_sparse_2x2_table_stays_row_major` — same clean-gutter geometry, but row-major stream emission (matching typical table generators) — output stays row-major, confirming the fix doesn't regress table reading at small scale
- [x] `cargo test --release --lib` — 5787/5787 pass, including the existing #534 regression guards (`test_short_cell_label_table_still_table_not_cut`, `test_short_verse_two_column_classified_prose_and_cut`) and the existing 6-span sibling test (`test_column_aware_reads_column1_before_column2`) — all still pass

Closes #979