### PR TITLE
fix(annotations): resolve explicit destinations to page-tree indices

### DIFF
--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -648,9 +648,10 @@ impl PdfDocument {
                 let page = match &arr[0] {
                     Object::Integer(n) => *n as u32,
                     Object::Reference(r) => {
-                        // Resolve page reference to page index
-                        // For now, just use object ID as approximation
-                        r.id
+                        // A reference names a page *object*; `Explicit.page`
+                        // is the 0-based position in the page tree
+                        // (ISO 32000-1 §12.3.2.2).
+                        self.page_index_of_ref(*r)? as u32
                     },
                     _ => 0,
                 };
@@ -729,8 +730,19 @@ impl PdfDocument {
                     crate::error::Error::InvalidPdf("GoTo action missing /D field".to_string())
                 })?;
 
-                let destination = self.parse_destination(dest_obj)?;
-                Ok(LinkAction::GoTo(destination))
+                // A destination that cannot be resolved (e.g. a dangling
+                // reference to a deleted page) invalidates the action, not
+                // the annotation: report the action type without inventing
+                // a page number.
+                match self.parse_destination(dest_obj) {
+                    Ok(destination) => Ok(LinkAction::GoTo(destination)),
+                    Err(e) => {
+                        log::warn!("GoTo destination unresolvable: {e}");
+                        Ok(LinkAction::Other {
+                            action_type: "GoTo".to_string(),
+                        })
+                    },
+                }
             },
             "GoToR" => {
                 // GoToR action - navigate to remote document

--- a/src/document.rs
+++ b/src/document.rs
@@ -5187,81 +5187,21 @@ impl PdfDocument {
         }
     }
 
-    /// 0-based page-tree position of a page object. The traversal mirrors
-    /// [`Self::get_page_ref_recursive`] so both directions of the
-    /// index ↔ reference mapping always agree.
+    /// 0-based page-tree position of a page object.
+    ///
+    /// Defers to [`Self::all_page_refs`] rather than walking the tree again:
+    /// that collector already handles the `/Count` fast path, nodes that omit
+    /// `/Type`, and cycles, and sharing it keeps this direction of the
+    /// index <-> reference mapping consistent with the other by construction.
+    /// A page whose object is not in the tree is an error, never a guess —
+    /// a plausible-but-wrong page number is worse than no destination.
     pub(crate) fn page_index_of_ref(&self, page_ref: ObjectRef) -> Result<usize> {
-        let catalog = self.catalog()?;
-        let catalog_dict = catalog.as_dict().ok_or_else(|| Error::InvalidObjectType {
-            expected: "Dictionary".to_string(),
-            found: catalog.type_name().to_string(),
-        })?;
-
-        let pages_ref = catalog_dict
-            .get("Pages")
-            .ok_or_else(|| Error::InvalidPdf("Catalog missing /Pages entry".to_string()))?
-            .as_reference()
-            .ok_or_else(|| Error::InvalidPdf("/Pages is not a reference".to_string()))?;
-
-        self.page_index_of_ref_recursive(pages_ref, page_ref, &mut 0, &mut HashSet::new())
-    }
-
-    fn page_index_of_ref_recursive(
-        &self,
-        node_ref: ObjectRef,
-        target_ref: ObjectRef,
-        current_index: &mut usize,
-        visited: &mut HashSet<ObjectRef>,
-    ) -> Result<usize> {
-        if !visited.insert(node_ref) {
-            return Err(Error::CircularReference(node_ref));
-        }
-        let node = self.load_object(node_ref)?;
-        let node_dict = node.as_dict().ok_or_else(|| {
-            Error::InvalidPdf(format!("Page tree node {} is not a dictionary", node_ref.id))
-        })?;
-
-        let node_type = node_dict
-            .get("Type")
-            .and_then(|t| t.as_name())
-            .ok_or_else(|| Error::InvalidPdf("Node missing Type".to_string()))?;
-
-        match node_type {
-            "Page" => {
-                if node_ref == target_ref {
-                    Ok(*current_index)
-                } else {
-                    *current_index += 1;
-                    Err(Error::InvalidPdf(format!("object {} is not this page", target_ref.id)))
-                }
-            },
-            "Pages" => {
-                let kids = node_dict
-                    .get("Kids")
-                    .and_then(|k| k.as_array())
-                    .ok_or_else(|| Error::InvalidPdf("Pages node missing Kids".to_string()))?;
-
-                for kid_obj in kids {
-                    if let Some(kid_ref) = kid_obj.as_reference() {
-                        match self.page_index_of_ref_recursive(
-                            kid_ref,
-                            target_ref,
-                            current_index,
-                            visited,
-                        ) {
-                            Ok(index) => return Ok(index),
-                            Err(_) => continue,
-                        }
-                    }
-                }
-
-                Err(Error::InvalidPdf(format!(
-                    "object {} is not a page in the page tree",
-                    target_ref.id
-                )))
-            },
-            _ => Err(Error::InvalidPdf(format!("Unknown node type: {}", node_type))),
-        }
+        self.all_page_refs()?
+            .iter()
+            .position(|candidate| *candidate == page_ref)
+            .ok_or_else(|| {
+                Error::InvalidPdf(format!("object {} is not a page in the page tree", page_ref.id))
+            })
     }
 
     /// Extract text from a page as a plain string.

--- a/src/document.rs
+++ b/src/document.rs
@@ -5187,6 +5187,83 @@ impl PdfDocument {
         }
     }
 
+    /// 0-based page-tree position of a page object. The traversal mirrors
+    /// [`Self::get_page_ref_recursive`] so both directions of the
+    /// index ↔ reference mapping always agree.
+    pub(crate) fn page_index_of_ref(&self, page_ref: ObjectRef) -> Result<usize> {
+        let catalog = self.catalog()?;
+        let catalog_dict = catalog.as_dict().ok_or_else(|| Error::InvalidObjectType {
+            expected: "Dictionary".to_string(),
+            found: catalog.type_name().to_string(),
+        })?;
+
+        let pages_ref = catalog_dict
+            .get("Pages")
+            .ok_or_else(|| Error::InvalidPdf("Catalog missing /Pages entry".to_string()))?
+            .as_reference()
+            .ok_or_else(|| Error::InvalidPdf("/Pages is not a reference".to_string()))?;
+
+        self.page_index_of_ref_recursive(pages_ref, page_ref, &mut 0, &mut HashSet::new())
+    }
+
+    fn page_index_of_ref_recursive(
+        &self,
+        node_ref: ObjectRef,
+        target_ref: ObjectRef,
+        current_index: &mut usize,
+        visited: &mut HashSet<ObjectRef>,
+    ) -> Result<usize> {
+        if !visited.insert(node_ref) {
+            return Err(Error::CircularReference(node_ref));
+        }
+        let node = self.load_object(node_ref)?;
+        let node_dict = node.as_dict().ok_or_else(|| {
+            Error::InvalidPdf(format!("Page tree node {} is not a dictionary", node_ref.id))
+        })?;
+
+        let node_type = node_dict
+            .get("Type")
+            .and_then(|t| t.as_name())
+            .ok_or_else(|| Error::InvalidPdf("Node missing Type".to_string()))?;
+
+        match node_type {
+            "Page" => {
+                if node_ref == target_ref {
+                    Ok(*current_index)
+                } else {
+                    *current_index += 1;
+                    Err(Error::InvalidPdf(format!("object {} is not this page", target_ref.id)))
+                }
+            },
+            "Pages" => {
+                let kids = node_dict
+                    .get("Kids")
+                    .and_then(|k| k.as_array())
+                    .ok_or_else(|| Error::InvalidPdf("Pages node missing Kids".to_string()))?;
+
+                for kid_obj in kids {
+                    if let Some(kid_ref) = kid_obj.as_reference() {
+                        match self.page_index_of_ref_recursive(
+                            kid_ref,
+                            target_ref,
+                            current_index,
+                            visited,
+                        ) {
+                            Ok(index) => return Ok(index),
+                            Err(_) => continue,
+                        }
+                    }
+                }
+
+                Err(Error::InvalidPdf(format!(
+                    "object {} is not a page in the page tree",
+                    target_ref.id
+                )))
+            },
+            _ => Err(Error::InvalidPdf(format!("Unknown node type: {}", node_type))),
+        }
+    }
+
     /// Extract text from a page as a plain string.
     ///
     /// # Arguments

--- a/tests/link_goto_explicit_dest_page_index.rs
+++ b/tests/link_goto_explicit_dest_page_index.rs
@@ -1,0 +1,91 @@
+//! An explicit destination `[pageRef /XYZ …]` names a page *object*;
+//! `LinkDestination::Explicit.page` is documented as a 0-based page index, so
+//! the reference must be resolved to the page's position in the page tree
+//! (ISO 32000-1 §12.3.2.2). The fixture makes the two diverge: page 2 of the
+//! document is object number 6. Both routes to a destination are covered —
+//! a `/A` GoTo action and a direct `/Dest` entry.
+
+use pdf_oxide::annotations::{LinkAction, LinkDestination};
+use pdf_oxide::PdfDocument;
+
+fn two_page_link_pdf() -> Vec<u8> {
+    let content: &[u8] = b"BT /F1 12 Tf 20 100 Td (Page One) Tj ET";
+    let mut bodies: Vec<Vec<u8>> = vec![Vec::new(); 9]; // ids 1..=8
+    bodies[1] = b"<< /Type /Catalog /Pages 2 0 R >>".to_vec();
+    bodies[2] = b"<< /Type /Pages /Kids [3 0 R 6 0 R] /Count 2 >>".to_vec();
+    bodies[3] = b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] \
+/Resources << /Font << /F1 7 0 R >> >> /Contents 5 0 R /Annots [4 0 R 8 0 R] >>"
+        .to_vec();
+    // GoTo action pointing at the page-2 object (6 0 R).
+    bodies[4] = b"<< /Type /Annot /Subtype /Link /Rect [10 10 100 30] /Border [0 0 0] \
+/A << /S /GoTo /D [6 0 R /XYZ 0 200 0] >> >>"
+        .to_vec();
+    let mut cs = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
+    cs.extend_from_slice(content);
+    cs.extend_from_slice(b"\nendstream");
+    bodies[5] = cs;
+    bodies[6] = b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>".to_vec();
+    bodies[7] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec();
+    // Direct /Dest destination to the same page object.
+    bodies[8] = b"<< /Type /Annot /Subtype /Link /Rect [10 40 100 60] /Border [0 0 0] \
+/Dest [6 0 R /XYZ 0 200 0] >>"
+        .to_vec();
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    let mut offsets = [0usize; 9];
+    for id in 1..=8 {
+        offsets[id] = out.len();
+        out.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        out.extend_from_slice(&bodies[id]);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(b"xref\n0 9\n0000000000 65535 f \n");
+    for id in 1..=8 {
+        out.extend_from_slice(format!("{:010} 00000 n \n", offsets[id]).as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size 9 /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+fn assert_page_index(dest: &LinkDestination, route: &str) {
+    match dest {
+        LinkDestination::Explicit { page, fit_type, .. } => {
+            assert_eq!(fit_type, "XYZ", "{route}");
+            assert_eq!(
+                *page, 1,
+                "{route}: destination must be the 0-based page-tree index \
+                 (page object 6 is page 1), not the raw object number"
+            );
+        },
+        other => panic!("{route}: expected explicit destination, got {other:?}"),
+    }
+}
+
+#[test]
+fn goto_action_resolves_page_ref_to_page_index() {
+    let doc = PdfDocument::from_bytes(two_page_link_pdf()).expect("parse");
+    let annots = doc.get_annotations(0).expect("annotations");
+    let action_dest = annots
+        .iter()
+        .find_map(|a| match &a.action {
+            Some(LinkAction::GoTo(dest)) => Some(dest.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("no GoTo action in {annots:#?}"));
+    assert_page_index(&action_dest, "/A GoTo action");
+}
+
+#[test]
+fn direct_dest_resolves_page_ref_to_page_index() {
+    let doc = PdfDocument::from_bytes(two_page_link_pdf()).expect("parse");
+    let annots = doc.get_annotations(0).expect("annotations");
+    let dest = annots
+        .iter()
+        .find_map(|a| a.destination.clone())
+        .unwrap_or_else(|| panic!("no /Dest destination in {annots:#?}"));
+    assert_page_index(&dest, "/Dest entry");
+}

--- a/tests/link_goto_explicit_dest_page_index.rs
+++ b/tests/link_goto_explicit_dest_page_index.rs
@@ -65,6 +65,73 @@ fn assert_page_index(dest: &LinkDestination, route: &str) {
     }
 }
 
+/// A balanced page tree: the target sits in the SECOND subtree, so the index
+/// only comes out right if pages in earlier subtrees are all counted. A flat
+/// fixture cannot tell a correct walk from one that loses a subtree's count.
+fn nested_tree_link_pdf() -> Vec<u8> {
+    let content: &[u8] = b"BT /F1 12 Tf 20 100 Td (One) Tj ET";
+    let mut bodies: Vec<Vec<u8>> = vec![Vec::new(); 12]; // ids 1..=11
+    bodies[1] = b"<< /Type /Catalog /Pages 2 0 R >>".to_vec();
+    // Root -> two intermediate Pages nodes, two leaves each.
+    bodies[2] = b"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 4 >>".to_vec();
+    bodies[3] = b"<< /Type /Pages /Parent 2 0 R /Kids [5 0 R 6 0 R] /Count 2 >>".to_vec();
+    bodies[4] = b"<< /Type /Pages /Parent 2 0 R /Kids [7 0 R 8 0 R] /Count 2 >>".to_vec();
+    bodies[5] = b"<< /Type /Page /Parent 3 0 R /MediaBox [0 0 200 200] \
+/Resources << /Font << /F1 11 0 R >> >> /Contents 9 0 R /Annots [10 0 R] >>"
+        .to_vec();
+    bodies[6] = b"<< /Type /Page /Parent 3 0 R /MediaBox [0 0 200 200] >>".to_vec();
+    bodies[7] = b"<< /Type /Page /Parent 4 0 R /MediaBox [0 0 200 200] >>".to_vec();
+    // The link target: 4th page overall, so index 3.
+    bodies[8] = b"<< /Type /Page /Parent 4 0 R /MediaBox [0 0 200 200] >>".to_vec();
+    let mut cs = format!("<< /Length {} >>\nstream\n", content.len()).into_bytes();
+    cs.extend_from_slice(content);
+    cs.extend_from_slice(b"\nendstream");
+    bodies[9] = cs;
+    bodies[10] = b"<< /Type /Annot /Subtype /Link /Rect [10 10 100 30] /Border [0 0 0] \
+/A << /S /GoTo /D [8 0 R /XYZ 0 200 0] >> >>"
+        .to_vec();
+    bodies[11] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec();
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    let mut offsets = [0usize; 12];
+    for id in 1..=11 {
+        offsets[id] = out.len();
+        out.extend_from_slice(format!("{id} 0 obj\n").as_bytes());
+        out.extend_from_slice(&bodies[id]);
+        out.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = out.len();
+    out.extend_from_slice(b"xref\n0 12\n0000000000 65535 f \n");
+    for id in 1..=11 {
+        out.extend_from_slice(format!("{:010} 00000 n \n", offsets[id]).as_bytes());
+    }
+    out.extend_from_slice(
+        format!("trailer\n<< /Size 12 /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n").as_bytes(),
+    );
+    out
+}
+
+#[test]
+fn destination_in_a_nested_subtree_counts_earlier_subtrees() {
+    let doc = PdfDocument::from_bytes(nested_tree_link_pdf()).expect("parse");
+    let annots = doc.get_annotations(0).expect("annotations");
+    let dest = annots
+        .iter()
+        .find_map(|a| match &a.action {
+            Some(LinkAction::GoTo(d)) => Some(d.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("no GoTo action in {annots:#?}"));
+    match dest {
+        LinkDestination::Explicit { page, .. } => assert_eq!(
+            page, 3,
+            "object 8 is the 4th page overall; both pages of the first subtree must be counted"
+        ),
+        other => panic!("expected explicit destination, got {other:?}"),
+    }
+}
+
 #[test]
 fn goto_action_resolves_page_ref_to_page_index() {
     let doc = PdfDocument::from_bytes(two_page_link_pdf()).expect("parse");


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #1081 and #1083.** Those two remove the remaining sources of nondeterminism in `main`; ~~#1008~~ is merged (landed as 690711ed). Until they land, a corpus comparison against `main` can flag pages that move on their own, so before/after evidence on this PR carries that caveat.

## Linked issue

Closes #1072

## What and why

Split from #996 per its review.

### The defect

An explicit link destination reported the raw PDF object number as the page index. A link to page 2 whose page object is number 6 reported page 6.

### The fix

Explicit destinations now resolve through the page tree to the 0-based position (§12.3.2.2).

### The resolver uses the shared collector

The private tree walk treated a malformed node as "not in this subtree". The pages under that node were never counted, so every later page resolved to an index that was silently too small — a plausible but wrong link target. The resolver now defers to the shared `all_page_refs` collector, which handles the `/Count` fast path, lenient leaves, and cycles.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [x] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): none beyond default; no binding sources are touched.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

The regression tests pin the page-tree resolution on flat and nested trees; the nested-subtree fixture covers the counting the flat one could not.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents (~470,000 pages), swept against `main`.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [ ] Diffed my branch against the **latest release**: same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** scoped to link annotations; the links class is the relevant population.

Swept on a fresh base built from current `main` in the same cargo session as this branch's arm, 470k pages, field-by-field digests with the measured noise floor and the fixture-engagement manifest armed.

| | |
|---|---|
| pages compared | 470207 |
| identical in every measured column | 0 |
| blockers | 0 |
| token-loss / token-duplication pages | 0 / 0 |
| class-permitted movement (the fix's own surface) | 9685 |

**Diff summary vs latest release:** not run separately; the sweep was against `main`.

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: the split from the bundled branch, the corpus sweep, and this description.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [x] Public-API changes considered for semver (`semver-checks` will run).

`CHANGELOG.md` is untouched; it is written per release under a version heading.



