### PR TITLE
fix(ruby): render/render_with_layers always returned empty bytes

### DIFF
--- a/ruby/lib/pdf_oxide/ffi/bindings.rb
+++ b/ruby/lib/pdf_oxide/ffi/bindings.rb
@@ -1742,6 +1742,17 @@ module PdfOxide
                          pointer size_t
                          pointer],
                       :pointer
+
+      # uint8_t *pdf_get_rendered_image_data(
+      #   const FfiRenderedImage *img, int32_t *data_len, int32_t *error_code)
+      # Returns the encoded image bytes (PNG or JPEG per the format the
+      # image was rendered with). Caller-owned; free with free_bytes.
+      # Overrides the auto-generated 8-pointer placeholder declared
+      # earlier in this file — that placeholder signature does not match
+      # the real 3-argument ABI and cannot be called as-is.
+      attach_function :pdf_get_rendered_image_data,
+                      %i[pointer pointer pointer],
+                      :pointer
     end
   end
 end

--- a/ruby/lib/pdf_oxide/pdf_document.rb
+++ b/ruby/lib/pdf_oxide/pdf_document.rb
@@ -438,26 +438,19 @@ module PdfOxide
     end
 
     def read_rendered_image_bytes(img_ptr)
-      # The cdylib renders to a "rendered image" handle.  Different
-      # accessors exist across versions; try the byte-buffer accessor
-      # first, fall back to a sensible default.
-      if Bindings.respond_to?(:pdf_oxide_rendered_image_get_bytes)
-        len_ptr = ::FFI::MemoryPointer.new(:size_t)
-        err = ::FFI::MemoryPointer.new(:int32)
-        buf = Bindings.pdf_oxide_rendered_image_get_bytes(img_ptr, len_ptr, err)
-        raise_for_code(err.read_int32, 'render_bytes')
-        return '' if buf.nil? || buf.null?
+      # The cdylib exposes the rendered-image byte buffer through
+      # pdf_get_rendered_image_data (data_len is *mut i32, not size_t);
+      # the caller owns the returned buffer and must free it via
+      # free_bytes.
+      len_ptr = ::FFI::MemoryPointer.new(:int32)
+      err = ::FFI::MemoryPointer.new(:int32)
+      buf = Bindings.pdf_get_rendered_image_data(img_ptr, len_ptr, err)
+      raise_for_code(err.read_int32, 'render_bytes')
+      return '' if buf.nil? || buf.null?
 
-        len = len_ptr.read(:size_t)
-        bytes = buf.read_string(len)
-        Bindings.free_bytes(buf) if Bindings.respond_to?(:free_bytes)
-        bytes
-      else
-        # Fall back to an empty BINARY string; render() callers see a
-        # clean error path rather than a segfault when the build is
-        # missing the rendered-image accessor.
-        ''
-      end
+      bytes = buf.read_string(len_ptr.read_int32)
+      Bindings.free_bytes(buf)
+      bytes
     end
 
     # Map a cdylib error code (`int32_t *err`) to the matching Ruby

--- a/ruby/spec/ffi_signature_regression_spec.rb
+++ b/ruby/spec/ffi_signature_regression_spec.rb
@@ -79,6 +79,31 @@ RSpec.describe 'FFI signature regressions' do
     end
   end
 
+  describe 'pdf_get_rendered_image_data (was 8-pointer placeholder + wrong accessor probed)' do
+    # Two stacked bugs: read_rendered_image_bytes probed a symbol
+    # (pdf_oxide_rendered_image_get_bytes) the cdylib never exported,
+    # silently falling back to ''; and the real accessor,
+    # pdf_get_rendered_image_data, was only declared via the
+    # auto-generated 8-pointer placeholder (real ABI takes 3 args:
+    # img, data_len, error_code). Pre-fix, render/render_with_layers
+    # returned an empty string for every PDF with no error raised.
+    it 'render returns non-empty, valid PNG bytes' do
+      PdfOxide::PdfDocument.open(fixture('simple.pdf')) do |doc|
+        png = doc.render(0, dpi: 72)
+        expect(png).not_to be_empty
+        expect(png.byteslice(0, 8)).to eq("\x89PNG\r\n\x1a\n".b)
+      end
+    end
+
+    it 'render_with_layers returns non-empty, valid image bytes' do
+      PdfOxide::PdfDocument.open(fixture('simple.pdf')) do |doc|
+        result = doc.render_with_layers(0, dpi: 72)
+        expect(result).not_to be_empty
+        expect(result.byteslice(0, 8)).to eq("\x89PNG\r\n\x1a\n".b)
+      end
+    end
+  end
+
   describe 'pdf_document_get_form_fields (A.1 — was 8-pointer placeholder)' do
     it 'returns an Array even for a fixture with no AcroForm' do
       PdfOxide::PdfDocument.open(fixture('simple.pdf')) do |doc|


### PR DESCRIPTION
## Summary
`PdfDocument#render` and `#render_with_layers` in the Ruby gem always returned an empty string, silently, for every PDF. Two stacked bugs in the shared `read_rendered_image_bytes` helper:

1. It probed `Bindings.respond_to?(:pdf_oxide_rendered_image_get_bytes)` — a symbol the cdylib never exports — and fell back to `''` when absent.
2. The real accessor, `pdf_get_rendered_image_data`, was only declared via the auto-generated 8-pointer placeholder shared by many unrelated FFI functions (`pdf_dss_get_ocsp`, `pdf_embedded_font_free`, `pdf_merge`, etc.); its actual C ABI is `(img, data_len, error_code) -> *mut u8` (3 args, `src/ffi.rs`).

## Fix
- `read_rendered_image_bytes` now calls `Bindings.pdf_get_rendered_image_data` directly, using an `FFI::MemoryPointer.new(:int32)` for `data_len` (it's `*mut i32`, not `size_t`), and frees the caller-owned buffer via `free_bytes`.
- `bindings.rb` gets a corrected `attach_function :pdf_get_rendered_image_data, %i[pointer pointer pointer], :pointer` in the existing "PHASE 3 EXTEND" override section, which documents that later `attach_function` calls override the earlier placeholder — the established idiom in this file for fixing this exact class of bug.
- Pattern verified against the Go binding's already-working `pdf_get_rendered_image_data` + `free_bytes` call.

## Test plan
- [x] New specs in `ffi_signature_regression_spec.rb` (the file that already tracks this exact bug class — wrong `attach_function` signatures against the real C ABI): `render` returns non-empty, valid-PNG-signature bytes; `render_with_layers` returns non-empty, valid image bytes
- [x] Built the cdylib locally with `--features rendering` and ran the full Ruby spec suite against it: 84/84 examples pass, 0 failures (previously the render specs didn't exist and the bug was invisible — the fallback swallowed the failure silently)
- [x] `rubocop` clean on all three touched files

Closes #1048

Thanks to @metheglin for the precise root-cause report and reference patch, which this PR follows closely.