### PR TITLE
fix(encryption): unwrap /UE and /OE for AES-256 R5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,10 +317,12 @@ crc32fast = "1.3"
 wasm-bindgen-test = "0.3"
 hex-literal = "1.1.0"
 jpeg-encoder = "0.7.0"
-# Independent spec-algorithm implementations for encryption fixtures built in
-# tests — deliberately not routed through the crate's own crypto so a fixture
-# cannot inherit the defect its test guards against. Same versions as the
-# main dependencies, so nothing new enters the build graph.
+# Independent implementations of the spec's primitives, so an encryption
+# fixture can be built without the crate's own crypto and cannot inherit the
+# defect its test guards against. Used by the R5 end-to-end fixture; the
+# unit tests round-trip through the crate's AES deliberately, since the
+# defect they pin is in key derivation, not in the cipher. Same versions as
+# the main dependencies, so nothing new enters the build graph.
 sha2 = "0.11"
 aes = "0.9"
 cbc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,6 +317,13 @@ crc32fast = "1.3"
 wasm-bindgen-test = "0.3"
 hex-literal = "1.1.0"
 jpeg-encoder = "0.7.0"
+# Independent spec-algorithm implementations for encryption fixtures built in
+# tests — deliberately not routed through the crate's own crypto so a fixture
+# cannot inherit the defect its test guards against. Same versions as the
+# main dependencies, so nothing new enters the build graph.
+sha2 = "0.11"
+aes = "0.9"
+cbc = "0.2"
 
 # `criterion` pulls `rayon`, which cannot target wasm32. Benches only
 # ever run natively, so keep criterion out of the wasm32 dev-dep graph

--- a/src/encryption/algorithms.rs
+++ b/src/encryption/algorithms.rs
@@ -230,22 +230,25 @@ fn authenticate_user_password_r5_r6(
         return None;
     }
 
-    if revision >= 6 {
-        // R6: Derive intermediate key via Algorithm 2.B, then unwrap UE
-        let ue = user_encryption?;
-        if ue.len() < 32 {
-            return None;
-        }
-        let intermediate_key = algorithm_2b(&password, key_salt, &[]);
-        let iv = [0u8; 16];
-        super::aes::aes256_decrypt_no_padding(&intermediate_key[..32], &iv, &ue[..32]).ok()
+    // The intermediate key differs between revisions (plain SHA-256 for R5,
+    // Algorithm 2.B for R6), but for both the file key is the AES-256
+    // unwrap of /UE with that intermediate key (ISO 32000-2 §7.6.4.4.8;
+    // Adobe Supplement ExtensionLevel 3 for R5). The intermediate key is
+    // never the file key itself.
+    let ue = user_encryption?;
+    if ue.len() < 32 {
+        return None;
+    }
+    let intermediate_key = if revision >= 6 {
+        algorithm_2b(&password, key_salt, &[])
     } else {
-        // R5: Simple SHA-256(password || key_salt)
         let mut hasher = Sha256::new();
         hasher.update(&password);
         hasher.update(key_salt);
-        Some(hasher.finalize().to_vec())
-    }
+        hasher.finalize().to_vec()
+    };
+    let iv = [0u8; 16];
+    super::aes::aes256_decrypt_no_padding(&intermediate_key[..32], &iv, &ue[..32]).ok()
 }
 
 /// Apply SASLprep (RFC 4013) normalization to a password.
@@ -836,23 +839,24 @@ fn authenticate_owner_password_r5_r6(
         return None;
     }
 
-    if revision >= 6 {
-        // R6: Derive intermediate key via Algorithm 2.B, then unwrap OE
-        let oe = owner_encryption?;
-        if oe.len() < 32 {
-            return None;
-        }
-        let intermediate_key = algorithm_2b(&password, owner_key_salt, u_value);
-        let iv = [0u8; 16];
-        super::aes::aes256_decrypt_no_padding(&intermediate_key[..32], &iv, &oe[..32]).ok()
+    // Same shape as the user path: the revision decides the intermediate
+    // hash, and the file key is always the AES-256 unwrap of /OE with it
+    // (ISO 32000-2 §7.6.4.4.8; Adobe Supplement ExtensionLevel 3 for R5).
+    let oe = owner_encryption?;
+    if oe.len() < 32 {
+        return None;
+    }
+    let intermediate_key = if revision >= 6 {
+        algorithm_2b(&password, owner_key_salt, u_value)
     } else {
-        // R5: SHA-256(password || owner_key_salt || U[0..48])
         let mut hasher = Sha256::new();
         hasher.update(&password);
         hasher.update(owner_key_salt);
         hasher.update(u_value);
-        Some(hasher.finalize().to_vec())
-    }
+        hasher.finalize().to_vec()
+    };
+    let iv = [0u8; 16];
+    super::aes::aes256_decrypt_no_padding(&intermediate_key[..32], &iv, &oe[..32]).ok()
 }
 
 /// Constant-time comparison to prevent timing attacks.
@@ -1160,18 +1164,36 @@ mod tests {
         user_key.extend_from_slice(&key_salt);
         assert_eq!(user_key.len(), 48);
 
-        let result = authenticate_user_password(
-            password, &user_key, &[0u8; 48], // owner_key unused for R>=5
-            -1, b"", 5, 32, true, None,
-        );
-        assert!(result.is_some());
-
-        // Verify the returned key is SHA-256("test" || key_salt)
+        // Wrap a known file key into /UE with the spec algorithm:
+        // UE = AES-256-CBC(key = SHA-256(password || key_salt), iv = 0, file key).
+        let file_key = [0x5Au8; 32];
         let mut hasher = Sha256::new();
         hasher.update(password);
         hasher.update(key_salt);
-        let expected_key = hasher.finalize().to_vec();
-        assert_eq!(result.unwrap(), expected_key);
+        let intermediate = hasher.finalize();
+        let ue =
+            crate::encryption::aes::aes256_encrypt_no_padding(&intermediate, &[0u8; 16], &file_key)
+                .unwrap();
+
+        let result = authenticate_user_password(
+            password,
+            &user_key,
+            &[0u8; 48], // owner_key unused for R>=5
+            -1,
+            b"",
+            5,
+            32,
+            true,
+            Some(&ue),
+        );
+        // The file key is the unwrapped /UE — never the intermediate hash.
+        assert_eq!(result.unwrap(), file_key.to_vec());
+
+        // Without /UE the file key is unobtainable; authentication must fail
+        // loudly rather than hand back the intermediate hash as a "key".
+        let no_ue =
+            authenticate_user_password(password, &user_key, &[0u8; 48], -1, b"", 5, 32, true, None);
+        assert!(no_ue.is_none());
     }
 
     #[test]
@@ -1346,19 +1368,39 @@ mod tests {
         owner_key.extend_from_slice(&owner_validation_salt);
         owner_key.extend_from_slice(&owner_key_salt);
 
-        let result = authenticate_owner_password(
-            password, &user_key, &owner_key, -1, b"", 5, 32, true, None,
-        )
-        .unwrap();
-        assert!(result.is_some());
-
-        // Verify the returned key is SHA-256(password || owner_key_salt || U[0..48])
+        // Wrap a known file key into /OE with the spec algorithm:
+        // OE = AES-256-CBC(key = SHA-256(password || owner_key_salt || U), iv = 0, file key).
+        let file_key = [0xC3u8; 32];
         let mut hasher = Sha256::new();
         hasher.update(password.as_slice());
         hasher.update(owner_key_salt);
         hasher.update(&user_key[..48]);
-        let expected_key = hasher.finalize().to_vec();
-        assert_eq!(result.unwrap(), expected_key);
+        let intermediate = hasher.finalize();
+        let oe =
+            crate::encryption::aes::aes256_encrypt_no_padding(&intermediate, &[0u8; 16], &file_key)
+                .unwrap();
+
+        let result = authenticate_owner_password(
+            password,
+            &user_key,
+            &owner_key,
+            -1,
+            b"",
+            5,
+            32,
+            true,
+            Some(&oe),
+        )
+        .unwrap();
+        // The file key is the unwrapped /OE — never the intermediate hash.
+        assert_eq!(result.unwrap(), file_key.to_vec());
+
+        // Without /OE the file key is unobtainable; authentication must fail.
+        let no_oe = authenticate_owner_password(
+            password, &user_key, &owner_key, -1, b"", 5, 32, true, None,
+        )
+        .unwrap();
+        assert!(no_oe.is_none());
     }
 
     #[test]

--- a/tests/aes256_r5_empty_password_extract.rs
+++ b/tests/aes256_r5_empty_password_extract.rs
@@ -1,0 +1,153 @@
+//! AES-256 revision 5 (PDF 2.0 / Adobe Extension Level 3): the file
+//! encryption key is stored AES-wrapped in /UE — the intermediate key
+//! SHA-256(password ‖ key salt) *decrypts* /UE, it is not itself the file
+//! key. A reader that skips the unwrap authenticates successfully and then
+//! decrypts every stream to noise.
+//!
+//! The fixture is built here from the spec algorithm using the RustCrypto
+//! primitives directly — deliberately not through pdf_oxide's own key
+//! derivation, so the fixture cannot inherit the defect under test.
+
+use sha2::{Digest, Sha256};
+
+use pdf_oxide::PdfDocument;
+
+const FILE_KEY: [u8; 32] = [
+    0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7,
+    0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7,
+];
+const USER_VALIDATION_SALT: [u8; 8] = *b"UVALSLT!";
+const USER_KEY_SALT: [u8; 8] = *b"UKEYSLT!";
+const OWNER_VALIDATION_SALT: [u8; 8] = *b"OVALSLT!";
+const OWNER_KEY_SALT: [u8; 8] = *b"OKEYSLT!";
+const CONTENT_IV: [u8; 16] = [0x5A; 16];
+const PERMS_P: i32 = -1028;
+
+fn sha256(parts: &[&[u8]]) -> Vec<u8> {
+    let mut h = Sha256::new();
+    for p in parts {
+        h.update(p);
+    }
+    h.finalize().to_vec()
+}
+
+fn aes256_cbc_nopad(key: &[u8], iv: &[u8], data: &[u8]) -> Vec<u8> {
+    use aes::cipher::{block_padding::NoPadding, BlockModeEncrypt, KeyIvInit};
+    let enc = cbc::Encryptor::<aes::Aes256>::new_from_slices(key, iv).expect("key/iv");
+    let mut buf = data.to_vec();
+    let len = buf.len();
+    enc.encrypt_padded::<NoPadding>(&mut buf, len)
+        .expect("encrypt")
+        .to_vec()
+}
+
+fn aes256_cbc_pkcs7(key: &[u8], iv: &[u8], data: &[u8]) -> Vec<u8> {
+    use aes::cipher::{block_padding::Pkcs7, BlockModeEncrypt, KeyIvInit};
+    let enc = cbc::Encryptor::<aes::Aes256>::new_from_slices(key, iv).expect("key/iv");
+    let mut buf = vec![0u8; data.len() + 16];
+    buf[..data.len()].copy_from_slice(data);
+    enc.encrypt_padded::<Pkcs7>(&mut buf, data.len())
+        .expect("encrypt")
+        .to_vec()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02X}")).collect()
+}
+
+/// Build a one-page R5 AES-256 encrypted PDF with empty user and owner
+/// passwords, whose page text is "secret payload text".
+fn r5_encrypted_pdf() -> Vec<u8> {
+    // U: SHA256(pw ‖ validation salt) ‖ validation salt ‖ key salt.
+    let mut u_entry = sha256(&[b"", &USER_VALIDATION_SALT]);
+    u_entry.extend_from_slice(&USER_VALIDATION_SALT);
+    u_entry.extend_from_slice(&USER_KEY_SALT);
+
+    // UE: AES-256-CBC(key = SHA256(pw ‖ key salt), iv = 0) over the file key.
+    let ue_entry = aes256_cbc_nopad(&sha256(&[b"", &USER_KEY_SALT]), &[0u8; 16], &FILE_KEY);
+
+    // O: SHA256(pw ‖ owner validation salt ‖ U) ‖ owner validation salt ‖ owner key salt.
+    let mut o_entry = sha256(&[b"", &OWNER_VALIDATION_SALT, &u_entry]);
+    o_entry.extend_from_slice(&OWNER_VALIDATION_SALT);
+    o_entry.extend_from_slice(&OWNER_KEY_SALT);
+
+    // OE: AES-256-CBC(key = SHA256(pw ‖ owner key salt ‖ U), iv = 0) over the file key.
+    let oe_entry =
+        aes256_cbc_nopad(&sha256(&[b"", &OWNER_KEY_SALT, &u_entry]), &[0u8; 16], &FILE_KEY);
+
+    // Perms: P (little-endian) ‖ FF FF FF FF ‖ 'T' ‖ "adb" ‖ 4 arbitrary bytes,
+    // AES-256 encrypted with the file key. A single block with iv = 0 is ECB.
+    let mut perms_plain = [0u8; 16];
+    perms_plain[..4].copy_from_slice(&PERMS_P.to_le_bytes());
+    perms_plain[4..8].copy_from_slice(&[0xFF; 4]);
+    perms_plain[8] = b'T';
+    perms_plain[9..12].copy_from_slice(b"adb");
+    perms_plain[12..16].copy_from_slice(b"salt");
+    let perms_entry = aes256_cbc_nopad(&FILE_KEY, &[0u8; 16], &perms_plain);
+
+    // Content stream, AES-256-CBC with the IV prepended (§7.6.2).
+    let plaintext: &[u8] = b"BT /F1 12 Tf 72 700 Td (secret payload text) Tj ET";
+    let mut stream_data = CONTENT_IV.to_vec();
+    stream_data.extend_from_slice(&aes256_cbc_pkcs7(&FILE_KEY, &CONTENT_IV, plaintext));
+
+    let mut bodies: Vec<Vec<u8>> = vec![Vec::new(); 7]; // ids 1..=6
+    bodies[1] = b"<< /Type /Catalog /Pages 2 0 R >>".to_vec();
+    bodies[2] = b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec();
+    bodies[3] = b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+        .to_vec();
+    let mut cs = format!("<< /Length {} >>\nstream\n", stream_data.len()).into_bytes();
+    cs.extend_from_slice(&stream_data);
+    cs.extend_from_slice(b"\nendstream");
+    bodies[4] = cs;
+    bodies[5] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec();
+    bodies[6] = format!(
+        "<< /Filter /Standard /V 5 /R 5 /Length 256 \
+         /CF << /StdCF << /AuthEvent /DocOpen /CFM /AESV3 /Length 32 >> >> \
+         /StmF /StdCF /StrF /StdCF /P {PERMS_P} /EncryptMetadata true \
+         /O <{}> /U <{}> /OE <{}> /UE <{}> /Perms <{}> >>",
+        hex(&o_entry),
+        hex(&u_entry),
+        hex(&oe_entry),
+        hex(&ue_entry),
+        hex(&perms_entry),
+    )
+    .into_bytes();
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    let mut offsets = [0usize; 7];
+    for id in 1..=6 {
+        offsets[id] = out.len();
+        out.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        out.extend_from_slice(&bodies[id]);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(b"xref\n0 7\n0000000000 65535 f \n");
+    for id in 1..=6 {
+        out.extend_from_slice(format!("{:010} 00000 n \n", offsets[id]).as_bytes());
+    }
+    out.extend_from_slice(
+        format!(
+            "trailer\n<< /Size 7 /Root 1 0 R /Encrypt 6 0 R \
+             /ID [<0123456789ABCDEF0123456789ABCDEF> <0123456789ABCDEF0123456789ABCDEF>] >>\n\
+             startxref\n{xref}\n%%EOF\n"
+        )
+        .as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn r5_empty_password_streams_decrypt_to_real_content() {
+    let doc = PdfDocument::from_bytes(r5_encrypted_pdf()).expect("parse");
+    let authenticated = doc.authenticate(b"").expect("authenticate");
+    assert!(authenticated, "empty user password must authenticate on R5");
+
+    let text = doc.extract_text(0).expect("extract_text");
+    assert!(
+        text.contains("secret payload text"),
+        "R5 file key must come from unwrapping /UE; extracted text = {text:?}"
+    );
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #1081 and #1083.** Those two remove the remaining sources of nondeterminism in `main`; ~~#1008~~ is merged (landed as 690711ed). Until they land, a corpus comparison against `main` can flag pages that move on their own, so before/after evidence on this PR carries that caveat.

## Linked issue

Closes #1068

## What and why

Split from #996 per its review.

AES-256 R5 files authenticated and then decrypted every stream to noise: the code returned the intermediate password hash as the file key. It now unwraps `/UE` or `/OE`, the way the R6 path already does for the identical file.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [x] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): `fips,icc` (the R5 unwrap runs under both crypto backends).
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

The regression test builds an R5-encrypted file in code, authenticates with the empty user password, and asserts the extracted text.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents (~470,000 pages), swept against `main`.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [ ] Diffed my branch against the **latest release**: same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** scoped to R5-encrypted files; the corpus's encrypted class is the relevant population.

Swept on a fresh base built from current `main` in the same cargo session as this branch's arm, 470k pages, field-by-field digests with the measured noise floor and the fixture-engagement manifest armed.

| | |
|---|---|
| pages compared | 470207 |
| identical in every measured column | 0 |
| blockers | 0 |
| token-loss / token-duplication pages | 1 / 0 |
| class-permitted movement (the fix's own surface) | 1 |

**Triage of the one flagged page.** The single token-loss page is an unencrypted rotated document. This PR changes only the AES-256 R5 key unwrap, which an unencrypted file never reaches, so the movement is structurally unattributable to this change — it is the known flicker family on rotated pages, measured on the base itself.

**Diff summary vs latest release:** not run separately; the sweep was against `main`.

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: the split from the bundled branch, the corpus sweep, and this description.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [x] Public-API changes considered for semver (`semver-checks` will run).

`CHANGELOG.md` is untouched; it is written per release under a version heading.



