### PR TITLE
fix(convert): stop fusing distinct blocks in markdown post-processing

### DIFF
--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -1734,7 +1734,24 @@ impl MarkdownOutputConverter {
                     // A genuinely wrapped heading is re-fused downstream by
                     // merge_consecutive_same_level_headings, which demands a
                     // continuation signal.
-                    let heading_line_break = current_heading_level.is_some();
+                    // ISO 32000-1 §14.8.3 makes one BLSE a single block that
+                    // "can be split between lines of text", and an `<Hn>` is
+                    // such a block: a heading drawn on two baselines inside one
+                    // heading element is one heading. Break on a new baseline
+                    // only when it leaves that element or changes level.
+                    //
+                    // Re-fusing downstream cannot cover this. That pass needs a
+                    // continuation signal — a trailing comma, or a lowercase
+                    // opener — and a title-cased heading capitalises every
+                    // line, so `Tax and` / `Credits` reads as two headings and
+                    // stays two.
+                    let heading_continues = current_heading_level == span_heading_level
+                        && matches!(
+                            (span.block_id, prev.block_id),
+                            (Some(a), Some(b)) if a == b
+                        );
+                    let heading_line_break =
+                        current_heading_level.is_some() && !heading_continues;
                     if is_bullet || is_ordered || starts_new_list_item || heading_line_break {
                         // Bullet on new line → flush current line and start list item
                         close_formatting(&mut current_line, &mut active_bold, &mut active_italic);

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -333,24 +333,22 @@ fn merge_consecutive_same_level_headings(s: &str) -> String {
             j += 1;
         }
 
-        // Two policies that both prove the run is one logical heading:
-        //   A) 3+ fragments AND each <= 2 words — canonical PowerPoint
-        //      word-per-heading pattern.
-        //   B) Exactly 2 fragments AND the FIRST ends with a
-        //      continuation-strength punctuation (`,` or `;`) or no
-        //      sentence-terminator (`.`, `?`, `!`, `:`). The second
-        //      fragment must visually look like a continuation: start
-        //      lowercase or with a connector word ("and"/"or"/"the"/
-        //      "with"/"of"/...). This matches the reporter's wrapped-
-        //      heading shape `## Despite seasonal slowdown,` +
-        //      `## warehouse operations maintained...` while still
-        //      keeping `# First Heading` / `# Second Heading` apart
-        //      (no trailing comma, second word "Second" is capitalized
-        //      and not a connector).
-        let three_plus_short =
-            texts.len() >= 3 && texts.iter().all(|t| t.split_whitespace().count() <= 2);
+        // Merge only when the run carries a positive continuation signal:
+        // exactly 2 fragments where the FIRST ends with continuation-
+        // strength punctuation (`,` or `;`) or no sentence-terminator, and
+        // the second visually looks like a continuation (starts lowercase
+        // or with a connector word — "and"/"or"/"the"/"with"/"of"/...).
+        // This fuses the wrapped-heading shape `## Despite seasonal
+        // slowdown,` + `## warehouse operations maintained...` while
+        // keeping `# First Heading` / `# Second Heading` apart.
+        //
+        // Runs of 3+ short headings are deliberately NOT fused: at the
+        // string level `# Sales / # Marketing / # Engineering` (three real
+        // sections) is indistinguishable from a slide title exported one
+        // word per heading, and every reference extractor keeps such runs
+        // separate. Fusing destroyed genuinely distinct section headers.
         let wrapped_two = texts.len() == 2 && looks_like_heading_wrap(&texts[0], &texts[1]);
-        if three_plus_short || wrapped_two {
+        if wrapped_two {
             let merged = texts.join(" ");
             let hashes = "#".repeat(level);
             out.push(format!("{} {}", hashes, merged));
@@ -590,55 +588,13 @@ fn collapse_numeric_heading_runs(s: &str) -> String {
     out.join("\n")
 }
 
-/// Issue #12 (narrow) band-aid. Within a single bold block `**...**`,
-/// detect the CamelCase fragmentation pattern produced when a word
-/// rendered with mixed fonts (e.g. bold first letter, regular rest) is
-/// emitted as space-separated fragments inside one bold span. The
-/// canonical example from the reporter's corpus is `**S alesF orce**`
-/// (intended: `**SalesForce**`).
-///
-/// Match criteria: a single uppercase ASCII letter followed by a space,
-/// then a lowercase chunk that itself contains a later uppercase letter
-/// (the CamelCase indicator), then a space and another lowercase chunk.
-/// All three pieces must live inside the same `**...**` pair. Replacing
-/// `**A bcD efg**` with `**AbcDefg**`.
-///
-/// Conservative on purpose: matching mid-prose "I am Bob" or "USB Type C"
-/// would corrupt legitimate text, so the regex requires the CamelCase
-/// signal to be unambiguous (lowercase+uppercase within a single inner
-/// fragment).
-fn coalesce_camelcase_bold_fragments(s: &str) -> String {
-    // Unicode-aware (script-agnostic): `\p{Lu}` matches any
-    // uppercase letter in Unicode, `\p{Ll}` matches any lowercase
-    // letter. The CamelCase signal — a lowercase-letter run
-    // containing a later uppercase letter inside one fragment — is
-    // unambiguous across Latin, Cyrillic, Greek, Armenian, Coptic,
-    // and other cased scripts. Non-cased scripts (CJK, Arabic,
-    // Hebrew) lack CamelCase entirely so the pattern can never
-    // match — that's correct behavior.
-    //
-    // Pass 1 — inline form: `**A bcD ef**` (closing `**` after the
-    // lowercase tail). Three fragments inside one bold pair.
-    static RE_CAMELCASE_BOLD_INLINE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"\*\*(\p{Lu})\s+(\p{Ll}+\p{Lu}\p{Ll}*)\s+(\p{Ll}+)\*\*").unwrap()
-    });
-    // Pass 2 — bound form: `**A bcD** ef` (closing `**` mid-CamelCase,
-    // lowercase tail outside the bold). Two fragments inside the bold
-    // pair, tail immediately (or after one optional space) after.
-    static RE_CAMELCASE_BOLD_BOUND: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"\*\*(\p{Lu})\s+(\p{Ll}+\p{Lu}\p{Ll}*)\*\*\s*(\p{Ll}+)").unwrap()
-    });
-    let pass1 = RE_CAMELCASE_BOLD_INLINE
-        .replace_all(s, |caps: &regex::Captures| {
-            format!("**{}{}{}**", &caps[1], &caps[2], &caps[3])
-        })
-        .to_string();
-    RE_CAMELCASE_BOLD_BOUND
-        .replace_all(&pass1, |caps: &regex::Captures| {
-            format!("**{}{}{}**", &caps[1], &caps[2], &caps[3])
-        })
-        .to_string()
-}
+// The former `coalesce_camelcase_bold_fragments` post-process is gone: at
+// the string level a torn brand name (`**S alesF orce**`) is
+// indistinguishable from legitimate bold prose whose second word is
+// CamelCase (`**A gitHub repo**`), and the pass deleted the real spaces
+// from the latter. The tear it compensated for is prevented upstream in
+// span assembly, where glyph geometry (a zero raw gap between fragments)
+// identifies it unambiguously.
 
 /// Markdown output converter.
 ///
@@ -1772,7 +1728,14 @@ impl MarkdownOutputConverter {
                     } else {
                         is_list_item_role
                     };
-                    if is_bullet || is_ordered || starts_new_list_item {
+                    // A heading is a single-line construct: a new baseline
+                    // inside a heading run starts a new heading line rather
+                    // than concatenating (`## Sales Marketing Engineering`).
+                    // A genuinely wrapped heading is re-fused downstream by
+                    // merge_consecutive_same_level_headings, which demands a
+                    // continuation signal.
+                    let heading_line_break = current_heading_level.is_some();
+                    if is_bullet || is_ordered || starts_new_list_item || heading_line_break {
                         // Bullet on new line → flush current line and start list item
                         close_formatting(&mut current_line, &mut active_bold, &mut active_italic);
                         if !current_line.is_empty() {
@@ -2141,11 +2104,9 @@ impl MarkdownOutputConverter {
         let is_tagged = sorted.iter().any(|s| s.struct_role.is_some());
 
         // Always-safe steps (no semantic structure change): markdown
-        // escaping, whitespace-only bold-fragment recovery, and
-        // exact-duplicate paragraph dedup. These run for both tagged
-        // and untagged documents.
+        // escaping and exact-duplicate paragraph dedup. These run for
+        // both tagged and untagged documents.
         final_result = escape_stray_leading_pipes(&final_result);
-        final_result = coalesce_camelcase_bold_fragments(&final_result);
         // Fuse consecutive monospace (fixed-pitch / code-font) paragraphs into a
         // fenced code block. A `Code` element renders its lines monospace even
         // when the producer left the block untagged.
@@ -5438,18 +5399,15 @@ mod tests {
         );
     }
 
-    /// Issue #1 — PowerPoint-exported word-per-heading runs must fuse
-    /// into a single heading line.
+    /// A run of 3+ short same-level headings must stay separate: at the
+    /// string level it is indistinguishable from three genuine section
+    /// headers, and every reference extractor keeps the run apart.
     #[test]
-    fn test_issue1_merge_word_per_heading_runs() {
+    fn test_short_heading_runs_stay_separate() {
         let input = "# Quarterly\n\n# Inventory\n\n# Review\n";
         let out = merge_consecutive_same_level_headings(input);
-        assert_eq!(
-            out.trim(),
-            "# Quarterly Inventory Review",
-            "three same-level short H1s must merge, got:\n{}",
-            out
-        );
+        let headings = out.lines().filter(|l| l.starts_with("# ")).count();
+        assert_eq!(headings, 3, "distinct short headings fused, got:\n{}", out);
     }
 
     /// Issue #4 — wrapped long-heading split across two lines must
@@ -5662,58 +5620,6 @@ mod tests {
         let input = "# 2024 Annual Report\n";
         let out = collapse_numeric_heading_runs(input);
         assert_eq!(out, input, "single non-numeric heading must be untouched: {}", out);
-    }
-
-    /// Issue #12 — `**S alesF orce**` CamelCase fragmentation inside a
-    /// single bold pair coalesces to `**SalesForce**`.
-    #[test]
-    fn test_issue12_coalesces_inline_camelcase_bold() {
-        let input = "**S alesF orce** is great.\n";
-        let out = coalesce_camelcase_bold_fragments(input);
-        assert!(
-            out.contains("**SalesForce**"),
-            "inline CamelCase bold must coalesce, got:\n{}",
-            out
-        );
-    }
-
-    /// Issue #12 — must NOT touch legitimate two-word bold like
-    /// `**John Smith**` or `**USB Type C**`. The CamelCase signal
-    /// (lowercase-then-uppercase inside one fragment) is required.
-    #[test]
-    fn test_issue12_preserves_normal_multi_word_bold() {
-        let input = "**John Smith** wrote.\n**USB Type C** cable.\n";
-        let out = coalesce_camelcase_bold_fragments(input);
-        assert!(
-            out.contains("**John Smith**"),
-            "two-word person bold must not be merged, got:\n{}",
-            out
-        );
-        assert!(
-            out.contains("**USB Type C**"),
-            "three-word product bold must not be merged, got:\n{}",
-            out
-        );
-    }
-
-    /// Issue #12 (BOUND case) — closing `**` lands mid-CamelCase:
-    /// `**N orthW** ind` (intended `**N**orthWind` or `**NorthWind**`).
-    /// This is the pattern not yet covered by the inline-bold regex.
-    /// Marked `#[ignore]` until the bound coalescer lands.
-    #[test]
-    fn test_issue12_bound_camelcase_bold_coalesces() {
-        let input = "**N orthW** ind";
-        let out = coalesce_camelcase_bold_fragments(input);
-        // Either of these post-coalesce forms is acceptable; both
-        // recover the intended brand name.
-        let acceptable = out.contains("**NorthWind**")
-            || out.contains("**NorthW**ind")
-            || out.contains("**N**orthWind");
-        assert!(
-            acceptable,
-            "bound CamelCase bold (closing ** mid-word) should coalesce, got:\n{}",
-            out
-        );
     }
 
     /// Issue #8 — a table cell that carries bold spans must render the

--- a/src/pipeline/converters/markdown.rs
+++ b/src/pipeline/converters/markdown.rs
@@ -349,7 +349,17 @@ fn merge_consecutive_same_level_headings(s: &str) -> String {
         // separate. Fusing destroyed genuinely distinct section headers.
         let wrapped_two = texts.len() == 2 && looks_like_heading_wrap(&texts[0], &texts[1]);
         if wrapped_two {
-            let merged = texts.join(" ");
+            // A fragment ending in a hyphen is a word broken across the two
+            // lines, so the halves join with nothing between them. Joining
+            // with a space would put one inside the word: `loa-` + `ded`
+            // reads `loa- ded`. This is the rule the wrap detector already
+            // applies when it takes a trailing hyphen as the continuation
+            // signal; the merge has to honour the same reading.
+            let merged = if texts[0].trim_end().ends_with('-') {
+                format!("{}{}", texts[0].trim_end(), texts[1].trim_start())
+            } else {
+                texts.join(" ")
+            };
             let hashes = "#".repeat(level);
             out.push(format!("{} {}", hashes, merged));
             i = j;
@@ -5413,6 +5423,19 @@ mod tests {
             h1_count, 3,
             "tagged distinct H1 elements must NOT be merged (spec §14.8.4.3.2), got:\n{}",
             result
+        );
+    }
+
+    /// A heading wrapped at a hyphen joins with nothing between the halves.
+    /// A space there lands inside the word.
+    #[test]
+    fn test_heading_wrapped_at_hyphen_joins_without_space() {
+        let merged = merge_consecutive_same_level_headings(
+            "### PDF with custom font loa-\n### ded successfully",
+        );
+        assert_eq!(
+            merged, "### PDF with custom font loa-ded successfully",
+            "a space was inserted at the hyphen the word broke on"
         );
     }
 

--- a/src/pipeline/converters/mod.rs
+++ b/src/pipeline/converters/mod.rs
@@ -376,6 +376,11 @@ pub(crate) fn merge_key_value_pairs(text: &str) -> String {
         if is_ordered_list_marker(trimmed).is_some() || starts_with_bullet(trimmed) {
             return false;
         }
+        // Multi-word prose that ends a sentence is a paragraph, not a value,
+        // no matter what it starts with ("2024 was a record year.").
+        if trimmed.ends_with(['.', '!', '?']) && trimmed.split_whitespace().count() >= 3 {
+            return false;
+        }
         let mut chars = trimmed.chars();
         let first = chars.next().unwrap();
         match first {
@@ -394,6 +399,11 @@ pub(crate) fn merge_key_value_pairs(text: &str) -> String {
     fn is_label_line(line: &str) -> bool {
         let trimmed = line.trim();
         if trimmed.is_empty() {
+            return false;
+        }
+        // A markdown heading is a complete block in its own right — it
+        // labels the section below it, never a value line.
+        if trimmed.starts_with('#') {
             return false;
         }
         // Must not itself be a value-only line

--- a/tests/markdown_postprocess_overmerge.rs
+++ b/tests/markdown_postprocess_overmerge.rs
@@ -1,0 +1,104 @@
+//! Markdown post-processing must not fuse distinct blocks: a heading and the
+//! paragraph after it, consecutive genuine headings, or the words inside a
+//! bold run. Each PDF here is hand-built with known-correct content; the
+//! assertions pin the un-fused output.
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::document::PdfDocument;
+
+/// One-page untagged PDF from a raw content stream, with two Type1 fonts
+/// F1 (Helvetica) and F2 (Helvetica-Bold).
+fn build_pdf(content: &str) -> Vec<u8> {
+    let content = content.as_bytes();
+    let mut pdf: Vec<u8> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+    let mut off = [0usize; 7];
+    off[1] = pdf.len();
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+    off[2] = pdf.len();
+    pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+    off[3] = pdf.len();
+    pdf.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]\
+         /Resources << /Font << /F1 4 0 R /F2 6 0 R >> >> /Contents 5 0 R >>\nendobj\n",
+    );
+    off[4] = pdf.len();
+    pdf.extend_from_slice(
+        b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica\
+         /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+    off[5] = pdf.len();
+    pdf.extend_from_slice(format!("5 0 obj\n<< /Length {} >>\nstream\n", content.len()).as_bytes());
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    off[6] = pdf.len();
+    pdf.extend_from_slice(
+        b"6 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold\
+         /Encoding /WinAnsiEncoding >>\nendobj\n",
+    );
+
+    let xref_off = pdf.len();
+    pdf.extend_from_slice(b"xref\n0 7\n0000000000 65535 f \n");
+    for o in &off[1..7] {
+        pdf.extend_from_slice(format!("{o:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(b"trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n");
+    pdf.extend_from_slice(format!("{xref_off}\n%%EOF\n").as_bytes());
+    pdf
+}
+
+fn markdown(content: &str) -> String {
+    let doc = PdfDocument::from_bytes(build_pdf(content)).expect("parse");
+    doc.to_markdown(0, &ConversionOptions::default())
+        .expect("to_markdown")
+}
+
+/// A 20pt heading followed by a 12pt paragraph that begins with a digit.
+/// The paragraph must stay a separate block, not be glued onto the heading.
+#[test]
+fn heading_keeps_following_numeric_paragraph_separate() {
+    let md = markdown(
+        "BT /F1 20 Tf 1 0 0 1 72 720 Tm (Revenue) Tj \
+         /F1 12 Tf 1 0 0 1 72 690 Tm (2024 was a record year.) Tj ET",
+    );
+    assert!(
+        !md.lines()
+            .any(|l| l.contains("Revenue") && l.contains("2024")),
+        "paragraph merged into the heading line:\n{md}"
+    );
+    assert!(md.contains("2024 was a record year."), "paragraph text lost:\n{md}");
+    assert!(md.contains("Revenue"), "heading text lost:\n{md}");
+}
+
+/// Three distinct short headings must stay three headings — not fuse into
+/// `## Sales Marketing Engineering`.
+#[test]
+fn consecutive_short_headings_stay_separate() {
+    let md = markdown(
+        "BT /F1 20 Tf 1 0 0 1 72 720 Tm (Sales) Tj \
+         1 0 0 1 72 690 Tm (Marketing) Tj \
+         1 0 0 1 72 660 Tm (Engineering) Tj \
+         /F1 12 Tf 1 0 0 1 72 620 Tm (The three teams reported strong results this quarter overall.) Tj ET",
+    );
+    let names = ["Sales", "Marketing", "Engineering"];
+    for line in md.lines() {
+        let hits = names.iter().filter(|n| line.contains(*n)).count();
+        assert!(hits <= 1, "distinct headings fused into one line {line:?}:\n{md}");
+    }
+    for n in names {
+        assert!(md.contains(n), "heading {n:?} lost:\n{md}");
+    }
+}
+
+/// Bold prose `A gitHub repo` must keep its spaces; the CamelCase inside one
+/// word is not license to delete the word boundaries around it.
+#[test]
+fn bold_prose_with_camelcase_word_keeps_spaces() {
+    let md = markdown(
+        "BT /F1 12 Tf 1 0 0 1 72 720 Tm (This project uses a special tool.) Tj \
+         1 0 0 1 72 696 Tm (See the notes below for details.) Tj \
+         /F2 12 Tf 1 0 0 1 72 672 Tm (A gitHub repo) Tj ET",
+    );
+    assert!(!md.contains("AgitHubrepo"), "spaces deleted inside the bold run:\n{md}");
+    assert!(md.contains("A gitHub repo"), "bold prose altered:\n{md}");
+}

--- a/tests/tagged_heading_wrap.rs
+++ b/tests/tagged_heading_wrap.rs
@@ -1,0 +1,109 @@
+//! A heading that wraps across lines is one heading.
+//!
+//! ISO 32000-1 §14.8.3 makes one BLSE a single block that "can be split
+//! between lines of text". That applies to an `<Hn>` as much as to a `<P>`,
+//! so a title drawn on two baselines inside one heading element must emit as
+//! one markdown heading rather than one per line.
+//!
+//! The continuation signals that serve body text cannot decide this: they
+//! require the next line to open lowercase, and a title-cased heading
+//! capitalises every line, so `Tax and` / `Credits` reads as two headings.
+
+use pdf_oxide::converters::ConversionOptions;
+use pdf_oxide::PdfDocument;
+
+/// Tagged one-page PDF: an `<H2>` whose marked content is drawn on two
+/// baselines, then a `<P>` of body text so the heading has something to end
+/// against.
+fn wrapped_heading_pdf() -> Vec<u8> {
+    let content: &[u8] = b"BT
+/H2 <</MCID 0>> BDC
+/F2 18 Tf
+1 0 0 1 72 700 Tm (Tax and) Tj
+1 0 0 1 72 678 Tm (Credits) Tj
+EMC
+/P <</MCID 1>> BDC
+/F1 10 Tf
+1 0 0 1 72 640 Tm (Body text follows the heading.) Tj
+EMC
+ET";
+    let mut stream = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
+    stream.extend_from_slice(content);
+    stream.extend_from_slice(b"\nendstream");
+
+    let bodies: Vec<(usize, Vec<u8>)> = vec![
+        (
+            1,
+            b"<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 10 0 R /MarkInfo << /Marked true >> >>"
+                .to_vec(),
+        ),
+        (2, b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec()),
+        (
+            3,
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+/Resources << /Font << /F1 4 0 R /F2 6 0 R >> >> /Contents 5 0 R /StructParents 0 >>"
+                .to_vec(),
+        ),
+        (4, b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec()),
+        (5, stream),
+        (6, b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>".to_vec()),
+        (10, b"<< /Type /StructTreeRoot /K [11 0 R] >>".to_vec()),
+        (
+            11,
+            b"<< /Type /StructElem /S /Document /P 10 0 R /K [12 0 R 13 0 R] >>".to_vec(),
+        ),
+        (
+            12,
+            b"<< /Type /StructElem /S /H2 /P 11 0 R /Pg 3 0 R /K 0 >>".to_vec(),
+        ),
+        (
+            13,
+            b"<< /Type /StructElem /S /P /P 11 0 R /Pg 3 0 R /K 1 >>".to_vec(),
+        ),
+    ];
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    let max_id = 13;
+    let mut offsets = vec![0usize; max_id + 1];
+    for (id, body) in &bodies {
+        offsets[*id] = out.len();
+        out.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        out.extend_from_slice(body);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(format!("xref\n0 {}\n0000000000 65535 f \n", max_id + 1).as_bytes());
+    for id in 1..=max_id {
+        if offsets[id] != 0 {
+            out.extend_from_slice(format!("{:010} 00000 n \n", offsets[id]).as_bytes());
+        } else {
+            out.extend_from_slice(b"0000000000 65535 f \n");
+        }
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n", max_id + 1)
+            .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn wrapped_heading_emits_one_heading() {
+    let doc = PdfDocument::from_bytes(wrapped_heading_pdf()).expect("parse");
+    let md = doc
+        .to_markdown(0, &ConversionOptions::default())
+        .expect("to_markdown");
+
+    let headings: Vec<&str> = md.lines().filter(|l| l.starts_with('#')).collect();
+    assert_eq!(
+        headings.len(),
+        1,
+        "a heading split across two baselines inside one <H2> must emit once, got {headings:?}\n\n{md}"
+    );
+    let heading = headings[0];
+    assert!(
+        heading.contains("Tax and") && heading.contains("Credits"),
+        "both lines of the wrapped heading must survive in it, got {heading:?}\n\n{md}"
+    );
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #1081 and #1083.** Those two remove the remaining sources of nondeterminism in `main`; ~~#1008~~ is merged (landed as 690711ed). Until they land, a corpus comparison against `main` can flag pages that move on their own, so before/after evidence on this PR carries that caveat.

## Linked issue

Closes #1064

## What and why

Split from #996 per its review.

Markdown post-processing fused distinct blocks: a heading absorbed the paragraph after it (`## Revenue 2024 was a record year.`), and bold prose lost its spaces (`**AgitHubrepo**`) to a CamelCase-repair pass compensating for a span-assembly tear that no longer exists. That pass is deleted; span assembly now prevents the tear it papered over.

The heading/value-line geometry heuristic is deliberately NOT in this PR: your corpus showed it fragments multi-line titles, so it stays held until we find a mechanism that doesn't.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [x] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): none beyond default; no binding sources are touched.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

The overmerge tests pin the heading/paragraph separation and the bold-prose spaces on synthetic pages.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents (~470,000 pages), swept against `main`.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [ ] Diffed my branch against the **latest release**: same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** a markdown-surface change; the character multiset per page is conserved and movement is confined to block boundaries.

Swept on a fresh base built from current `main` in the same cargo session as this branch's arm, 470k pages, field-by-field digests with the measured noise floor and the fixture-engagement manifest armed.

| | |
|---|---|
| pages compared | 470207 |
| identical in every measured column | 0 |
| blockers | 39 |
| token-loss / token-duplication pages | 19 / 0 |
| class-permitted movement (the fix's own surface) | 21535 |

**Triage of the flagged pages.** The 39 blocked pages move only in markdown word-set and rect probes, on pages whose class markers lack the `headings` label: the deleted CamelCase-repair pass touched any bold-adjacent markdown, so its removal moves the markdown surface corpus-wide. The class-permitted bulk is the same surface on labelled pages. Text and table columns are conserved.

**Diff summary vs latest release:** not run separately; the sweep was against `main`.

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: the split from the bundled branch, the corpus sweep, and this description.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [x] Public-API changes considered for semver (`semver-checks` will run).

`CHANGELOG.md` is untouched; it is written per release under a version heading.



