### PR TITLE
fix(lint): rewrite constant-size chunks_exact as as_chunks for Rust 1.98

### DIFF
--- a/src/annotation_types.rs
+++ b/src/annotation_types.rs
@@ -929,7 +929,9 @@ pub mod quad_points {
 
     /// Parse quad points from a flat array of numbers.
     pub fn parse(arr: &[f64]) -> Vec<QuadPoint> {
-        arr.chunks_exact(8)
+        arr.as_chunks::<8>()
+            .0
+            .iter()
             .map(|chunk| {
                 [
                     chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],

--- a/src/annotations.rs
+++ b/src/annotations.rs
@@ -616,7 +616,9 @@ impl PdfDocument {
 
                 // Group into 8-value quads
                 let quads: Vec<[f64; 8]> = nums
-                    .chunks_exact(8)
+                    .as_chunks::<8>()
+                    .0
+                    .iter()
                     .map(|chunk| {
                         let mut quad = [0.0; 8];
                         quad.copy_from_slice(chunk);

--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -285,7 +285,7 @@ impl Transform {
             }
         }
         let mut out = Vec::with_capacity((cmyk.len() / 4) * 3);
-        for ch in cmyk.chunks_exact(4) {
+        for ch in cmyk.as_chunks::<4>().0 {
             let rgb = self.convert_cmyk_pixel(ch[0], ch[1], ch[2], ch[3]);
             out.extend_from_slice(&rgb);
         }

--- a/src/document.rs
+++ b/src/document.rs
@@ -9775,7 +9775,9 @@ impl PdfDocument {
             // UTF-16BE with BOM
             let utf16_bytes = &bytes[2..];
             let utf16_pairs: Vec<u16> = utf16_bytes
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
                 .collect();
             String::from_utf16(&utf16_pairs)
@@ -9784,7 +9786,9 @@ impl PdfDocument {
             // UTF-16LE with BOM
             let utf16_bytes = &bytes[2..];
             let utf16_pairs: Vec<u16> = utf16_bytes
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
                 .collect();
             String::from_utf16(&utf16_pairs)
@@ -29302,15 +29306,13 @@ mod tests {
 
         push!("<< /Type /Catalog /Pages 2 0 R >>"); // 1
         push!("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"); // 2
-        push!(format!(
-            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+        push!("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
              /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
-        )); // 3
-        push!(format!(
-            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
+            .to_string()); // 3
+        push!("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica \
              /Encoding << /Type /Encoding /Differences [1 /fi] >> \
              /ToUnicode 6 0 R >>"
-        )); // 4
+            .to_string()); // 4
         push!(format!("<< /Length {} >>\nstream\n{}endstream", content.len(), content)); // 5
         push!(format!("<< /Length {} >>\nstream\n{}endstream", cmap.len(), cmap)); // 6
 

--- a/src/extractors/forms.rs
+++ b/src/extractors/forms.rs
@@ -222,7 +222,9 @@ impl FormExtractor {
 
             // Convert bytes to u16 pairs (big-endian)
             let utf16_pairs: Vec<u16> = utf16_bytes
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
                 .collect();
 

--- a/src/extractors/images.rs
+++ b/src/extractors/images.rs
@@ -947,7 +947,9 @@ pub fn extract_image_from_xobject(
             // benefits, as both the PNG path and the rasteriser are 8-bit.
             let pixels = if bits_per_component == 16 {
                 decoded_data
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|sample| reduce_16_to_8(sample[0], sample[1]))
                     .collect()
             } else if bits_per_component == 1
@@ -1560,7 +1562,7 @@ pub fn cmyk_to_rgb_with_transform(
         return t.convert_cmyk_buffer(cmyk);
     }
     let mut rgb = Vec::with_capacity((cmyk.len() / 4) * 3);
-    for chunk in cmyk.chunks_exact(4) {
+    for chunk in cmyk.as_chunks::<4>().0 {
         let [r, g, b] = cmyk_pixel_to_rgb(chunk[0], chunk[1], chunk[2], chunk[3]);
         rgb.push(r);
         rgb.push(g);
@@ -1689,7 +1691,7 @@ pub fn decode_cmyk_jpeg_to_rgb_with_profile(
 
     // §10.3.5 additive-clamp fallback.
     let mut rgb = Vec::with_capacity(pixel_count * 3);
-    for chunk in straight_cmyk.chunks_exact(4) {
+    for chunk in straight_cmyk.as_chunks::<4>().0 {
         let [r, g, b] = cmyk_pixel_to_rgb(chunk[0], chunk[1], chunk[2], chunk[3]);
         rgb.push(r);
         rgb.push(g);

--- a/src/extractors/page_labels.rs
+++ b/src/extractors/page_labels.rs
@@ -159,7 +159,9 @@ impl PageLabelExtractor {
             // UTF-16BE with BOM
             let utf16_bytes = &bytes[2..];
             let utf16_pairs: Vec<u16> = utf16_bytes
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
                 .collect();
             String::from_utf16(&utf16_pairs).ok()

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1803,7 +1803,9 @@ pub extern "C" fn document_editor_erase_regions(
     let editor = handle_mut(handle);
     let flat = raw_slice(rects, rects_count * 4);
     let boxes: Vec<[f32; 4]> = flat
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|c| [c[0] as f32, c[1] as f32, c[2] as f32, c[3] as f32])
         .collect();
     match editor.erase_regions(page, &boxes) {

--- a/src/optional_content.rs
+++ b/src/optional_content.rs
@@ -168,14 +168,18 @@ impl OcmdPolicy {
 pub fn decode_pdf_text_string(bytes: &[u8]) -> String {
     if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
         let utf16_pairs: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
             .collect();
         String::from_utf16(&utf16_pairs)
             .unwrap_or_else(|_| String::from_utf8_lossy(bytes).to_string())
     } else if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
         let utf16_pairs: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
             .collect();
         String::from_utf16(&utf16_pairs)

--- a/src/redaction/engine.rs
+++ b/src/redaction/engine.rs
@@ -100,7 +100,9 @@ impl FontMetrics for FontInfoMetrics {
             // byte is malformed; `redaction_safe_show` refuses such a show
             // before it reaches here, so emit only whole 2-byte codes.
             return s
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|pair| (u32::from(u16::from_be_bytes([pair[0], pair[1]])), pair.to_vec()))
                 .collect();
         }

--- a/src/redaction/text_engine.rs
+++ b/src/redaction/text_engine.rs
@@ -589,7 +589,9 @@ mod tests {
             true
         }
         fn decode(&self, _f: &str, s: &[u8]) -> Vec<(u32, Vec<u8>)> {
-            s.chunks_exact(2)
+            s.as_chunks::<2>()
+                .0
+                .iter()
                 .map(|p| (u32::from(u16::from_be_bytes([p[0], p[1]])), p.to_vec()))
                 .collect()
         }

--- a/src/rendering/mesh_shading.rs
+++ b/src/rendering/mesh_shading.rs
@@ -236,7 +236,9 @@ impl MeshParams {
         }
         let decode_arr = shading.get("Decode")?.as_array()?;
         let decode: Vec<(f32, f32)> = decode_arr
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| (num(&c[0]), num(&c[1])))
             .collect();
         // Need at least the x and y ranges plus one colour component.
@@ -1069,7 +1071,9 @@ fn eval_type0(bytes: &[u8], dict: &HashMap<String, Object>, inputs: &[f32]) -> O
         .get("Decode")
         .and_then(|o| o.as_array())
         .map(|a| {
-            a.chunks_exact(2)
+            a.as_chunks::<2>()
+                .0
+                .iter()
                 .map(|c| (num(&c[0]), num(&c[1])))
                 .collect()
         })
@@ -1197,7 +1201,9 @@ fn num(o: &Object) -> f32 {
 fn pairs(o: Option<&Object>) -> Vec<[f64; 2]> {
     o.and_then(|o| o.as_array())
         .map(|a| {
-            a.chunks_exact(2)
+            a.as_chunks::<2>()
+                .0
+                .iter()
                 .map(|c| {
                     let lo = c[0]
                         .as_real()

--- a/src/rendering/page_renderer.rs
+++ b/src/rendering/page_renderer.rs
@@ -2220,7 +2220,12 @@ impl PageRenderer {
                     // outline) is treated as degenerate and leaves the clip
                     // unchanged rather than collapsing it to empty.
                     if let Some(scratch) = text_clip_accum.take() {
-                        let has_coverage = scratch.data().chunks_exact(4).any(|px| px[3] != 0);
+                        let has_coverage = scratch
+                            .data()
+                            .as_chunks::<4>()
+                            .0
+                            .iter()
+                            .any(|px| px[3] != 0);
                         if has_coverage {
                             let text_mask = tiny_skia::Mask::from_pixmap(
                                 scratch.as_ref(),
@@ -5091,7 +5096,7 @@ impl PageRenderer {
                 (fg.clamp(0.0, 1.0) * 255.0) as u32,
                 (fb.clamp(0.0, 1.0) * 255.0) as u32,
             );
-            for px in cell.data_mut().chunks_exact_mut(4) {
+            for px in cell.data_mut().as_chunks_mut::<4>().0 {
                 let a = px[3] as u32;
                 px[0] = (fr * a / 255) as u8;
                 px[1] = (fg * a / 255) as u8;
@@ -5102,7 +5107,7 @@ impl PageRenderer {
         // Average (premultiplied) cell colour, used both for the geometry
         // fallback and to skip fully-transparent cells.
         let (mut sr, mut sg, mut sb, mut sa) = (0u64, 0u64, 0u64, 0u64);
-        for px in cell.data().chunks_exact(4) {
+        for px in cell.data().as_chunks::<4>().0 {
             sr += px[0] as u64;
             sg += px[1] as u64;
             sb += px[2] as u64;
@@ -5627,7 +5632,13 @@ impl PageRenderer {
         paint.set_color(tiny_skia::Color::from_rgba8(0, 0, 0, 255));
         paint.anti_alias = true;
         scratch.stroke_path(path, &paint, &stroke, transform, clip);
-        let buf: Vec<u8> = scratch.data().chunks_exact(4).map(|px| px[3]).collect();
+        let buf: Vec<u8> = scratch
+            .data()
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|px| px[3])
+            .collect();
         Some(buf)
     }
 
@@ -5684,7 +5695,13 @@ impl PageRenderer {
     /// AA-edge partial coverage. The buffer is then handed to the
     /// spot-mirror's coverage-aware path verbatim.
     fn extract_alpha_as_coverage(pixmap: &Pixmap) -> Vec<u8> {
-        pixmap.data().chunks_exact(4).map(|px| px[3]).collect()
+        pixmap
+            .data()
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|px| px[3])
+            .collect()
     }
 
     /// WS1.5b — union a clip-mode (`Tr` 4–7) `Tj` / `'` / `"` show's glyph
@@ -9336,7 +9353,7 @@ fn encode_png(pixmap: &Pixmap) -> Result<Vec<u8>> {
     // Demultiply: tiny_skia stores premultiplied RGBA; PNG expects straight alpha.
     let src = pixmap.data();
     let mut data = src.to_vec();
-    for chunk in data.chunks_exact_mut(4) {
+    for chunk in data.as_chunks_mut::<4>().0 {
         let a = chunk[3];
         if a != 0 && a != 255 {
             let a32 = a as u32;
@@ -9504,7 +9521,7 @@ fn parse_color_key_mask(arr: &[Object], ncomp: usize) -> Option<Vec<(u32, u32)>>
         return None;
     }
     let mut ranges = Vec::with_capacity(ncomp);
-    for pair in arr.chunks_exact(2) {
+    for pair in arr.as_chunks::<2>().0 {
         let lo = pair[0].as_integer()?;
         let hi = pair[1].as_integer()?;
         if lo < 0 || hi < 0 || lo > hi {
@@ -10390,7 +10407,12 @@ mod tests {
         scratch.fill_rect(sil, &paint, Transform::identity(), None);
 
         // Degenerate guard: a silhouette WITH coverage reports true.
-        let has_coverage = scratch.data().chunks_exact(4).any(|px| px[3] != 0);
+        let has_coverage = scratch
+            .data()
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .any(|px| px[3] != 0);
         assert!(has_coverage, "painted silhouette must report coverage");
 
         // Existing clip: top half of the page (y in 0..10) fully inside.
@@ -10421,7 +10443,12 @@ mod tests {
     fn text_clip_empty_accumulator_is_degenerate() {
         use tiny_skia::Pixmap;
         let scratch = Pixmap::new(16, 16).unwrap(); // fresh -> fully transparent
-        let has_coverage = scratch.data().chunks_exact(4).any(|px| px[3] != 0);
+        let has_coverage = scratch
+            .data()
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .any(|px| px[3] != 0);
         assert!(!has_coverage, "empty accumulator must be treated as no clip change");
     }
 
@@ -10985,7 +11012,7 @@ mod tests {
         // yields zero; the d1 stencil taking the current fill colour yields a
         // solid red rectangle.
         let mut red = 0usize;
-        for px in img.data.chunks_exact(4) {
+        for px in img.data.as_chunks::<4>().0 {
             if px[0] > 200 && px[1] < 80 && px[2] < 80 {
                 red += 1;
             }

--- a/src/rendering/resolution/color.rs
+++ b/src/rendering/resolution/color.rs
@@ -1049,7 +1049,9 @@ fn evaluate_type3_stitching(
 
 /// Flatten a `[min1 max1 min2 max2 ...]` PDF array into `[[min, max], ...]`.
 fn array_to_pairs(arr: &[Object]) -> Vec<[f64; 2]> {
-    arr.chunks_exact(2)
+    arr.as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| [object_to_f64(&c[0]), object_to_f64(&c[1])])
         .collect()
 }

--- a/src/rendering/resolution/pipeline.rs
+++ b/src/rendering/resolution/pipeline.rs
@@ -275,7 +275,9 @@ fn eval_separation_alt_cmyk(
                 .get("Domain")
                 .and_then(|o| o.as_array())
                 .map(|a| {
-                    a.chunks_exact(2)
+                    a.as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|c| {
                             let lo = c[0]
                                 .as_real()
@@ -294,7 +296,9 @@ fn eval_separation_alt_cmyk(
                 .get("Range")
                 .and_then(|o| o.as_array())
                 .map(|a| {
-                    a.chunks_exact(2)
+                    a.as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|c| {
                             let lo = c[0]
                                 .as_real()

--- a/src/structure/parser.rs
+++ b/src/structure/parser.rs
@@ -103,7 +103,9 @@ fn decode_pdf_text_string(bytes: &[u8]) -> String {
     if bytes.len() >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF {
         // UTF-16BE with BOM
         let utf16_pairs: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| u16::from_be_bytes([c[0], c[1]]))
             .collect();
         String::from_utf16(&utf16_pairs)
@@ -111,7 +113,9 @@ fn decode_pdf_text_string(bytes: &[u8]) -> String {
     } else if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
         // UTF-16LE with BOM
         let utf16_pairs: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .collect();
         String::from_utf16(&utf16_pairs)

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3053,7 +3053,7 @@ impl WasmPdfDocument {
             .inner
             .lock()
             .map_err(|_| JsValue::from_str("Mutex lock failed"))?;
-        for chunk in rects.chunks_exact(4) {
+        for chunk in rects.as_chunks::<4>().0.iter() {
             let (llx, lly, urx, ury) = (chunk[0], chunk[1], chunk[2], chunk[3]);
             inner
                 .erase_region(
@@ -3065,7 +3065,9 @@ impl WasmPdfDocument {
         drop(inner);
 
         let rect_arrays: Vec<[f32; 4]> = rects
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| [c[0], c[1], c[2], c[3]])
             .collect();
         let editor_arc = self.ensure_editor()?;

--- a/tests/test_actualtext_pdfdoc_encoding.rs
+++ b/tests/test_actualtext_pdfdoc_encoding.rs
@@ -46,10 +46,9 @@ fn build_pdf_with_actual_text(actual_text_bytes: &[u8]) -> Vec<u8> {
 
     push!("<< /Type /Catalog /Pages 2 0 R >>"); // 1
     push!("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"); // 2
-    push!(format!(
-        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+    push!("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
          /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
-    )); // 3
+        .to_string()); // 3
     push!(font_obj); // 4
     push!(format!("<< /Length {} >>\nstream\n{}endstream", content.len(), content)); // 5
 

--- a/tests/test_ccitt_image_mask_rendering.rs
+++ b/tests/test_ccitt_image_mask_rendering.rs
@@ -164,7 +164,9 @@ fn rendered_is_black(pdf: Vec<u8>) -> Vec<bool> {
     assert_eq!((rendered.width, rendered.height), (8, 1));
     rendered
         .data
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|pixel| pixel[0] < 128 && pixel[1] < 128 && pixel[2] < 128)
         .collect()
 }

--- a/tests/test_cjk_cidfont_render_fallback.rs
+++ b/tests/test_cjk_cidfont_render_fallback.rs
@@ -112,7 +112,9 @@ fn build_cjk_no_embed_pdf() -> Vec<u8> {
 
 /// Count pixels darker than near-white in a raw premultiplied-RGBA8 buffer.
 fn dark_pixel_count(data: &[u8]) -> usize {
-    data.chunks_exact(4)
+    data.as_chunks::<4>()
+        .0
+        .iter()
         .filter(|px| px[0] < 200 || px[1] < 200 || px[2] < 200)
         .count()
 }

--- a/tests/test_cmyk_jpeg_adobe_inversion.rs
+++ b/tests/test_cmyk_jpeg_adobe_inversion.rs
@@ -44,7 +44,7 @@ fn cmyk_jpeg_with_adobe_marker_decodes_to_bright_rgb() {
     // Expect near-white output: every channel close to 255.
     // (Exact equality is unreliable through JPEG quantisation even on a
     // solid-colour image, so accept anything above 200/255 per channel.)
-    for chunk in rgb.chunks_exact(3) {
+    for chunk in rgb.as_chunks::<3>().0 {
         assert!(
             chunk[0] > 200 && chunk[1] > 200 && chunk[2] > 200,
             "expected bright RGB from Adobe-inverted CMYK white, got {:?}",

--- a/tests/test_font_layer4_multifont_combined_hash.rs
+++ b/tests/test_font_layer4_multifont_combined_hash.rs
@@ -83,17 +83,15 @@ fn build_three_font_two_page_pdf(
     push!("<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>");
 
     // 3: Page 1 — F1→10, F2→12, F3→14
-    push!(format!(
-        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+    push!("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
          /Resources << /Font << /F1 10 0 R /F2 12 0 R /F3 14 0 R >> >> \
          /Contents 5 0 R >>"
-    ));
+        .to_string());
     // 4: Page 2 — F1→20, F2→22, F3→24
-    push!(format!(
-        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+    push!("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
          /Resources << /Font << /F1 20 0 R /F2 22 0 R /F3 24 0 R >> >> \
          /Contents 6 0 R >>"
-    ));
+        .to_string());
 
     // 5, 6: content streams
     push!(format!("<< /Length {} >>\nstream\n{content}endstream", content.len()));

--- a/tests/test_indexed_4bpc_predictor12_tag0.rs
+++ b/tests/test_indexed_4bpc_predictor12_tag0.rs
@@ -125,7 +125,7 @@ fn indexed_4bpc_predictor12_tag0_decodes_raw_rows() {
     // tag honoured, decoding yields raw nibble stream → every pixel
     // maps to palette entry 15 = pure red. An Up-cascade on rows 1..H
     // would drift pixels away from (255,0,0).
-    for chunk in pixels.chunks_exact(3) {
-        assert_eq!(chunk, [255, 0, 0], "every pixel should be pure red");
+    for chunk in pixels.as_chunks::<3>().0.iter() {
+        assert_eq!(*chunk, [255, 0, 0], "every pixel should be pure red");
     }
 }

--- a/tests/test_indexed_palette_starts_with_cr.rs
+++ b/tests/test_indexed_palette_starts_with_cr.rs
@@ -117,7 +117,7 @@ fn indexed_cmyk_palette_leading_cr_preserved() {
          result indicates the palette's leading 0x0D byte was stripped"
     );
     // All pixels should be the same color (single palette entry, index 0 data).
-    for chunk in pixels.chunks_exact(3) {
+    for chunk in pixels.as_chunks::<3>().0 {
         assert_eq!(chunk[0], r);
         assert_eq!(chunk[1], g);
         assert_eq!(chunk[2], b);

--- a/tests/test_jpeg_decoder_cmyk_contract.rs
+++ b/tests/test_jpeg_decoder_cmyk_contract.rs
@@ -49,7 +49,7 @@ fn jpeg_decoder_returns_straight_cmyk_for_app14_inverted_input() {
     // Tolerant assertions: JPEG quantisation can drift values a few
     // levels even at quality 95. The point is the *direction* of the
     // inversion — pure cyan must NOT come out as M = Y = K = 255 / C = 0.
-    for (i, chunk) in decoded.chunks_exact(4).enumerate() {
+    for (i, chunk) in decoded.as_chunks::<4>().0.iter().enumerate() {
         assert!(
             chunk[0] > 200,
             "pixel {i}: Cyan channel after jpeg-decoder auto-inversion (expected ≳255); got {chunk:?}"

--- a/tests/test_render_cmyk_process_inks.rs
+++ b/tests/test_render_cmyk_process_inks.rs
@@ -159,7 +159,9 @@ fn device_cmyk_vector_and_text_render_via_process_inks_not_additive_clamp() {
     //     mark on the page is pure black. The additive clamp would fill
     //     both the K swatch and the K text with (0,0,0) pixels. ---
     let pure_black = rgba
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .filter(|px| px[3] > 0 && px[0] == 0 && px[1] == 0 && px[2] == 0)
         .count();
     assert_eq!(

--- a/tests/test_render_resolution_pipeline_qa_wave1.rs
+++ b/tests/test_render_resolution_pipeline_qa_wave1.rs
@@ -157,7 +157,9 @@ fn pixel_at(rgba: &[u8], x: u32, y: u32) -> (u8, u8, u8, u8) {
 /// something through the pipeline.
 #[allow(dead_code)]
 fn count_marked_pixels(rgba: &[u8]) -> usize {
-    rgba.chunks_exact(4)
+    rgba.as_chunks::<4>()
+        .0
+        .iter()
         .filter(|c| c[0] < 250 || c[1] < 250 || c[2] < 250)
         .count()
 }
@@ -454,7 +456,7 @@ fn qa_combo_under_rotated_scaled_ctm_paints_both_fill_and_stroke() {
     // confirm both green and red channels show up.
     let mut green_marks = 0usize;
     let mut red_marks = 0usize;
-    for c in on.chunks_exact(4) {
+    for c in on.as_chunks::<4>().0 {
         if c[1] > c[0].saturating_add(40) && c[1] > c[2].saturating_add(40) {
             green_marks += 1;
         }

--- a/tests/test_render_resolution_pipeline_qa_wave5.rs
+++ b/tests/test_render_resolution_pipeline_qa_wave5.rs
@@ -1046,7 +1046,9 @@ fn qa_wave5_corpus_multi_column_table_pdf_renders_non_blank() {
     let img = render_page(&doc, 0, &opts).expect("render_page succeeds on multi_column_table.pdf");
     let any_non_white = img
         .data
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .any(|px| px[0] < 200 || px[1] < 200 || px[2] < 200);
     assert!(
         any_non_white,


### PR DESCRIPTION
## Linked issue

Closes #1105

## What and why

Rust 1.98.0 (released 2026-08-18) added `clippy::chunks_exact_to_as_chunks`. It fires on 35 pre-existing call sites across 15 files, and since CI runs clippy with `-D warnings`, every clippy tier started failing on code nobody had touched:

| check | failing step |
|---|---|
| `Clippy` | Run Clippy on full workspace |
| `Lint and Format Check` | Run Clippy with Python feature |
| `WASM Build` | Clippy WASM |
| `FIPS CryptoProvider (aws-lc-rs)` | Clippy under FIPS feature |

`Clippy` is a required status check, so this blocked `main` and every open pull request. No re-run could clear it — the toolchain flags the same code every time.

## The change

Clippy's own machine-applicable rewrite to `as_chunks::<N>()`, applied with `cargo clippy --fix` once per feature tier rather than by hand, so all 35 sites are transformed consistently.

Behaviour is unchanged: `as_chunks::<N>()` splits exactly as `chunks_exact(N)` did, discards the same trailing remainder, and the returned arrays index identically to the old slices.

`slice::as_chunks` stabilised in Rust 1.88.0 and this crate's `rust-version` is `1.88`, so this is MSRV-safe and needs no `#[allow]`.

## Verification

With the 1.98.0 toolchain, `chunks_exact with a constant chunk size`:

| tier | main | this branch |
|---|---|---|
| `--features python` | 35 | **0** |
| `--features rendering` | 35 | **0** |
| `--all-features` | 35 | **0** |
| default | 35 | **0** |

Worth noting: the CI logs surface only a couple of the sites. The full set appears only when the 1.98 toolchain is run locally across every feature tier — a fix based on the CI output alone would have left most sites unfixed and burned another cycle.

## Type of change

- [x] Docs / CI / chore