### PR TITLE
fix(text): strip soft hyphens (U+00AD) from extract_text/to_markdown/to_html

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -8405,15 +8405,30 @@ impl PdfDocument {
         }
         if Self::is_column_spanning_decimal(span) {
             let dot = span.text.find('.').unwrap();
-            out.push_str(&span.text[..dot]);
+            Self::push_str_without_soft_hyphens(out, &span.text[..dot]);
             out.push(' ');
-            out.push_str(&span.text[dot + 1..]);
+            Self::push_str_without_soft_hyphens(out, &span.text[dot + 1..]);
         } else if let Some(split) = Self::char_widths_boundary_split(span) {
-            out.push_str(&span.text[..split]);
+            Self::push_str_without_soft_hyphens(out, &span.text[..split]);
             out.push(' ');
-            out.push_str(&span.text[split..]);
+            Self::push_str_without_soft_hyphens(out, &span.text[split..]);
         } else {
-            out.push_str(&span.text);
+            Self::push_str_without_soft_hyphens(out, &span.text);
+        }
+    }
+
+    /// Append `s` to `out`, dropping U+00AD (SOFT HYPHEN). Per ISO 32000-1
+    /// §14.8.2.2.3 a soft hyphen only marks a discretionary line-break point —
+    /// it is never meaningful rendered content, so it must not survive into
+    /// flat-text output regardless of whether it sits at a line boundary (the
+    /// PDF's own line wrap is not preserved here) or mid-word within a span
+    /// whose glyphs were positioned individually.
+    #[inline]
+    fn push_str_without_soft_hyphens(out: &mut String, s: &str) {
+        if s.contains('\u{00AD}') {
+            out.extend(s.chars().filter(|&c| c != '\u{00AD}'));
+        } else {
+            out.push_str(s);
         }
     }
 
@@ -26189,6 +26204,26 @@ mod tests {
         let mut out = String::new();
         PdfDocument::push_span_text(&mut out, &span);
         assert_eq!(out, "3.14");
+    }
+
+    #[test]
+    fn test_push_span_text_strips_soft_hyphen_mid_word() {
+        // ISO 32000-1 §14.8.2.2.3: U+00AD marks a discretionary line-break
+        // point only — it must never survive into extract_text/to_markdown/
+        // to_html output, even mid-word with no adjacent line break (the
+        // span was drawn as a single reflowed run, not split across lines).
+        let span = make_decimal_span("recon\u{00AD}struction", vec![], 80.0, 12.0);
+        let mut out = String::new();
+        PdfDocument::push_span_text(&mut out, &span);
+        assert_eq!(out, "reconstruction");
+    }
+
+    #[test]
+    fn test_push_span_text_strips_multiple_soft_hyphens() {
+        let span = make_decimal_span("un\u{00AD}be\u{00AD}liev\u{00AD}able", vec![], 100.0, 12.0);
+        let mut out = String::new();
+        PdfDocument::push_span_text(&mut out, &span);
+        assert_eq!(out, "unbelievable");
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary
`TextPostProcessor::rejoin_hyphenated_words` correctly strips soft hyphens (U+00AD) per ISO 32000-1 §14.8.2.2.3 — but it's only reachable from the deprecated `MarkdownConverter` path and the opt-in `apply_intelligent_text_processing()`, never from `to_markdown()`, `extract_text()`, or `to_html()`. Soft hyphens land in that output verbatim, e.g. `"recon\u{00AD}struction"`.

Reusing `rejoin_hyphenated_words` in those paths wouldn't actually fix this, though: it only strips U+00AD when it sits at the very end of a line, immediately before a `\n`. By the time text reaches `to_markdown()`/`extract_text()`/`to_html()`, a soft-hyphenated word has already been reflowed onto a single line — the character survives stranded mid-word with no adjacent line break for that line-oriented logic to key off.

## Fix
`push_span_text` — the function shared by `extract_text`, `to_markdown` (via `src/pipeline/converters/markdown.rs`), and `to_html` (via `src/pipeline/converters/html.rs`) — now filters U+00AD out of the text it appends, regardless of position. This:
- Fixes all three prose surfaces in one place (the reporter only flagged `to_markdown()`, but `extract_text()` and `to_html()` have the identical gap)
- Catches the actual reported pattern (mid-word, no adjacent line break), which the reporter's suggested "just call the post-processor" fix would not have
- Leaves `extract_chars`/`extract_words`/`extract_spans` untouched — those don't route through `push_span_text` and are meant to be glyph-position-faithful, where a literal U+00AD in the ToUnicode mapping is legitimate raw data
- No new `ConversionOptions` flag — per this repo's own convention (solve extraction bugs with one correct default, not opt-in flags), and a soft hyphen is never meaningful content, so there's no correctness tradeoff an opt-out would need to guard

## Test plan
- [x] New tests: `test_push_span_text_strips_soft_hyphen_mid_word`, `test_push_span_text_strips_multiple_soft_hyphens`
- [x] `cargo test --release --lib document::tests::` — 458/458 pass
- [x] `cargo test --release --lib` (full suite) — 5787/5787 pass, 0 regressions
- [x] `cargo fmt -- --check` / `cargo clippy --release --lib -- -D warnings` clean

Closes #1023