### PR TITLE
docs: fork guidance, a reporting channel, and conduct/volume separated

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,11 +56,39 @@ Examples of representing our community include using an official e-mail address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
+## Additional project rules
+
+_This section is specific to pdf_oxide. The Contributor Covenant text above is
+unmodified._
+
+This document governs **conduct**. Contribution volume and submission rate are
+governed separately, by
+[CONTRIBUTING.md → Communication volume](CONTRIBUTING.md#communication-volume).
+
+They are two ladders with different triggers, and they do not overlap. A rate
+limit, an auto-reject, or a block applied for **volume** is a resource-management
+measure: it reflects what one maintainer can review, and carries no implication
+about a contributor's conduct, good faith, or the quality of their work. It is
+not a finding under this Code of Conduct and should not be described or appealed
+as one. Conversely, nothing in the volume rules is a substitute for this
+document: being within the rate limits does not license behaviour the standards
+above prohibit.
+
+When a limit is applied, the notice will say which of the two it comes from.
+
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement.
+reported privately to the maintainer at **yfedoseev@gmail.com**. If you are
+reporting someone else's behavior, use that address rather than a public issue —
+reporting should not cost you your privacy, and it should not try the matter in
+public before it has been looked at.
 All complaints will be reviewed and investigated promptly and fairly.
+
+This does not restrict a maintainer from stating a moderation decision, or the
+reason for one, in the thread it concerns; nor does it stop anyone from saying
+plainly and civilly, in the moment, that something was not acceptable. What
+belongs in private is a report **about** a person.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,16 @@ issue" step (rule 1) — but never rule 2.
 ## Code of Conduct
 
 This project adheres to the [Contributor Covenant](CODE_OF_CONDUCT.md). By
-participating you agree to uphold it. Report unacceptable behavior by opening an
-issue or contacting the maintainer.
+participating you agree to uphold it. To report someone else's behavior, email
+the maintainer at **yfedoseev@gmail.com** rather than opening a public issue.
+That applies to reports about a person; it does not stop anyone — maintainer
+included — from addressing something directly and civilly in the thread where it
+happened.
+
+Conduct is governed there. **Contribution volume and submission rate are governed
+by [Communication volume](#communication-volume) below**, and the two are
+separate: a rate limit or an intake cap reflects what one maintainer can review,
+not a judgement about your conduct or your work.
 
 ## Before you open a pull request
 
@@ -192,6 +200,15 @@ in your own words, it isn't ready.
 **7. Run the full local gate before pushing** (see
 [CI gates](#continuous-integration-gates)) — a green subset is necessary, not
 sufficient.
+
+**8. Disclose a material downstream interest.** If you maintain a fork of this
+project, or a product that vendors it, say so in the PR description. Forking is
+permitted — see [TRADEMARKS.md](TRADEMARKS.md) and [FORKS.md](FORKS.md) — and
+downstream maintainers are often the best contributors here, because they run
+this code against real documents at volume. This is a disclosure, not a
+restriction, and it does not affect whether a change is accepted. It exists so
+review effort can be weighed with the full picture visible, and so nobody has to
+infer a relationship later.
 
 ## Communication volume
 

--- a/FORKS.md
+++ b/FORKS.md
@@ -1,0 +1,62 @@
+# Forking PDFOxide
+
+PDFOxide is dual-licensed `MIT OR Apache-2.0`. **Forking is allowed, and this
+page is not an argument against it.** Forks exist for good reasons — a different
+release cadence, a smaller build, a feature we declined, a product that needs the
+engine on its own terms. This page says what the licence requires, what the
+trademark policy requires, and what you can and cannot expect from us afterwards.
+
+This project does **not** maintain a register of forks, and does not rank,
+endorse or comment on them.
+
+## What the licence requires
+
+You may fork, modify, relicense under either arm of the dual offer, and ship
+commercially, with no obligation to contribute anything back.
+
+- **Keep the copyright notice.** Both licences require it. Retain the existing
+  `Copyright (c) … Yury Fedoseev` line in your `LICENSE` and add your own
+  alongside it — do not replace it.
+- **If you elect Apache-2.0**, §4(d) additionally requires you to carry forward
+  the attribution notices in [NOTICE](NOTICE). Electing MIT instead is permitted
+  and removes that requirement; either arm is a valid choice.
+- **Vendored third-party code carries its own terms.** If you keep our vendored
+  components and bundled fonts, keep their licences with them.
+
+## What the trademark policy requires
+
+The code is open source; the name is not. See [TRADEMARKS.md](TRADEMARKS.md) for
+the full policy. In short:
+
+- **Give it a different name** — one that does not contain "PDFOxide",
+  "pdf_oxide" or "pdf-oxide" as a component, prefix and suffix included.
+- **Say it is not the official project.** A line in your README is enough.
+- You may accurately describe it as *"a fork of PDFOxide"* or *"derived from
+  PDFOxide"*. That is explicitly permitted and is not something you need to ask
+  about.
+
+None of this is adversarial. The policy exists so a user who types the official
+package name gets the official package — the same protection your own fork's name
+will give your users.
+
+## What to expect from us
+
+- **We support only the official distributions**: the `pdf_oxide` crate and the
+  first-party bindings published from this repository. If you are running a fork
+  and something misbehaves, its maintainer is the right place to start — we
+  cannot reproduce against code we do not ship.
+- **Bug reports must reproduce against an official release.** A report against a
+  fork's build tells us nothing actionable about ours.
+- **Security reports are the exception.** If you find something in forked code
+  that plausibly also affects us, report it under [SECURITY.md](SECURITY.md) and
+  we will treat it as ours until shown otherwise.
+
+## Sending fixes back
+
+Fixes are welcome and are the cheapest way to stop carrying a patch set. Normal
+rules apply — see [CONTRIBUTING.md](CONTRIBUTING.md) — with one addition: say in
+the PR that you maintain a fork. That is a disclosure, not a restriction, and it
+does not affect whether a change is accepted.
+
+If you would rather not open pull requests, an issue with a reproducer and a root
+cause is genuinely valuable on its own, and often more so than a patch.

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ If it's useful to you, a star on GitHub genuinely helps. If something's broken o
 
 The **code** is dual-licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) at your option. Unlike AGPL-licensed alternatives, pdf_oxide can be used freely in any project — commercial or open-source — with no copyleft restrictions.
 
-The **name and brand** are not covered by the code license: **"PDFOxide"** (the product name) and **"pdf_oxide"** (the package name), together with any associated logo, are trademarks of Yury Fedoseev. You may say your product "uses PDFOxide"; please don't name a different or modified product "PDFOxide" or "pdf_oxide". See [TRADEMARKS.md](TRADEMARKS.md).
+The **name and brand** are not covered by the code license: **"PDFOxide"** (the product name) and **"pdf_oxide"** (the package name), together with any associated logo, are trademarks of Yury Fedoseev. You may say your product "uses PDFOxide"; please don't name a different or modified product "PDFOxide" or "pdf_oxide". See [TRADEMARKS.md](TRADEMARKS.md), and [FORKS.md](FORKS.md) if you are forking.
 
 © 2025–2026 Yury Fedoseev and the PDFOxide contributors. Contributions are accepted under the project's [DCO](CONTRIBUTING.md#commits-dco-and-review) and [CLA](CLA.md); contributors retain ownership of their work.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,10 @@ We take the security of pdf_oxide seriously. If you believe you have found a sec
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please email security reports to the maintainers. You can find contact information in [CONTRIBUTING.md](CONTRIBUTING.md).
+Instead, please email security reports to **yfedoseev@gmail.com**, or open a
+private advisory through GitHub's
+[Security Advisories](https://github.com/yfedoseev/pdf_oxide/security/advisories/new)
+form.
 
 ### What to Include
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -44,6 +44,15 @@ distribute a modified version, please give it a **different name** and make clea
 it is not the official PDFOxide. You may still say it is *"a fork of PDFOxide"* or
 *"derived from PDFOxide"*.
 
+A **different name** means one that does not contain "PDFOxide", "pdf_oxide" or
+"pdf-oxide" as a component — including as a prefix or a suffix. `acme-pdf-oxide`
+is not a different name; `acme-pdf` is. This is a clarification of the existing
+rule, and it applies going forward.
+
+[FORKS.md](FORKS.md) collects what a fork needs to know in one place — licence
+obligations, naming, and what to expect from this project afterwards. We do not
+keep a register of forks and do not rank or endorse them.
+
 ## Questions / permission
 For any use not clearly covered above, or to request permission, contact
 **yfedoseev@gmail.com**. We aim to be permissive for good-faith community use and


### PR DESCRIPTION
Four documentation gaps, all surfaced by the project's own process over the last two weeks.

### `FORKS.md` (new)

Generic guidance for anyone forking: which licence obligations attach to each arm of the dual offer, what the trademark policy asks of a name, what support to expect afterwards, and how to send fixes back. It opens by saying forking is allowed and that this page is not an argument against it, and states explicitly that this project keeps no register of forks and does not rank or endorse them. Names no one.

Security reports are called out as the exception to "we support only official distributions" — anything found in forked code that plausibly affects us is treated as ours until shown otherwise.

### `TRADEMARKS.md`

Says what "a different name" means for a fork: one that does not contain `PDFOxide`, `pdf_oxide` or `pdf-oxide` as a component, prefix and suffix included. `acme-pdf-oxide` is not a different name; `acme-pdf` is. A clarification of the existing rule, applying going forward.

### `CODE_OF_CONDUCT.md`

The Contributor Covenant text is **unmodified**; a project-specific section is appended after *Scope*.

Conduct is governed there; contribution volume and submission rate are governed by `CONTRIBUTING.md`, and the two do not overlap. A rate limit, an auto-reject or a block applied for volume is a resource-management measure — it reflects what one maintainer can review, and is not a finding under the Code of Conduct. Keeping the ladders apart is what stops a throughput limit being heard as a judgement about a contributor's work or good faith.

### A reporting channel that exists

The Code of Conduct named none at all: the Covenant's `[INSERT CONTACT METHOD]` placeholder had been removed rather than filled in. The fallbacks were circular — `CONTRIBUTING.md` pointed at "the maintainer" with no address and suggested opening an issue, which is the wrong surface for a conduct report, and `SECURITY.md` pointed at `CONTRIBUTING.md` for contact details it does not contain.

All three now name one. Reports *about a person* go to email; a maintainer's notice of a decision stays in the thread it concerns, because that is how a rule is seen to be applied evenly. `SECURITY.md` also links the repository's private advisory form, which is enabled.

Enforcement is only defensible if the process was available to begin with.

### `CONTRIBUTING.md`

Contributors are asked to disclose a material downstream interest — maintaining a fork, or a product that vendors this project. Disclosure, not restriction: it does not affect whether a change is accepted, and downstream maintainers are often the best contributors because they run this code against real documents at volume.

---

Docs only. No code, no CI, no behaviour change.

https://claude.ai/code/session_01KKiaA75XWSqQ22sq2AGtPs