### PR TITLE
fix(forms): keep a selected button's export value

### DIFF
--- a/src/extractors/forms.rs
+++ b/src/extractors/forms.rs
@@ -542,10 +542,13 @@ impl FormExtractor {
             Object::Name(name) => {
                 // Name value (for radio buttons, choice fields)
                 if *field_type == FieldType::Button {
-                    // For checkboxes, common values are /Yes or /Off
+                    // ISO 32000-1 §12.7.4.2.3: a button's /V names its selected
+                    // appearance state and only /Off means "unselected". Any
+                    // other name — including /No — is a real on-state whose
+                    // export value must be preserved.
                     if name == "Yes" || name == "On" {
                         FieldValue::Boolean(true)
-                    } else if name == "No" || name == "Off" {
+                    } else if name == "Off" {
                         FieldValue::Boolean(false)
                     } else {
                         FieldValue::Name(name.clone())
@@ -921,9 +924,11 @@ mod tests {
 
     #[test]
     fn test_parse_field_value_button_no() {
+        // /No is a real on-state (only /Off means unselected, ISO 32000-1
+        // §12.7.4.2.3): the export value must survive.
         let obj = Object::Name("No".to_string());
         let value = FormExtractor::parse_field_value(&obj, &FieldType::Button);
-        assert!(matches!(value, FieldValue::Boolean(false)));
+        assert!(matches!(value, FieldValue::Name(ref s) if s == "No"));
     }
 
     #[test]

--- a/tests/button_field_no_export_value.rs
+++ b/tests/button_field_no_export_value.rs
@@ -1,0 +1,81 @@
+//! A button field's /V names its selected appearance state; only /Off means
+//! "unselected" (ISO 32000-1 §12.7.4.2.3). An export value of /No is a real
+//! on-state — collapsing it to `Boolean(false)` makes a selected "No" answer
+//! indistinguishable from an untouched field.
+
+use pdf_oxide::extractors::{FieldValue, FormExtractor};
+use pdf_oxide::PdfDocument;
+
+fn form_pdf(button_value: &str) -> Vec<u8> {
+    let mut bodies: Vec<Vec<u8>> = vec![Vec::new(); 8]; // ids 1..=7
+    bodies[1] = b"<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R 7 0 R] >> >>".to_vec();
+    bodies[2] = b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec();
+    bodies[3] =
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Annots [4 0 R 7 0 R] >>".to_vec();
+    bodies[4] = format!(
+        "<< /Type /Annot /Subtype /Widget /FT /Btn /T (Answer) /V /{button_value} /AS /{button_value} \
+         /Rect [10 10 30 30] /AP << /N << /No 5 0 R /Off 6 0 R >> >> >>"
+    )
+    .into_bytes();
+    bodies[5] = b"<< /Length 0 >>\nstream\n\nendstream".to_vec();
+    bodies[6] = b"<< /Length 0 >>\nstream\n\nendstream".to_vec();
+    bodies[7] =
+        b"<< /Type /Annot /Subtype /Widget /FT /Tx /T (Name) /V (Alice) /Rect [10 40 100 60] >>"
+            .to_vec();
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    let mut offsets = [0usize; 8];
+    for id in 1..=7 {
+        offsets[id] = out.len();
+        out.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        out.extend_from_slice(&bodies[id]);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(b"xref\n0 8\n0000000000 65535 f \n");
+    for id in 1..=7 {
+        out.extend_from_slice(format!("{:010} 00000 n \n", offsets[id]).as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size 8 /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn field_value(pdf: Vec<u8>, name: &str) -> FieldValue {
+    let doc = PdfDocument::from_bytes(pdf).expect("parse");
+    let fields = FormExtractor::extract_fields(&doc).expect("fields");
+    fields
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("no field named {name:?}"))
+        .value
+        .clone()
+}
+
+#[test]
+fn selected_no_state_keeps_its_export_value() {
+    let value = field_value(form_pdf("No"), "Answer");
+    assert_eq!(
+        value,
+        FieldValue::Name("No".to_string()),
+        "a selected /No on-state must keep its export value, not collapse to Boolean(false)"
+    );
+}
+
+#[test]
+fn off_state_still_reports_unselected() {
+    let value = field_value(form_pdf("Off"), "Answer");
+    assert_eq!(
+        value,
+        FieldValue::Boolean(false),
+        "/Off is the one name that genuinely means unselected"
+    );
+}
+
+#[test]
+fn text_field_value_unaffected() {
+    let value = field_value(form_pdf("No"), "Name");
+    assert_eq!(value, FieldValue::Text("Alice".to_string()));
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #1081 and #1083.** Those two remove the remaining sources of nondeterminism in `main`; ~~#1008~~ is merged (landed as 690711ed). Until they land, a corpus comparison against `main` can flag pages that move on their own, so before/after evidence on this PR carries that caveat.

## Linked issue

Closes #1070

## What and why

Split from #996 per its review.

A selected `/No` button read as `Boolean(false)`, indistinguishable from an unanswered field. Only `/Off` now means unselected (§12.7.4.2.3); any other name is the export value and is reported as such.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [x] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): none beyond default; no binding sources are touched.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

The regression test builds a checkbox with `/V /No` in code and asserts the export value.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents (~470,000 pages), swept against `main`.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [ ] Diffed my branch against the **latest release**: same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** scoped to form extraction; the forms class is the relevant population.

Swept on a fresh base built from current `main` in the same cargo session as this branch's arm, 470k pages, field-by-field digests with the measured noise floor and the fixture-engagement manifest armed.

| | |
|---|---|
| pages compared | 470207 |
| identical in every measured column | 0 |
| blockers | 0 |
| token-loss / token-duplication pages | 0 / 0 |
| class-permitted movement (the fix's own surface) | 2 |

**Diff summary vs latest release:** not run separately; the sweep was against `main`.

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: the split from the bundled branch, the corpus sweep, and this description.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [x] Public-API changes considered for semver (`semver-checks` will run).

`CHANGELOG.md` is untouched; it is written per release under a version heading.



