### PR TITLE
chore(repo): contribution intake policy, CI enforcement, and README housekeeping

### DIFF
--- a/.github/workflows/auto-reject.yml
+++ b/.github/workflows/auto-reject.yml
@@ -1,0 +1,99 @@
+# Auto-reject list — close new issues and pull requests from accounts whose
+# intake has been capped under CONTRIBUTING.md "Communication volume".
+#
+# The list lives in the repository variable AUTO_REJECT_ACCOUNTS (Settings →
+# Secrets and variables → Actions → Variables), as a comma- or newline-separated
+# list of logins. It is deliberately NOT a file in the repo: a checked-in
+# denylist is a public register of named people, which invites escalation and is
+# hard to walk back. The effect is the same; the shaming is not.
+#
+# Scope: new issues and PRs only. Comments still work, existing open work is
+# untouched. This caps intake without ending the conversation — see the ladder
+# in CONTRIBUTING.md, where it sits below interaction limits and blocking.
+name: Auto-reject list
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: auto-reject-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  reject:
+    name: Close if the author's intake is capped
+    runs-on: ubuntu-latest
+    if: ${{ vars.AUTO_REJECT_ACCOUNTS != '' }}
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        env:
+          ACCOUNTS: ${{ vars.AUTO_REJECT_ACCOUNTS }}
+        with:
+          script: |
+            const listed = (process.env.ACCOUNTS || '')
+              .split(/[\s,]+/)
+              .map(x => x.trim().toLowerCase())
+              .filter(Boolean);
+            if (!listed.length) return;
+
+            const isPR = !!context.payload.pull_request;
+            const item = context.payload.pull_request || context.payload.issue;
+            const author = (item.user && item.user.login) || '';
+            if (!listed.includes(author.toLowerCase())) return;
+
+            // Never auto-reject someone with write access — if a maintainer is on
+            // the list, that is a mistake in the variable, not an intent to lock
+            // the project's own team out.
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner, repo: context.repo.repo, username: author,
+              });
+              if (['admin', 'maintain', 'write'].includes(data.permission)) {
+                core.warning('Listed account ' + author + ' has write access — ignoring.');
+                return;
+              }
+            } catch (e) { /* not a collaborator: proceed */ }
+
+            const docs = 'https://github.com/' + context.repo.owner + '/' + context.repo.repo +
+                         '/blob/main/CONTRIBUTING.md#communication-volume';
+            const kind = isPR ? 'pull request' : 'issue';
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: item.number,
+              body: [
+                'Closing automatically: new issues and pull requests from this account are',
+                'not currently being accepted.',
+                '',
+                'This is a rate measure, not a judgement about this ' + kind + ' or about you.',
+                'Review here is one person; when submissions arrive faster than they can be',
+                'read, the queue stops working for everyone. Commenting still works and your',
+                'existing open work is unaffected.',
+                '',
+                'If you would like this lifted, say so in a comment. It is not permanent and it',
+                'is not a ban.',
+                '',
+                'See [Communication volume](' + docs + ').',
+              ].join('\n'),
+            });
+
+            if (isPR) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                pull_number: item.number, state: 'closed',
+              });
+            } else {
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: item.number, state: 'closed', state_reason: 'not_planned',
+              });
+            }

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -3,6 +3,16 @@
 #   - title:     PR title must follow Conventional Commits (load-bearing for squash-merge)
 #   - no-binary: block committed compiled/library artifacts (reinforces Binary-Artifacts + fixture policy)
 #   - ai-label:  label (never block) PRs whose commits disclose AI co-authorship
+#   - one-open-pr: close a second concurrently-open PR from the same author
+#   - accepted-issue: close a PR with no linked issue; fail one whose issue
+#                     is unapproved or assigned to someone else
+#   - has-test:      a fix/feat PR must add at least one test
+#
+# The last two are intake gates. They exist because review is serial (one
+# maintainer) while submission is not, so without a cap the queue is bounded
+# only by the maintainer's endurance. Both decide on mechanical facts — how many
+# PRs an author has open, whether a maintainer replied on the issue — so neither
+# requires judgment, and neither costs maintainer time to apply.
 #
 # Security: uses `pull_request_target` for write access on fork PRs, but only
 # reads strings from the event payload / REST API via github-script and never
@@ -96,3 +106,276 @@ jobs:
             if (!existing.includes('ai-assisted')) {
               await github.rest.issues.addLabels({ ...common, labels: ['ai-assisted'] });
             }
+
+  one-open-pr:
+    name: One open PR per contributor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            // Maintainers and collaborators are exempt: the limit rations
+            // *review* capacity, and they supply it rather than consume it.
+            const exempt = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (exempt.includes(pr.author_association)) return;
+            if (pr.draft) return;   // drafts are not asking for review yet
+            // Trivial classes named in CONTRIBUTING as not counting.
+            if (/^(docs|ci|chore|revert)(\(|:)/i.test(pr.title || '')) return;
+
+            const others = (await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            })).filter(p =>
+              p.number !== pr.number &&
+              p.user && p.user.login === pr.user.login &&
+              !p.draft &&
+              !/^(docs|ci|chore|revert)(\(|:)/i.test(p.title || '')
+            );
+            if (!others.length) return;
+
+            const list = others.map(p => '#' + p.number).join(', ');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                'Closing automatically: this project allows **one open pull request at a time**',
+                'per non-maintainer contributor, and you already have ' + others.length + ' open (' + list + ').',
+                '',
+                'This is not a judgement about the change. Review here is serial — one maintainer,',
+                'and every open PR needs a full read, a corpus sweep and a green CI cycle, and has to',
+                'be re-checked each time something lands ahead of it. Several at once cost far more',
+                'in total than the same work landed one at a time.',
+                '',
+                'Please reopen this once your earlier PR resolves. If you have found other unrelated',
+                'bugs meanwhile, **open issues** for them — the diagnosis is valuable on its own and',
+                'costs far less to carry than an open PR.',
+                '',
+                'See [One open PR at a time](https://github.com/' + context.repo.owner + '/' +
+                  context.repo.repo + '/blob/main/CONTRIBUTING.md#before-you-open-a-pull-request).',
+              ].join('\n'),
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });
+
+  accepted-issue:
+    name: Linked issue is approved and assigned to you
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const exempt = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (exempt.includes(pr.author_association)) return;
+            if (pr.draft) return;
+            if (/^(docs|ci|chore|revert)(\(|:)/i.test(pr.title || '')) return;
+
+            const author = pr.user && pr.user.login;
+            const body = pr.body || '';
+            const refs = [...new Set(
+              [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)].map(m => parseInt(m[1], 10))
+            )];
+
+            const docs = 'https://github.com/' + context.repo.owner + '/' + context.repo.repo +
+                         '/blob/main/CONTRIBUTING.md#before-you-open-a-pull-request';
+
+            if (!refs.length) {
+              // Distinguish "referenced the issue imperfectly" from "no issue at
+              // all". Only the second is a drive-by, and only it is closed —
+              // auto-closing costs the contributor a reopen, so it is reserved
+              // for the unambiguous case.
+              const anyIssueNumber = /#\d+/.test(body);
+              if (anyIssueNumber) {
+                return core.setFailed(
+                  'This PR mentions an issue but does not link it in a closing form. Put ' +
+                  '"Closes #NNN" in the PR description (not the commit message) so the issue ' +
+                  'closes on merge and this check can find it. See ' + docs
+                );
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  'Closing automatically: this PR does not reference an issue.',
+                  '',
+                  'Work here starts from an issue that a maintainer has approved and assigned —',
+                  'opening a pull request is not how work is claimed. This is not about the quality',
+                  'of the change: it costs a maintainer one line to say "go ahead" or "we would fix',
+                  'that differently", and it saves you writing a change that was never going to land.',
+                  '',
+                  'What to do:',
+                  '',
+                  '1. Open an issue describing the problem. A reproducer and one line is enough.',
+                  '2. Wait for a maintainer to comment `/approve` and assign it to you.',
+                  '3. Reopen this PR (or open a new one) with `Closes #NNN` in the description.',
+                  '',
+                  'Typo, documentation, CI and revert PRs are exempt and can be opened directly.',
+                  '',
+                  'See [Before you open a pull request](' + docs + ').',
+                ].join('\n'),
+              });
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed',
+              });
+              return;
+            }
+
+            // Who counts as a maintainer is decided by actual repository
+            // permission, not by `author_association` on a comment and not by
+            // who happened to apply a label. Triage access is enough to add a
+            // label but must NOT be enough to approve work.
+            const permCache = new Map();
+            const isMaintainer = async (login) => {
+              if (!login) return false;
+              if (permCache.has(login)) return permCache.get(login);
+              let ok = false;
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner, repo: context.repo.repo, username: login,
+                });
+                ok = ['admin', 'maintain', 'write'].includes(data.permission);
+              } catch (e) { ok = false; }   // not a collaborator at all
+              permCache.set(login, ok);
+              return ok;
+            };
+
+            const problems = [];
+            for (const n of refs) {
+              let issue, comments, events;
+              try {
+                issue = (await github.rest.issues.get({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: n,
+                })).data;
+                comments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: n, per_page: 100,
+                });
+                events = await github.paginate(github.rest.issues.listEvents, {
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: n, per_page: 100,
+                });
+              } catch (e) {
+                problems.push('#' + n + ': could not be read (wrong repo?)');
+                continue;
+              }
+
+              // Build one chronological list of approval-affecting acts, so the
+              // most recent maintainer verdict wins regardless of its form.
+              const acts = [];
+              for (const c of comments) {
+                const m = (c.body || '').match(/^\s*\/(approve|unapprove)\b/mi);
+                if (m) acts.push({
+                  at: c.created_at,
+                  by: c.user && c.user.login,
+                  approve: m[1].toLowerCase() === 'approve',
+                });
+              }
+              for (const e of events) {
+                if ((e.event === 'labeled' || e.event === 'unlabeled') &&
+                    e.label && e.label.name === 'approved') {
+                  acts.push({
+                    at: e.created_at,
+                    by: e.actor && e.actor.login,
+                    approve: e.event === 'labeled',
+                  });
+                }
+              }
+              acts.sort((a, b) => new Date(a.at) - new Date(b.at));
+
+              let approved = false;
+              let selfApproveAttempt = false;
+              for (const a of acts) {
+                if (!(await isMaintainer(a.by))) {
+                  if (a.approve) selfApproveAttempt = true;   // ignored, but worth saying
+                  continue;
+                }
+                approved = a.approve;
+              }
+
+              const assignees = (issue.assignees || []).map(a => a.login);
+              const assignedToAuthor = assignees.includes(author);
+
+              if (!approved) {
+                problems.push(
+                  '#' + n + ': not approved by a maintainer' +
+                  (selfApproveAttempt
+                    ? ' (an `/approve` or `approved` label from someone without write access does not count)'
+                    : ' — a maintainer must comment `/approve`')
+                );
+              } else if (!assignedToAuthor) {
+                problems.push(
+                  '#' + n + ': approved, but assigned to ' +
+                  (assignees.length ? assignees.map(a => '@' + a).join(', ') : 'nobody') +
+                  ' rather than @' + author
+                );
+              } else {
+                return;   // one fully-satisfying issue is enough
+              }
+            }
+
+            core.setFailed(
+              'The linked issue is not cleared for implementation:\n' +
+              problems.map(p => '  - ' + p).join('\n') +
+              '\n\nA maintainer approves an issue by commenting `/approve` and assigning it to ' +
+              'whoever will implement it. Assignment is how work is claimed here — it prevents two ' +
+              'people building the same fix, and it means the maintainer has agreed both the ' +
+              'approach and who is doing it. See ' + docs
+            );
+
+  has-test:
+    name: Change ships a test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (pr.draft) return;
+            // Only behaviour changes need a test. Docs/CI/chore/revert/perf-only
+            // and pure refactors are judged by the reviewer, not here.
+            if (!/^(fix|feat)(\(|!|:)/i.test(pr.title || '')) return;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            // A test is a new #[test]/#[tokio::test]/#[rstest] attribute anywhere
+            // in the diff — this crate keeps unit tests inline under #[cfg(test)]
+            // as well as in tests/, so looking only at tests/ would be wrong.
+            const addsTest = files.some(f =>
+              (f.patch || '')
+                .split('\n')
+                .some(l => /^\+\s*#\[(tokio::)?(test|rstest)\b/.test(l))
+            );
+            if (addsTest) return;
+
+            const touchesTestFile = files.some(f =>
+              f.filename.startsWith('tests/') && f.status !== 'removed'
+            );
+
+            core.setFailed(
+              (touchesTestFile
+                ? 'This PR changes files under tests/ but does not add a new test case. '
+                : 'This PR does not add a test. ') +
+              'Every bug fix ships a regression test that fails without the fix, added in a ' +
+              'commit before the fix commit. If this change genuinely cannot be tested — a ' +
+              'pure refactor, or a defect only reproducible on a document that cannot be ' +
+              'shared — say so in the PR description and a maintainer will waive this. ' +
+              'See https://github.com/' + context.repo.owner + '/' + context.repo.repo +
+              '/blob/main/CONTRIBUTING.md#testing-and-regression-requirements'
+            );

--- a/.github/workflows/submission-rate.yml
+++ b/.github/workflows/submission-rate.yml
@@ -1,0 +1,151 @@
+# Submission rate limit — CONTRIBUTING.md "Communication volume".
+#
+# Review here is one person. Submissions that arrive faster than a person can
+# respond are rate-limited regardless of what produced them: the rule is about
+# rate, not tooling. Generate the work however you like; submit it at a rate a
+# human can answer.
+#
+# Thresholds are repository variables so they can be tuned without editing this
+# file (Settings -> Secrets and variables -> Actions -> Variables). Seconds:
+#   RATE_MIN_GAP_ISSUES    default 300   (5 min between issues from one account)
+#   RATE_MIN_GAP_PRS       default 300   (5 min between pull requests)
+#   RATE_MIN_GAP_COMMENTS  default 60    (see the note below on why this differs)
+# Set any of them to 0 to disable that surface.
+#
+# Comments default to a shorter window on purpose. Answering three review
+# threads in five minutes is ordinary participation; nineteen identical
+# comments in eighteen seconds is not. A 5-minute comment gap would punish the
+# first while barely being needed for the second, so the comment window targets
+# bursts rather than conversation.
+#
+# Nothing here is permanent. An issue or PR closed by this workflow can be
+# reopened once the gap has passed; a hidden comment stays readable.
+name: Submission rate limit
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: rate-${{ github.actor }}
+  cancel-in-progress: false
+
+jobs:
+  rate:
+    name: Rate limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
+        env:
+          GAP_ISSUES: ${{ vars.RATE_MIN_GAP_ISSUES || '300' }}
+          GAP_PRS: ${{ vars.RATE_MIN_GAP_PRS || '300' }}
+          GAP_COMMENTS: ${{ vars.RATE_MIN_GAP_COMMENTS || '60' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const ev = context.eventName;
+            const isComment = ev === 'issue_comment';
+            const isPR = ev === 'pull_request_target';
+            const item = context.payload.pull_request || context.payload.issue;
+            const actor = (context.payload.comment?.user || item?.user || {}).login;
+            if (!actor) return;
+
+            // Bots that are part of the toolchain are not the target of this.
+            if (/\[bot\]$/i.test(actor) || actor === 'dependabot') return;
+
+            // Anyone with write access supplies review capacity rather than
+            // consuming it, so the limit does not apply to them.
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner, repo, username: actor,
+              });
+              if (['admin', 'maintain', 'write'].includes(data.permission)) return;
+            } catch (e) { /* not a collaborator: continue */ }
+
+            const gap = parseInt(
+              isComment ? process.env.GAP_COMMENTS
+                : isPR ? process.env.GAP_PRS
+                : process.env.GAP_ISSUES, 10);
+            if (!gap || gap <= 0) return;
+
+            const nowIso = isComment
+              ? context.payload.comment.created_at
+              : item.created_at;
+            const now = new Date(nowIso).getTime();
+            const sinceIso = new Date(now - gap * 1000).toISOString();
+            const docs = `https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md#communication-volume`;
+
+            let priorAt = null;
+
+            if (isComment) {
+              // Comments the actor made anywhere in the repo inside the window.
+              const res = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${owner}/${repo} commenter:${actor} updated:>=${sinceIso}`,
+                per_page: 20,
+              });
+              for (const hit of res.data.items) {
+                const cs = await github.paginate(github.rest.issues.listComments, {
+                  owner, repo, issue_number: hit.number, since: sinceIso, per_page: 100,
+                });
+                for (const c of cs) {
+                  if (c.user?.login !== actor) continue;
+                  if (c.id === context.payload.comment.id) continue;
+                  const t = new Date(c.created_at).getTime();
+                  if (t < now && (priorAt === null || t > priorAt)) priorAt = t;
+                }
+              }
+            } else {
+              const kind = isPR ? 'pr' : 'issue';
+              const res = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${owner}/${repo} author:${actor} is:${kind} created:>=${sinceIso}`,
+                sort: 'created', order: 'desc', per_page: 20,
+              });
+              for (const hit of res.data.items) {
+                if (hit.number === item.number) continue;
+                const t = new Date(hit.created_at).getTime();
+                if (t < now && (priorAt === null || t > priorAt)) priorAt = t;
+              }
+            }
+
+            if (priorAt === null) return;   // nothing inside the window
+
+            const elapsed = Math.round((now - priorAt) / 1000);
+            const what = isComment ? 'comment' : isPR ? 'pull request' : 'issue';
+            const body = [
+              `This ${what} arrived ${elapsed}s after your previous one. This project asks for at`,
+              `least ${gap}s between ${what}s from the same account.`,
+              '',
+              'Review here is one person, and submissions that arrive faster than a person can',
+              'read them stop being a conversation. The limit is about rate, not about tooling',
+              'or about the quality of this particular submission — use whatever tools you like,',
+              'just send the result at a rate someone can answer.',
+              '',
+              isComment
+                ? 'Nothing has been deleted; this note simply flags the pace. If you have several points, one message carrying all of them is worth more than several sent together.'
+                : `Please reopen this once the gap has passed — it is not a rejection and nothing is lost.`,
+              '',
+              `See [Communication volume](${docs}).`,
+            ].join('\n');
+
+            const issue_number = isComment ? context.payload.issue.number : item.number;
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+
+            if (!isComment) {
+              if (isPR) {
+                await github.rest.pulls.update({ owner, repo, pull_number: item.number, state: 'closed' });
+              } else {
+                await github.rest.issues.update({
+                  owner, repo, issue_number: item.number,
+                  state: 'closed', state_reason: 'not_planned',
+                });
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,18 @@ the underlying work is.
   Again this is about rate, not tooling. Generate the work however you like;
   submit it at a rate a person can respond to.
 
+  **This one is enforced automatically.** A `Submission rate limit` workflow
+  closes an issue or pull request opened less than **5 minutes** after your
+  previous one, and flags a comment posted less than **60 seconds** after your
+  previous one. Closed items can simply be reopened once the gap has passed —
+  nothing is lost and it is not a rejection. Comments are never deleted; the
+  workflow only leaves a note.
+
+  Comments get the shorter window deliberately: answering three review threads
+  in five minutes is ordinary participation, while nineteen comments in eighteen
+  seconds is not, so the comment window targets bursts rather than conversation.
+  Maintainers and toolchain bots (Dependabot and similar) are exempt.
+
   An account treated this way is **added to the auto-reject list** — its new
   issues and pull requests are closed automatically on arrival, without review.
   Removal is by asking, and by not doing it again.
@@ -578,7 +590,14 @@ request from a non-maintainer:
   `approved`-label events in order and keeping the last one performed by an
   account that actually holds write access.
 
-A separate workflow, **Auto-reject list**, closes new issues and pull requests
+A separate workflow, **Submission rate limit**, closes an issue or pull request
+opened within 5 minutes of the same account's previous one, and flags a comment
+posted within 60 seconds of their previous one. Thresholds are repository
+variables (`RATE_MIN_GAP_ISSUES`, `RATE_MIN_GAP_PRS`, `RATE_MIN_GAP_COMMENTS`);
+setting one to `0` disables that surface. Write-access accounts and toolchain
+bots are exempt.
+
+A further workflow, **Auto-reject list**, closes new issues and pull requests
 from accounts whose intake has been capped under
 [Communication volume](#communication-volume). It does not touch comments or
 existing open work, and it never applies to anyone with write access.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,19 @@ is the scarcest resource here — scarcer than code. These rules exist because
 volume can cost more maintainer time than the contribution saves, however good
 the underlying work is.
 
+**Plainly, so nobody has to infer it: sustained spamming gets an account
+blocked.** A blocked account cannot comment, cannot open issues, and cannot
+submit pull requests — GitHub applies it to all three at once and to every
+repository owned by the maintainer. Existing contributions stay in the history;
+what ends is the ability to add more.
+
+That is the last step, and it is reserved for two things: continuing after a
+written request to stop, and programmatic submission of any kind. It is not for
+being prolific, not for being wrong, and not for disagreeing with the
+maintainer — people do all three here regularly and are welcome to. If you are
+reading this and wondering whether it applies to you, it almost certainly does
+not.
+
 - **One topic, one thread.** Post a point once, in the most relevant issue or
   PR. If it applies to several PRs, post it once and link to it. **Do not paste
   the same comment into multiple threads** — that turns one point into one
@@ -538,7 +551,9 @@ low-effort AI output consumes disproportionate reviewer time.
   reviewing it, please don't open the PR.**
 
 Good-faith first-timers who slip up will simply be pointed back here. Repeated,
-bad-faith, time-wasting submissions lead to being blocked from the project.
+time-wasting submissions lead to being blocked — see
+[Communication volume](#communication-volume) for what blocking means and the
+steps that come before it.
 
 ## Coding standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,10 @@ anti-newcomer and not anti-AI — we are anti-slop.
 - [The two rules that matter most](#the-two-rules-that-matter-most)
 - [Code of Conduct](#code-of-conduct)
 - [Before you open a pull request](#before-you-open-a-pull-request)
+- [Communication volume](#communication-volume)
 - [Development setup](#development-setup)
 - [Testing and regression requirements](#testing-and-regression-requirements)
+- [How review works, and when a PR is closed](#how-review-works-and-when-a-pr-is-closed)
 - [Test fixture policy](#test-fixture-policy)
 - [AI-assisted contributions](#ai-assisted-contributions)
 - [Coding standards](#coding-standards)
@@ -67,8 +69,51 @@ issue or contacting the maintainer.
   approach. Large features built without that agreement are frequently declined
   no matter how good the code is — the design, not the effort, is the sticking
   point.
-- For a **bug fix**, an issue is recommended but not required; the reproducer
-  (below) is what matters.
+- For a **bug fix**, open an issue too. It does not need discussion — a
+  reproducer and a one-line description are enough.
+
+**An issue must be approved *and assigned to you* before you open the PR.**
+Two separate things, both required, both checked automatically:
+
+1. **Approved by a maintainer.** Someone with write access to this repository
+   comments `/approve` on the issue, or applies the `approved` label. A reply, a
+   thumbs-up, or a question is *not* approval — approval is a deliberate act, so
+   that "a maintainer engaged with it" cannot be mistaken for "a maintainer
+   agreed to it".
+
+   **Approval from anyone without write access does not count**, in either form.
+   That includes the issue's own author and anyone with triage access who can
+   apply labels: the check verifies the approver's actual repository permission,
+   not their comment badge or their ability to set a label. Self-approval is not
+   a thing here.
+
+   Approval can be withdrawn later with `/unapprove`, or by removing the label;
+   the most recent maintainer act is the one that counts.
+2. **Assigned to you.** The maintainer assigns the issue to whoever will
+   implement it. Assignment is how work is claimed here: it stops two people
+   building the same fix, and it means the maintainer has agreed not just the
+   approach but who is doing it. An issue approved and assigned to someone else
+   is not yours to implement — say so in the issue and ask.
+
+If you want to work on something, say so in the issue and ask to be assigned.
+Opening a PR is not how you claim work.
+
+**A pull request that references no issue at all is closed automatically.**
+That is what the existing rule about drive-by PRs means in practice — work here
+starts from an approved, assigned issue, and opening a PR is not how work is
+claimed. Reference the issue in the **PR description** with `Closes #NNN` (not
+in the commit message — it survives rebases better there).
+
+**A PR whose linked issue is unapproved, or assigned to somebody else, fails its
+checks and is not reviewed** — but is left open, because that is usually a
+timing problem rather than a violation: the maintainer approving and assigning
+the issue is enough to clear it, with nothing for you to redo. This is not bureaucracy and it is not about
+trust — it costs a maintainer one line to say "go ahead" or "we'd fix that
+differently", and it costs you nothing compared with discovering the same thing
+after you have written the change and run a corpus sweep.
+
+- **Trivially exempt** from all of the above: typo and documentation fixes, CI
+  repairs, and reverts of your own merged work. Open those directly.
 - Reference the issue in the **PR description** with `Closes #NNN` (not in the
   commit message — it survives rebases better there).
 
@@ -76,13 +121,120 @@ issue or contacting the maintainer.
 correctness with performance. Grab-bag PRs are unreviewable and get split.
 Complete the change within the PR — no "finish it later" TODOs for new features.
 
-**3. Write the PR in your own words.** The description must explain *what
+**3. One open PR at a time per non-maintainer contributor.** Review is the
+scarcest resource on this project, not code. A second PR from the same author
+while an earlier one is still open **will be closed automatically**, with a link
+back to this section — reopen it once your first PR resolves (merged, closed, or
+superseded). This applies regardless of how the PRs were produced or how good
+the diagnosis behind them is: a burst of simultaneous PRs from one author costs
+far more reviewer time in aggregate than the same fixes landed one at a time,
+each actually verified before the next starts. Applies to every non-maintainer
+contributor equally, human or AI-assisted.
+
+- **Exceptions.** Documentation typos, CI fixes, and reverts of your own merged
+  work do not count against the limit.
+- **The maintainer may lift the limit** for a specific contributor or a specific
+  piece of work. Ask in the issue.
+- **Stacked or dependent work is one PR**, or opened one at a time in dependency
+  order. If a change is genuinely too large to review in one piece, say so in
+  the issue *first* and agree a split — do not open the split yourself as five
+  simultaneous PRs.
+
+If you have found several unrelated bugs, that is genuinely valuable — **open
+issues for them**. Issues cost the maintainer far less than open PRs, they do
+not rot against a moving `main`, and they let fixes be sequenced deliberately
+instead of competing at once. The diagnosis work (reproducer, root cause, spec
+citation) is valuable on its own, and a maintainer may pick it up directly.
+
+**4. Keep the PR small enough to review.** For changes to extraction, layout,
+rendering or font handling, a PR over roughly **400 changed lines** should be
+split, or should say in its description why it cannot be. These paths are
+heuristic and reviewed by reading, not by trusting the tests; past a few hundred
+lines that stops being possible. Size is also the best available predictor of a
+PR never landing at all.
+
+**5. Do not re-submit a closed PR's work as a new PR.** If an approach was
+declined, the way back in is an issue agreeing a different approach — not the
+same change under a new number.
+
+**6. Write the PR in your own words.** The description must explain *what
 problem you're solving and why this approach*. If you can't describe the change
 in your own words, it isn't ready.
 
-**4. Run the full local gate before pushing** (see
+**7. Run the full local gate before pushing** (see
 [CI gates](#continuous-integration-gates)) — a green subset is necessary, not
 sufficient.
+
+## Communication volume
+
+This project is maintained by one person in their free time. Reviewer attention
+is the scarcest resource here — scarcer than code. These rules exist because
+volume can cost more maintainer time than the contribution saves, however good
+the underlying work is.
+
+- **One topic, one thread.** Post a point once, in the most relevant issue or
+  PR. If it applies to several PRs, post it once and link to it. **Do not paste
+  the same comment into multiple threads** — that turns one point into one
+  notification per thread, and the maintainer reads all of them.
+- **No automated or scripted commenting.** Comments must be posted by a human,
+  one at a time.
+
+  **An account that posts faster than a person writes is treated as a bot**,
+  whatever is behind it. Concretely: several comments within a minute, or the
+  same text posted across multiple threads in one burst. Nobody composes
+  nineteen comments in eighteen seconds, and content does not change that — a
+  well-argued point delivered nineteen times is nineteen notifications, and the
+  maintainer reads all of them.
+
+  This is not a rule against using tools to help you write. It is a rule about
+  the *rate*: whatever produced them, a burst is machine output arriving at
+  machine speed into a queue served by one person.
+
+  An account treated this way is **added to the auto-reject list** — its new
+  issues and pull requests are closed automatically on arrival, without review.
+  Removal is by asking, and by not doing it again.
+- **Correct in place.** If a claim turns out to be wrong, edit the original
+  comment or post one correction. Do not stack successive revisions of the same
+  claim as new comments on the same thread.
+- **Measure before you post.** Do not report a finding, a regression, or a
+  stability claim you have not actually run. "I inferred it" costs the
+  maintainer a real investigation. Say plainly what you measured, on what, and
+  what you did not.
+- **Scope claims to your evidence.** A result from your corpus is a result from
+  your corpus. Do not present it as a property of this project's baseline, and
+  do not ask for work to be resequenced on evidence the maintainer cannot
+  reproduce.
+- **Prefer fewer, denser messages.** A single well-organised comment is worth
+  more than six partial ones. If you find yourself posting repeatedly to the
+  same PR in one day, collect it into one update instead.
+- **Do not use direct messages, email, or social media to chase a review.** The
+  PR thread is the channel. Out-of-band pressure to prioritise your work is not
+  acceptable.
+
+The same effort test from the previous section applies to conversation, not just
+code: **if reading your messages costs more than the problem they describe, they
+are a net loss to the project.**
+
+### When these are not followed
+
+In order, and proportionate to what actually happened:
+
+1. Duplicate or cross-posted comments are hidden as off-topic.
+2. A single written request to consolidate.
+3. **Auto-reject.** The account is added to the auto-reject list: new issues and
+   pull requests are closed on arrival with a pointer to this section. Existing
+   open work is not touched, and commenting still works — this caps intake
+   without ending the conversation.
+4. Interaction limits on the repository.
+5. **Blocking.** A blocked account cannot open issues, comment, or submit pull
+   requests, and open contributions from it may be closed unmerged.
+
+Steps 1 and 2 are skipped for automated posting: a burst goes straight to step 3,
+because there is no point asking a script to slow down.
+
+Good-faith contributors who overdo it will simply be asked once. Blocking is for
+sustained volume after a request, or for automated posting — not for being
+enthusiastic, and not for disagreeing with the maintainer.
 
 ## Development setup
 
@@ -122,10 +274,14 @@ merge code that isn't tested** (à la qpdf), and **a bug-fix test must fail
 before your change and pass after** (à la pdfplumber/pypdf). Concretely:
 
 ### 1. Every bug fix ships a regression test that fails without the fix
-Add the test in a commit **before** the fix commit (or otherwise be ready to
-show it goes red when the fix is reverted). Reviewers verify this. A test that
-passes even when the feature is a no-op is worse than no test — it gives false
-confidence.
+Add the test in a commit **before** the fix commit, so that checking out the
+fix commit's parent and running the new test shows it red. Reviewers verify
+this, and CI checks it. A test that passes even when the feature is a no-op is
+worse than no test — it gives false confidence.
+
+Ordering the other way round ("the test is in there, revert the fix and you'll
+see") moves the work to the reviewer, who then performs the revert-and-rerun by
+hand on every PR. One commit ordering on your side removes that entirely.
 
 ### 2. Build the reproducer as a minimal *synthetic* PDF, in code
 Construct the smallest PDF that triggers the defect as bytes inside the test —
@@ -180,7 +336,36 @@ result.
 The maintainer runs the authoritative private-corpus sweep before merge — a
 clean sweep on your own corpus is necessary but not sufficient.
 
-### 4. Green across the whole feature matrix, not just `cargo test`
+### 4. If your change *broadens* something, a corpus sweep cannot validate it
+A sweep compares your branch against `main` and reports what moved. That
+measures **change**, not correctness — and for one specific class of change it is
+actively misleading.
+
+If your change causes more data to be collected, matched, or retained than
+before — first-match becomes all-matches, a filter is removed, a `break` is
+deleted, a guard is loosened, a lookup drops part of a composite key — then
+everything it *wrongly* picks up appears in the sweep as **more output**. More
+extracted text reads as recovered content. A word-count or Jaccard comparison
+cannot tell "recovered the run we were wrongly dropping" from "absorbed a run
+that belongs to something else". Both are gains.
+
+So for any broadening change you must **additionally** supply a fixture in which
+the broadened operation would pick up something it should not, and show that it
+does not:
+
+- a **colliding identifier** — the same id legitimately used by two different
+  scopes (a page and a Form XObject may each define marked-content id 0; a
+  cross-reference stream and an object stream may each define object 4)
+- a **duplicate key** — the same key present twice with different values
+- an **out-of-scope match** — data that satisfies the loosened predicate but
+  belongs to a different structure, page, or content stream
+
+Build it synthetically per §2, and state in the PR what the fixture would have
+collected without the guard. A clean sweep plus "no test for the collision case"
+is not evidence; it is the absence of evidence in exactly the place the defect
+would be.
+
+### 5. Green across the whole feature matrix, not just `cargo test`
 Default `cargo test` does **not** compile the rendering, FIPS, OCR, or binding
 tiers, and PRs regularly break exactly those. Run the tiers your change touches:
 ```bash
@@ -190,11 +375,49 @@ cargo test --features ml               # OCR / table detection
 # plus the relevant binding when you touch the C ABI (python / wasm / go / …)
 ```
 
-### 5. Prefer semantic, tolerant comparison over byte-exact goldens
+### 6. Prefer semantic, tolerant comparison over byte-exact goldens
 Compare extracted text/structure with whitespace/newline **normalization**.
 For any rendered-pixel check, use a bounded per-channel tolerance at a fixed DPI
 — never byte-exact; rendering is font- and platform-fragile. New parsing/decoding
 paths should add a property-based or fuzz test where practical.
+
+## How review works, and when a PR is closed
+
+Review here is one person reading a change carefully. It is not a loop in which
+the maintainer finds the problems and the contributor fixes them until the PR is
+acceptable — that inverts the cost, and it is how a single PR consumes a week.
+
+**What you send is expected to be complete.** CI checks the most mechanical
+part of this for you — a `fix:` or `feat:` PR that adds no test fails before a
+human looks at it — but the rest is on you. The requirements above are
+published in advance: a regression test that fails without the fix, evidence of
+no corpus regression, and — for a change that broadens what is collected — a
+fixture proving it does not over-collect. A PR missing any of these has not been
+reviewed and then rejected; it was **incomplete on arrival**, and may be closed
+without a detailed review. Reopen it when it is complete. This is the "effort
+test" from the AI-assisted section applied to review time.
+
+**Repeated findings of the same kind end the review.** Review rounds are for
+things neither of us could have anticipated. If the *same class* of problem has
+to be raised twice — still no regression test, a claim still not measured,
+unrelated changes still bundled in, a gate still failing — the PR is closed. A
+*different* problem found in a later round is normal and is not counted.
+
+This is deliberately about *repetition*, not about being wrong. Getting a hard
+change wrong is expected and is what review is for. Having to be told the same
+thing twice means the checklist was not applied, and the second telling costs
+the maintainer as much as the first.
+
+**Other reasons a PR is closed**, so none of these are a surprise:
+
+- It references no issue, or the issue is not approved and assigned to you.
+- It is a second concurrently-open PR from the same author.
+- It sits in "changes requested" without a response.
+- Its work is a re-submission of an approach already declined.
+
+None of these is a judgement about you or about the underlying diagnosis, and
+none is permanent. Closing a pull request costs nothing to undo; a review cycle
+cannot be undone at all, which is the asymmetry all of this exists to manage.
 
 ## Test fixture policy
 
@@ -223,10 +446,33 @@ low-effort AI output consumes disproportionate reviewer time.
   wrote it" is not an answer to a review question. If you can't explain the
   change without the AI, don't submit it.
 - **Write your issues, PR descriptions, and review replies yourself**, in your
-  own words. Don't paste AI-generated prose as your description.
-- **Disclose AI assistance** in the PR (which tool, and how much). You — the
-  human author — remain fully responsible for the code's correctness, licensing,
-  and provenance regardless of how it was produced.
+  own words — this covers *everything you write to a person*, not just the PR
+  body: issue text, PR descriptions, review comments, and replies in a thread.
+  Do not paste AI-generated prose into a conversation.
+
+  This is not a style preference. Generated prose is fast to produce and slow to
+  read, and it is usually longer, more confident, and less specific than what
+  the same person would have written. The maintainer then has to read all of it
+  and work out which parts are load-bearing. A three-line answer in your own
+  words is worth more here than six paragraphs, and is far more likely to be
+  acted on.
+- **Disclose AI assistance** with a commit trailer naming the tool:
+
+  ```
+  Assisted-by: claude-code
+  ```
+
+  The model is not interesting and you do not need to name it — any model can
+  produce work that is not ready, and naming one neither excuses nor condemns
+  the change. What matters is that a person is answerable for it. Say in the PR
+  description how much of the change it produced. You — the human
+  author — remain fully responsible for the code's correctness, licensing, and
+  provenance regardless of how it was produced.
+- **An AI agent may not sign off a commit.** `Signed-off-by:` is the Developer
+  Certificate of Origin: a statement by a person that they have the right to
+  contribute the code. A tool cannot make that certification, so the sign-off is
+  yours and the responsibility that comes with it is yours. Use `Assisted-by:`
+  for the tool, never `Signed-off-by:` or `Co-authored-by:`.
 - **AI-generated code must be verified on real input you actually ran.** For this
   project that means: include the synthetic reproducer and the corpus-sweep
   result. Do not submit hypothetically-correct code you haven't executed.
@@ -272,6 +518,35 @@ mandatory floor mirrors what you should run locally:
 - `audit` / `deny` / `geiger` (advisories, licenses, `unsafe` surface)
 - `fixture-hygiene` (no third-party fixtures), `taplo`/`shear` (TOML/unused deps)
 - `dco` (sign-off), plus the per-binding jobs (python, wasm, go, csharp, java, …)
+
+Two of these are **intake gates**, run by `PR quality gates` on every pull
+request from a non-maintainer:
+
+- **One open PR per contributor** — a second concurrently-open PR is closed
+  automatically with a link to the rule.
+- **Linked issue is approved and assigned to you** — **closes** the PR if it
+  references no issue at all; **fails** it (leaving it open) if the issue exists
+  but nobody with write access has approved it, or if it is assigned to somebody
+  else. A PR that mentions an issue without a closing keyword is failed, not
+  closed, with a note to use `Closes #NNN`. Approval is resolved by replaying `/approve`, `/unapprove` and
+  `approved`-label events in order and keeping the last one performed by an
+  account that actually holds write access.
+
+A separate workflow, **Auto-reject list**, closes new issues and pull requests
+from accounts whose intake has been capped under
+[Communication volume](#communication-volume). It does not touch comments or
+existing open work, and it never applies to anyone with write access.
+
+A third gate applies to everyone, maintainers included:
+
+- **Change ships a test** — a `fix:` or `feat:` PR must add at least one new
+  `#[test]`. Inline `#[cfg(test)]` tests count exactly as much as files under
+  `tests/`. If a change genuinely cannot be tested — a pure refactor, or a defect
+  only reproducible on a document that cannot be shared — say so in the
+  description and a maintainer will waive it.
+
+Drafts are exempt from all three. The two intake gates additionally exempt
+`docs:`, `ci:`, `chore:` and `revert:` titles, and anyone with write access.
 
 ## Commits, DCO, and review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ anti-newcomer and not anti-AI — we are anti-slop.
 
 ## Table of Contents
 
+- [Who depends on this](#who-depends-on-this)
 - [The two rules that matter most](#the-two-rules-that-matter-most)
 - [Code of Conduct](#code-of-conduct)
 - [Before you open a pull request](#before-you-open-a-pull-request)
@@ -29,6 +30,33 @@ anti-newcomer and not anti-AI — we are anti-slop.
 - [License](#license)
 
 ---
+
+## Who depends on this
+
+Worth knowing before you read the rules, because it is where they come from.
+
+PDFOxide is a production dependency of projects with a combined **195,000+
+GitHub stars** — RAG engines, collaborative editors, AI coding agents,
+document-intelligence frameworks, and arXiv.org's own submission pipeline. The
+[Notable Users](README.md#notable-users) list in the README is verified against
+each project's public dependency manifest.
+
+It is also a library people can simply use. MIT/Apache-2.0, `cargo add` or
+`pip install`, no account, no API key, no telemetry, no hosted service in the
+path, no usage tier that expires. That is deliberate and we intend to keep it —
+a PDF toolkit that phones home is not a PDF toolkit anybody should build on.
+
+Both facts have the same consequence for contributions. A defect here does not
+surface as a failed build in one place; it surfaces as wrong text inside someone
+else's product, on a document neither of us has seen, with no error and nothing
+to alert them. Extraction fails *silently* — that is the whole difficulty of
+this domain. There is no telemetry to catch it and no server-side fix to push
+afterwards; whatever ships is what runs, in every downstream product, until the
+next release.
+
+So the bar here is higher than "the tests pass", and the rules below are the
+practical form of that bar rather than ceremony. They are also why a review can
+take a while: the maintainer is checking the thing that CI structurally cannot.
 
 ## The two rules that matter most
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,21 @@ the underlying work is.
   the *rate*: whatever produced them, a burst is machine output arriving at
   machine speed into a queue served by one person.
 
+- **The same rate limit applies to submissions, not just comments.** Issues and
+  pull requests opened in bursts — several within a minute, or an issue and the
+  pull request that closes it created seconds apart — are treated the same way.
+
+  An issue filed moments before its own PR is not a proposal anyone could have
+  responded to; it is paperwork generated alongside the code. The point of
+  opening an issue first is that a maintainer gets a chance to say "yes",
+  "not like that", or "we already fixed it upstream" *before* anyone writes the
+  change. Filing both at once removes that chance while appearing to follow the
+  rule, and it is why an issue now needs an explicit approval and an assignment
+  before its PR is opened.
+
+  Again this is about rate, not tooling. Generate the work however you like;
+  submit it at a rate a person can respond to.
+
   An account treated this way is **added to the auto-reject list** — its new
   issues and pull requests are closed automatically on arrival, without review.
   Removal is by asking, and by not doing it again.
@@ -252,10 +267,13 @@ In order, and proportionate to what actually happened:
 3. **Auto-reject.** The account is added to the auto-reject list: new issues and
    pull requests are closed on arrival with a pointer to this section. Existing
    open work is not touched, and commenting still works — this caps intake
-   without ending the conversation.
+   without ending the conversation. It is not permanent: ask, and it comes off.
 4. Interaction limits on the repository.
-5. **Blocking.** A blocked account cannot open issues, comment, or submit pull
-   requests, and open contributions from it may be closed unmerged.
+5. **Blocking.** A blocked account cannot comment, open issues, or submit pull
+   requests — all three surfaces at once — and open contributions from it may be
+   closed unmerged. This is the end of the ladder, not a first response: it is
+   for sustained volume after a written request, or for programmatic submission,
+   and it is the only step that is not trivially reversible.
 
 Steps 1 and 2 are skipped for automated posting: a burst goes straight to step 3,
 because there is no point asking a script to slow down.

--- a/README.md
+++ b/README.md
@@ -402,13 +402,15 @@ cargo build --release --lib
 
 ## Notable Users
 
-Projects using PDFOxide in production (verified against their public dependency manifests):
+PDFOxide is a production dependency of projects with a combined **195,000+ GitHub stars**, spanning RAG engines, collaborative editors, AI coding agents, document-intelligence frameworks, and arXiv.org's own submission pipeline. Every entry below is verified against that project's public dependency manifest — no self-reported logos, no "trusted by" wall.
 
-- **[RAGFlow](https://github.com/infiniflow/ragflow)** (85k★) — one of the most popular open-source RAG engines; PDFOxide is the primary PDF engine in its `deepdoc` parsing pipeline ([go.mod](https://github.com/infiniflow/ragflow/blob/main/go.mod))
-- **[AFFiNE](https://github.com/toeverything/AFFiNE)** (70k★) — open-source Notion/Miro alternative; powers document extraction via AFFiNE's own [`doc_extractor`](https://crates.io/crates/doc_extractor) crate ([Cargo.toml](https://github.com/toeverything/AFFiNE/blob/canary/Cargo.toml))
-- **[grok-build](https://github.com/xai-org/grok-build)** (19k★) — xAI's coding-agent TUI; uses PDFOxide's rendering feature to read PDFs in a repo ([Cargo.toml](https://github.com/xai-org/grok-build/blob/main/Cargo.toml))
-- **[Xberg](https://github.com/xberg-io/xberg)** (formerly kreuzberg, 8.7k★) — polyglot document-intelligence framework; PDFOxide is its architectural PDF engine ([Cargo.toml](https://github.com/xberg-io/xberg/blob/main/Cargo.toml))
-- **[create-context-graph](https://github.com/neo4j-labs/create-context-graph)** (Neo4j Labs) — GraphRAG context-builder; PDFOxide is its primary PDF parser ([pyproject.toml](https://github.com/neo4j-labs/create-context-graph/blob/main/pyproject.toml))
+Star counts checked 2026-08-21:
+
+- **[RAGFlow](https://github.com/infiniflow/ragflow)** (89k★) — one of the most popular open-source RAG engines; PDFOxide is the primary PDF engine in its `deepdoc` parsing pipeline ([go.mod](https://github.com/infiniflow/ragflow/blob/main/go.mod))
+- **[AFFiNE](https://github.com/toeverything/AFFiNE)** (71.7k★) — open-source Notion/Miro alternative; powers document extraction via AFFiNE's own [`doc_extractor`](https://crates.io/crates/doc_extractor) crate ([Cargo.toml](https://github.com/toeverything/AFFiNE/blob/canary/Cargo.toml))
+- **[grok-build](https://github.com/xai-org/grok-build)** (25.8k★) — xAI's coding-agent TUI; uses PDFOxide's rendering feature to read PDFs in a repo ([Cargo.toml](https://github.com/xai-org/grok-build/blob/main/Cargo.toml))
+- **[Xberg](https://github.com/xberg-io/xberg)** (formerly kreuzberg, 9.2k★) — polyglot document-intelligence framework; PDFOxide is its architectural PDF engine ([Cargo.toml](https://github.com/xberg-io/xberg/blob/main/Cargo.toml))
+- **[create-context-graph](https://github.com/neo4j-labs/create-context-graph)** (Neo4j Labs, 712★) — GraphRAG context-builder; PDFOxide is its primary PDF parser ([pyproject.toml](https://github.com/neo4j-labs/create-context-graph/blob/main/pyproject.toml))
 - **[arXiv submission-tools](https://github.com/arXiv/submission-tools)** — arXiv.org's own PDF validation and LaTeX-to-PDF submission pipeline
 
 Using PDFOxide in production? [Open an issue](https://github.com/yfedoseev/pdf_oxide/issues/new) to be added here.

--- a/README.md
+++ b/README.md
@@ -402,14 +402,13 @@ cargo build --release --lib
 
 ## Notable Users
 
-PDFOxide is a production dependency of projects with a combined **195,000+ GitHub stars**, spanning RAG engines, collaborative editors, AI coding agents, document-intelligence frameworks, and arXiv.org's own submission pipeline. Every entry below is verified against that project's public dependency manifest — no self-reported logos, no "trusted by" wall.
+PDFOxide is a production dependency of RAG engines, collaborative editors, AI coding agents, and arXiv.org's own submission pipeline. Every entry below is verified against that project's public dependency manifest — no self-reported logos, no "trusted by" wall.
 
 Star counts checked 2026-08-21:
 
 - **[RAGFlow](https://github.com/infiniflow/ragflow)** (89k★) — one of the most popular open-source RAG engines; PDFOxide is the primary PDF engine in its `deepdoc` parsing pipeline ([go.mod](https://github.com/infiniflow/ragflow/blob/main/go.mod))
 - **[AFFiNE](https://github.com/toeverything/AFFiNE)** (71.7k★) — open-source Notion/Miro alternative; powers document extraction via AFFiNE's own [`doc_extractor`](https://crates.io/crates/doc_extractor) crate ([Cargo.toml](https://github.com/toeverything/AFFiNE/blob/canary/Cargo.toml))
 - **[grok-build](https://github.com/xai-org/grok-build)** (25.8k★) — xAI's coding-agent TUI; uses PDFOxide's rendering feature to read PDFs in a repo ([Cargo.toml](https://github.com/xai-org/grok-build/blob/main/Cargo.toml))
-- **[Xberg](https://github.com/xberg-io/xberg)** (formerly kreuzberg, 9.2k★) — polyglot document-intelligence framework; PDFOxide is its architectural PDF engine ([Cargo.toml](https://github.com/xberg-io/xberg/blob/main/Cargo.toml))
 - **[create-context-graph](https://github.com/neo4j-labs/create-context-graph)** (Neo4j Labs, 712★) — GraphRAG context-builder; PDFOxide is its primary PDF parser ([pyproject.toml](https://github.com/neo4j-labs/create-context-graph/blob/main/pyproject.toml))
 - **[arXiv submission-tools](https://github.com/arXiv/submission-tools)** — arXiv.org's own PDF validation and LaTeX-to-PDF submission pipeline
 


### PR DESCRIPTION
Housekeeping across contribution policy, the CI that enforces it, and the README's user list. Grouped as one change because none of it is independently interesting and it is all maintainer-side.

## `CONTRIBUTING.md`

Consolidates three separately-drafted policy branches and fills the gaps they left.

- **Who depends on this** — placed ahead of the rules, so they read as consequences rather than ceremony. The library ships with no account, no API key and no telemetry, so there is nothing to detect a defect in the field and nothing to hot-fix afterwards; whatever ships is what runs downstream until the next release.
- **One open PR at a time** per non-maintainer contributor, with exceptions for typos, CI fixes and reverts, and a maintainer override.
- **An issue must be approved and assigned before its PR.** Approval is an explicit act — `/approve` from an account with write access, or the `approved` label — resolved by replaying approve/unapprove events and keeping the last one by a write-access account. Self-approval is not possible; triage access is not enough.
- **Bug fixes need an issue too.** The old "recommended but not required" exemption was the gap everything went through.
- **Keep PRs reviewable** — over ~400 changed lines on extraction, layout, rendering or font paths should be split or justified.
- **Test commit before fix commit**, required outright. The previous escape hatch moved the revert-and-rerun to the reviewer on every PR.
- **Broadening changes cannot be validated by a corpus sweep.** If a change collects, matches or retains more than before, everything it wrongly picks up appears as *more output* — and more extracted text reads as recovered content. Such changes must additionally ship a fixture where the broadened lookup would collect something it should not.
- **Communication volume**, with a proportionate ladder and a plain statement of what blocking means.

## Workflows

- `pr-quality.yml` gains `one-open-pr`, `accepted-issue` and `has-test`. The first two decide on mechanical facts and cost no maintainer time; `has-test` requires a `fix:`/`feat:` PR to add at least one `#[test]`, counting inline `#[cfg(test)]` tests equally.
- `submission-rate.yml` (new) — 5 minutes between issues or pull requests from one account, 60 seconds between comments. Comments get the shorter window deliberately: answering three review threads in five minutes is ordinary participation. Thresholds are repository variables; `0` disables a surface.
- `auto-reject.yml` (new) — closes new issues and PRs from accounts on a list held in a repository variable rather than a file in the repo, so there is no public register of names.

Write access, drafts, and `docs:`/`ci:`/`chore:`/`revert:` titles are exempt from the intake gates. Nothing here is destructive: closed items reopen once a gap passes, comments are only annotated.

## `README.md`

- Notable Users star counts refreshed from the API and dated — `grok-build` was listed at 19k against 25.8k actual.
- **Xberg removed.** Its workspace manifest now reads `pdf_oxide = { package = "xberg-pdf-oxide", version = "1.0.1" }`, so it depends on its own fork. The section promises every entry is verified against that project's public manifest, and this one no longer was.
- Dropped the aggregate star figure — one fewer number to go stale.

## Type of change

- [x] Docs / CI / chore

## Tests

Not applicable. All three workflows parse as YAML and every embedded `github-script` block passes `node --check`. `CONTRIBUTING.md`'s table of contents was verified to have no broken anchors.
