### PR TITLE
fix(ci): name the remedy in the DCO failure message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1857,7 +1857,7 @@ jobs:
           MISSING=0
           while IFS= read -r sha; do
             if ! git log -1 --format=%B "$sha" | grep -q "^Signed-off-by:"; then
-              echo "::error::Commit $sha is missing a Signed-off-by trailer"
+              echo "::error::Commit $sha is missing a Signed-off-by trailer. Sign a new commit with 'git commit -s', the last one with 'git commit --amend -s', a merge with 'git merge --signoff', or a range with 'git rebase --signoff <base>'. Merge commits are checked too, so a merge you made to sync needs its own trailer."
               MISSING=$((MISSING+1))
             fi
           done < <(git log --pretty=format:"%H" "${BASE}..${HEAD}")


### PR DESCRIPTION
## Linked issue

Follows #1094, per your note there.

## What and why

The check printed the fact and nothing about the remedy. It now names the command for each case, without preferring one workflow: `git commit -s` for a new commit, `git commit --amend -s` for the last one, `git merge --signoff` for a merge, `git rebase --signoff <base>` for a range.

It also says merge commits are checked, since a merge made to sync is the case that sends people looking for an explanation.

The message string is the whole diff.

## Type of change

- [x] Docs / CI / chore

## Tests

Not applicable. The workflow YAML parses and the shell line is syntax-clean; the check's logic is untouched.
