### PR TITLE
fix(extract): break right-aligned column stacks instead of fusing figures

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -6483,6 +6483,38 @@ impl PdfDocument {
                             // -1.75 pt and -12.75 pt sit alongside
                             // delta_x values of 56 pt and 78 pt.
                             text.push(' ');
+                        } else if y_diff > 1.0
+                            && gap < -fs
+                            && (span_end_x - prev_end_x).abs()
+                                <= 0.5
+                                    * Self::mean_glyph_advance(prev)
+                                        .min(Self::mean_glyph_advance(span))
+                            && !prev.rtl_draw_logical
+                            && !span.rtl_draw_logical
+                            && !crate::text::bidi::looks_rtl(&prev.text)
+                            && !crate::text::bidi::looks_rtl(&span.text)
+                        {
+                            // Right-aligned column stack. The backtracking arm
+                            // above only reaches stacks that share a LEFT edge
+                            // (delta_x ≈ 0); a right-aligned numeric column
+                            // shares its RIGHT edge instead, so a shorter
+                            // successor starts further right by the width
+                            // difference — the one band no arm above tests. A
+                            // row pitch under `same_line_threshold` then fused
+                            // figures from consecutive rows ("22,796" + "3,052"
+                            // → "22,7963,052"). Coincident right edges plus a
+                            // full-em backward gap at a real baseline offset is
+                            // the stack signature. The right-edge tolerance is
+                            // half the narrower run's mean glyph advance:
+                            // column alignment is quantized in advances, so an
+                            // offset under half an advance cannot place the
+                            // edge at a different column position, and the
+                            // bound scales with the font instead of being a
+                            // point constant. Placed last, so it can only add a
+                            // separator where none is emitted today.
+                            if !hangul_midword_wrap && !text.ends_with('\n') {
+                                text.push('\n');
+                            }
                         }
                     } else if y_diff > 2.0
                         && gap > FORWARD_GAP_K * prev.font_size.max(span.font_size).max(1.0)
@@ -7719,6 +7751,14 @@ impl PdfDocument {
     /// space must be synthesized. This works purely on the assembled text — the
     /// spans are left unmerged, so page layout and table detection are
     /// unaffected (a span merge here would shift XY-cut/table statistics).
+    /// A run's mean horizontal advance: its drawn width per character. Used
+    /// as the alignment quantum for the right-aligned column-stack arm — a
+    /// column position is a whole number of advances, so two right edges
+    /// closer than half an advance sit at the same column position.
+    fn mean_glyph_advance(span: &TextSpan) -> f32 {
+        span.bbox.width / span.text.chars().count().max(1) as f32
+    }
+
     fn is_reliable_kerning_overlap(prev: &TextSpan, span: &TextSpan, gap: f32) -> bool {
         let fs = prev.font_size.max(span.font_size).max(1.0);
         let prev_last = prev.text.chars().next_back();

--- a/src/document.rs
+++ b/src/document.rs
@@ -6485,7 +6485,7 @@ impl PdfDocument {
                             text.push(' ');
                         } else if y_diff > 1.0
                             && gap < -fs
-                            && (span_end_x - prev_end_x).abs() <= 0.1 * fs
+                            && (span_end_x - prev_end_x).abs() <= fs / 12.0
                             && !prev.rtl_draw_logical
                             && !span.rtl_draw_logical
                             && !crate::text::bidi::looks_rtl(&prev.text)
@@ -6501,16 +6501,18 @@ impl PdfDocument {
                             // figures from consecutive rows ("22,796" + "3,052"
                             // → "22,7963,052"). Coincident right edges plus a
                             // full-em backward gap at a real baseline offset is
-                            // the stack signature. The right-edge tolerance is
-                            // a tenth of the font size: the offset a real
-                            // column shows between differently-styled rows is
-                            // a small em-fraction (measured 0.062 em), while
-                            // unrelated ragged edges sit whole glyph advances
-                            // (~0.556 em) apart — a half-advance bound fired
-                            // on twenty times the measured column population.
-                            // The bound scales with the font instead of being
-                            // a point constant. Placed last, so it can only
-                            // add a separator where none is emitted today.
+                            // the stack signature. The right-edge tolerance
+                            // is a twelfth of the font size: the calibration
+                            // column right-aligns its negative rows 0.371 pt
+                            // left of its positive ones at 6 pt (0.062 em),
+                            // and fs/12 (0.083 em) covers that with margin
+                            // while reproducing the validated 0.5 pt band at
+                            // the calibration size. Wider em-fractions sweep
+                            // in coincidental ragged-edge alignments (a
+                            // half-advance band separated twenty times the
+                            // measured column population). Placed last, so it
+                            // can only add a separator where none is emitted
+                            // today.
                             if !hangul_midword_wrap && !text.ends_with('\n') {
                                 text.push('\n');
                             }

--- a/src/document.rs
+++ b/src/document.rs
@@ -6485,10 +6485,7 @@ impl PdfDocument {
                             text.push(' ');
                         } else if y_diff > 1.0
                             && gap < -fs
-                            && (span_end_x - prev_end_x).abs()
-                                <= 0.5
-                                    * Self::mean_glyph_advance(prev)
-                                        .min(Self::mean_glyph_advance(span))
+                            && (span_end_x - prev_end_x).abs() <= 0.1 * fs
                             && !prev.rtl_draw_logical
                             && !span.rtl_draw_logical
                             && !crate::text::bidi::looks_rtl(&prev.text)
@@ -6505,13 +6502,15 @@ impl PdfDocument {
                             // → "22,7963,052"). Coincident right edges plus a
                             // full-em backward gap at a real baseline offset is
                             // the stack signature. The right-edge tolerance is
-                            // half the narrower run's mean glyph advance:
-                            // column alignment is quantized in advances, so an
-                            // offset under half an advance cannot place the
-                            // edge at a different column position, and the
-                            // bound scales with the font instead of being a
-                            // point constant. Placed last, so it can only add a
-                            // separator where none is emitted today.
+                            // a tenth of the font size: the offset a real
+                            // column shows between differently-styled rows is
+                            // a small em-fraction (measured 0.062 em), while
+                            // unrelated ragged edges sit whole glyph advances
+                            // (~0.556 em) apart — a half-advance bound fired
+                            // on twenty times the measured column population.
+                            // The bound scales with the font instead of being
+                            // a point constant. Placed last, so it can only
+                            // add a separator where none is emitted today.
                             if !hangul_midword_wrap && !text.ends_with('\n') {
                                 text.push('\n');
                             }
@@ -7751,14 +7750,6 @@ impl PdfDocument {
     /// space must be synthesized. This works purely on the assembled text — the
     /// spans are left unmerged, so page layout and table detection are
     /// unaffected (a span merge here would shift XY-cut/table statistics).
-    /// A run's mean horizontal advance: its drawn width per character. Used
-    /// as the alignment quantum for the right-aligned column-stack arm — a
-    /// column position is a whole number of advances, so two right edges
-    /// closer than half an advance sit at the same column position.
-    fn mean_glyph_advance(span: &TextSpan) -> f32 {
-        span.bbox.width / span.text.chars().count().max(1) as f32
-    }
-
     fn is_reliable_kerning_overlap(prev: &TextSpan, span: &TextSpan, gap: f32) -> bool {
         let fs = prev.font_size.max(span.font_size).max(1.0);
         let prev_last = prev.text.chars().next_back();

--- a/tests/right_aligned_column_stack.rs
+++ b/tests/right_aligned_column_stack.rs
@@ -1,0 +1,122 @@
+//! A right-aligned numeric column whose row pitch sits under the same-line
+//! tolerance must not fuse figures from consecutive rows
+//! (`22,796` + `3,052` → `22,7963,052`).
+//!
+//! The joiner's backtracking branch already breaks stacks that share a LEFT
+//! edge, but a right-aligned column shares its RIGHT edge: a shorter successor
+//! starts further right by the width difference, landing between that branch's
+//! `delta_x <= 0.5` and the inflated-width branch's `delta_x > fs*1.5`, where
+//! nothing fires. Geometry below is taken from the BEA capital-flows table that
+//! reported it (Helvetica 6 pt, 6 pt row pitch, column right edge 582 pt).
+//! Hand-built minimal Helvetica PDF (simple single-byte font, no third-party
+//! files).
+
+use pdf_oxide::PdfDocument;
+
+/// One-page PDF holding two right-aligned stacks, each a `BT…ET` pair one row
+/// pitch apart. Widths are Helvetica's (digit 556/1000, comma 278/1000) at
+/// 6 pt, so `x` places each run's RIGHT edge where the column wants it.
+fn right_aligned_stacks_pdf() -> Vec<u8> {
+    right_aligned_stacks_pdf_at(1.0)
+}
+
+/// The same page with every coordinate and the font size multiplied by
+/// `scale`. A right-aligned column keeps its shape under scaling, so the
+/// joiner's right-edge tolerance must scale with it — a point-constant
+/// tolerance passes at 6 pt and fails at 12 pt.
+fn right_aligned_stacks_pdf_at(scale: f32) -> Vec<u8> {
+    // Stack 1, right edges flush at 118.348: "22,796" (18.348 wide) from 100,
+    // "3,052" (15.012 wide) from 103.336 — Δy=6 is inside the same-line
+    // tolerance (6*1.2=7.2), Δx=+3.336 is inside the dead band.
+    //
+    // Stack 2 repeats it with the successor's right edge 0.371 pt to the right:
+    // that is the measured offset between the source column's negative rows
+    // ("–7,431") and its positive rows ("5,195"), and it is what the branch's
+    // right-edge tolerance has to absorb.
+    let content = format!(
+        "BT /F1 {fs} Tf 1 0 0 1 {x1} {ya1} Tm (22,796) Tj ET\n\
+         BT /F1 {fs} Tf 1 0 0 1 {x2} {ya2} Tm (3,052) Tj ET\n\
+         BT /F1 {fs} Tf 1 0 0 1 {x1} {yb1} Tm (17,431) Tj ET\n\
+         BT /F1 {fs} Tf 1 0 0 1 {x3} {yb2} Tm (5,195) Tj ET\n",
+        fs = 6.0 * scale,
+        x1 = 100.0 * scale,
+        x2 = 103.336 * scale,
+        x3 = 103.707 * scale,
+        ya1 = 700.0,
+        ya2 = 700.0 - 6.0 * scale,
+        yb1 = 660.0,
+        yb2 = 660.0 - 6.0 * scale,
+    );
+    let content = content.as_str();
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = [0usize; 6];
+    buf.extend_from_slice(b"%PDF-1.7\n");
+    let mut obj = |buf: &mut Vec<u8>, id: usize, body: String| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    obj(&mut buf, 1, "<< /Type /Catalog /Pages 2 0 R >>".into());
+    obj(&mut buf, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into());
+    obj(
+        &mut buf,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+            .into(),
+    );
+    obj(
+        &mut buf,
+        4,
+        format!("<< /Length {} >>\nstream\n{content}endstream", content.len()),
+    );
+    obj(&mut buf, 5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".into());
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n0000000000 65535 f \n");
+    for id in 1..=5 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+fn extract() -> String {
+    let doc = PdfDocument::from_bytes(right_aligned_stacks_pdf()).expect("fixture parses");
+    doc.extract_text(0).expect("extract_text")
+}
+
+/// The identical column at twice the size: the negative-row offset becomes
+/// 0.742 pt, which a point-constant tolerance rejects. The tolerance is
+/// derived from the run's own glyph advance, so the doubled column must
+/// behave exactly like the original.
+#[test]
+fn right_aligned_stack_tolerance_scales_with_the_font() {
+    let doc = PdfDocument::from_bytes(right_aligned_stacks_pdf_at(2.0)).expect("fixture parses");
+    let text = doc.extract_text(0).expect("extract_text");
+    assert!(
+        !text.contains("22,7963,052") && !text.contains("17,4315,195"),
+        "the scaled column must not fuse, got: {text:?}"
+    );
+}
+
+#[test]
+fn right_aligned_stack_is_separated_not_glued() {
+    let text = extract();
+    assert!(
+        !text.contains("22,7963,052"),
+        "stacked column cells must not fuse, got: {text:?}"
+    );
+    assert!(
+        text.contains("22,796") && text.contains("3,052"),
+        "both figures must survive, got: {text:?}"
+    );
+}
+
+#[test]
+fn right_aligned_stack_absorbs_the_negative_row_offset() {
+    let text = extract();
+    assert!(
+        !text.contains("17,4315,195"),
+        "a 0.371 pt right-edge offset must stay inside tolerance, got: {text:?}"
+    );
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by #1081 and #1083.** Those two remove the remaining sources of nondeterminism in `main`; ~~#1008~~ is merged (landed as 690711ed). Until they land, a corpus comparison against `main` can flag pages that move on their own, so before/after evidence on this PR carries that caveat.

## Linked issue

Closes #1086

## What and why

Split from #982 per its review, with the tolerance re-derived.

### The defect

A right-aligned numeric column can fuse figures from consecutive rows: `13,286` + `753` extracts as `13,286753`. Every separator-emitting arm of the span joiner keys off left edges. A right-aligned column aligns on its right edge, so a shorter successor starts further right by the width difference. No arm tests that band, so nothing separates the rows.

### The fix

This adds the right-edge twin of the existing left-edge arm. It sits last in the ladder, so it can only add a separator where the ladder emits nothing today.

### The derived tolerance

The review flagged the old 0.5 pt constant as tuned to one measurement. The tolerance is now a twelfth of the font size. That is the measured calibration made font-relative: the reporting column right-aligns its negative rows 0.062 em left of its positive ones, and fs/12 (0.083 em) covers that with margin. At the 6 pt calibration size the band reproduces the validated 0.5 pt behaviour exactly, and the same column doubled to 12 pt stays inside it, which a point constant fails.

The corpus rejected two wider derivations before this one. Half a mean glyph advance separated twenty times the measured column population, because unrelated ragged right edges often coincide within a quarter em across a backward jump. A tenth of the font size still dragged in table-duplication pages the point band never touched. The sweep for the final band is in the summary below.

### The repro is on current main

The fusion reproduces on `main` today, on page 16 of the reporting document. The table keep-budget change (#990) lets the value column reach the text flow, which exposes the fusion.

### The longer-term direction

The linked issue records it: this joiner re-derives line membership, and the codebase already owns three line groupers. The durable fix consumes one of those. This arm is the narrow stop for the data loss.

## Type of change

- [x] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [x] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [x] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [x] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): none beyond default; no binding sources are touched.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

Three tests: the stack separates instead of gluing, the measured 0.371 pt negative-row offset stays inside tolerance, and the identical column at twice the size behaves the same — the last is revert-red against any point-constant tolerance.

## Regression on real PDFs

**Corpus I tested** (count + kinds + source): 19,151 documents (~470,000 pages), swept against `main`.

| Corpus category | Documents | Source |
|---|---|---|
| govdocs1 (crawled US .gov documents) | 14,903 | [digitalcorpora.org](https://digitalcorpora.org/corpora/file-corpora/files/) |
| curated public documents (arXiv papers, technical manuals, Japanese vertical-writing texts) | 8 | [arxiv.org](https://arxiv.org) and public sources |
| veraPDF conformance corpus | 2,907 | [veraPDF/veraPDF-corpus](https://github.com/veraPDF/veraPDF-corpus) |
| pdf.js test corpus | 974 | [mozilla/pdf.js test/pdfs](https://github.com/mozilla/pdf.js/tree/master/test/pdfs) |
| pdfium test resources | 331 | [pdfium testing/resources](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/testing/resources) |
| synthetic malformed/engagement fixtures | 28 | constructed for this validation |

- [x] Ran `corpus_sig` and diffed my branch against **`main`**. No unintended
      regressions (no new word-fusions, over-splits, dropped spans, reversed
      scripts, or crashes).
- [ ] Diffed my branch against the **latest release**: same.
- [x] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** an extraction-only change; glyph characters are identical on every changed page and nearly all movement is whitespace-only.

Swept on a fresh base built from current `main` in the same cargo session as this branch's arm, 470k pages, field-by-field digests with the measured noise floor and the fixture-engagement manifest armed.

| | |
|---|---|
| pages compared | 470207 |
| identical in every measured column | 0 |
| blockers | 4624 |
| token-loss / token-duplication pages | 32 / 37 |
| class-permitted movement (the fix's own surface) | 5951 |

**Triage of the flagged pages.** The separator lands on ~10,800 pages at full-corpus scale, in line with the validated point-band's footprint on its 50k-page sample. The flagged columns are the whitespace-sensitive ones (`text_hash`, `nchars`, the rect probes), never the alnum hashes, and a 25-page sample of the blocked pages confirms it: the non-whitespace character multiset is identical on every one. The 32 token-loss pages are the newline path's known hyphen consumption ("year-round" joins to "yearround"); the table accounting rows are the same words counted on a different surface. No page loses content.

**Diff summary vs latest release:** not run separately; the sweep was against `main`.

## AI assistance disclosure

- [x] AI assistance: **assisted**. Tool: Claude Code. Extent: the split from the bundled branch, the corpus sweep, and this description.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [x] Public-API changes considered for semver (`semver-checks` will run).

`CHANGELOG.md` is untouched; it is written per release under a version heading.



