### PR TITLE
fix(php): expose rendered page image bytes (render/renderWithLayers)

### DIFF
--- a/php/src/FFI/FunctionBindings.php
+++ b/php/src/FFI/FunctionBindings.php
@@ -686,6 +686,34 @@ class FunctionBindings
     }
 
     /**
+     * Get the encoded image bytes (PNG or JPEG, per the format the image
+     * was rendered with) from a rendered-image handle.
+     *
+     * @param CData $imageHandle The image handle (from pdfRenderPage*)
+     * @return string Encoded image binary data
+     */
+    public function pdfGetRenderedImageData(CData $imageHandle): string
+    {
+        // C: uint8_t *pdf_get_rendered_image_data(const FfiRenderedImage *img,
+        //        int32_t *data_len, int32_t *error_code)
+        $dataLen = $this->ffi->new('int32_t');
+        $errorCode = $this->ffi->new('int32_t');
+        $dataPtr = $this->ffi->pdf_get_rendered_image_data(
+            $imageHandle,
+            FFI::addr($dataLen),
+            FFI::addr($errorCode)
+        );
+        ErrorHandler::check((int) $errorCode->cdata, 'pdf_get_rendered_image_data');
+        if ($dataPtr === null) {
+            return '';
+        }
+        $bytes = FFI::string($dataPtr, (int) $dataLen->cdata);
+        // Caller-owned buffer — must free.
+        $this->ffi->free_bytes($this->ffi->cast('uint8_t*', $dataPtr));
+        return $bytes;
+    }
+
+    /**
      * Estimate rendering time for a page.
      *
      * @param CData $handle The document handle

--- a/php/src/PdfDocument.php
+++ b/php/src/PdfDocument.php
@@ -277,6 +277,65 @@ final class PdfDocument
         $this->bindings->pdfDocumentClearSearchIndex($this->requireHandle());
     }
 
+    // ─────────────────────── rendering ──────────────────────
+
+    /**
+     * Render a single page to PNG bytes at the supplied DPI.
+     *
+     * @throws InvalidStateException when the document has been closed
+     */
+    public function render(int $pageIndex, int $dpi = 150): string
+    {
+        $imageHandle = $this->bindings->pdfRenderPageZoom($this->requireHandle(), $pageIndex, $dpi / 72.0);
+        try {
+            return $this->bindings->pdfGetRenderedImageData($imageHandle);
+        } finally {
+            $this->bindings->pdfRenderedImageFree($imageHandle);
+        }
+    }
+
+    /**
+     * Render a single page with the full render-options surface plus
+     * Optional-Content-Group (OCG) layer filtering.
+     *
+     * @param int $format 0 = PNG, 1 = JPEG
+     * @param array{0: float, 1: float, 2: float, 3: float} $background RGBA, each 0.0..1.0
+     * @param list<string> $excludedLayers OCG `/Name`s to suppress
+     *
+     * @throws InvalidStateException when the document has been closed
+     */
+    public function renderWithLayers(
+        int $pageIndex,
+        int $dpi = 150,
+        int $format = 0,
+        array $background = [1.0, 1.0, 1.0, 1.0],
+        bool $transparent = false,
+        bool $renderAnnotations = true,
+        int $jpegQuality = 90,
+        array $excludedLayers = []
+    ): string {
+        [$bgR, $bgG, $bgB, $bgA] = $background;
+        $imageHandle = $this->bindings->pdfRenderPageWithOptionsEx(
+            $this->requireHandle(),
+            $pageIndex,
+            $dpi,
+            $format,
+            $bgR,
+            $bgG,
+            $bgB,
+            $bgA,
+            $transparent ? 1 : 0,
+            $renderAnnotations ? 1 : 0,
+            $jpegQuality,
+            $excludedLayers
+        );
+        try {
+            return $this->bindings->pdfGetRenderedImageData($imageHandle);
+        } finally {
+            $this->bindings->pdfRenderedImageFree($imageHandle);
+        }
+    }
+
     // ───────────────────── page iteration ──────────────────
 
     /**

--- a/php/tests/Integration/PdfDocumentTest.php
+++ b/php/tests/Integration/PdfDocumentTest.php
@@ -146,4 +146,28 @@ final class PdfDocumentTest extends IntegrationTestCase
             $doc->close();
         }
     }
+
+    public function testRenderReturnsNonEmptyValidPng(): void
+    {
+        $doc = PdfDocument::open($this->fixture('simple.pdf'));
+        try {
+            $png = $doc->render(0, 72);
+            $this->assertNotSame('', $png);
+            $this->assertSame("\x89PNG\r\n\x1a\n", substr($png, 0, 8));
+        } finally {
+            $doc->close();
+        }
+    }
+
+    public function testRenderWithLayersReturnsNonEmptyValidImage(): void
+    {
+        $doc = PdfDocument::open($this->fixture('simple.pdf'));
+        try {
+            $png = $doc->renderWithLayers(0, dpi: 72);
+            $this->assertNotSame('', $png);
+            $this->assertSame("\x89PNG\r\n\x1a\n", substr($png, 0, 8));
+        } finally {
+            $doc->close();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Found while auditing every binding for the same bug class as #1048 (Ruby's `render` silently returning empty bytes). The PHP binding had no way to retrieve rendered page image bytes at all: `FunctionBindings::pdfRenderPage*()` correctly returns a raw `FfiRenderedImage*` handle, and the C header (`php/include/pdf_oxide.h`) correctly declares `pdf_get_rendered_image_data`, but nothing in `php/src/` ever called it. The only existing render-related test obtained a handle and immediately freed it without reading bytes, so the gap went unnoticed.

Every other actively-maintained binding was audited and found correct or immune to this bug class:
- Go, C#, Dart: manually declare the FFI signature (like Ruby did) — all three already have the correct 3-arg `(img, data_len, error_code)` signature.
- Elixir, Zig, Objective-C, Swift, R, Julia, C++, Node (N-API): link directly against the compiled C header — a signature mismatch there is a compile error, not a silent bug.
- Python, Java: don't go through the C ABI for rendering at all (native in-process PyO3 / JNI calls).

PHP was the one real gap — not a wrong-signature bug, but a missing capability.

## Fix
- `FunctionBindings::pdfGetRenderedImageData()` — mirrors the existing `pdfBarcodeGetImagePng()` caller-owned-buffer-plus-`free_bytes` pattern.
- `PdfDocument::render(int $pageIndex, int $dpi = 150): string` — wired to the existing `pdfRenderPageZoom()`.
- `PdfDocument::renderWithLayers(...)` — wired to the existing `pdfRenderPageWithOptionsEx()`, mirroring the OCG-layer-filtering variant other bindings (Ruby, Go, C#) already expose.

## Test plan
- [x] New tests in `PdfDocumentTest.php`: `render()` and `renderWithLayers()` both return non-empty, valid-PNG-signature bytes
- [x] Built the cdylib locally with `--features rendering` and ran the full PHP suite against it: 96/103 pass (the 7 failures are pre-existing, unrelated — `PdfSignerSignTest` needs the `signatures` feature, not built in this local test cdylib)
- [x] `composer cs-check` clean (0 files need fixing)
- [x] `vendor/bin/phpstan analyse` clean (no errors)

Closes #1053