### PR TITLE
ci: stop the intake gates rejecting work they should not

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -122,6 +122,34 @@ jobs:
             if (pr.draft) return;   // drafts are not asking for review yet
             // Trivial classes named in CONTRIBUTING as not counting.
             if (/^(docs|ci|chore|revert)(\(|:)/i.test(pr.title || '')) return;
+            // These intake rules took effect when CONTRIBUTING.md landed. A PR
+            // opened before that could not have complied with them, so applying
+            // them retroactively rejects work for failing a rule that did not
+            // exist. Exempt anything older than the policy.
+            const POLICY_EPOCH = Date.parse('2026-08-22T08:45:07Z');
+            if (Date.parse(pr.created_at) < POLICY_EPOCH) {
+              core.notice('PR predates the intake policy — exempt.');
+              return;
+            }
+
+            // Post-once guard. These jobs re-run on every reopen and edit; without
+            // it a contributor who reopens after correcting the PR is told the same
+            // thing again. Never say the same thing twice on one PR.
+            const sayOnce = async (marker, body) => {
+              const prior = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pr.number, per_page: 100,
+              });
+              if (prior.some(c => (c.body || '').includes(marker))) {
+                core.notice('Already commented on this PR — not repeating.');
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pr.number,
+                body: body + '\n\n<!-- ' + marker + ' -->',
+              });
+            };
 
             const others = (await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
@@ -137,11 +165,7 @@ jobs:
             if (!others.length) return;
 
             const list = others.map(p => '#' + p.number).join(', ');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: [
+            await sayOnce('pr-quality:one-open-pr', [
                 'Closing automatically: this project allows **one open pull request at a time**',
                 'per non-maintainer contributor, and you already have ' + others.length + ' open (' + list + ').',
                 '',
@@ -156,8 +180,7 @@ jobs:
                 '',
                 'See [One open PR at a time](https://github.com/' + context.repo.owner + '/' +
                   context.repo.repo + '/blob/main/CONTRIBUTING.md#before-you-open-a-pull-request).',
-              ].join('\n'),
-            });
+            ].join('\n'));
             await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -178,10 +201,48 @@ jobs:
             if (pr.draft) return;
             if (/^(docs|ci|chore|revert)(\(|:)/i.test(pr.title || '')) return;
 
+            // These intake rules took effect when CONTRIBUTING.md landed. A PR
+            // opened before that could not have complied with them, so applying
+            // them retroactively rejects work for failing a rule that did not
+            // exist. Exempt anything older than the policy.
+            const POLICY_EPOCH = Date.parse('2026-08-22T08:45:07Z');
+            if (Date.parse(pr.created_at) < POLICY_EPOCH) {
+              core.notice('PR predates the intake policy — exempt.');
+              return;
+            }
+
+            // Post-once guard. These jobs re-run on every reopen and edit; without
+            // it a contributor who reopens after correcting the PR is told the same
+            // thing again. Never say the same thing twice on one PR.
+            const sayOnce = async (marker, body) => {
+              const prior = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pr.number, per_page: 100,
+              });
+              if (prior.some(c => (c.body || '').includes(marker))) {
+                core.notice('Already commented on this PR — not repeating.');
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pr.number,
+                body: body + '\n\n<!-- ' + marker + ' -->',
+              });
+            };
+
             const author = pr.user && pr.user.login;
             const body = pr.body || '';
+            // GitHub honours several closing forms, including a full issue URL
+            // (`Closes https://github.com/o/r/issues/12`), which closes the issue
+            // on merge exactly as `Closes #12` does. Matching only the short form
+            // rejects a correctly-linked PR.
+            const CLOSING = new RegExp(
+              '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+' +
+              '(?:#|GH-|https?://github\\.com/[\\w.-]+/[\\w.-]+/issues/)(\\d+)',
+              'gi',
+            );
             const refs = [...new Set(
-              [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)].map(m => parseInt(m[1], 10))
+              [...body.matchAll(CLOSING)].map(m => parseInt(m[1], 10))
             )];
 
             const docs = 'https://github.com/' + context.repo.owner + '/' + context.repo.repo +
@@ -200,11 +261,7 @@ jobs:
                   'closes on merge and this check can find it. See ' + docs
                 );
               }
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: [
+              await sayOnce('pr-quality:linked-issue', [
                   'Closing automatically: this PR does not reference an issue.',
                   '',
                   'Work here starts from an issue that a maintainer has approved and assigned —',
@@ -221,8 +278,7 @@ jobs:
                   'Typo, documentation, CI and revert PRs are exempt and can be opened directly.',
                   '',
                   'See [Before you open a pull request](' + docs + ').',
-                ].join('\n'),
-              });
+              ].join('\n'));
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
Three defects in the gates added by #1112. All three hit one contributor within a day of the policy landing, closing two of her PRs — one for "does not reference an issue" when it did, the other for a rule that post-dated it by weeks.

## 1. Only one closing form was recognised

```js
/(?:closes|fixes|resolves)\s+#(\d+)/gi
```

GitHub also honours a full issue URL — `Closes https://github.com/owner/repo/issues/12` — which closes the issue on merge exactly as `Closes #12` does. A PR using that form was told it had not linked an issue, and closed.

Now accepts `#`, `GH-`, and the full URL, plus the past-tense forms GitHub allows (`closed`, `fixed`, `resolved`). Verified against eight cases — including that a bare `Closes #` placeholder and a passing mention (`see #794 for background`) still correctly do **not** match, so the gate keeps its teeth.

## 2. The gates applied retroactively

They fire on `opened`/`reopened`/`synchronize` with no notion of when the policy began. Every PR opened before CONTRIBUTING.md landed was therefore one push away from being auto-closed for failing a rule that did not exist when it was written — and since those PRs are mostly `BEHIND` or `DIRTY`, pushing is exactly what has to happen next.

At the time this was written that was **every open PR in the repo**, including the only approved one.

Both gates now exempt anything created before the policy commit's timestamp. The rules apply in full to everything opened from here.

## 3. They repeated themselves

Re-running on reopen, the same rejection was posted again to a contributor who had just explained why it was wrong. Both rejection comments now route through a `sayOnce` helper that checks for its own HTML marker before posting. Nothing says the same thing twice on one PR.

## What does not change

One open PR at a time, and issue-first, both still stand and still apply to new work. What changes is that the gates no longer reject work for failing a rule it predates, no longer misread a valid issue link, and no longer argue with someone who is right.

## Verification

- `yaml.safe_load` on the workflow, and `node --check` on every embedded `github-script` block
- Regex unit-tested against 8 positive and negative cases
- Epoch checked against the real creation dates of #908, #967, #976, #1097 — all exempt — and a future date, gated