### PR TITLE
chore: unblock the PR queue and drop two dead dependencies

### DIFF
--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -1,0 +1,99 @@
+# Weekly review of the advisory suppressions in osv-scanner.toml.
+#
+# This replaces the `ignoreUntil` dates those entries used to carry. A date is
+# a hard expiry that fails silently and late: the entry stops suppressing with
+# no warning, and the next pull request to touch Cargo.lock fails its
+# security-audit job. On 2026-08-23 that blocked the whole open PR queue behind
+# advisories nobody could have fixed.
+#
+# So the suppressions are open-ended and the review moved here instead. This
+# workflow is SCHEDULED-ONLY — it has no `pull_request` trigger and therefore
+# can never block a PR. It reports; it does not gate.
+#
+# What it answers each week: has any suppressed advisory gained a fixed version
+# upstream, and is any entry now suppressing nothing?
+name: Advisory Review
+
+on:
+  schedule:
+    # Weekly on Tuesday at 05:40 UTC — off the hour, and off the days already
+    # used by codeql (Wed 02:00) and scorecard (Mon 01:30).
+    - cron: '40 5 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: advisory-review
+  cancel-in-progress: false
+
+jobs:
+  review:
+    name: Review suppressed advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.0
+
+      # Unsuppressed scan. The suppressed advisories are EXPECTED here — the
+      # point is to see them with their current upstream metadata, in
+      # particular whether a fixed version has appeared. `|| true` because a
+      # findings-present exit code is the normal outcome, not a failure.
+      - name: OSV-Scanner without suppressions
+        run: |
+          {
+            echo '## OSV-Scanner — suppressions disabled'
+            echo
+            echo 'Suppressed advisories are expected below. What matters is the'
+            echo '`FIXED VERSION` column: anything other than `--` means that entry'
+            echo 'can now be retired from `osv-scanner.toml`.'
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          docker run --rm -v "$PWD":/src -w /src \
+            ghcr.io/google/osv-scanner:v2.3.8 \
+            --lockfile=Cargo.lock --lockfile=ruby/Gemfile.lock \
+            2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # Suppressed scan. Surfaces "unused ignores" — an entry that no longer
+      # matches anything in the lock is dead config and should be deleted, the
+      # way RUSTSEC-2026-0173 was once proc-macro-error2 left the tree.
+      - name: OSV-Scanner with suppressions (unused-ignore check)
+        run: |
+          {
+            echo
+            echo '## OSV-Scanner — suppressions applied'
+            echo
+            echo 'Any entry reported as an *unused ignore* is suppressing nothing and'
+            echo 'should be removed from `osv-scanner.toml`.'
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          docker run --rm -v "$PWD":/src -w /src \
+            ghcr.io/google/osv-scanner:v2.3.8 \
+            --config=osv-scanner.toml \
+            --lockfile=Cargo.lock --lockfile=ruby/Gemfile.lock \
+            2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      # cargo-audit sees the RustSec database directly, which carries the
+      # `patched` metadata OSV summarises. Note it does NOT report
+      # RUSTSEC-2023-0071: with no patched range, semver will not match the
+      # `rsa` pre-release against the advisory's open range. Both scanners run
+      # here precisely because neither alone is sufficient.
+      - name: cargo-audit
+        run: |
+          cargo install cargo-audit --locked --version '^0.21' || true
+          {
+            echo
+            echo '## cargo-audit'
+            echo
+            echo 'Reads the RustSec database directly. Does not report'
+            echo '`RUSTSEC-2023-0071` — semver will not match the `rsa` pre-release'
+            echo 'against an advisory with no patched range. Cross-read with OSV above.'
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          cargo audit --color never 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,6 +9,7 @@ on:
       - 'include/pdf_oxide_c/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'osv-scanner.toml'
       - '.github/workflows/ruby.yml'
   pull_request:
     branches: [ main, develop ]
@@ -18,6 +19,7 @@ on:
       - 'include/pdf_oxide_c/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'osv-scanner.toml'
       - '.github/workflows/ruby.yml'
 
 # Cancel any in-progress run on the same branch when a new one starts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to PDFOxide are documented here.
 
 - **An element's page-space rectangle is now exposed in every language binding** — `page_bbox()` reports a rect already mapped into the page's displayed frame, so callers on a rotated page get coordinates that match what they see rather than pre-`/Rotate` space. Available across the C ABI and every binding built on it (#1056, #1057).
 
+### Changed
+
+- **Two dependencies that nothing imported were removed, taking 43 packages out of the tree** — `imageproc` and `tokenizers` were declared optional, wired into the `ocr` and `ml` features, and referenced by zero lines of Rust anywhere in the workspace. Both also sat on the `cargo-shear` ignore list, which is why the unused-dependency gate never reported them: that list exists for crates used behind a `dep:` feature gate (`cms`, `rsa`, `x509-parser` genuinely are), and these two had outlived it. Removing them drops 43 packages including the `esaxx-rs` / `onig-sys` / `spm_precompiled` C/C++ chain, `nalgebra`, and `ab_glyph`. Both are also gone from the ignore list, so the gate can police them from now on. `ocr` and `ml` build unchanged; there is no behavioural difference, because nothing was calling them.
+- **`ttf-parser` is now reached only by our own font parsing** — with `imageproc` gone, the `imageproc` → `ab_glyph` → `owned_ttf_parser` → `ttf-parser` chain leaves the tree, and `fontdb` 0.24 had already dropped its own dependency on it. That leaves no third-party consumer at all, so the planned migration onto `skrifa`/`read-fonts` (both already present via `subsetter` and `harfrust`) no longer has to wait on anyone else.
+
 ### Fixed
 
 - **`extract_chars` and `extract_spans` disagreed because they used different parsers** — the two APIs walked the content stream through separate code paths, so a page could report characters that no span contained (and vice versa), leaving callers unable to correlate the two. Both now parse through the same parser, so their output describes the same glyphs (#1006, #1010).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,22 +3,6 @@
 version = 4
 
 [[package]]
-name = "ab_glyph"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
-dependencies = [
- "ab_glyph_rasterizer",
- "owned_ttf_parser",
-]
-
-[[package]]
-name = "ab_glyph_rasterizer"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,9 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -342,7 +324,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey 0.1.1",
+ "pastey",
  "rayon",
  "thiserror 2.0.20",
  "v_frame",
@@ -426,12 +408,6 @@ name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -601,15 +577,6 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "cbc"
@@ -810,21 +777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,56 +957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "daachorse"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,37 +1052,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1365,12 +1236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "esaxx-rs"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-
-[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,12 +1354,6 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-types"
@@ -1652,30 +1511,6 @@ dependencies = [
  "color_quant",
  "weezl 0.1.12",
 ]
-
-[[package]]
-name = "glam"
-version = "0.30.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
-
-[[package]]
-name = "glam"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
-
-[[package]]
-name = "glam"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
-
-[[package]]
-name = "glam"
-version = "0.33.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c426daf70099baff33fac0ba85151c42424861c56828cef9ba02dacb78eb6b26"
 
 [[package]]
 name = "glob"
@@ -1839,12 +1674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,25 +1705,6 @@ checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
  "quick-error",
-]
-
-[[package]]
-name = "imageproc"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b27bc0867dc40df08deb53d6e96342db6e0702e7ae33ed09a4eba33e594b05"
-dependencies = [
- "ab_glyph",
- "approx",
- "getrandom 0.4.3",
- "image",
- "itertools 0.14.0",
- "nalgebra",
- "num",
- "rand 0.10.2",
- "rand_distr 0.6.0",
- "rayon",
- "rustdct",
 ]
 
 [[package]]
@@ -2383,22 +2193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro_rules_attribute"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
-dependencies = [
- "macro_rules_attribute-proc_macro",
- "pastey 0.2.3",
-]
-
-[[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,28 +2276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "monostate"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
-dependencies = [
- "monostate-impl",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "monostate-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,25 +2283,6 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
-dependencies = [
- "approx",
- "glam 0.30.10",
- "glam 0.31.1",
- "glam 0.32.1",
- "glam 0.33.5",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba",
- "typenum",
 ]
 
 [[package]]
@@ -2572,7 +2325,7 @@ checksum = "f093b3db6fd194718dcdeea6bd8c829417deae904e3fcc7732dabcd4416d25d8"
 dependencies = [
  "ndarray 0.16.1",
  "rand 0.8.7",
- "rand_distr 0.4.3",
+ "rand_distr",
 ]
 
 [[package]]
@@ -2658,19 +2411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,16 +2453,6 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
-dependencies = [
- "num-integer",
  "num-traits",
 ]
 
@@ -2787,28 +2517,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "onig"
-version = "6.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,15 +2546,6 @@ name = "ort-sys"
 version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
-
-[[package]]
-name = "owned_ttf_parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
-dependencies = [
- "ttf-parser",
-]
 
 [[package]]
 name = "p12-keystore"
@@ -2944,12 +2643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
-name = "pastey"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
-
-[[package]]
 name = "pbkdf2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,7 +2659,7 @@ dependencies = [
  "aes",
  "aws-lc-rs",
  "barcoders",
- "base64 0.23.1",
+ "base64",
  "bitflags 2.13.1",
  "brotli",
  "byteorder",
@@ -2993,7 +2686,6 @@ dependencies = [
  "hayro-jpeg2000",
  "hex-literal",
  "image",
- "imageproc",
  "jpeg-decoder",
  "jpeg-encoder",
  "js-sys",
@@ -3037,7 +2729,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tiny-skia",
- "tokenizers",
  "tract-onnx",
  "ttf-parser",
  "unicode-bidi",
@@ -3717,16 +3408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
-dependencies = [
- "num-traits",
- "rand 0.10.2",
-]
-
-[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,17 +3489,6 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
-]
-
-[[package]]
-name = "rayon-cond"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
-dependencies = [
- "either",
- "itertools 0.14.0",
- "rayon",
 ]
 
 [[package]]
@@ -3975,15 +3645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustdct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551"
-dependencies = [
- "rustfft",
-]
-
-[[package]]
 name = "rustfft"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4059,21 +3720,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "safe_arch"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "safetensors"
@@ -4260,18 +3906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simba"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a7200d82ff1c7b4235efd12f11e2537a402c91cf83a5cb97ce80eef787fde7"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "wide",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4358,18 +3992,6 @@ checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "spm_precompiled"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
-dependencies = [
- "base64 0.13.1",
- "nom 7.1.3",
- "serde",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -4676,39 +4298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokenizers"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
-dependencies = [
- "ahash",
- "compact_str",
- "daachorse",
- "dary_heap",
- "derive_builder",
- "esaxx-rs",
- "getrandom 0.3.4",
- "itertools 0.14.0",
- "log",
- "macro_rules_attribute",
- "monostate",
- "onig",
- "paste",
- "rand 0.9.5",
- "rayon",
- "rayon-cond",
- "regex",
- "regex-syntax",
- "serde",
- "serde_json",
- "spm_precompiled",
- "thiserror 2.0.20",
- "unicode-normalization-alignments",
- "unicode-segmentation",
- "unicode_categories",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,7 +4335,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-traits",
- "pastey 0.1.1",
+ "pastey",
  "rustfft",
  "smallvec",
  "tract-data",
@@ -4809,7 +4398,7 @@ dependencies = [
  "liquid-derive",
  "log",
  "num-traits",
- "pastey 0.1.1",
+ "pastey",
  "scan_fmt",
  "smallvec",
  "time",
@@ -4865,7 +4454,7 @@ dependencies = [
  "getrandom 0.2.17",
  "log",
  "rand 0.8.7",
- "rand_distr 0.4.3",
+ "rand_distr",
  "rustfft",
  "tract-nnef",
 ]
@@ -4932,15 +4521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-normalization-alignments"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,12 +4531,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"
@@ -4986,7 +4560,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "log",
  "percent-encoding",
  "rustls",
@@ -5002,7 +4576,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "http",
  "httparse",
  "log",
@@ -5215,16 +4789,6 @@ name = "weezl"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ca08e5ef825b65b056d9efbd95c8750683f0a6d0466d02e96dc2e4e360f3d2"
-
-[[package]]
-name = "wide"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,9 @@ ignored = [
     "spki",
     "x509-parser",
     # ML / table detection / OCR (gated on `ml`, `table-ml`, `ocr` features)
-    "imageproc",
     "linfa",
     "linfa-clustering",
     "pdfium-render",
-    "tokenizers",
     "tract-onnx",
     # WASM-only runtime deps (gated on `wasm` feature)
     "getrandom_02",
@@ -64,7 +62,7 @@ version = "0.3.77"
 # MSRV — driven up from 1.82 for v0.3.38. Transitive deps pulled in
 # this release push the floor to 1.88:
 #   - hybrid-array 0.4.10 (via RustCrypto) → edition 2024 → 1.85
-#   - image 0.25.10 / imageproc 0.26.1 → 1.87 / 1.88
+#   - image 0.25.10 → 1.87
 #   - nalgebra 0.34.2 → 1.87
 #   - libloading 0.9.0, ort 2.0.0-rc.12, ort-sys 2.0.0-rc.12 → 1.88
 # 1.88 was released 2025-06-26, so this is still a reasonable floor.
@@ -239,14 +237,12 @@ linfa-clustering = { version = "0.8", optional = true }
 
 # ML (CPU-only)
 tract-onnx = { version = "0.22", optional = true }
-tokenizers = { version = "0.23", optional = true, default-features = false, features = ["onig"] }
 
 # OCR - PaddleOCR via ONNX Runtime (optional)
 ort = { version = "=2.0.0-rc.11", optional = true, default-features = false, features = [
     "ndarray",
     "load-dynamic",
 ] }
-imageproc = { version = "0.27.0", optional = true }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
@@ -406,14 +402,13 @@ python = [
 # The following features are planned for v1.0 and are not yet production-ready.
 # We define them here to avoid check-cfg warnings, but their dependencies are commented out.
 # Lean pure-Rust ONNX inference backend (tract): the *only* ML deps the
-# OCR path needs. Kept separate from `ml` so the wasm OCR build (#524)
-# does not drag in `tokenizers` (esaxx-rs / onig_sys / spm_precompiled —
-# C/C++ via `cc`, no clean wasm32 story) or `linfa`. `ml` is a strict
-# superset, so native `ml` / `table-ml` consumers are unchanged.
+# OCR path needs. Kept separate from `ml` so the wasm OCR build does not
+# drag in `linfa`. `ml` is a strict superset, so native `ml` / `table-ml`
+# consumers are unchanged.
 ocr-tract = ["dep:tract-onnx", "dep:ndarray"]
-ml = ["ocr-tract", "dep:linfa", "dep:linfa-clustering", "dep:tokenizers"]
+ml = ["ocr-tract", "dep:linfa", "dep:linfa-clustering"]
 table-ml = ["ml", "dep:pdfium-render"]
-ocr = ["dep:ort", "dep:imageproc", "dep:ndarray", "dep:ureq"]
+ocr = ["dep:ort", "dep:ndarray", "dep:ureq"]
 gpu = ["dep:ort", "ml"]
 wasm = [
     "dep:wasm-bindgen",
@@ -427,9 +422,9 @@ wasm = [
     "signatures",
     "barcodes",
 ]
-# OCR in the browser/Deno/edge build (#524): wasm + the *lean* tract
-# backend only (`ocr-tract`, NOT full `ml` — that pulls tokenizers'
-# C/C++ deps which need clang and have no clean wasm32 story).
+# OCR in the browser/Deno/edge build: wasm + the *lean* tract backend
+# only (`ocr-tract`, NOT full `ml` — `ml` adds the linfa clustering
+# stack, which the browser build has no use for).
 # `getrandom_03` activates the `wasm_js` backend for the getrandom 0.3
 # that tract drags in (a no-op off-wasm32: the dep only exists under
 # the wasm32 target table).

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,52 +1,91 @@
 # OSV-Scanner configuration for pdf_oxide.
 #
-# Documents the (small) set of known-upstream Rust advisories that have no
-# available — or no currently *adoptable* — fix, with explicit per-CVE
-# justifications and a review horizon. Re-evaluate every release.
+# The (small) set of known-upstream Rust advisories that have no available —
+# or no currently *adoptable* — fix, with explicit per-advisory justifications
+# and, for each, the concrete condition that would retire it.
 #
-# NOTE ON `ignoreUntil`: an expired entry does not warn — it silently stops
-# suppressing, and the scanner then fails every pull request that touches
-# Cargo.lock. Renew or remove an entry *before* its date.
+# WHY THESE ENTRIES CARRY NO `ignoreUntil`
+#
+# `ignoreUntil` is a hard expiry, and it fails loudly in the worst possible
+# place: an expired entry emits no warning, it silently stops suppressing, and
+# the next pull request to touch Cargo.lock fails its security-audit job. On
+# 2026-08-23 two dates fell due on the same day and blocked the entire open PR
+# queue behind an advisory that nobody could have fixed.
+#
+# A date is the wrong instrument here because none of these advisories can be
+# closed by any action of ours (see each entry). Their real end conditions are
+# upstream events, not calendar dates, so a dated review only re-arms the trap.
+#
+# Review still happens — see `.github/workflows/advisory-review.yml`, which runs
+# weekly, reports the live status of every entry below, and flags any that has
+# gained a fixed version upstream. That job is scheduled-only: it can never
+# fail a pull request.
+#
+# ADDING AN ENTRY: state the advisory kind (informational vs CVE), why it is
+# not exploitable or not adoptable here, and the upstream event that retires it.
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2024-0436"
-# `paste` crate: "no longer maintained" advisory (informational, not a CVE).
-# No remote-code-execution or memory-safety implication; the advisory exists
-# solely to flag the unmaintained status, and there is no fixed version.
+# `paste` — "no longer maintained". Informational, not a CVE: no
+# remote-code-execution and no memory-safety implication. No fixed version, and
+# none is coming; the advisory exists solely to flag maintenance status.
 #
-# Reviewed 2026-08-23: not fixable by any version bump — it is not a direct
-# dependency and reaches the tree three independent transitive ways:
-#   tokenizers -> {paste, macro_rules_attribute -> paste}
-#   image -> ravif -> rav1e -> paste
-#   image -> exr -> pulp -> paste
-# Re-evaluate when those consumers migrate off paste (the community is moving
-# to `pastey` / plain `quote`).
-ignoreUntil = 2026-09-23
+# Not a direct dependency, and absent from the default build graph entirely
+# (`cargo tree -i paste` with default features finds nothing). It enters only
+# through optional features, three ways, all by third-party feature unification:
+#   barcodes -> barcoders (declares `image` without default-features = false,
+#               so every image format switches on) -> {ravif -> rav1e,
+#               exr -> pulp} -> paste
+# Our own `image` dependency is already minimal (png/jpeg/tiff only).
+#
+# Two further entry points existed until this change and are now gone with the
+# dead `imageproc` and `tokenizers` dependencies: `ocr` -> imageproc (whose
+# `default` includes "image/default") and `ml` -> tokenizers -> paste. Only the
+# barcoders path remains, and it is upstream's to fix.
+#
+# Pruning cannot retire this. Verified 2026-08-23: with all three entry points
+# severed and Cargo.lock regenerated from scratch,
+# `cargo tree -i paste --all-features --target all` printed nothing while
+# `cargo audit` still reported the advisory — OSV-Scanner and cargo-audit both
+# read the lockfile, not the build graph.
+#
+# RETIRES WHEN: barcoders sets `default-features = false` on `image` (a small
+# upstream change worth sending), or pulp and rav1e move off paste (the
+# ecosystem is migrating to `pastey` / plain `quote`).
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2023-0071"
-# `rsa` crate: Marvin-attack timing side-channel (CVE-2023-49092, CVSS 5.9).
-# The advisory records `patched = []` — *every* published version is affected
-# and no fix exists on any release line, so this cannot be closed by upgrading.
+# `rsa` — Marvin-attack timing side-channel (CVE-2023-49092, CVSS 5.9). The
+# only entry here with a real CVE, and the one to watch.
 #
-# Exposure in our usage is limited: the advisory concerns timing observable
-# against RSA *decryption* oracles. pdf_oxide performs PAdES signature
-# verification (public-key only) and detached signing with a locally-held key
-# — it never decrypts attacker-supplied ciphertext, so there is no remote
-# oracle to time. The `fips` build routes RSA through `aws-lc-rs` instead and
-# is unaffected either way.
+# The advisory records `patched = []` with no `unaffected` range: EVERY
+# published version is affected, so no upgrade closes it. We are on
+# 0.10.0-rc.18, the release-candidate line carrying the constant-time rewrite,
+# and the version `cms` 0.3 requires.
 #
-# Reviewed 2026-08-23: we are on 0.10.0-rc.18 — the release-candidate line
-# carrying the constant-time rewrite, and the version `cms` 0.3 requires — but
-# the advisory still lists no patched range. Re-evaluate when rsa 0.10.0 ships
-# final and the advisory records a fix.
-ignoreUntil = 2026-09-23
+# Not exploitable in our usage. The advisory concerns timing observable against
+# an RSA *decryption* oracle. pdf_oxide verifies PAdES signatures (public-key
+# only) and signs with a locally-held key; it never decrypts attacker-supplied
+# ciphertext, so there is no remote oracle to time. The `fips` build routes RSA
+# through `aws-lc-rs` and is unaffected either way.
+#
+# Not removable: we depend on it directly (src/crypto/rust_provider.rs, both
+# verify and sign), and `cms` 0.3 depends on it too, reaching us via
+# p12-keystore -> pkcs12 — so dropping our direct use would not clear the lock
+# while PKCS#12 keystore support exists.
+#
+# NOTE: `cargo audit` does NOT report this. With no patched range, semver will
+# not match the `0.10.0-rc.18` pre-release against the advisory's open range.
+# OSV-Scanner catches it; cargo-audit alone would call this dependency clean.
+#
+# RETIRES WHEN: rsa 0.10.0 ships final and the advisory records a patched
+# range. This is the one the weekly review job exists to catch.
 
 # RUSTSEC-2026-0173 (`proc-macro-error2` unmaintained) was ignored while the
 # crate reached the tree via env_logger -> defmt -> defmt-macros. It is no
-# longer present in Cargo.lock at all, and OSV-Scanner reported the entry as
-# an unused ignore, so the suppression is removed rather than renewed. It will
-# be re-flagged normally if the crate ever returns.
+# longer present in Cargo.lock at all, and OSV-Scanner reported the entry as an
+# unused ignore, so the suppression is removed rather than carried forward. It
+# will be re-flagged normally if the crate ever returns.
 
 # RUSTSEC-2026-0194 and RUSTSEC-2026-0195 (quick-xml < 0.41 DoS advisories)
 # were previously ignored because office_oxide 0.1.2 pulled the vulnerable
@@ -57,24 +96,27 @@ ignoreUntil = 2026-09-23
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0192"
-# `ttf-parser` crate: "unmaintained" advisory (informational, not a CVE; no
-# memory-safety or RCE implication — the author has stated the crate will
-# receive no further fixes; its repo has since moved under the harfbuzz org).
-# There is no patched version.
+# `ttf-parser` — "unmaintained". Informational, not a CVE; no memory-safety or
+# RCE implication. The author has stated the crate will receive no further
+# fixes and its repo has moved under the harfbuzz org. There is no patched
+# version.
 #
-# Decision: replacement is scheduled for the 0.4.0 font-stack work, not for a
-# patch release. It is not removable by a version bump — it reaches the tree
-# two ways:
-#   1. directly — we parse embedded-font cmap tables, glyph outlines, metrics
-#      and name records through it (core font parsing + the render outline
-#      path): 29 references across src/fonts/{truetype_cmap,truetype_parser,
-#      font_dict}.rs and src/rendering/text_rasterizer.rs;
-#   2. imageproc (`ocr` feature) -> ab_glyph -> owned_ttf_parser -> ttf-parser,
-#      which still ships no fontations-based release.
-# The successor stack is already in the tree — skrifa 0.42 / read-fonts via
-# subsetter and harfrust (the rustybuzz migration has landed; rustybuzz is no
-# longer a dependency), and fontdb 0.24 has itself dropped ttf-parser, so path
-# (2) of the three previously recorded here is already gone. What remains is
-# porting our own 29 direct call sites and replacing ab_glyph — core
-# font-parsing and render work with real regression risk, hence 0.4.0.
-ignoreUntil = 2026-12-31
+# Not removable by a version bump. As of this change it reaches the tree by
+# exactly ONE path: directly, from our own font parsing — embedded-font cmap
+# tables, glyph outlines, metrics and name records, 29 references across
+# src/fonts/{truetype_cmap,truetype_parser,font_dict}.rs and
+# src/rendering/text_rasterizer.rs.
+#
+# Two transitive paths recorded here previously are both gone:
+#   - fontdb -> ttf-parser: fontdb 0.24 no longer depends on it;
+#   - imageproc -> ab_glyph -> owned_ttf_parser -> ttf-parser: removed with the
+#     dead `imageproc` dependency in this change.
+# `rustybuzz` is likewise gone — the harfrust migration has landed.
+#
+# The successor stack is already in the tree: skrifa 0.42 and read-fonts, via
+# subsetter and harfrust.
+#
+# RETIRES WHEN: the 0.4.0 font-stack migration ports those direct call sites to
+# skrifa. With ab_glyph gone that migration is now the only remaining work —
+# there is no third-party consumer left to wait on. Scheduled work, not a
+# patch-release change.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,36 +2,51 @@
 #
 # Documents the (small) set of known-upstream Rust advisories that have no
 # available — or no currently *adoptable* — fix, with explicit per-CVE
-# justifications and a 90-day review horizon. Re-evaluate every release.
+# justifications and a review horizon. Re-evaluate every release.
+#
+# NOTE ON `ignoreUntil`: an expired entry does not warn — it silently stops
+# suppressing, and the scanner then fails every pull request that touches
+# Cargo.lock. Renew or remove an entry *before* its date.
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2024-0436"
 # `paste` crate: "no longer maintained" advisory (informational, not a CVE).
-# Used transitively by build-macro crates we don't directly depend on. No
-# remote-code-execution or memory-safety implication; advisory exists solely
-# to flag the unmaintained status. Re-evaluate when transitive consumers
-# move off paste (community is migrating to `pastey` / `quote`).
-ignoreUntil = 2026-08-23
+# No remote-code-execution or memory-safety implication; the advisory exists
+# solely to flag the unmaintained status, and there is no fixed version.
+#
+# Reviewed 2026-08-23: not fixable by any version bump — it is not a direct
+# dependency and reaches the tree three independent transitive ways:
+#   tokenizers -> {paste, macro_rules_attribute -> paste}
+#   image -> ravif -> rav1e -> paste
+#   image -> exr -> pulp -> paste
+# Re-evaluate when those consumers migrate off paste (the community is moving
+# to `pastey` / plain `quote`).
+ignoreUntil = 2026-09-23
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2023-0071"
-# `rsa` crate: known potential Marvin-attack timing side-channel for RSA
-# decryption keys. NOT exploitable in our usage: pdf_oxide uses RSA only
-# for PAdES signature *verification* of detached signatures (never
-# decryption of attacker-controlled ciphertexts), where the timing channel
-# is not applicable. No fix version released upstream. Re-evaluate when
-# rustcrypto/RSA ships the constant-time rewrite.
-ignoreUntil = 2026-08-23
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0173"
-# `proc-macro-error2` crate: advisory marks it as unmaintained (no CVE, no
-# memory-safety implication). Pulled in transitively:
-#   env_logger → defmt → defmt-macros → proc-macro-error2
-# `env_logger` is a dev dependency only; this crate does not reach published
-# builds. No fix version available upstream. Re-evaluate when defmt or
-# env_logger migrates off proc-macro-error2.
+# `rsa` crate: Marvin-attack timing side-channel (CVE-2023-49092, CVSS 5.9).
+# The advisory records `patched = []` — *every* published version is affected
+# and no fix exists on any release line, so this cannot be closed by upgrading.
+#
+# Exposure in our usage is limited: the advisory concerns timing observable
+# against RSA *decryption* oracles. pdf_oxide performs PAdES signature
+# verification (public-key only) and detached signing with a locally-held key
+# — it never decrypts attacker-supplied ciphertext, so there is no remote
+# oracle to time. The `fips` build routes RSA through `aws-lc-rs` instead and
+# is unaffected either way.
+#
+# Reviewed 2026-08-23: we are on 0.10.0-rc.18 — the release-candidate line
+# carrying the constant-time rewrite, and the version `cms` 0.3 requires — but
+# the advisory still lists no patched range. Re-evaluate when rsa 0.10.0 ships
+# final and the advisory records a fix.
 ignoreUntil = 2026-09-23
+
+# RUSTSEC-2026-0173 (`proc-macro-error2` unmaintained) was ignored while the
+# crate reached the tree via env_logger -> defmt -> defmt-macros. It is no
+# longer present in Cargo.lock at all, and OSV-Scanner reported the entry as
+# an unused ignore, so the suppression is removed rather than renewed. It will
+# be re-flagged normally if the crate ever returns.
 
 # RUSTSEC-2026-0194 and RUSTSEC-2026-0195 (quick-xml < 0.41 DoS advisories)
 # were previously ignored because office_oxide 0.1.2 pulled the vulnerable
@@ -47,23 +62,19 @@ id = "RUSTSEC-2026-0192"
 # receive no further fixes; its repo has since moved under the harfbuzz org).
 # There is no patched version.
 #
-# Decision: keep waiting. Removing ttf-parser is NOT achievable by a version
-# bump — it reaches the tree three independent ways:
+# Decision: replacement is scheduled for the 0.4.0 font-stack work, not for a
+# patch release. It is not removable by a version bump — it reaches the tree
+# two ways:
 #   1. directly — we parse embedded-font cmap tables, glyph outlines, metrics
 #      and name records through it (core font parsing + the render outline
-#      path), ~29 call sites;
-#   2. fontdb (system-fonts) -> ttf-parser — latest fontdb 0.23.0 still depends
-#      on it and ships no skrifa/fontations release;
-#   3. imageproc (ml) -> ab_glyph -> owned_ttf_parser -> ttf-parser — likewise
-#      no fontations-based release exists.
-# The actively-maintained successor is `skrifa`/`read-fonts` (fontations),
-# already in our tree via subsetter (and via harfrust once the shaping
-# migration off rustybuzz lands). Fully clearing this advisory requires porting
-# our direct usage to skrifa AND replacing both fontdb and ab_glyph with
-# fontations-based equivalents — a large, multi-crate migration touching the
-# core font-parsing and render paths, with real regression risk that is
-# disproportionate while the advisory remains informational-only.
-# Re-evaluate when fontdb or ab_glyph ship a fontations backend, or when the
-# standalone font-stack migration is scheduled.
+#      path): 29 references across src/fonts/{truetype_cmap,truetype_parser,
+#      font_dict}.rs and src/rendering/text_rasterizer.rs;
+#   2. imageproc (`ocr` feature) -> ab_glyph -> owned_ttf_parser -> ttf-parser,
+#      which still ships no fontations-based release.
+# The successor stack is already in the tree — skrifa 0.42 / read-fonts via
+# subsetter and harfrust (the rustybuzz migration has landed; rustybuzz is no
+# longer a dependency), and fontdb 0.24 has itself dropped ttf-parser, so path
+# (2) of the three previously recorded here is already gone. What remains is
+# porting our own 29 direct call sites and replacing ab_glyph — core
+# font-parsing and render work with real regression risk, hence 0.4.0.
 ignoreUntil = 2026-12-31
-


### PR DESCRIPTION
Closes #1116

**This should merge ahead of the rest of the open batch**, which is blocked behind it.

## 1. The block

Two `ignoreUntil` dates in `osv-scanner.toml` fell due on 2026-08-23. An expired entry does not warn — it stops suppressing silently, so OSV-Scanner began reporting `paste` (RUSTSEC-2024-0436) and `rsa` (RUSTSEC-2023-0071) as live findings and failing the `Security audit (bundler-audit + OSV-Scanner)` job on **every PR touching `Cargo.lock`**. It surfaced as the red check on #976, but it is repo-wide and time-triggered, not that PR's defect.

## 2. Why the dates are gone rather than renewed

Renewing only re-arms the trap, and a date is the wrong instrument: none of these advisories can be closed by anything we do. Their end conditions are upstream events.

I checked whether the obvious lever — pruning the dependencies — clears them. **It does not.** With all three `paste` entry points severed and `Cargo.lock` regenerated from scratch:

```
cargo tree -i paste --all-features --target all  →  "nothing to print"
cargo audit                                      →  still reports RUSTSEC-2024-0436
```

Nothing in any feature or target combination could reach `paste`, and the scanner flagged it anyway. Both OSV-Scanner and cargo-audit read the **lockfile**, not the build graph.

So the suppressions are now open-ended, each recording the concrete upstream event that retires it:

| advisory | crate | kind | retires when |
|---|---|---|---|
| RUSTSEC-2024-0436 | `paste` 1.0.15 | unmaintained, informational | `barcoders` sets `default-features = false` on `image`, or pulp/rav1e move off `paste` |
| RUSTSEC-2023-0071 | `rsa` 0.10.0-rc.18 | CVE-2023-49092, CVSS 5.9 | `rsa` 0.10.0 ships final and the advisory records a patched range |
| RUSTSEC-2026-0192 | `ttf-parser` 0.25.1 | unmaintained, informational | the 0.4.0 skrifa migration |

`RUSTSEC-2026-0173` (`proc-macro-error2`) is dropped — the crate is no longer in `Cargo.lock` and the scanner reported the entry as an unused ignore.

Review moves to a new `advisory-review.yml`: weekly schedule plus `workflow_dispatch`, and **deliberately no `pull_request` trigger**, so it can never gate a PR. It runs OSV twice — without suppressions to catch a new fixed version, with them to catch dead entries — and cargo-audit, because neither scanner alone suffices. **cargo-audit does not report `RUSTSEC-2023-0071` at all**: with no patched range, semver will not match the `0.10.0-rc.18` pre-release against the advisory's open range. Relying on it alone would call that dependency clean.

## 3. Two dead dependencies removed

Analysing the `paste` paths turned these up. `imageproc` and `tokenizers` were declared optional, wired into the `ocr` and `ml` features, and referenced by **zero lines of Rust anywhere in the workspace**. Both also sat on the `cargo-shear` ignore list, which is why the unused-dependency gate never reported them — that list is for crates genuinely used behind a `dep:` gate (`cms`, `rsa`, `x509-parser` are), and these two had outlived it. Both are removed from the list so the gate can police them.

**43 packages leave the tree** (563 → 520), including the `esaxx-rs` / `onig-sys` / `spm_precompiled` C/C++ chain, `nalgebra`, `rustdct` and `ab_glyph`.

With `ab_glyph` gone, **`ttf-parser` is now reached only by our own font parsing** — `fontdb` 0.24 had already dropped its dependency on it — so the planned `skrifa`/`read-fonts` migration no longer waits on any third party. Both are already in the tree via `subsetter` and `harfrust`.

No behavioural change: nothing was calling them.

## Verification

- `cargo check` clean on **default**, `ocr`, `ml`, and `rendering`.
- `cargo clippy --all-targets --workspace -- -D warnings` clean.
- `cargo shear` exits 0; the two ignore entries are no longer needed.
- `osv-scanner.toml` and both workflow files parse; `advisory-review.yml` asserted to have no `pull_request` trigger.
- Dependency paths re-derived from `cargo tree` on this branch, not carried forward from the old comments — two of which were stale (`fontdb` had dropped `ttf-parser`; the `rsa` entry claimed verification-only when we also sign).

No corpus sweep applies: this touches no extraction, render or write surface, so every sweep harness is structurally incapable of observing it.

Also adds `osv-scanner.toml` to the Ruby workflow's `paths` filters — it was absent, so editing the suppression config did not re-run the scanner that consumes it.

https://claude.ai/code/session_01293vukWLSK5WA5GVpxUmBi