### PR TITLE
fix(structure): reject out-of-range marked-content ids instead of wrapping

### DIFF
--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -6682,9 +6682,13 @@ impl<'doc> TextExtractor<'doc> {
 
                 if let Some(props_dict) = self.resolve_bdc_properties(&properties) {
                     if let Some(mcid_obj) = props_dict.get("MCID") {
-                        if let Some(mcid) = mcid_obj.as_integer() {
-                            own_mcid = Some(mcid as u32);
-                            self.current_mcid = Some(mcid as u32);
+                        // Same id-space contract as the structure-tree side:
+                        // wrapping would alias a malformed id onto a real MCID.
+                        if let Some(mcid) =
+                            mcid_obj.as_integer().and_then(crate::structure::checked_mcid)
+                        {
+                            own_mcid = Some(mcid);
+                            self.current_mcid = Some(mcid);
                             log::debug!("Entered marked content with MCID: {}", mcid);
                         }
                     }

--- a/src/extractors/text.rs
+++ b/src/extractors/text.rs
@@ -6684,8 +6684,9 @@ impl<'doc> TextExtractor<'doc> {
                     if let Some(mcid_obj) = props_dict.get("MCID") {
                         // Same id-space contract as the structure-tree side:
                         // wrapping would alias a malformed id onto a real MCID.
-                        if let Some(mcid) =
-                            mcid_obj.as_integer().and_then(crate::structure::checked_mcid)
+                        if let Some(mcid) = mcid_obj
+                            .as_integer()
+                            .and_then(crate::structure::checked_mcid)
                         {
                             own_mcid = Some(mcid);
                             self.current_mcid = Some(mcid);

--- a/src/structure/mod.rs
+++ b/src/structure/mod.rs
@@ -49,6 +49,7 @@ pub mod types;
 
 pub use article_threads::{parse_article_threads, ArticleThread, Bead};
 pub use converter::StructureConverter;
+pub(crate) use parser::checked_mcid;
 pub use parser::{parse_structure_tree, parse_structure_tree_with_budget};
 pub use spatial_table_detector::{
     detect_tables_from_spans, DetectedTable, SpatialTableDetector, TableDetectionConfig,

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -533,12 +533,14 @@ fn parse_k_children(
             // Single MCID — bare integer child references the page's
             // own content stream (ISO 32000-1:2008 §14.7.5.4.2 "MCR"
             // form is reserved for cross-stream refs).
-            let page = parent.page.unwrap_or(0);
-            parent.add_child(StructChild::MarkedContentRef {
-                mcid: *mcid as u32,
-                page,
-                scope: crate::structure::McidScope::Page(page),
-            });
+            if let Some(mcid) = checked_mcid(*mcid) {
+                let page = parent.page.unwrap_or(0);
+                parent.add_child(StructChild::MarkedContentRef {
+                    mcid,
+                    page,
+                    scope: crate::structure::McidScope::Page(page),
+                });
+            }
         },
 
         Object::Array(arr) => {
@@ -568,12 +570,14 @@ fn parse_k_children(
                 match &child_obj {
                     Object::Integer(mcid) => {
                         // Bare integer MCID — page's own content stream.
-                        let page = parent.page.unwrap_or(0);
-                        parent.add_child(StructChild::MarkedContentRef {
-                            mcid: *mcid as u32,
-                            page,
-                            scope: crate::structure::McidScope::Page(page),
-                        });
+                        if let Some(mcid) = checked_mcid(*mcid) {
+                            let page = parent.page.unwrap_or(0);
+                            parent.add_child(StructChild::MarkedContentRef {
+                                mcid,
+                                page,
+                                scope: crate::structure::McidScope::Page(page),
+                            });
+                        }
                     },
 
                     Object::Dictionary(_) => {
@@ -746,6 +750,9 @@ fn parse_marked_content_ref(
         Some(mcid) => mcid,
         None => return Ok(None), // Missing /MCID, skip gracefully
     };
+    let Some(mcid) = checked_mcid(mcid) else {
+        return Ok(None);
+    };
 
     // Get /Pg (page reference) and resolve to page number.
     let page = dict
@@ -765,11 +772,21 @@ fn parse_marked_content_ref(
     // namespace.
     let scope = resolve_mcr_scope(document, dict, page);
 
-    Ok(Some(StructChild::MarkedContentRef {
-        mcid: mcid as u32,
-        page,
-        scope,
-    }))
+    Ok(Some(StructChild::MarkedContentRef { mcid, page, scope }))
+}
+
+/// Narrow a `/K` or `/MCID` integer to the `u32` marked-content id space.
+///
+/// Wrapping collides a malformed id with a real one: `2^32 + 5` becomes MCID 5
+/// and duplicates that entry in the page's reading order.
+fn checked_mcid(raw: i64) -> Option<u32> {
+    match u32::try_from(raw) {
+        Ok(mcid) => Some(mcid),
+        Err(_) => {
+            log::warn!("Structure tree: marked-content id {raw} is out of range, skipping");
+            None
+        },
+    }
 }
 
 /// Determine the `McidScope` for a marked-content reference dict.

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -779,11 +779,11 @@ fn parse_marked_content_ref(
 ///
 /// Wrapping collides a malformed id with a real one: `2^32 + 5` becomes MCID 5
 /// and duplicates that entry in the page's reading order.
-fn checked_mcid(raw: i64) -> Option<u32> {
+pub(crate) fn checked_mcid(raw: i64) -> Option<u32> {
     match u32::try_from(raw) {
         Ok(mcid) => Some(mcid),
         Err(_) => {
-            log::warn!("Structure tree: marked-content id {raw} is out of range, skipping");
+            log::warn!("Marked-content id {raw} is out of range, skipping");
             None
         },
     }

--- a/tests/structure_mcid_range.rs
+++ b/tests/structure_mcid_range.rs
@@ -1,0 +1,119 @@
+//! `/K` marked-content ids that do not fit a `u32` must be rejected, not wrapped.
+//!
+//! A structure element's `/K` may carry integer children (bare MCIDs) and
+//! marked-content reference dictionaries carrying `/MCID`. Both are `u32` in
+//! the reading-order model. Truncating a wider or negative integer into that
+//! `u32` makes a malformed id alias a real one, which silently corrupts the
+//! page's reading order rather than dropping the bad entry.
+
+use pdf_oxide::PdfDocument;
+
+fn obj(buf: &mut Vec<u8>, off: &mut [usize], id: usize, body: &str) {
+    off[id] = buf.len();
+    buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+}
+
+fn stream(buf: &mut Vec<u8>, off: &mut [usize], id: usize, data: &[u8]) {
+    off[id] = buf.len();
+    buf.extend_from_slice(format!("{id} 0 obj\n<< /Length {} >>\nstream\n", data.len()).as_bytes());
+    buf.extend_from_slice(data);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+}
+
+fn finish(buf: &mut Vec<u8>, off: &[usize], max_id: usize) {
+    let xref = buf.len();
+    buf.extend_from_slice(format!("xref\n0 {}\n0000000000 65535 f \n", max_id + 1).as_bytes());
+    for id in 1..=max_id {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n", max_id + 1).as_bytes(),
+    );
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+}
+
+/// A one-page tagged PDF whose single paragraph carries the given `/K` body.
+/// The page's content stream declares one real marked-content id, MCID 5.
+fn tagged_pdf_with_k(k_body: &str) -> Vec<u8> {
+    let content = b"BT /F1 12 Tf\n\
+        /P <</MCID 5>> BDC 1 0 0 1 60 700 Tm (Real content with MCID five) Tj EMC\n\
+        ET\n";
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 9];
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(
+        &mut buf,
+        &mut off,
+        1,
+        "<< /Type /Catalog /Pages 2 0 R /MarkInfo << /Marked true >> /StructTreeRoot 7 0 R >>",
+    );
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 6 0 R >> >> /Contents 4 0 R /StructParents 0 >>",
+    );
+    stream(&mut buf, &mut off, 4, content);
+    obj(&mut buf, &mut off, 5, "<< >>");
+    obj(&mut buf, &mut off, 6, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    obj(&mut buf, &mut off, 7, "<< /Type /StructTreeRoot /K [8 0 R] >>");
+    obj(
+        &mut buf,
+        &mut off,
+        8,
+        &format!("<< /Type /StructElem /S /P /P 7 0 R /Pg 3 0 R /K {k_body} >>"),
+    );
+    finish(&mut buf, &off, 8);
+    buf
+}
+
+fn reading_order(k_body: &str) -> Vec<u32> {
+    let doc = PdfDocument::from_bytes(tagged_pdf_with_k(k_body)).expect("fixture parses");
+    let tree = doc
+        .structure_tree()
+        .expect("structure tree read")
+        .expect("structure tree present");
+    pdf_oxide::structure::extract_reading_order(&tree, 0).expect("reading order")
+}
+
+#[test]
+fn k_mcid_above_u32_max_is_skipped_not_wrapped() {
+    // 4294967301 is 2^32 + 5. Truncated to u32 it becomes 5 and aliases the
+    // page's real MCID 5, so the page reports MCID 5 twice.
+    let order = reading_order("[4294967301 5]");
+    assert_eq!(order, vec![5], "out-of-range /K child aliased onto the real MCID 5");
+}
+
+#[test]
+fn negative_k_mcid_is_skipped_not_wrapped() {
+    let order = reading_order("-1");
+    assert!(
+        order.is_empty(),
+        "negative /K child was kept as {order:?} instead of being skipped"
+    );
+}
+
+#[test]
+fn negative_k_mcid_in_an_array_is_skipped_not_wrapped() {
+    let order = reading_order("[-1 5]");
+    assert_eq!(order, vec![5], "negative /K child was not skipped: {order:?}");
+}
+
+#[test]
+fn out_of_range_mcr_mcid_is_skipped_not_wrapped() {
+    // The marked-content reference dictionary form of the same defect.
+    let order = reading_order("[<< /Type /MCR /Pg 3 0 R /MCID 4294967301 >> 5]");
+    assert_eq!(
+        order,
+        vec![5],
+        "out-of-range /MCID in an /MCR dict aliased onto the real MCID 5"
+    );
+}
+
+#[test]
+fn in_range_k_mcids_are_unaffected() {
+    let order = reading_order("[5]");
+    assert_eq!(order, vec![5]);
+}

--- a/tests/structure_mcid_range.rs
+++ b/tests/structure_mcid_range.rs
@@ -1,10 +1,11 @@
-//! `/K` marked-content ids that do not fit a `u32` must be rejected, not wrapped.
+//! Marked-content ids that do not fit a `u32` must be rejected, not wrapped.
 //!
-//! A structure element's `/K` may carry integer children (bare MCIDs) and
-//! marked-content reference dictionaries carrying `/MCID`. Both are `u32` in
-//! the reading-order model. Truncating a wider or negative integer into that
-//! `u32` makes a malformed id alias a real one, which silently corrupts the
-//! page's reading order rather than dropping the bad entry.
+//! The id space is written from two sides: a structure element's `/K` (bare
+//! integer MCIDs and `/MCR` dictionaries carrying `/MCID`) and the content
+//! stream's BDC property dictionaries. All are `u32` in the reading-order
+//! model. Truncating a wider or negative integer into that `u32` makes a
+//! malformed id alias a real one, which silently corrupts the page's reading
+//! order rather than dropping the bad entry.
 
 use pdf_oxide::PdfDocument;
 
@@ -116,4 +117,62 @@ fn out_of_range_mcr_mcid_is_skipped_not_wrapped() {
 fn in_range_k_mcids_are_unaffected() {
     let order = reading_order("[5]");
     assert_eq!(order, vec![5]);
+}
+
+/// A one-page untagged PDF whose content stream carries the given BDC bodies.
+/// Same id-space contract as the `/K` fixtures above, exercised from the
+/// content-stream (BDC `/MCID`) side.
+fn pdf_with_content(content: &str) -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 6];
+    buf.extend_from_slice(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n");
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    );
+    stream(&mut buf, &mut off, 4, content.as_bytes());
+    obj(&mut buf, &mut off, 5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    finish(&mut buf, &off, 5);
+    buf
+}
+
+fn span_mcids(bad_mcid: &str) -> Vec<(String, Option<u32>)> {
+    let content = format!(
+        "BT /F1 12 Tf\n\
+         /P <</MCID {bad_mcid}>> BDC 1 0 0 1 60 700 Tm (Aliased) Tj EMC\n\
+         /P <</MCID 5>> BDC 1 0 0 1 60 650 Tm (Real) Tj EMC\n\
+         ET\n"
+    );
+    let doc = PdfDocument::from_bytes(pdf_with_content(&content)).expect("fixture parses");
+    let spans = doc.extract_spans(0).expect("spans extract");
+    spans.into_iter().map(|s| (s.text, s.mcid)).collect()
+}
+
+fn mcid_of(spans: &[(String, Option<u32>)], needle: &str) -> Option<u32> {
+    spans
+        .iter()
+        .find(|(text, _)| text.contains(needle))
+        .unwrap_or_else(|| panic!("no span containing {needle:?} in {spans:?}"))
+        .1
+}
+
+#[test]
+fn bdc_mcid_above_u32_max_is_dropped_not_wrapped() {
+    // 4294967301 is 2^32 + 5. Truncated to u32 it becomes 5 and aliases the
+    // real MCID 5 region in the same content stream.
+    let spans = span_mcids("4294967301");
+    assert_eq!(mcid_of(&spans, "Aliased"), None, "out-of-range BDC /MCID aliased a real id");
+    assert_eq!(mcid_of(&spans, "Real"), Some(5));
+}
+
+#[test]
+fn negative_bdc_mcid_is_dropped_not_wrapped() {
+    let spans = span_mcids("-1");
+    assert_eq!(mcid_of(&spans, "Aliased"), None, "negative BDC /MCID was kept");
+    assert_eq!(mcid_of(&spans, "Real"), Some(5));
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #1081 and #1083.** Those two remove the remaining sources of nondeterminism in `main`; ~~#1008~~ is merged (landed as 690711ed). Until they land, a corpus comparison against `main` can flag pages that move on their own, so before/after evidence on this PR carries that caveat.

## Linked issue

Closes #1084

## What and why

Split from #998 per its review.

Marked-content ids were narrowed with `as u32` at two entry points — the structure tree's `/K`/`/MCID` values and the content stream's `BDC` properties — so an id of `2^32+5` wrapped onto the page's real MCID 5 and aliased it, duplicating that entry in the page's reading order. Both entry points now route through one checked narrowing that skips an out-of-range id rather than guessing.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [x] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): none beyond default; the render tier passes untouched.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

The range tests pin skip-not-wrap for `/K`, MCR and `BDC` ids, negative and above-`u32::MAX`, with an in-range control.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents (~470,000 pages), swept against `main`.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [ ] Diffed my branch against the **latest release**: same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** scoped to tagged PDFs carrying out-of-range ids; well-formed ids are unaffected.

Swept on a fresh base built from current `main` in the same cargo session as this branch's arm, 470k pages, field-by-field digests with the measured noise floor and the fixture-engagement manifest armed.

| | |
|---|---|
| pages compared | 470207 |
| identical in every measured column | 0 |
| blockers | 0 |
| token-loss / token-duplication pages | 1 / 0 |
| class-permitted movement (the fix's own surface) | 1 |

**Triage of the one flagged page.** 470,203 of 470,207 pages are byte-identical. The single token-loss page is a rotated document that a second, unrelated arm in the same round flags with the identical movement — a measured flicker page on the base, not this change. Out-of-range ids do not occur in the crawled corpus, so the fix's own surface is the synthetic fixtures, where the engagement tests pin it.

**Diff summary vs latest release:** not run separately; the sweep was against `main`.

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: the split from the bundled branch, the corpus sweep, and this description.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [x] Public-API changes considered for semver (`semver-checks` will run).

`CHANGELOG.md` is untouched; it is written per release under a version heading.



