### PR TITLE
chore(ci): bump Go toolchain pin to 1.26.6 (govulncheck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,12 +898,14 @@ jobs:
         with:
           # go.mod's `go 1.21` directive keeps us compatible with older
           # consumers; CI builds with the newest patched toolchain (>=1.25
-          # required by govulncheck v1.3+). Pinned to 1.26.5 because the
+          # required by govulncheck v1.3+). Pinned to 1.26.6 because the
           # setup-go `stable` alias lagged behind it, which govulncheck flags
-          # for GO-2026-5037 (crypto/x509), GO-2026-5039 (net/textproto), and
-          # GO-2026-5856 (crypto/tls ECH privacy leak), all fixed in
-          # go1.26.5. Bump as new patch releases land.
-          go-version: '1.26.5'
+          # for GO-2026-6218 (net/url resolvePath quadratic complexity),
+          # GO-2026-6090 (crypto/tls post-handshake message limit),
+          # GO-2026-5972 (encoding/asn1 recursion depth), and GO-2026-5026
+          # (golang.org/x/net/idna Punycode validation), all fixed in
+          # go1.26.6. Bump as new patch releases land.
+          go-version: '1.26.6'
 
       # Download the pre-built native lib (extended features: barcodes,
       # rendering, signatures, tsa-client, system-fonts). Artifact preserves


### PR DESCRIPTION
## Summary
`govulncheck` currently fails the "Go Bindings" CI job on every open PR, regardless of what the PR actually changes — the scan covers the pinned Go toolchain/stdlib, not the diff. Bumps the pin from 1.26.5 to 1.26.6, which fixes:

- **GO-2026-6218** — quadratic complexity in `net/url` resolvePath
- **GO-2026-6090** — missing post-handshake message limit in `crypto/tls`
- **GO-2026-5972** — missing recursion-depth limit in `encoding/asn1`
- **GO-2026-5026** — Punycode validation gap in `golang.org/x/net/idna`

Discovered while processing the v0.3.78 merge queue — this was blocking every PR's "Go Bindings" check identically, unrelated to any of their actual content.

## Test plan
- [x] Version-string-only change, no code touched
- [x] CI itself is the verification (govulncheck should pass clean at 1.26.6)

Priority: land this first, ahead of the rest of the v0.3.78 merge queue, so subsequent PRs don't keep hitting the same unrelated failure.