### PR TITLE
fix(1107): apply_redactions_destructive indirect reference to an indirect reference to an array

### DIFF
--- a/src/editor/document_editor.rs
+++ b/src/editor/document_editor.rs
@@ -2838,11 +2838,14 @@ impl DocumentEditor {
                                 // Destructive redaction (#231): REPLACE the
                                 // page /Contents with the single rewritten
                                 // stream (secret physically removed + opaque
-                                // overlay). The old content object becomes
-                                // unreferenced and is dropped by the
-                                // garbage-collected full rewrite (no residual
-                                // recoverable bytes, G6). /Redact annotations
-                                // are removed (ISO 32000-1 §12.5.6.23).
+                                // overlay). The old content stream ids are
+                                // kept out of the output via
+                                // `redacted_orphan_ids` (populated in
+                                // `apply_redactions_destructive_for_page`),
+                                // hard-dropped at write time independent of
+                                // reachability (no residual recoverable
+                                // bytes, G6). /Redact annotations are
+                                // removed (ISO 32000-1 §12.5.6.23).
                                 if let (Some((_, redacted_id)), Some(page_dict)) =
                                     (&destructive_redaction, final_page_obj.as_dict())
                                 {
@@ -6985,35 +6988,104 @@ impl DocumentEditor {
         Ok(annots + prog)
     }
 
-    /// Decode a source page's `/Contents` to raw bytes (the `/Contents`
-    /// array, if any, is the logical concatenation of its streams,
-    /// ISO 32000-1:2008 §7.8.2). Empty if the page has no contents.
-    fn get_page_content_bytes(&mut self, source_page: usize) -> Result<Vec<u8>> {
+    /// Resolve a page's `/Contents` into its ordered list of content-stream
+    /// elements: `(Option<ObjectRef>, Object)` pairs — the object reference,
+    /// when this element was reached via an indirect reference (needed by
+    /// callers that must track object ids, e.g. orphaning pre-redaction
+    /// stream bytes so they can't survive a save even as an unreferenced
+    /// object), paired with the resolved object itself (expected to be a
+    /// `Stream`; decoding it is the caller's job).
+    ///
+    /// `/Contents` is typed "stream or array" with no direct/indirect
+    /// qualifier (ISO 32000-1:2008 Table 30), unlike e.g. `/Parent` in the
+    /// same table which explicitly requires "an indirect reference" — so by
+    /// §7.3.10 ("Any object in a PDF file may be labelled as an indirect
+    /// object") both a direct array and an indirect reference to an array
+    /// are legal, in addition to the direct-single-stream-reference case.
+    /// This is the single place that handles all of them, so future callers
+    /// don't have to redrive this analysis (and drift out of sync with each
+    /// other) themselves:
+    /// - a direct reference to a single stream
+    /// - a direct array of stream references, written inline in the page
+    ///   dictionary
+    /// - an indirect reference to an object that is itself an array
+    ///
+    /// A bare `Stream` written directly as `/Contents`' value with no
+    /// reference at all is not actually legal (§7.3.7: "All streams shall
+    /// be indirect objects") — the `other` fallback arm below exists only
+    /// to not panic on that malformed shape, not because it's spec-legal.
+    ///
+    /// `Object::Null` array entries are skipped: some producers leave one
+    /// behind after deleting a stream, and `Null` is a generic `Object`
+    /// value, so it's syntactically valid there even though §7.3.9 itself
+    /// only specifically calls out null-as-a-dictionary-value.
+    fn resolve_page_content_elements(
+        &self,
+        source_page: usize,
+    ) -> Result<Vec<(Option<ObjectRef>, Object)>> {
+        fn push_element(
+            source: &PdfDocument,
+            item: &Object,
+            out: &mut Vec<(Option<ObjectRef>, Object)>,
+        ) -> Result<()> {
+            match item {
+                Object::Null => {},
+                Object::Reference(r) => out.push((Some(*r), source.load_object(*r)?)),
+                other => out.push((None, other.clone())),
+            }
+            Ok(())
+        }
+
         let page_ref = self.source.get_page_ref(source_page)?;
         let page_obj = self.source.load_object(page_ref)?;
         let page_dict = page_obj
             .as_dict()
             .ok_or_else(|| Error::InvalidPdf("Page is not a dictionary".to_string()))?;
         let contents = match page_dict.get("Contents") {
+            Some(Object::Null) | None => return Ok(Vec::new()),
             Some(c) => c.clone(),
-            None => return Ok(Vec::new()),
         };
+
+        let mut out = Vec::new();
         match contents {
-            Object::Reference(r) => Ok(self.source.load_object(r)?.decode_stream_data()?),
-            Object::Array(arr) => {
-                let mut data = Vec::new();
-                for item in arr {
-                    if let Object::Reference(r) = item {
-                        if let Ok(s) = self.source.load_object(r)?.decode_stream_data() {
-                            data.extend_from_slice(&s);
-                            data.push(b'\n');
-                        }
+            Object::Reference(r) => {
+                let resolved = self.source.load_object(r)?;
+                if let Object::Array(arr) = &resolved {
+                    for item in arr {
+                        push_element(&self.source, item, &mut out)?;
                     }
+                } else {
+                    out.push((Some(r), resolved));
                 }
-                Ok(data)
             },
-            _ => Ok(Vec::new()),
+            Object::Array(arr) => {
+                for item in &arr {
+                    push_element(&self.source, item, &mut out)?;
+                }
+            },
+            other => out.push((None, other)),
         }
+        Ok(out)
+    }
+
+    /// Decode a source page's `/Contents` to raw bytes
+    /// the `/Contents` array, if any, is the logical concatenation of its
+    /// streams — ISO 32000-1:2008 §7.7.3.3, Table 30's `/Contents` row:
+    ///  "If the value is an array, the effect shall be as if all of the streams
+    ///   in the array were concatenated, in order, to form a single stream").
+    /// Empty if the page has no contents.
+    fn get_page_content_bytes(&mut self, source_page: usize) -> Result<Vec<u8>> {
+        let elements = self.resolve_page_content_elements(source_page)?;
+        let mut data = Vec::new();
+        for (r, obj) in elements {
+            let decoded = match r {
+                Some(r) => self.source.decode_stream_with_encryption(&obj, r)?,
+                None => obj.decode_stream_data()?,
+            };
+            data.extend_from_slice(&decoded);
+            data.push(b'\n');
+        }
+        Ok(data)
     }
 
     /// Build the [`crate::redaction::FontInfoMetrics`] for a source page
@@ -7156,25 +7228,16 @@ impl DocumentEditor {
         }
         let fonts = self.build_page_font_metrics(src)?;
         let (bytes, rep) = redact_content_stream(&content, &rs, opts, &fonts)?;
-        // Record the original /Contents object ids so the save path
-        // hard-drops them (G6) — the secret must not survive even as
-        // an orphaned, GC-missed object.
-        if let Ok(page_ref) = self.source.get_page_ref(src) {
-            if let Ok(page_obj) = self.source.load_object(page_ref) {
-                if let Some(d) = page_obj.as_dict() {
-                    match d.get("Contents") {
-                        Some(Object::Reference(r)) => {
-                            self.redacted_orphan_ids.insert(r.id);
-                        },
-                        Some(Object::Array(arr)) => {
-                            for it in arr {
-                                if let Object::Reference(r) = it {
-                                    self.redacted_orphan_ids.insert(r.id);
-                                }
-                            }
-                        },
-                        _ => {},
-                    }
+        // Record the original /Contents stream object ids so the save path
+        // hard-drops them — the secret must not survive even as an
+        // orphaned, GC-missed object. Uses the same shape-resolution as
+        // `get_page_content_bytes` (`resolve_page_content_elements`) so
+        // this can't drift out of sync with what was actually decoded and
+        // redacted above.
+        if let Ok(elements) = self.resolve_page_content_elements(src) {
+            for (maybe_obj_ref, _) in elements {
+                if let Some(obj_ref) = maybe_obj_ref {
+                    self.redacted_orphan_ids.insert(obj_ref.id);
                 }
             }
         }
@@ -7475,41 +7538,20 @@ impl DocumentEditor {
             return Err(Error::InvalidPdf("Page has been deleted".to_string()));
         }
 
-        // Get page reference
-        let page_ref = self.source.get_page_ref(original_page_idx as usize)?;
-        let page_obj = self.source.load_object(page_ref)?;
-        let page_dict = page_obj
-            .as_dict()
-            .ok_or_else(|| Error::InvalidPdf("Page is not a dictionary".to_string()))?;
-
-        // Get Contents
-        let contents = match page_dict.get("Contents") {
-            Some(c) => c.clone(),
-            None => return Ok(Vec::new()),
-        };
-
         // Load content stream data
-        let content_data = match contents {
-            Object::Reference(ref_obj) => {
-                let obj = self.source.load_object(ref_obj)?;
-                obj.decode_stream_data()?
-            },
-            Object::Array(arr) => {
-                // Concatenate multiple content streams
-                let mut data = Vec::new();
-                for item in arr {
-                    if let Object::Reference(ref_obj) = item {
-                        let obj = self.source.load_object(ref_obj)?;
-                        if let Ok(stream_data) = obj.decode_stream_data() {
-                            data.extend_from_slice(&stream_data);
-                            data.push(b'\n');
-                        }
-                    }
-                }
-                data
-            },
-            _ => return Ok(Vec::new()),
-        };
+        // if any stream fails to decode, silently skip over that one
+        let elements = self.resolve_page_content_elements(original_page_idx as usize)?;
+        let mut content_data = Vec::new();
+        for (maybe_obj_ref, obj) in elements {
+            let decoded = match maybe_obj_ref {
+                Some(obj_ref) => self.source.decode_stream_with_encryption(&obj, obj_ref),
+                None => obj.decode_stream_data(),
+            };
+            if let Ok(decoded) = decoded {
+                content_data.extend_from_slice(&decoded);
+                content_data.push(b'\n');
+            }
+        }
 
         // Parse the content stream
         let operators = parse_content_stream(&content_data)?;

--- a/tests/issue_redaction_indirect_contents_array.rs
+++ b/tests/issue_redaction_indirect_contents_array.rs
@@ -1,0 +1,75 @@
+//! A page's `/Contents` may validly be an indirect reference to an object
+//! that is itself an array of content-stream references (`/Contents 5 0 R`
+//! where object 5 is `[6 0 R 7 0 R]`), not just a direct reference to a
+//! single stream or a direct array of stream references. Redacting such a
+//! page should work the same as any other.
+
+use pdf_oxide::editor::DocumentEditor;
+
+/// Build a minimal single-page PDF where `/Contents` is an indirect
+/// reference (object 4) to an array of two content-stream references,
+/// rather than a direct array or a direct stream reference.
+fn pdf_with_indirect_contents_array() -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 8];
+    let obj = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, body: &str| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    let stream = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, data: &[u8]| {
+        off[id] = buf.len();
+        buf.extend_from_slice(
+            format!("{id} 0 obj\n<< /Length {} >>\nstream\n", data.len()).as_bytes(),
+        );
+        buf.extend_from_slice(data);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+    };
+
+    buf.extend_from_slice(b"%PDF-1.5\n%\xE2\xE3\xCF\xD3\n");
+
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 6 0 R >> >> /Contents 4 0 R >>",
+    );
+    // Object 4 is itself an array, reached only via an indirect reference.
+    obj(&mut buf, &mut off, 4, "[5 0 R 7 0 R]");
+    stream(&mut buf, &mut off, 5, b"BT /F1 24 Tf 72 700 Td (Top half) Tj ET");
+    obj(&mut buf, &mut off, 6, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+    stream(&mut buf, &mut off, 7, b"BT /F1 24 Tf 72 650 Td (Bottom half) Tj ET");
+
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 8\n0000000000 65535 f \n");
+    for id in 1..=7 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 8 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+
+    buf
+}
+
+/// Open a PDF, redact a region on a page, apply the redaction — should
+/// succeed regardless of how `/Contents` is structured internally.
+#[test]
+fn redaction_on_indirect_contents_array_does_not_error() {
+    let bytes = pdf_with_indirect_contents_array();
+    let mut editor = DocumentEditor::from_bytes(bytes).expect("should open");
+
+    editor
+        .add_redaction(0, [72.0, 690.0, 300.0, 710.0], None)
+        .expect("should queue redaction");
+
+    let result = editor.apply_redactions_destructive(Default::default());
+
+    assert!(
+        result.is_ok(),
+        "apply_redactions_destructive failed on a page whose /Contents is an \
+         indirect reference to an array of stream references: {:?}",
+        result.err()
+    );
+}

--- a/tests/test_redaction_destructive.rs
+++ b/tests/test_redaction_destructive.rs
@@ -131,6 +131,141 @@ fn destructive_redaction_is_idempotent() {
     assert!(!page0_text(&twice).contains(SECRET), "secret reappeared after re-redaction");
 }
 
+/// #1107: a page dict may have `/Contents` as an indirect reference to an
+/// object that is itself an array of stream references — a third legal
+/// shape beyond a direct single-stream reference or a direct array written
+/// inline in the page dict (ISO 32000-1:2008 Table 30 types `/Contents` as
+/// "stream or array" with no direct/indirect qualifier, unlike e.g.
+/// `/Parent` in the same table which explicitly requires "an indirect
+/// reference").
+/// This asserts the real, secret-relevant behavior — same
+/// control/G6-byte-scan/G1-re-extraction oracle as
+/// `destructive_redaction_removes_secret_text_and_bytes` above
+fn indirect_contents_array_pdf() -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut off = vec![0usize; 8];
+    let obj = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, body: &str| {
+        off[id] = buf.len();
+        buf.extend_from_slice(format!("{id} 0 obj\n{body}\nendobj\n").as_bytes());
+    };
+    let stream = |buf: &mut Vec<u8>, off: &mut Vec<usize>, id: usize, data: &[u8]| {
+        off[id] = buf.len();
+        buf.extend_from_slice(
+            format!("{id} 0 obj\n<< /Length {} >>\nstream\n", data.len()).as_bytes(),
+        );
+        buf.extend_from_slice(data);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+    };
+
+    buf.extend_from_slice(b"%PDF-1.5\n%\xE2\xE3\xCF\xD3\n");
+    obj(&mut buf, &mut off, 1, "<< /Type /Catalog /Pages 2 0 R >>");
+    obj(&mut buf, &mut off, 2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+    obj(
+        &mut buf,
+        &mut off,
+        3,
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+         /Resources << /Font << /F1 7 0 R >> >> /Contents 4 0 R >>",
+    );
+    // Object 4 is itself an array, reached only via an indirect reference —
+    // the shape `resolve_page_content_elements` now handles.
+    obj(&mut buf, &mut off, 4, "[5 0 R 6 0 R]");
+    let header = b"BT /F1 24 Tf 72 700 Td (PUBLIC HEADER LINE) Tj ET".to_vec();
+    stream(&mut buf, &mut off, 5, &header);
+    let secret_content = format!("BT /F1 24 Tf 72 650 Td ({SECRET}) Tj ET").into_bytes();
+    stream(&mut buf, &mut off, 6, &secret_content);
+    obj(&mut buf, &mut off, 7, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+    let xref = buf.len();
+    buf.extend_from_slice(b"xref\n0 8\n0000000000 65535 f \n");
+    for id in 1..=7 {
+        buf.extend_from_slice(format!("{:010} 00000 n \n", off[id]).as_bytes());
+    }
+    buf.extend_from_slice(b"trailer\n<< /Size 8 /Root 1 0 R >>\nstartxref\n");
+    buf.extend_from_slice(format!("{xref}\n%%EOF\n").as_bytes());
+    buf
+}
+
+#[test]
+fn destructive_redaction_indirect_contents_array_removes_secret_text_and_bytes() {
+    let src = indirect_contents_array_pdf();
+    assert!(
+        page0_text(&src).contains(SECRET),
+        "fixture must contain the secret before redaction"
+    );
+
+    let raw_opts = pdf_oxide::editor::SaveOptions {
+        compress: false,
+        ..pdf_oxide::editor::SaveOptions::full_rewrite()
+    };
+
+    // Control: unredacted, saved through the exact same uncompressed path,
+    // must still contain the literal secret bytes — proves the byte scan
+    // below is a valid oracle.
+    {
+        let mut ctrl =
+            DocumentEditor::from_bytes(indirect_contents_array_pdf()).expect("open control");
+        let ctrl_bytes = ctrl
+            .save_to_bytes_with_options(raw_opts.clone())
+            .expect("save control pdf");
+        assert!(
+            ctrl_bytes
+                .windows(SECRET.len())
+                .any(|w| w == SECRET.as_bytes()),
+            "control: uncompressed save must preserve the literal secret"
+        );
+    }
+
+    let mut ed = DocumentEditor::from_bytes(src).expect("open editor");
+    // Region over the secret's baseline only (y ~650) — leaves the header
+    // line (y ~700) untouched, so success here can't be explained by
+    // redacting the whole page.
+    ed.add_redaction(0, [0.0, 630.0, 612.0, 680.0], None)
+        .expect("queue redaction");
+    let report = ed
+        .apply_redactions_destructive(RedactionOptions::default())
+        .expect(
+            "apply_redactions_destructive must not error on an indirect \
+                 reference to an array of stream references",
+        );
+    assert!(report.glyphs_removed > 0, "expected glyphs removed, report={report:?}");
+
+    let out = ed
+        .save_to_bytes_with_options(raw_opts)
+        .expect("save redacted pdf");
+
+    // G6: the secret literal must not survive anywhere in the raw saved
+    // bytes — not just absent from the *live* /Contents, but genuinely
+    // dropped, including as an orphaned object. This is what the parallel
+    // orphan-id fix in `apply_redactions_destructive_for_page` actually
+    // buys: fixing only the crash without it would still pass a
+    // text-re-extraction-only check while leaving this assertion failing.
+    if let Some(pos) = out
+        .windows(SECRET.len())
+        .position(|w| w == SECRET.as_bytes())
+    {
+        let lo = pos.saturating_sub(120);
+        let hi = (pos + SECRET.len() + 120).min(out.len());
+        let ctx = String::from_utf8_lossy(&out[lo..hi]);
+        panic!(
+            "G6 VIOLATION: secret at byte {pos}/{}, indirect-reference-to-array \
+             page. Context:\n>>>{}<<<",
+            out.len(),
+            ctx
+        );
+    }
+
+    // re-extraction must not yield the secret either.
+    let text = page0_text(&out);
+    assert!(!text.contains(SECRET), "secret still recoverable via text extraction: {text:?}");
+    // Unrelated header text on the other stream in the same array must
+    // survive — proves this isn't a whole-page wipe.
+    assert!(
+        text.contains("PUBLIC HEADER LINE"),
+        "unredacted header text from the other stream must survive: {text:?}"
+    );
+}
+
 /// `redaction_count` reflects queued programmatic regions.
 #[test]
 fn redaction_count_tracks_queued_regions() {

--- a/tools/probes/probe_contents_shapes_corpus.rs
+++ b/tools/probes/probe_contents_shapes_corpus.rs
@@ -1,0 +1,84 @@
+//! Probe for #1107: for each corpus PDF, open via `DocumentEditor::from_bytes`,
+//! queue a redaction region on page 0, and call `apply_redactions_destructive`.
+//! Queuing any region is enough to exercise `get_page_content_bytes`'s
+//! `/Contents`-shape parsing (via `resolve_page_content_elements`)
+//! regardless of whether the region overlaps any text, so this checks the
+//! actual code this fix touches without needing to know each page's layout.
+//!
+//! Not general user value (hardcoded corpus paths) — per `tools/probes/`
+//! convention, copy into `examples/` to build/run, delete the copy after.
+//!
+//! Usage: `probe_contents_shapes_corpus <dir1> [dir2 ...]`
+
+use pdf_oxide::editor::DocumentEditor;
+use std::path::PathBuf;
+
+fn find_pdfs(dirs: &[PathBuf]) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for dir in dirs {
+        visit(dir, &mut out);
+    }
+    out.sort();
+    out
+}
+
+fn visit(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.metadata().map(|m| m.is_dir()).unwrap_or(false) {
+            visit(&path, out);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) == Some("pdf") {
+            out.push(path);
+        }
+    }
+}
+
+fn main() {
+    let dirs: Vec<PathBuf> = std::env::args().skip(1).map(PathBuf::from).collect();
+    if dirs.is_empty() {
+        eprintln!("usage: probe_contents_shapes_corpus <dir1> [dir2 ...]");
+        std::process::exit(2);
+    }
+
+    let pdfs = find_pdfs(&dirs);
+    println!("Found {} PDFs", pdfs.len());
+
+    let mut ok = 0usize;
+    let mut errors = 0usize;
+
+    for path in &pdfs {
+        let name = path.display();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| check_one(path)));
+        match result {
+            Ok(Ok(())) => ok += 1,
+            Ok(Err(e)) => {
+                errors += 1;
+                println!("ERROR {name}: {e}");
+            },
+            Err(_) => {
+                errors += 1;
+                println!("PANIC {name}");
+            },
+        }
+    }
+
+    println!("\n{} PDFs scanned, {ok} ok, {errors} errors", pdfs.len());
+    if errors > 0 {
+        std::process::exit(1);
+    }
+}
+
+fn check_one(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = std::fs::read(path)?;
+    let mut editor = DocumentEditor::from_bytes(bytes)?;
+    // Region doesn't need to overlap text — queuing any region is enough to
+    // route apply_redactions_destructive through get_page_content_bytes.
+    editor.add_redaction(0, [0.0, 0.0, 50.0, 50.0], None)?;
+    editor.apply_redactions_destructive(Default::default())?;
+    Ok(())
+}


### PR DESCRIPTION
apply_redactions_destructive fails on pages whose /Contents is an indirect reference to an array

## Linked issue
Closes https://github.com/yfedoseev/pdf_oxide/issues/1107

## What and why

I should be able to call apply_redactions_destructive on any spec-compliant PDF

## Type of change

- [X] Bug fix
- [ ] New feature (has an accepted issue: #___)
- [ ] Performance
- [ ] Refactor / internal
- [ ] Docs / CI / chore
- [ ] Breaking change

## Tests

- [X] I added a test that **fails before this change and passes after**
      (revert-checked). For bug fixes the reproducer is a **minimal synthetic
      PDF built in code** — no third-party/reporter PDF is committed.
- [X] Test named by defect **class**, not an issue/PR number; no
      contributor/company names in code or fixtures.
- [X] `cargo test` passes, **and** the affected feature tiers:
      `rendering` / `fips,icc` / `ml` / binding (list which): ____
- [X] `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Regression on real PDFs

**Corpus I tested**: 32 PDFs total (including the PDF where I found this failure)
* 20 IRS tax forms
* 9 personal-library documents
* 2 exported from Google Docs (public domain text w/ page headers, footers)
* 1 large real-world scan — warandpeace030164mbp.pdf, 725 pages, from archive.org

- [X] Ran `corpus_sig` and diffed my branch against **`main`** 
- [X] Diffed my branch against the **latest release** (`v0.3.77`) 
- [n/a] Judged with a structural metric (word-Jaccard + spacing outliers), not
      char-Levenshtein.

**Diff summary vs `main`:** 

zero diff, no regressions

**Diff summary vs latest release:** 

zero diff, no regressions

## AI assistance disclosure

- [X] AI assistance: **none**, or **assisted** — tool: Claud, extent:draft code/test, wrote probe, ran corpus testing
- [X] I understand and can explain every line; the description and my review
      replies are written by me, not generated. This PR is not fully or
      predominantly AI-generated.

## Checklist

- [X] One logical change (no bundled refactor/perf/correctness).
- [X] Commits follow Conventional Commits and are **DCO signed-off** (`git commit -s`).
- [n/a] Docs/`CHANGELOG.md` updated if user-facing; reporters credited in the
      CHANGELOG (not in code).
- [n/a] Public-API changes considered for semver (`semver-checks` will run).
