### PR TITLE
fix(text): keep a sign with the number it belongs to in right-to-left text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,10 @@ encoding_rs = "0.8"                               # Shift-JIS, EUC-JP, and other
 # Unicode bidirectional algorithm (UAX #9) — used by both the HTML+CSS
 # inline formatter (Phase LAYOUT-3) and the markdown converter's RTL
 # emphasis cleanup (#377 D7).
-unicode-bidi = { version = "0.3", default-features = false }
+# `hardcoded-data` carries the bidi class tables `bidi_class` reads. Without
+# it the crate compiles only while some other dependency happens to turn the
+# feature on, so it is declared here rather than relied on by unification.
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data"] }
 unicode-normalization = "0.1"                                # NFC composition of overlapping combining marks emitted as separate glyph runs (e.g. "´" + "E" → "É")
 
 # Image processing

--- a/src/text/bidi.rs
+++ b/src/text/bidi.rs
@@ -618,7 +618,10 @@ pub fn wrap_rtl_isolates(text: &str, block_is_rtl: bool) -> String {
 /// therefore not mirrored when the surrounding RTL is reversed. A separator
 /// (`.` `,` `:` and the Arabic decimal/thousands separators) is treated as part
 /// of the number only when it sits between two digits, so `1,000` and `3.14`
-/// stay intact while a trailing comma reverses as an ordinary neutral.
+/// stay intact while a trailing comma reverses as an ordinary neutral. A
+/// European terminator — `%`, a currency sign, a degree sign — joins the number
+/// whenever it touches one (UAX #9 rule W5), so `50%` keeps its sign on the
+/// side the reader expects instead of reversing away from the digits.
 ///
 /// For any run containing no digits this is byte-identical to a plain
 /// `chars().rev().collect()`, so the digit-free RTL case (the corpus-validated
@@ -654,6 +657,31 @@ pub fn reverse_rtl_keep_numbers(s: &str) -> String {
             }
             i = j;
         } else {
+            i += 1;
+        }
+    }
+    // UAX #9 W5: a sequence of European terminators adjacent to a European
+    // number becomes part of that number, so a sign touching the digits travels
+    // with them instead of reversing away as a neutral. The class comes from
+    // the `unicode-bidi` tables this module wraps rather than a second local
+    // list of sign characters.
+    let is_terminator = |c: char| unicode_bidi::bidi_class(c) == unicode_bidi::BidiClass::ET;
+    let mut i = 0;
+    while i < n {
+        if !in_num[i] {
+            i += 1;
+            continue;
+        }
+        let mut before = i;
+        while before > 0 && is_terminator(chars[before - 1]) {
+            before -= 1;
+            in_num[before] = true;
+        }
+        while i < n && in_num[i] {
+            i += 1;
+        }
+        while i < n && is_terminator(chars[i]) {
+            in_num[i] = true;
             i += 1;
         }
     }
@@ -708,6 +736,22 @@ mod tests {
         // Thousands / decimal separators between digits stay with the number.
         assert_eq!(reverse_rtl_keep_numbers(",1,000-ל"), "ל-1,000,");
         assert_eq!(reverse_rtl_keep_numbers("3.14-ל"), "ל-3.14");
+    }
+
+    #[test]
+    fn reverse_keep_numbers_keeps_a_terminator_with_its_number() {
+        // UAX #9 W5: a European terminator touching a European number joins it,
+        // so the sign stays on the side of the digits it was drawn on.
+        assert_eq!(reverse_rtl_keep_numbers("50%"), "50%");
+        assert_eq!(reverse_rtl_keep_numbers("%50"), "%50");
+        assert_eq!(reverse_rtl_keep_numbers("$50"), "$50");
+        assert_eq!(reverse_rtl_keep_numbers("47.500%-ל"), "ל-47.500%");
+    }
+
+    #[test]
+    fn reverse_keep_numbers_leaves_a_lone_terminator_alone() {
+        // No number to join, so the terminator reverses as an ordinary neutral.
+        assert_eq!(reverse_rtl_keep_numbers("%ל"), "ל%");
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue

Closes #1101

## What and why

`reverse_rtl_keep_numbers` counted a number as digits plus the separators between them, so a sign touching the digits fell outside the run and reversed away as an ordinary neutral. A visual-order `50%` came back as `%50`.

UAX #9 rule W5 makes a sequence of European terminators adjacent to a European number part of that number, so the sign keeps the side of the digits it was drawn on. The class comes from the `unicode-bidi` tables this module already wraps, not from a second local list of sign characters.

Separators keep the existing rule. They join a number only between two digits, and `-` and `+` are European separators, so `-2009, ` is unchanged.

## Type of change

- [x] Bug fix

## Tests

- [x] I added a test that **fails before this change and passes after**
- [x] Test named by defect **class**, not an issue/PR number


## Regression on real PDFs

**Corpus I tested**: 19,151 documents / 470,207 pages (govdocs plus the pdfium, pdfjs and mutool exotic sets), diffed against `main`.

- [x] Diffed my branch against **`main`** — all 470,207 pages byte-identical, no page moves.
- [ ] Diffed against the **latest release** — not run.
- [x] Judged by per-page output hashes across text, markdown, HTML and table columns.

Read that as a no-regression result and nothing more. The corpus is Latin-script government documents and holds almost no right-to-left text, so it barely exercises the path this touches: the fix is expected to move nothing there, and it moved nothing. The unit tests are what actually pin the behaviour.

## AI assistance disclosure

- [x] AI assistance: **assisted** — tool: Claude Code, extent: design exploration, implementation, tests, and a first draft of this description, all reviewed and edited by me.
- [ ] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [x] One logical change (no bundled refactor/perf/correctness).
- [x] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [ ] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [x] Public-API changes considered for semver. No public API changes: `reverse_rtl_keep_numbers` keeps its signature.

